### PR TITLE
Updating GCP docs

### DIFF
--- a/data/docs/gcp-monitoring/app-engine/logging.mdx
+++ b/data/docs/gcp-monitoring/app-engine/logging.mdx
@@ -145,18 +145,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -167,7 +175,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -183,6 +191,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -376,18 +385,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -398,7 +415,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -418,6 +435,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/cloud-run/logging.mdx
+++ b/data/docs/gcp-monitoring/cloud-run/logging.mdx
@@ -74,18 +74,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -96,7 +104,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -112,6 +120,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -234,18 +243,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -256,7 +273,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -276,6 +293,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/cloud-sql/logging.mdx
+++ b/data/docs/gcp-monitoring/cloud-sql/logging.mdx
@@ -73,18 +73,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -95,7 +103,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
 exporters:
@@ -106,6 +114,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -229,18 +238,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -251,7 +268,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -271,6 +288,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/compute-engine/logging.mdx
+++ b/data/docs/gcp-monitoring/compute-engine/logging.mdx
@@ -102,18 +102,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -124,7 +132,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -140,6 +148,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -325,18 +334,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -347,7 +364,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -367,6 +384,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/gcp-clb/logging.mdx
+++ b/data/docs/gcp-monitoring/gcp-clb/logging.mdx
@@ -137,18 +137,26 @@ Let us now proceed to the OTel Collector installation:
 **Step 1:** Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 **Step 2:** Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 **Step 3:** Create config.yaml in the folder _otelcol-contrib_ with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `"<SIGNOZ_INGESTION_KEY>"` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -159,7 +167,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/lb-logs-signoz-sub-new-9-aug
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -175,6 +183,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]

--- a/data/docs/gcp-monitoring/gcp-fns/logging.mdx
+++ b/data/docs/gcp-monitoring/gcp-fns/logging.mdx
@@ -253,18 +253,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -275,7 +283,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -291,6 +299,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -890,18 +899,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -912,7 +929,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -932,6 +949,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/gcs/logging.mdx
+++ b/data/docs/gcp-monitoring/gcs/logging.mdx
@@ -120,18 +120,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -142,7 +150,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -158,6 +166,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -376,18 +385,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -398,7 +415,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -418,6 +435,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]

--- a/data/docs/gcp-monitoring/vpc/logging.mdx
+++ b/data/docs/gcp-monitoring/vpc/logging.mdx
@@ -122,18 +122,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. Replace `<region>` with the appropriate SigNoz Cloud region. Replace `SIGNOZ_INGESTION_KEY` with what is provided by SigNoz:
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -144,7 +152,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -160,6 +168,7 @@ exporters:
     headers:
       "signoz-ingestion-key": "<SigNoz-Key>"
 service:
+  extensions: [text_encoding]
   pipelines:
     traces:
       receivers: [otlp]
@@ -327,18 +336,26 @@ Let us now proceed to the OTel Collector installation:
 Step 1: Download otel-collector tar.gz for your architecture
 
 ```bash
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.135.0/otelcol-contrib_0.135.0_linux_amd64.tar.gz
 ```
 
 Step 2: Extract otel-collector tar.gz to the otelcol-contrib folder
 
 ```bash
-mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.135.0_linux_amd64.tar.gz -C otelcol-contrib
 ```
 
 Step 3: Create `config.yaml` in the folder `otelcol-contrib` with the below content in it. We are using the `clickhouselogsexporter` in this case.
 
+<Admonition type="note">
+Note: The googlecloudpubsub receiver’s encoding was updated from the deprecated raw_text to
+text_encoding. This configuration has been tested and works with otelcol-contrib v0.135.0.
+</Admonition>
+
 ```yaml
+extensions:
+  text_encoding:
+    encoding: utf-8
 receivers:
   otlp:
     protocols:
@@ -349,7 +366,7 @@ receivers:
   googlecloudpubsub:
     project: <gcp-project-id>
     subscription: projects/<gcp-project-id>/subscriptions/<pubsub-topic's-subscription>
-    encoding: raw_text
+    encoding: text_encoding
 processors:
   batch: {}
   resource/env:
@@ -369,6 +386,7 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 service:
+  extensions: [text_encoding]
   pipelines:
     logs:
       receivers: [otlp, googlecloudpubsub]


### PR DESCRIPTION
Summary:
1) Bump Collector to otelcol-contrib v0.135.0 (updated download + extract steps).
2) Switch googlecloudpubsub encoding from deprecated raw_text → text_encoding (added extension + wiring).
3) Tested on GCP (GCE + Pub/Sub); logs flow to SigNoz Cloud successfully.
Based on: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42775