### PR TITLE
fix: issue with 8080 port already bind issue in the signoz in ECS setup

### DIFF
--- a/data/docs/install/ecs.mdx
+++ b/data/docs/install/ecs.mdx
@@ -440,7 +440,7 @@ Each section below shows one `containerDefinition` snippet. Replace all `<…>` 
     { "name": "ZOO_ENABLE_PROMETHEUS_METRICS","value": "yes" },
     { "name": "ZOO_AUTOPURGE_INTERVAL",       "value": "1"   },
     { "name": "ZOO_PROMETHEUS_METRICS_PORT_NUMBER","value":"9141"},
-    {"name": "ZOOKEEPER_ADMIN_SERVER_PORT_NUMBER", "value":"3181"}
+    {"name": "ZOO_ADMIN_SERVER_PORT_NUMBER", "value":"3181"}
   ],
   "healthCheck": {
     "command": ["CMD-SHELL","curl -s -m 2 http://localhost:3181/commands/ruok | grep error | grep null"],


### PR DESCRIPTION
By default, SigNoz uses port 8080.
In this setup, ZooKeeper also runs its admin server on port 8080. Because the wrong environment variable (`ZOOKEEPER_ADMIN_SERVER_PORT_NUMBER`) was used, ZooKeeper did not correctly configure its admin server port, which led to a direct conflict with SigNoz 8080 port.

To fix this, update the environment variable to the correct one:

> ZOO_ADMIN_SERVER_PORT_NUMBER

This resolves the port binding conflict on 8080.

![WhatsApp Image 2025-09-11 at 23 19 29_91099d9b](https://github.com/user-attachments/assets/09e3c1d0-52e1-4b05-b4d5-13a96487b345)
