### PR TITLE
Deleting Old Angular file

### DIFF
--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -2593,11 +2593,6 @@ const docsSideNav = [
       },
       {
         type: 'doc',
-        route: '/docs/tutorial/instrumenting-angular-frontend',
-        label: 'Instrumenting Angular Frontend Web App',
-      },
-      {
-        type: 'doc',
         route: '/docs/tutorial/setting-up-sso-saml-with-keycloak',
         label: 'Setting Up SSO SAML 2.0 With Keycloak',
       },

--- a/data/docs/tutorial/instrumenting-angular-frontend.mdx
+++ b/data/docs/tutorial/instrumenting-angular-frontend.mdx
@@ -1,9 +1,0 @@
----
-date: 2024-06-06
-id: instrumenting-angular-frontend
-tags : [SigNoz Cloud, Self-Host]
-title: Instrumenting Angular Frontend Web App
-description: Instrument your angular frontend app.
----
-
-To instrument your Angular application, please refer to [this documentation](https://signoz.io/docs/instrumentation/angular/).


### PR DESCRIPTION
1) Removed the deprecated Angular instrumentation documentation and its associated UI reference.
2) Ensured that the old Angular file no longer appears in the docs navigation.