### PR TITLE
Fix typos on PostgreSQL integrations and otel collector docs

### DIFF
--- a/data/docs/integrations/postgresql.mdx
+++ b/data/docs/integrations/postgresql.mdx
@@ -280,7 +280,7 @@ To stop this, you can select the `Remove from SigNoz` button.
 
 ## PostgreSQL dashboard
 Once SigNoz has started listening to your PostgreSQL data, head over to the Dashboards tab and search for Postgres, this will show you a newly created dashboard which shows
-differnet PostgreSQL metrics.
+different PostgreSQL metrics.
 
 <figure data-zoomable align='center'>
     <img src="/img/docs/integrations/postgres/postgres-integration-dashboard.webp" alt="Dashboard for monitoring PostgreSQL Metrics"/>
@@ -304,7 +304,7 @@ can monitor for your PostgreSQL instance. The tables below gives you a list of t
 </figure>
 
 
-### PostgrSQL log attributes 
+### PostgreSQL log attributes 
 
 - **Name**: The name of the log attribute.
 - **Path**: The specific location or attribute within a log entry where the corresponding data can be found.

--- a/data/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine.mdx
+++ b/data/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine.mdx
@@ -130,7 +130,7 @@ Here are the steps to set up OpenTelemetry binary as an agent.
 
 ## Test Sending Traces
 
-OpenTelemetry collector binary should be able to forward all types of telemetry data recevied:
+OpenTelemetry collector binary should be able to forward all types of telemetry data received:
 traces, metrics, and logs, to SigNoz OTLP endpoint via gRPC.
 
 Let's send sample traces to the `otelcol` using `telemetrygen`.
@@ -240,8 +240,7 @@ sudo dpkg -i otelcol-contrib_0.88.0_linux_arm64.deb
 ### Plain Binary
 
 Using the `tar.gz` release asset, we can extract the OpenTelemetry collector binary
-and default configuration at our desired path. We can run the binary directly
-with flags either use `tmux
+and default configuration at our desired path.
 
 <Tabs groupId="plainbin-arch">
 <TabItem value="linux-amd" label="Linux (amd64)" default>

--- a/data/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine.mdx
+++ b/data/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine.mdx
@@ -240,7 +240,8 @@ sudo dpkg -i otelcol-contrib_0.88.0_linux_arm64.deb
 ### Plain Binary
 
 Using the `tar.gz` release asset, we can extract the OpenTelemetry collector binary
-and default configuration at our desired path.
+and default configuration at our desired path. You can run the binary directly
+with flags by using tools like `screen` or `tmux`.
 
 <Tabs groupId="plainbin-arch">
 <TabItem value="linux-amd" label="Linux (amd64)" default>


### PR DESCRIPTION
Fixes a couple misspellings and removes a partial sentence in `data/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine.mdx` that probably doesn't belong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical errors in PostgreSQL and OpenTelemetry documentation for improved clarity.
	- Enhanced consistency in spelling of "PostgreSQL" throughout the documentation.
	- Streamlined explanations related to OpenTelemetry binary usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->