### PR TITLE
docs(api): Add server URL to OpenAPI specification

### DIFF
--- a/public/openAPISpec/api.yaml
+++ b/public/openAPISpec/api.yaml
@@ -20,6 +20,8 @@ info:
     name: API Support
     email: dev@signoz.io
     url: https://signoz.io
+servers:
+  - url: 'https://your-workspace-url'
 tags:
   - name: alerts
     description: Alerts API


### PR DESCRIPTION
Adds a 'servers' section to the OpenAPI specification file (public/openAPISpec/api.yaml) to include the base URL for the API. 

Currently, hostname (signoz.io) is being populated for the API endpoints in request sample section, which is incorrect, this PR fixes that by introducing a placeholder for URL.

Example page: https://signoz.io/api-reference/#/operations/createRule

Closes: https://github.com/SigNoz/engineering-pod/issues/2588