### PR TITLE
docs: scope Typography (.prose) to MDX body and restore title spacing

### DIFF
--- a/app/docs/(main-docs)/layout.tsx
+++ b/app/docs/(main-docs)/layout.tsx
@@ -61,13 +61,11 @@ export default function DocLayout({ children }: LayoutProps) {
           )}
 
           <div
-            className={`doc-content md:px-0 lg:px-4 ${
+            className={`doc-content md:px-0 lg:px-4 py-6 ${
               source === ONBOARDING_SOURCE ? 'product-onboarding' : ''
             }`}
           >
-            <article className="prose prose-slate max-w-none py-6 dark:prose-invert">
-              {children}
-            </article>
+            {children}
           </div>
         </div>
       </SectionContainer>

--- a/components/CopyAsMarkdown/CopyAsMarkdown.tsx
+++ b/components/CopyAsMarkdown/CopyAsMarkdown.tsx
@@ -44,7 +44,7 @@ const CopyAsMarkdown: React.FC<CopyAsMarkdownProps> = ({
     try {
       await navigator.clipboard.writeText(markdownContent)
       setCopied(true)
-      
+
       // Reset the copied state after 2 seconds
       setTimeout(() => {
         setCopied(false)
@@ -74,3 +74,4 @@ const CopyAsMarkdown: React.FC<CopyAsMarkdownProps> = ({
 }
 
 export default CopyAsMarkdown
+

--- a/components/CopyAsMarkdown/index.ts
+++ b/components/CopyAsMarkdown/index.ts
@@ -1,1 +1,2 @@
 export { default } from './CopyAsMarkdown'
+

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -23,29 +23,27 @@ const DocContent: React.FC<{
 }> = ({ title, post, toc, hideTableOfContents, editLink }) => {
   const searchParams = useSearchParams()
   const lastUpdatedDate = post?.lastmod || post?.date
-  const formattedDate =
-    lastUpdatedDate
-      ? new Date(lastUpdatedDate).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })
-      : null
+  const formattedDate = lastUpdatedDate
+    ? new Date(lastUpdatedDate).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
   const source = searchParams.get(QUERY_PARAMS.SOURCE)
   const isOnboarding = source === ONBOARDING_SOURCE
-  
   // Check if this is the introduction page (exclude copy functionality)
   const isIntroductionPage = post.slug === 'introduction'
 
   return (
     <>
       <div className={`doc-content ${source === ONBOARDING_SOURCE ? 'product-onboarding' : ''}`}>
-        <div className="flex items-center justify-between gap-2">
+        <div className="doc-title-row flex items-center justify-between gap-2">
           <div className="flex flex-col items-start gap-2">
             {!isOnboarding && post.tags && post.tags.length > 0 && (
               <TagsWithTooltips tags={post.tags} />
             )}
-            <h2 className="text-3xl leading-tight mt-2">{title}</h2>
+            <h2 className="mt-2 text-3xl leading-tight">{title}</h2>
           </div>
           {!isIntroductionPage && post.body?.raw && (
             <CopyAsMarkdown
@@ -57,17 +55,15 @@ const DocContent: React.FC<{
             />
           )}
         </div>
-        <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
-        <div className="flex justify-between items-center mt-8 text-sm">
+        <article className="prose prose-slate max-w-none pb-6 dark:prose-invert">
+          <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
+        </article>
+        <div className="mt-8 flex items-center justify-between text-sm">
           {formattedDate && (
             <p className="text-gray-500 dark:text-gray-400">Last updated: {formattedDate}</p>
           )}
           {editLink && (
-            <Button
-              href={editLink}
-              variant='outline'
-              className="gap-2 no-underline"
-            >
+            <Button href={editLink} variant="outline" className="gap-2 no-underline">
               <Edit size={16} />
               Edit on GitHub
             </Button>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -38,7 +38,7 @@ const DocContent: React.FC<{
   return (
     <>
       <div className={`doc-content ${source === ONBOARDING_SOURCE ? 'product-onboarding' : ''}`}>
-        <div className="doc-title-row flex items-center justify-between gap-2">
+        <div className="doc-title-row mb-4 flex items-center justify-between gap-2">
           <div className="flex flex-col items-start gap-2">
             {!isOnboarding && post.tags && post.tags.length > 0 && (
               <TagsWithTooltips tags={post.tags} />


### PR DESCRIPTION
- Wrap MDX body in <article class=prose> inside DocContent
- Keep title + Copy-as-Markdown outside prose (SEO-safe)
- Move page vertical padding to layout (py-6) and use pb-6 on MDX wrapper
- Reintroduce CopyAsMarkdown with subtle ghost button + responsive label

This removes the unintended top margin above the first content heading while preserving expected spacing when text precedes the first heading.