### PR TITLE
chore: use v4 endpoint for query range

### DIFF
--- a/data/docs/logs-management/logs-api/overview.mdx
+++ b/data/docs/logs-management/logs-api/overview.mdx
@@ -18,7 +18,7 @@ The SigNoz Logs API is a robust interface which enables developers to manage and
 
 Endpoint for Logs API:
 
-`POST` `https://{URL}/api/v3/query_range`
+`POST` `https://{URL}/api/v4/query_range`
 
 Replace `{URL}` with your instance URL, e.g., example.signoz.io.
 

--- a/data/docs/metrics-management/query-range-api.mdx
+++ b/data/docs/metrics-management/query-range-api.mdx
@@ -12,7 +12,7 @@ The Query Range API is a robust interface which enables developers to query metr
 
 Endpoint for Query Range API:
 
-`POST` `https://{URL}/api/v3/query_range`
+`POST` `https://{URL}/api/v4/query_range`
 
 Replace `{URL}` with your instance URL.
 

--- a/data/docs/traces-management/trace-api/overview.mdx
+++ b/data/docs/traces-management/trace-api/overview.mdx
@@ -16,7 +16,7 @@ The SigNoz Trace API is a robust interface which enables developers to manage an
 
 Endpoint for Trace API:
 
-`POST` `https://{URL}/api/v3/query_range`
+`POST` `https://{URL}/api/v4/query_range`
 
 Replace `{URL}` with your instance URL, e.g., example.signoz.io.
 


### PR DESCRIPTION
- for traces and logs there is no change in payload between v3 and v4
- for metrics, the "timeAggregation" and "spaceAggregation" were newly added
- examples used in traces and logs don't require any change
- examples used in metrics were recently added and don't require any updates because they use the v4 format https://github.com/SigNoz/signoz-web/pull/1262
