### PR TITLE
fix(linux): remove metrics key from collector config

### DIFF
--- a/data/docs/install/linux.mdx
+++ b/data/docs/install/linux.mdx
@@ -378,8 +378,6 @@ service:
   telemetry:
     logs:
       encoding: json
-    metrics:
-      address: 0.0.0.0:8888
   extensions: [health_check, zpages, pprof]
   pipelines:
     traces:


### PR DESCRIPTION
#### Fixes

- remove metrics key from collector config