### PR TITLE
Fix dead documentation URLs

### DIFF
--- a/data/blog/launching-signoz-single-binary.mdx
+++ b/data/blog/launching-signoz-single-binary.mdx
@@ -127,7 +127,7 @@ has now been updated to:
 docker exec -it signoz-signoz sh
 ```
 
-You can find the relevant commands in the Operate self-hosted SigNoz [section](https://signoz.io/docs/operate/) of our docs.
+You can find the relevant commands in the Operate self-hosted SigNoz [section](https://signoz.io/docs/manage/administrator-guide/) of our docs.
 
 ## What’s next?
 

--- a/data/blog/using-signoz-to-monitor-your-kubernetes-cluster.mdx
+++ b/data/blog/using-signoz-to-monitor-your-kubernetes-cluster.mdx
@@ -29,8 +29,8 @@ Large teams that use complex clusters in production have generally ended up buil
 
 Building a system to collect, tabulate, manage, and display your observability data from scratch doesn’t make much sense for a mid sized team, or one that doesn’t have a dedicated developer experience and operations team. SigNoz is an open source tool to do just that. This piece is a complete guide on using SigNoz on your Kubernetes cluster. This includes:
 
-- running SigNoz as a service within your own cluster [→](https://signoz.io/docs/operate/kubernetes/)
-- monitoring your applications running on your cluster [→](https://signoz.io/docs/operate/kubernetes/)
+- running SigNoz as a service within your own cluster [→](https://signoz.io/docs/install/kubernetes/)
+- monitoring your applications running on your cluster [→](https://signoz.io/docs/install/kubernetes/)
 - Monitoring the status of your cluster within a Signoz dashboard [→](https://signoz.io/docs/tutorial/kubernetes-infra-metrics/)
 
 If you only want to do one of the things listed above, there are individual guides (linked above) that will be more useful, this is intended as a start-to-finish guide.
@@ -245,4 +245,4 @@ _don’t forget to select a namespace to view!_
 
 ## Wrapping up
 
-Now that you've got basic metrics flowing both from your cluster infrastructure and your application on your Kubernetes cluster, you can go further with our <a href="https://signoz.io/docs/operate/kubernetes/" rel="noopener noreferrer nofollow" target="_blank" >operating kubernetes guide</a>. If you're excited about SigNoz and want to go deeper, <a href="https://signoz-community.slack.com/join/shared_invite/zt-1v5ms4lg2-uupFbX9_qFIWNeVXbMszkw#/shared-invite/email"  rel="noopener noreferrer nofollow" target="_blank" >join the SigNoz slack</a> to be part of this awesome open source community!
+Now that you've got basic metrics flowing both from your cluster infrastructure and your application on your Kubernetes cluster, you can go further with our <a href="https://signoz.io/docs/install/kubernetes/" rel="noopener noreferrer nofollow" target="_blank" >operating kubernetes guide</a>. If you're excited about SigNoz and want to go deeper, <a href="https://signoz-community.slack.com/join/shared_invite/zt-1v5ms4lg2-uupFbX9_qFIWNeVXbMszkw#/shared-invite/email"  rel="noopener noreferrer nofollow" target="_blank" >join the SigNoz slack</a> to be part of this awesome open source community!

--- a/data/docs/migration/migrate-from-elk/metrics.mdx
+++ b/data/docs/migration/migrate-from-elk/metrics.mdx
@@ -15,7 +15,7 @@ If your Metricbeat setup primarily used the `prometheus` module to scrape existi
 
 1.  **Install the OpenTelemetry Collector:** If you haven't already, install the Collector in your environment.
     *   [Instructions for VMs/Bare Metal](/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/)
-    *   [Instructions for Kubernetes](/docs/kubernetes/deployment/)
+    *   [Instructions for Kubernetes](/docs/install/kubernetes/)
 2.  **Configure the Prometheus Receiver:** Add the Prometheus receiver configuration to your OpenTelemetry Collector (`config.yaml`) to scrape your existing targets.
     *   [Configuration steps for SigNoz Cloud](/docs/userguide/send-metrics-cloud/#enable-a-prometheus-receiver)
     *   [Configuration steps for Self-Hosted SigNoz](/docs/userguide/send-metrics/#enable-a-prometheus-receiver)

--- a/data/docs/migration/migrate-from-newrelic/traces.mdx
+++ b/data/docs/migration/migrate-from-newrelic/traces.mdx
@@ -65,7 +65,7 @@ SigNoz provides detailed instrumentation guides for various languages and framew
 - [Python](/docs/instrumentation/python)
 - [Node.js](/docs/instrumentation/nodejs)
 - [Go](/docs/instrumentation/golang)
-- [Ruby](/docs/instrumentation/ruby)
+- [Ruby on Rails](/docs/instrumentation/ruby-on-rails)
 - [.NET](/docs/instrumentation/dotnet)
 - [PHP](/docs/instrumentation/php)
 Check this [document](https://signoz.io/docs/instrumentation/) for a list of languages and frameworks

--- a/data/guides/devops-monitoring-tools.mdx
+++ b/data/guides/devops-monitoring-tools.mdx
@@ -225,7 +225,7 @@ So far we have discussed monitoring and its importance in terms of DevOps. Let u
 - Best For:
     - It is best suited for organizations looking for a comprehensive, cost-effective, and open-source alternative to proprietary APM solutions with a native opentelemetry support.
 - Community Support:
-    - It is an emerging tool, and SigNoz has a growing community. It has active forums, GitHub issues, and documentation, and a <a href="signoz.io/slack/" rel="noopener noreferrer nofollow" target="_blank">slack community</a> of over 4000+ people.
+    - It is an emerging tool, and SigNoz has a growing community. It has active forums, GitHub issues, and documentation, and a <a href="https://signoz.io/slack/" rel="noopener noreferrer nofollow" target="_blank">slack community</a> of over 4000+ people.
 - Performance:
     - SigNoz performs well in monitoring and tracing, especially for microservices architectures. However, as with any newer tool, it may have performance limitations in extremely large or complex environments.
 - Pricing:

--- a/next.config.js
+++ b/next.config.js
@@ -179,6 +179,11 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/docs/kubernetes/deployment/',
+          destination: '/docs/install/kubernetes/',
+          permanent: true,
+        },
+        {
           source: '/docs/installation/',
           destination: '/docs/install',
           permanent: true,
@@ -191,6 +196,16 @@ module.exports = () => {
         {
           source: '/docs/operate/migration',
           destination: '/docs/operate/upgrade',
+          permanent: true,
+        },
+        {
+          source: '/docs/operate/',
+          destination: '/docs/manage/administrator-guide/',
+          permanent: true,
+        },
+        {
+          source: '/docs/operate/kubernetes/',
+          destination: '/docs/install/kubernetes/',
           permanent: true,
         },
         {
@@ -362,6 +377,11 @@ module.exports = () => {
         {
           source: '/docs/instrumentation/python/',
           destination: '/docs/instrumentation/opentelemetry-python/',
+          permanent: true,
+        },
+        {
+          source: '/docs/instrumentation/ruby/',
+          destination: '/docs/instrumentation/ruby-on-rails/',
           permanent: true,
         },
         {


### PR DESCRIPTION
## Summary
- replace outdated kubernetes docs URLs in blog and migration content
- point operate section reference to administrator guide and fix ruby guide link
- correct slack CTA link in devops monitoring guide
