### PR TITLE
fix: add padding for docs in mobile view

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -46,7 +46,7 @@ export default function DocLayout({ children }: LayoutProps) {
     <main ref={mainRef} className="">
       <SectionContainer>
         <ProgressBar target={mainRef} />
-        <div className="doc overflow-clip">
+        <div className="max-sm:px-4 doc overflow-clip">
           <div className="doc-sidenav border-r border-signoz_slate-500">
             <DocsSidebar />
           </div>


### PR DESCRIPTION
# before:

<img width="544" alt="image" src="https://github.com/user-attachments/assets/b57e65e9-dc01-43f6-986a-4c4efabd96a3">

# after:

<img width="543" alt="image" src="https://github.com/user-attachments/assets/15ec607d-c56e-49b8-aa10-5da5062b5fb0">
