### PR TITLE
chore: minor v0.55 migration changes

### DIFF
--- a/data/docs/operate/migration.mdx
+++ b/data/docs/operate/migration.mdx
@@ -15,6 +15,12 @@ The following sections provide instructions to migrate SigNoz components across 
 />
 
 <DocCard
+    title="📄️ Upgrade to v0.51"
+    description=""
+    href="/docs/operate/migration/upgrade-0.51"
+/>
+
+<DocCard
     title="📄️ Upgrade to v0.49"
     description=""
     href="/docs/operate/migration/upgrade-0.49"

--- a/data/docs/operate/migration.mdx
+++ b/data/docs/operate/migration.mdx
@@ -9,6 +9,12 @@ The following sections provide instructions to migrate SigNoz components across 
 <DocCardContainer>
 
 <DocCard
+    title="📄️ Upgrade to v0.55"
+    description=""
+    href="/docs/operate/migration/upgrade-0.55"
+/>
+
+<DocCard
     title="📄️ Upgrade to v0.49"
     description=""
     href="/docs/operate/migration/upgrade-0.49"

--- a/data/docs/operate/migration/upgrade-0.55.mdx
+++ b/data/docs/operate/migration/upgrade-0.55.mdx
@@ -53,7 +53,7 @@ You can skip this step if the retention setting is default and SigNoz version `>
 
 ## Migrating the Existing Materialized Columns and TTL Settings
 
-After upgrading to SigNoz version v0.55 i.e. SigNoz chart version v0.53.0, you need to run the migration script to copy the TTL settings and materialized columns from the old table.
+After upgrading to SigNoz version v0.55 i.e. SigNoz chart version v0.53.1, you need to run the migration script to copy the TTL settings and materialized columns from the old table.
 
 Migration changes include:
 * materialized columns from the old table to the new table


### PR DESCRIPTION
#### Chores

- include v0.55 migration card in the migration main page
- update post-upgrade SigNoz chart version to v0.53.1