### PR TITLE
fixing typo in nextjs telemtry docs for signoz url 

### DIFF
--- a/data/docs/instrumentation/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/opentelemetry-nextjs.mdx
@@ -62,7 +62,7 @@ export function register() {
   registerOTel({
     serviceName: '<service_name>',
     traceExporter: new OTLPHttpJsonTraceExporter({
-        url: 'https://ingest.<region>.staging.signoz.cloud:443/v1/traces',
+        url: 'https://ingest.<region>.signoz.cloud:443/v1/traces',
         headers: { 'signoz-ingestion-key': '<your-ingestion-key>' },
     }),
   });
@@ -88,7 +88,7 @@ exports.register = function() {
   registerOTel({
     serviceName: '<service_name>',
     traceExporter: new OTLPHttpJsonTraceExporter({
-        url: 'https://ingest.<region>.staging.signoz.cloud:443/v1/traces',
+        url: 'https://ingest.<region>.signoz.cloud:443/v1/traces',
         headers: { 'signoz-ingestion-key': '<your-ingestion-key>' },
     }),
   });
@@ -538,7 +538,7 @@ export function register() {
   registerOTel({
     serviceName: '<service_name>',
     traceExporter: new OTLPHttpJsonTraceExporter({
-        url: 'https://ingest.<region>.staging.signoz.cloud:443/v1/traces',
+        url: 'https://ingest.<region>.signoz.cloud:443/v1/traces',
         headers: { 'signoz-ingestion-key': '<your-ingestion-key>' },
     }),
   });
@@ -564,7 +564,7 @@ exports.register = function() {
   registerOTel({
     serviceName: '<service_name>',
     traceExporter: new OTLPHttpJsonTraceExporter({
-        url: 'https://ingest.<region>.staging.signoz.cloud:443/v1/traces',
+        url: 'https://ingest.<region>.signoz.cloud:443/v1/traces',
         headers: { 'signoz-ingestion-key': '<your-ingestion-key>' },
     }),
   });


### PR DESCRIPTION
`https://ingest.<region>.staging.signoz.cloud:443/v1/traces` -> `https://ingest.<region>.signoz.cloud:443/v1/traces`