### PR TITLE
correct reciever to receiver

### DIFF
--- a/data/blog/opentelemetry-logs.mdx
+++ b/data/blog/opentelemetry-logs.mdx
@@ -272,7 +272,7 @@ These logs can be collected using the OpenTelemetry file receiver and then proce
 You will need OpenTelemetry Collector (otel collector) to collect syslogs. In this example, we will illustrate collecting syslogs from your VM and sending it to SigNoz.
 
 - Add otel collector binary to your VM by following this [guide](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/).
-- Add the syslog reciever to `config.yaml` to otel-collector.
+- Add the syslog receiver to `config.yaml` to otel-collector.
 
   ```yaml {2-10}
   receivers:

--- a/data/blog/shedding-light-on-kafkas-black-box-problem.mdx
+++ b/data/blog/shedding-light-on-kafkas-black-box-problem.mdx
@@ -64,8 +64,8 @@ The magic of OpenTelemetry is that context propagation is performed automaticall
 We have three sources of metrics when instrumenting a kafka ecosystem.
 
 - The metrics collected by OTel when auto-instrumenting/ manually instrumenting with a metrics collector.
-- Metrics scraped by the jmx reciever
-- Metrics scraped by the kafkametrics reciever
+- Metrics scraped by the jmx receiver
+- Metrics scraped by the kafkametrics receiver
 
 Metrics collected by OTel on instrumenting your producer/ consumer is the same as the generic metrics collected by OTel from any application and gives values for error rates, latency etc.
 

--- a/data/blog/syslog-monitoring.mdx
+++ b/data/blog/syslog-monitoring.mdx
@@ -102,7 +102,7 @@ Below are the steps to collect syslogs.
     ...
     ```
 
-* Add the syslog reciever to `otel-collector-config.yaml` which is present inside `deploy/docker`
+* Add the syslog receiver to `otel-collector-config.yaml` which is present inside `deploy/docker`
     ```yaml {2-10}
     receivers:
       syslog:

--- a/data/docs/userguide/logs.mdx
+++ b/data/docs/userguide/logs.mdx
@@ -287,7 +287,7 @@ The receivers FluentForward and OTLP doesn’t have operators. But for parsing t
 ## Processors available for processing logs
 Processors are used at various stages of a pipeline. Generally, a processor pre-processes data before it is exported (e.g. modify attributes or sample) or helps ensure that data makes it through a pipeline successfully (e.g. batch/retry).
 
-Process are also helpful when you have multiple recivers for logs and you want parse/transforms logs collected from all the recievers.
+Process are also helpful when you have multiple receivers for logs and you want parse/transforms logs collected from all the receivers.
 
 **We highly recommend users to use Batch and Memory Limiter Processor with logs**
 


### PR DESCRIPTION
While going through opentelemetry-log doc, I noticed a few typos: “recieve” should be corrected to “receive”. Just in case “recieve” was a valid word, I looked it up on the Internet, but it turns out it’s not correct. While correcting it, I came across a few more “recieve” typos and fixed them.

