### PR TITLE
fix: make trust markers text in login page clickable

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -329,12 +329,13 @@ export default function Login() {
                   />
                 )}
 
-                <span className="text-xs text-signoz_vanilla-400">{badge.text}</span>
-
-                {badge.url && (
-                  <a href={badge.url} target="_blank">
+                {badge.url ? (
+                  <a href={badge.url} className="flex items-center gap-2" target="_blank">
+                    <span className="text-xs text-signoz_vanilla-400">{badge.text}</span>
                     <ArrowUpRight size={12} />
                   </a>
+                ) : (
+                  <span className="text-xs text-signoz_vanilla-400">{badge.text}</span>
                 )}
 
                 {index < trustBadges.length - 1 && (


### PR DESCRIPTION
<img width="638" alt="Screenshot 2024-11-21 at 12 54 13" src="https://github.com/user-attachments/assets/c1bccbe5-fee7-48f3-b289-73720602f8ae">
