### PR TITLE
restore doc-content width

### DIFF
--- a/css/doc.css
+++ b/css/doc.css
@@ -40,7 +40,7 @@
 }
 
 .doc-content {
-  /* width: calc(100% - 320px); */
+  width: calc(100% - 320px);
   box-sizing: border-box;
 }
 

--- a/css/global.css
+++ b/css/global.css
@@ -170,7 +170,7 @@ body::-webkit-scrollbar-thumb {
 
 @media only screen and (max-width: 1024px) {
   .doc-content {
-    /* width: calc(100% - 320px) !important; */
+    width: calc(100% - 320px) !important;
   }
 
   .product-onboarding .doc-content {


### PR DESCRIPTION
Before:
<img width="1470" height="956" alt="Screenshot 2025-08-05 at 3 01 55 PM" src="https://github.com/user-attachments/assets/3912a1d3-0cca-41e5-98c4-0f96c512117e" />
After:
<img width="1470" height="956" alt="Screenshot 2025-08-05 at 3 01 34 PM" src="https://github.com/user-attachments/assets/043ab191-d58f-4d8c-942b-3ec1a4cf364b" />