### PR TITLE
fix: metadata title layout for docs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteMetadata.siteUrl),
   title: {
     default: siteMetadata.title,
-    template: `${siteMetadata.title} | %s`,
+    template: `%s | ${siteMetadata.title}`,
   },
   description: siteMetadata.description,
   openGraph: {

--- a/app/pricing/metrics-cost-estimation/page.tsx
+++ b/app/pricing/metrics-cost-estimation/page.tsx
@@ -3,7 +3,9 @@ import MetricsCostEstimation from './MetricsCostEstimation'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Metrics Cost Estimation',
+  title: {
+    absolute: 'SigNoz | Metrics Cost Estimation',
+  },
   openGraph: {
     title: 'SigNoz | Metrics Cost Estimation',
     description: 'Understand the pricing of metrics in SigNoz cloud.',

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -3,7 +3,9 @@ import Pricing from './Pricing'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Pricing',
+  title: {
+    absolute: 'SigNoz | Pricing',
+  },
   openGraph: {
     title: 'SigNoz | Pricing',
     description: 'Explore SigNoz plans and pricing. Transparent & predictable with only usage-based pricing. No user-based pricing, no pricing based on containers, hosts, or nodes. No special pricing for custom metrics.',

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -3,7 +3,9 @@ import Teams from './Teams'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Teams',
+  title: {
+    absolute: 'SigNoz | Teams',
+  },
   openGraph: {
     title: 'SigNoz | Teams',
     description: ' Sign up for SigNoz cloud and get 30 days of free trial with access to all features.',


### PR DESCRIPTION
Example doc:

# before:

<img width="253" alt="image" src="https://github.com/user-attachments/assets/35ce7d66-d605-4677-b891-17c2610b5f99">

# after:

<img width="251" alt="image" src="https://github.com/user-attachments/assets/22c09b8a-9f06-4f56-ba2c-2501f10064eb">
