### PR TITLE
fix: update about how to allow any origins

### DIFF
--- a/data/docs/userguide/otlp-http-enable-cors.mdx
+++ b/data/docs/userguide/otlp-http-enable-cors.mdx
@@ -44,14 +44,16 @@ To enable CORS, there are mainly three steps involved:
         - http://localhost:3000 
   ```
 
-  To allow any origin to make requests, you can use `*` wildcard character instead.
+  To allow any origin to make requests, you can use `http://*`, `https://*` instead.
   However, it is not recommended to set allow all origins due to security risks.
+
 
   ```yaml
   http:
     cors:
       allowed_origins:
-        - "*"
+        - "https://*"
+        - "http://*"
   ```
 
 3. Save the updated configurations and restart SigNoz OtelCollector.


### PR DESCRIPTION
Hello,

While configuring the OpenTelemetry collector in SigNoz, I found a discrepancy between the official OpenTelemetry documentation and the SigNoz documentation regarding CORS configuration.

The OpenTelemetry documentation explicitly warns against using a plain wildcard ["\*"] for allowed_origins when Access-Control-Allow-Credentials is true (which is the case with the OTel collector). Instead, it recommends using protocol-specific wildcards like ["http://\*", "https://\*"] to allow any origin while complying with browser security policies.

I'd like to update the SigNoz documentation to reflect this important security detail to help users avoid CORS issues when sending data from web browsers.

Reference from OpenTelemetry docs:
https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md#server-configuration

Related Issue:
https://github.com/SigNoz/signoz/issues/3835

Thank you!
