### PR TITLE
chore: decrease the build issues 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -238,6 +238,12 @@ module.exports = () => {
         use: ['@svgr/webpack'],
       })
 
+      if (config.cache && !options.dev) {
+        config.cache = Object.freeze({
+          type: 'memory',
+        })
+      }
+
       return config
     },
   })

--- a/next.config.js
+++ b/next.config.js
@@ -238,6 +238,8 @@ module.exports = () => {
         use: ['@svgr/webpack'],
       })
 
+      // this is to avoid caching for webpack
+      // reference https://nextjs.org/docs/app/building-your-application/optimizing/memory-usage#disable-webpack-cache
       if (config.cache && !options.dev) {
         config.cache = Object.freeze({
           type: 'memory',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "cross-env INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules --max-old-space-size=6144' node ./scripts/postbuild.mjs",
+    "build": "cross-env INIT_CWD=$PWD NODE_OPTIONS='--max-old-space-size=6144' next build && cross-env NODE_OPTIONS='--experimental-json-modules' node ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "lint": "next lint --fix --dir pages --dir app --dir components --dir lib --dir layouts --dir scripts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
     "skipLibCheck": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "composite": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
- the extra memory was being provided for the rss feed rather than the next build. 
- tried profiling the build process as well the heap snapshots do not show any obvious errors ( nothing major occupying any memory or any suggestive memory leaks )
- the logs suggest the build has been failing when checking for types and incremental builds 
- further debugging pointed to the fact that webpack cache occupied **_4.3 GB_** of space while the total container space was **_8 GB_** so that's why even setting the node options to be higher wouldn't make any difference. 
- removed the webpack cache from the repo. The build times doesn't change much though but now the node runtime should get enough memory to perform type-checking / linting tasks.