### PR TITLE
docs(opentelemetry): Fix OTLP endpoint in Express instrumentation guide

### DIFF
--- a/data/docs/instrumentation/opentelemetry-express.mdx
+++ b/data/docs/instrumentation/opentelemetry-express.mdx
@@ -204,7 +204,7 @@ npm install --save @opentelemetry/auto-instrumentations-node
 
 ```bash
 export OTEL_TRACES_EXPORTER="otlp"
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
 export OTEL_NODE_RESOURCE_DETECTORS="env,host,os"
 export OTEL_SERVICE_NAME="<service_name>"
 export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"


### PR DESCRIPTION
Corrected the `OTEL_EXPORTER_OTLP_ENDPOINT` to remove the `/v1/traces` path, aligning with standard OTLP endpoint configuration.

Closes: #1936 