### PR TITLE
chore: use api.signoz.cloud instead of signup

### DIFF
--- a/app/signoz-cloud-signup-form/index.tsx
+++ b/app/signoz-cloud-signup-form/index.tsx
@@ -127,7 +127,7 @@ export default function SignozCloudSignUpForm() {
     }
 
     try {
-      const response = await fetch('https://signup.signoz.cloud/api/register', {
+      const response = await fetch('https://api.signoz.cloud/api/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/components/SignozCloudSignupForm/index.tsx
+++ b/components/SignozCloudSignupForm/index.tsx
@@ -127,7 +127,7 @@ export default function SignozCloudSignUpForm() {
     }
 
     try {
-      const response = await fetch('https://signup.signoz.cloud/api/register', {
+      const response = await fetch('https://api.signoz.cloud/api/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/components/signoz-cloud-signup-form/index.tsx
+++ b/components/signoz-cloud-signup-form/index.tsx
@@ -126,7 +126,7 @@ export default function SignozCloudSignUpForm() {
     }
 
     try {
-      const response = await fetch('https://signup.signoz.cloud/api/register', {
+      const response = await fetch('https://api.signoz.cloud/api/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
#### Chores
- use api.signoz.cloud instead of signup