### PR TITLE
docs: add arm64 to supported architectures

### DIFF
--- a/components/shared/k8s-common-prerequisites.md
+++ b/components/shared/k8s-common-prerequisites.md
@@ -1,5 +1,5 @@
 - Kubernetes version >= `1.22`
-- `x86-64`/`amd64` workloads as currently `arm64` architecture is not supported
+- Currently supports `⁠x86-64`, `⁠amd64` and `⁠arm64` architectures
 - Helm version >= `3.8`
 - You must have `kubectl` access to your cluster
 - The following table describes the hardware requirements that are needed


### PR DESCRIPTION
This pull request updates the documentation to reflect support for the `arm64` architecture. Key changes include:

- **Architectures Supported:**
  - Previously listed only `x86-64`/`amd64`.
  - Now includes `arm64`, aligning with current project capabilities.

This update ensures documentation accuracy, allowing users to leverage project features on ARM systems [like it was discussed in this issue](https://github.com/SigNoz/signoz/issues/1498#issuecomment-2684941921).
Thank you for reviewing!