### PR TITLE
docs: subtle top-right 'Copy markdown' button (icon-only on mobile)

### DIFF
--- a/components/CopyAsMarkdown/CopyAsMarkdown.tsx
+++ b/components/CopyAsMarkdown/CopyAsMarkdown.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react'
 import { Copy, Check } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import Button, { type ButtonProps } from '@/components/ui/Button'
 
 interface CopyAsMarkdownProps {
   /**
@@ -13,9 +13,27 @@ interface CopyAsMarkdownProps {
    * Additional CSS classes
    */
   className?: string
+  /**
+   * Optional label override (defaults to a subtle 'Copy markdown')
+   */
+  label?: string
+  /**
+   * Button variant to use. Defaults to a subtle ghost button.
+   */
+  buttonVariant?: ButtonProps['variant']
+  /**
+   * Button size to use. Defaults to `sm`.
+   */
+  buttonSize?: ButtonProps['size']
 }
 
-const CopyAsMarkdown: React.FC<CopyAsMarkdownProps> = ({ markdownContent, className = '' }) => {
+const CopyAsMarkdown: React.FC<CopyAsMarkdownProps> = ({
+  markdownContent,
+  className = '',
+  label = 'Copy markdown',
+  buttonVariant = 'ghost',
+  buttonSize = 'sm',
+}) => {
   const [copied, setCopied] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
@@ -40,24 +58,17 @@ const CopyAsMarkdown: React.FC<CopyAsMarkdownProps> = ({ markdownContent, classN
 
   return (
     <Button
-      variant="secondary"
-      size="sm"
+      variant={buttonVariant}
+      size={buttonSize}
       onClick={handleCopy}
       disabled={isLoading || !markdownContent}
       className={`gap-1 ${className}`}
       isButton={true}
+      aria-label={label}
+      title={label}
     >
-      {copied ? (
-        <>
-          <Check size={16} />
-          Copied!
-        </>
-      ) : (
-        <>
-          <Copy size={16} />
-          {isLoading ? 'Copying...' : 'Copy as Markdown'}
-        </>
-      )}
+      {copied ? <Check size={16} /> : <Copy size={16} />}
+      <span className="hidden lg:inline">{isLoading ? 'Copying...' : label}</span>
     </Button>
   )
 }

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -38,13 +38,18 @@ const DocContent: React.FC<{
   return (
     <>
       <div className={`doc-content ${source === ONBOARDING_SOURCE ? 'product-onboarding' : ''}`}>
-        <h2 className="mt-2 text-3xl">{title}</h2>
-        {!isIntroductionPage && post.body?.raw && (
-          <CopyAsMarkdown 
-            markdownContent={post.body.raw}
-            className="shrink-0"
-          />
-        )}
+        <div className="mt-2 flex items-baseline justify-between gap-2">
+          <h2 className="text-3xl leading-tight">{title}</h2>
+          {!isIntroductionPage && post.body?.raw && (
+            <CopyAsMarkdown
+              markdownContent={post.body.raw}
+              className="shrink-0"
+              buttonVariant="ghost"
+              buttonSize="sm"
+              label="Copy markdown"
+            />
+          )}
+        </div>
         <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
         <div className="flex justify-between items-center mt-8 text-sm">
           {formattedDate && (


### PR DESCRIPTION
- Move copy control to the top-right of doc header, out of the reading flow
- Use ghost variant for subtle styling, baseline-aligned with title
- Keep label visible on desktop; icon-only on mobile/tablet with aria-label
- On copy, swap icon to checkmark instead of changing text

Files:
- components/DocContent/DocContent.tsx
- components/CopyAsMarkdown/CopyAsMarkdown.tsx