### PR TITLE
disable crawling on non-production pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ storybook-static
 .env.local
 events-definition.md
 package-lock.json
+public/**/feed.xml

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,6 +2,20 @@ import { MetadataRoute } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 
 export default function robots(): MetadataRoute.Robots {
+  console.log('VERCEL_ENV', process.env.VERCEL_ENV)
+  const isProduction = process.env.VERCEL_ENV === 'production'
+  
+  if (!isProduction) {
+    return {
+      rules: {
+        userAgent: '*',
+        disallow: '/',
+      },
+      sitemap: `${siteMetadata.siteUrl}/sitemap.xml`,
+      host: siteMetadata.siteUrl,
+    }
+  }
+  
   return {
     rules: {
       userAgent: '*',

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,8 +2,13 @@ import { MetadataRoute } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 
 export default function robots(): MetadataRoute.Robots {
-  console.log('VERCEL_ENV', process.env.VERCEL_ENV)
+  console.log("\nVERCEL_ENV", process.env.VERCEL_ENV)
+  console.log("\nVERCEL_URL", process.env.VERCEL_URL)
+  
   const isProduction = process.env.VERCEL_ENV === 'production'
+  const currentUrl = isProduction 
+    ? siteMetadata.siteUrl 
+    : `https://${process.env.VERCEL_URL}`
   
   if (!isProduction) {
     return {
@@ -11,8 +16,8 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: '*',
         disallow: '/',
       },
-      sitemap: `${siteMetadata.siteUrl}/sitemap.xml`,
-      host: siteMetadata.siteUrl,
+      sitemap: `${currentUrl}/sitemap.xml`,
+      host: currentUrl,
     }
   }
   
@@ -21,7 +26,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${siteMetadata.siteUrl}/sitemap.xml`,
-    host: siteMetadata.siteUrl,
+    sitemap: `${currentUrl}/sitemap.xml`,
+    host: currentUrl,
   }
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,13 +2,10 @@ import { MetadataRoute } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 
 export default function robots(): MetadataRoute.Robots {
-  console.log("\nVERCEL_ENV", process.env.VERCEL_ENV)
-  console.log("\nVERCEL_URL", process.env.VERCEL_URL)
-  
   const isProduction = process.env.VERCEL_ENV === 'production'
   const currentUrl = isProduction 
     ? siteMetadata.siteUrl 
-    : `https://${process.env.VERCEL_URL}`
+    : `https://staging.signoz.io`
   
   if (!isProduction) {
     return {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -12,9 +12,7 @@ export default function robots(): MetadataRoute.Robots {
       rules: {
         userAgent: '*',
         disallow: '/',
-      },
-      sitemap: `${currentUrl}/sitemap.xml`,
-      host: currentUrl,
+      }
     }
   }
   


### PR DESCRIPTION
## 📄 PR Summary
Action item from https://github.com/SigNoz/engineering-pod/issues/2798 
1. disallow: / if url is non-production
2. add feed.xml files to .gitignore

## 🧪 How to Test
1. Prod - Go to production url /robots.txt - ensure allow: / and sitemap field contains correct url
2. Preview/Staging - Go to url /robots.txt - ensure disallow: / and host and sitemap fields are not present


## 🔍 Related Issues
NA

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)
NA