### PR TITLE
Update pino OTEL_EXPORTER_OTLP_LOGS_ENDPOINT in docs

### DIFF
--- a/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
@@ -208,7 +208,7 @@ logger.info('Hello, World! from pino');
 Execute your application with OpenTelemetry Environment variables:
 
 ```Bash
-OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4317/v1/logs OTEL_RESOURCE_ATTRIBUTES="service.name=<service_name>,service.version=1.2.3" node app.js
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4318/v1/logs OTEL_RESOURCE_ATTRIBUTES="service.name=<service_name>,service.version=1.2.3" node app.js
 ```
 - Replace `<service_name>` with name of your service
 ## Usage Examples


### PR DESCRIPTION
Documentation specifies pino logs should be sent to port `4317` but should be port `4318`.