### PR TITLE
feat: Add "Edit this page" button to docs

### DIFF
--- a/app/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/docs/(main-docs)/[...slug]/page.tsx
@@ -57,11 +57,12 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
   return (
     <div className="doc">
       <DocContent
-        title={title}
-        post={post}
-        toc={toc}
-        hideTableOfContents={hide_table_of_contents || false}
-      />
+  title={title}
+  post={post}
+  toc={toc}
+  hideTableOfContents={hide_table_of_contents || false}
+  editLink={`https://github.com/SigNoz/signoz-web/edit/main/data/docs/${slug}.mdx`}
+/>
     </div>
   )
 }

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { Edit3 } from 'lucide-react'
 import { components } from '@/components/MDXComponents'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import PageFeedback from '../PageFeedback/PageFeedback'
@@ -34,18 +35,19 @@ const DocContent: React.FC<{
       <div className={`doc-content ${source === ONBOARDING_SOURCE ? 'product-onboarding' : ''}`}>
         <h2 className="mt-2 text-3xl">{title}</h2>
         <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
-        <div className="flex justify-between items-center mt-8 text-sm text-gray-500 dark:text-gray-400">
+        <div className="flex justify-between items-center mt-8 text-sm">
           {formattedDate && (
-            <p>Last updated: {formattedDate}</p>
+            <p className="text-gray-500 dark:text-gray-400">Last updated: {formattedDate}</p>
           )}
           {editLink && (
             <a
               href={editLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-500 dark:text-gray-400"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200"
             >
-              Edit
+              <Edit3 size={16} />
+              Edit on GitHub
             </a>
           )}
         </div>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Edit3 } from 'lucide-react'
+import { Edit } from 'lucide-react'
 import { components } from '@/components/MDXComponents'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import PageFeedback from '../PageFeedback/PageFeedback'
@@ -46,7 +46,7 @@ const DocContent: React.FC<{
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200 no-underline"
             >
-              <Edit3 size={16} />
+              <Edit size={16} />
               Edit on GitHub
             </a>
           )}

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -45,7 +45,7 @@ const DocContent: React.FC<{
               rel="noopener noreferrer"
               className="text-gray-500 dark:text-gray-400"
             >
-              Edit this page
+              Edit
             </a>
           )}
         </div>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -34,24 +34,30 @@ const DocContent: React.FC<{
       <div className={`doc-content ${source === ONBOARDING_SOURCE ? 'product-onboarding' : ''}`}>
         <h2 className="mt-2 text-3xl">{title}</h2>
         <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
-        {formattedDate && (
-          <p className="mt-8 text-sm text-gray-500">
-            Last updated: {formattedDate}
-            {editLink && (
-              <>
-                {' '}
-                <a
-                  href={editLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                >
-                  (Edit this page)
-                </a>
-              </>
-            )}
-          </p>
-        )}
+        <div className="flex justify-between items-center mt-8 text-sm text-gray-500 dark:text-gray-400">
+          {formattedDate && (
+            <p>Last updated: {formattedDate}</p>
+          )}
+          {editLink && (
+            <a
+              href={editLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center space-x-1 text-gray-500 hover:text-primary-600 dark:hover:text-primary-400 dark:text-gray-400"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-4 h-4"
+              >
+                <path d="M5.433 13.917l1.262-3.155A4 4 0 0111.27 9.782l3.106-1.262a2 2 0 01.815.815l-1.262 3.106a4 4 0 01-1.885 1.885l-3.106 1.262a2 2 0 01-.815-.815z" />
+                <path d="M10.92 2.08a6 6 0 00-7.03 7.03l-1.262 3.106a2 2 0 00.815.815l3.106-1.262a6 6 0 007.03-7.03l-3.106-1.262a2 2 0 00-.815-.815zM14.25 12.25a1.75 1.75 0 100 3.5 1.75 1.75 0 000-3.5z" />
+              </svg>
+              <span>Edit this page</span>
+            </a>
+          )}
+        </div>
         <PageFeedback />
         <DocsPrevNext />
       </div>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -15,7 +15,8 @@ const DocContent: React.FC<{
   post: any
   toc: any
   hideTableOfContents: boolean
-}> = ({ title, post, toc, hideTableOfContents }) => {
+  editLink?: string
+}> = ({ title, post, toc, hideTableOfContents, editLink }) => {
   const searchParams = useSearchParams()
   const lastUpdatedDate = post?.lastmod || post?.date
   const formattedDate =
@@ -36,6 +37,19 @@ const DocContent: React.FC<{
         {formattedDate && (
           <p className="mt-8 text-sm text-gray-500">
             Last updated: {formattedDate}
+            {editLink && (
+              <>
+                {' '}
+                <a
+                  href={editLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                >
+                  (Edit this page)
+                </a>
+              </>
+            )}
           </p>
         )}
         <PageFeedback />

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -43,18 +43,9 @@ const DocContent: React.FC<{
               href={editLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center space-x-1 text-gray-500 hover:text-primary-600 dark:hover:text-primary-400 dark:text-gray-400"
+              className="text-gray-500 dark:text-gray-400"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="w-4 h-4"
-              >
-                <path d="M5.433 13.917l1.262-3.155A4 4 0 0111.27 9.782l3.106-1.262a2 2 0 01.815.815l-1.262 3.106a4 4 0 01-1.885 1.885l-3.106 1.262a2 2 0 01-.815-.815z" />
-                <path d="M10.92 2.08a6 6 0 00-7.03 7.03l-1.262 3.106a2 2 0 00.815.815l3.106-1.262a6 6 0 007.03-7.03l-3.106-1.262a2 2 0 00-.815-.815zM14.25 12.25a1.75 1.75 0 100 3.5 1.75 1.75 0 000-3.5z" />
-              </svg>
-              <span>Edit this page</span>
+              Edit this page
             </a>
           )}
         </div>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React from 'react'
-import { Edit3 } from 'lucide-react'
 import { components } from '@/components/MDXComponents'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import PageFeedback from '../PageFeedback/PageFeedback'
@@ -44,9 +43,8 @@ const DocContent: React.FC<{
               href={editLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200 no-underline"
             >
-              <Edit3 size={16} />
               Edit on GitHub
             </a>
           )}

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { Edit3 } from 'lucide-react'
 import { components } from '@/components/MDXComponents'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import PageFeedback from '../PageFeedback/PageFeedback'
@@ -45,6 +46,7 @@ const DocContent: React.FC<{
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200 no-underline"
             >
+              <Edit3 size={16} />
               Edit on GitHub
             </a>
           )}

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Edit } from 'lucide-react'
+import Button from '@/components/ui/Button'
 import { components } from '@/components/MDXComponents'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import PageFeedback from '../PageFeedback/PageFeedback'
@@ -40,15 +41,14 @@ const DocContent: React.FC<{
             <p className="text-gray-500 dark:text-gray-400">Last updated: {formattedDate}</p>
           )}
           {editLink && (
-            <a
+            <Button
               href={editLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 hover:shadow-sm transition-all duration-200 no-underline"
+              variant='outline'
+              className="gap-2 no-underline"
             >
               <Edit size={16} />
               Edit on GitHub
-            </a>
+            </Button>
           )}
         </div>
         <PageFeedback />


### PR DESCRIPTION
This PR adds an "Edit" button on documentation pages. The button links directly to the GitHub edit page for the corresponding markdown file.

Fixes: https://github.com/SigNoz/signoz-web/issues/1756
