### PR TITLE
minor: improve doc sidebar item

### DIFF
--- a/components/DocsSidebar/DocsSidebar.tsx
+++ b/components/DocsSidebar/DocsSidebar.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { NavItem, Doc, Category } from './types'
 import docsSideNav from 'constants/docsSideNav'
 import { usePathname } from 'next/navigation'
+import { Tooltip } from '@nextui-org/react'
 
 interface DocsSidebarProps {
   onNavItemClick?: () => void
@@ -113,8 +114,10 @@ const DocsSidebar: React.FC<DocsSidebarProps> = ({ onNavItemClick }) => {
           href={doc.route}
           className={`line-clamp-2 flex w-full items-center gap-2 ${doc.className}`}
         >
-          <FileText size={12} />
-          <div className="sidebar-label line-clamp-2 text-sm"> {doc.label} </div>
+          <FileText className="flex-none" size={12} />
+          <Tooltip content={doc.label}>
+            <div className="sidebar-label line-clamp-2 text-sm"> {doc.label} </div>
+          </Tooltip>
         </Link>
       </li>
     )


### PR DESCRIPTION
Closes #915 
This PR addresses issue #915 and includes the following changes to the documentation sidebar:

- Fixed the size of the FileText icon
- Added tooltips for links to display on hover


**Before**

![image](https://github.com/user-attachments/assets/adade8c7-09a2-472d-a576-2dd4635c3260)

**After**

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/baab5a89-a286-4955-bfe2-a3f2dd5d5333">
