### PR TITLE
docs: update dir path for deployment with docker swarm

### DIFF
--- a/data/docs/install/docker-swarm.mdx
+++ b/data/docs/install/docker-swarm.mdx
@@ -60,7 +60,7 @@ Please use non-root user (mainly for Git repository cloning), otherwise you may 
     - The name of the stack (`signoz`)
 
     ```bash
-    cd deploy/docker
+    cd deploy/docker-swarm
     docker stack deploy -d --prune -c docker-compose.yaml signoz
     ```
 


### PR DESCRIPTION
Fixes docker swarm deployment directory path: `deploy/docker` → `deploy/docker-swarm`