### PR TITLE
docs: /operate/docker-standalone.mdx: change "Remove the Sample Application from SigNoz Dashboard" section

### DIFF
--- a/data/docs/operate/docker-standalone.mdx
+++ b/data/docs/operate/docker-standalone.mdx
@@ -71,22 +71,15 @@ Enter the following command to uninstall SigNoz:
 docker compose -f docker/clickhouse-setup/docker-compose.yaml down -v
 ```
 
-## Remove the Sample Application from SigNoz Dashboard
+## Running SigNoz without Sample Application
 
-Follow the steps in this section to remove the sample application that comes installed with SigNoz:
+By default, `docker-compose.yaml` includes a sample application setup.
+To run SigNoz without the sample application, instead of using `docker-compose.yaml`, use `docker-compose-minimal.yaml` in all previously mentioned commands.
 
-1. From the directory in which you installed SigNoz, open Docker Compose file `deploy/docker/clickhouse-setup/docker-compose.yaml` in a plain-text editor. 
-
-2. Comment out or remove the `services.hotrod` and `services.load-hotrod` sections:
-
-  ![Remove the sample application on Docker Standalone](/img/docker-standalone-remove-the-sample-application.webp)
-
-3. Move into the `deploy` directory and run the `install.sh` script again:
-
-    ```bash
-    cd deploy && ./install.sh
-    ```
-
+For example,
+```bash
+docker compose -f docker/clickhouse-setup/docker-compose-minimal.yaml up -d
+```
 <Admonition>
-If you still see the HotROD services on the dashboard, just wait for a few minutes and the changes will reflect.
+If you still see the HotROD services on the dashboard, wait for a few minutes, and the changes will be reflected.
 </Admonition>


### PR DESCRIPTION
The new section is "Running SigNoz without Sample Application".

It reflects changes made in https://github.com/SigNoz/signoz/pull/5839