### PR TITLE
fix(smtp): use SMTP_ENABLED environment as string

### DIFF
--- a/data/docs/operate/query-service/user-invitation-smtp.mdx
+++ b/data/docs/operate/query-service/user-invitation-smtp.mdx
@@ -48,7 +48,7 @@ You can include the following section in your Helm override values YAML file.
 ```yaml {3-8}
 queryService:
   additionalEnvs:
-    SMTP_ENABLED: true
+    SMTP_ENABLED: "true"
     SMTP_FROM: <email address>
     SMTP_HOST: <smtp host>
     SMTP_PORT: <smtp port>


### PR DESCRIPTION
#### Fixes

- use SMTP_ENABLED environment as string

Using it as boolean `true`/`false` gives out error.