### PR TITLE
fix: update instrumentation docs for Next.js on Vercel

### DIFF
--- a/data/docs/instrumentation/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/opentelemetry-nextjs.mdx
@@ -78,6 +78,7 @@ export const traceExporter = new OTLPHttpJsonTraceExporter(exporterOptions);
 **Step 4.** Create `instrumentation.ts` file<br></br>
 ```tsx
 import { registerOTel } from '@vercel/otel';
+import { traceExporter } from './instrumentation.node';
 
 export function register() {
   registerOTel({

--- a/data/docs/instrumentation/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/opentelemetry-nextjs.mdx
@@ -56,7 +56,7 @@ You need to configure the endpoint for SigNoz cloud in this file.
 
 ```tsx
 'use strict'
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPHttpJsonTraceExporter } from '@vercel/otel';
 
 // Add otel logging
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
@@ -67,7 +67,7 @@ const exporterOptions = {
   headers: { 'signoz-ingestion-key': 'your-ingestion-key' }, // Set if you are using SigNoz Cloud
 }
 
-export const traceExporter = new OTLPTraceExporter(exporterOptions);
+export const traceExporter = new OTLPHttpJsonTraceExporter(exporterOptions);
 ```
 
 - Set the `<region>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
@@ -80,14 +80,10 @@ export const traceExporter = new OTLPTraceExporter(exporterOptions);
 import { registerOTel } from '@vercel/otel';
 
 export function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { traceExporter } = await import('./instrumentation.node.ts');
-
-    registerOTel({
-      serviceName: 'Sample Next.js App',
-      traceExporter: traceExporter,
-    });
-  }
+  registerOTel({
+    serviceName: 'Sample Next.js App',
+    traceExporter: traceExporter,
+  });
 }
 ```
 

--- a/data/docs/instrumentation/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/opentelemetry-nextjs.mdx
@@ -78,13 +78,16 @@ export const traceExporter = new OTLPTraceExporter(exporterOptions);
 **Step 4.** Create `instrumentation.ts` file<br></br>
 ```tsx
 import { registerOTel } from '@vercel/otel';
-import { traceExporter } from './instrumentation.node';
 
 export function register() {
-  registerOTel({
-    serviceName: 'Sample Next.js App',
-    traceExporter: traceExporter,
-  });
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { traceExporter } = await import('./instrumentation.node.ts');
+
+    registerOTel({
+      serviceName: 'Sample Next.js App',
+      traceExporter: traceExporter,
+    });
+  }
 }
 ```
 


### PR DESCRIPTION
`OTLPTraceExporter` uses `XMLHTTPRequest` under the hood which is incompatible with Vercel Edge runtime and should only be used with `Node.js` runtime. We recommend using `OTLPHttpJsonTraceExporter` from `@vercel/otel` instead for better compatibility with all the runtimes.