### PR TITLE
fix(search-modal): Added a fix for search modal in mobile screen

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -239,6 +239,10 @@ body::-webkit-scrollbar-thumb {
   padding: 24px;
 }
 
+body #trieve-search-modal {
+  top: calc(40vh - 225px);
+}
+
 body #trieve-search-modal.dark .item.start-chat {
   @apply bg-signoz_sakura-600/10;
 }


### PR DESCRIPTION
### Added fix for search modal not rendering properly on mobile device.

- Previously
<img width="376" alt="Screenshot 2025-04-27 at 1 54 32 AM" src="https://github.com/user-attachments/assets/2d02e258-f94c-403c-a3ea-1dc70dc141fa" />


- Now
<img width="374" alt="Screenshot 2025-04-27 at 1 56 21 AM" src="https://github.com/user-attachments/assets/4a1affd3-dd28-4814-ae1e-a29afad0a93b" />
