### PR TITLE
fix: preview images for blogs in guides section

### DIFF
--- a/app/guides/[...slug]/page.tsx
+++ b/app/guides/[...slug]/page.tsx
@@ -42,8 +42,8 @@ export async function generateMetadata({
   const modifiedAt = new Date(post.lastmod || post.date).toISOString()
   const authors = authorDetails.map((author) => author.name)
   let imageList = [siteMetadata.socialBanner]
-  if (post.images) {
-    imageList = typeof post.images === 'string' ? [post.images] : post.images
+  if (post.image) {
+    imageList = typeof post.image === 'string' ? [post.image] : post.image
   }
   const ogImages = imageList.map((img) => {
     return {


### PR DESCRIPTION
This PR fixes issue: https://github.com/SigNoz/signoz-web/issues/272

# before:
<img width="364" alt="image" src="https://github.com/SigNoz/signoz-web/assets/170525115/e02977ae-1a5d-48e8-beb6-d81272dd04ba">

# after:
<img width="368" alt="image" src="https://github.com/SigNoz/signoz-web/assets/170525115/6cfcedfb-6cd4-44d9-98cb-330c2e7d8485">