### PR TITLE
Remove links to correct semantics of document

### DIFF
--- a/data/docs/userguide/alerts-management.mdx
+++ b/data/docs/userguide/alerts-management.mdx
@@ -55,7 +55,7 @@ The Triggered Alerts Tab shows the currently firing alerts. It provides a real-t
 
 ## Creating a New Alert in SigNoz
 
-After setting up a new notification channel, you can create an alert by clicking the "New Alert" button in the Alerts Tab. You will see four types of alerts to choose from:
+After setting up a new notification channel, you can create an alert by clicking the "New Alert" button in the Alerts Tab. You will see five types of alerts to choose from:
 
 - **[Anomaly-based Alert](../../alerts-management/anomaly-based-alerts)**: Sends a notification when a condition occurs in metric data (e.g., CPU usage, memory utilization, request rates). You can set thresholds or rate-based conditions.
 
@@ -67,8 +67,4 @@ After setting up a new notification channel, you can create an alert by clicking
 
 - **[Exceptions-based Alert](../../alerts-management/exceptions-based-alerts)**: Sends a notification when a condition occurs in exceptions data (e.g., application exceptions or errors). You can set conditions to trigger the alert when specific exceptions are detected.
 
-- **[Planned Maintenance](../../alerts-management/planned-maintenance)**: Sends a notification when a condition occurs in exceptions data (e.g., application exceptions or errors). You can set conditions to trigger the alert when specific exceptions are detected.
-
-- **[Alerts History](../../alerts-management/alerts-history)**: Helps you analyze and understand the behavior of your alerts over time.
-
-These four types of alerts offer flexibility in monitoring different system aspects. 
+These five types of alerts offer flexibility in monitoring different system aspects. 


### PR DESCRIPTION
This PR removes two links from "Alerts Management" to correct semantics of the sentence at bottom
- That statement was written with the intent of pointing to the explanatory pages for each type of SigNoz Alert, but the list also included links to irrelevant documents