### PR TITLE
Update SigNal 19 blog title to clarify Grafana import deprecation

### DIFF
--- a/constants/guidesRelatedArticles.json
+++ b/constants/guidesRelatedArticles.json
@@ -3348,7 +3348,7 @@
         "url": "/guides/how-to-set-dashboards-on-grafana-home-page/"
       },
       {
-        "title": "Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
+        "title": "Ability to import Grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
         "publishedOn": "2022-12-02",
         "url": "/blog/community-update-19/"
       },

--- a/constants/guidesRelatedArticles.json
+++ b/constants/guidesRelatedArticles.json
@@ -5273,7 +5273,7 @@
         "url": "/guides/what-is-the-default-username-and-password-for-grafana-login-page/"
       },
       {
-        "title": "Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
+        "title": "Ability to import Grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
         "publishedOn": "2022-12-02",
         "url": "/blog/community-update-19/"
       },

--- a/constants/guidesRelatedArticles.json
+++ b/constants/guidesRelatedArticles.json
@@ -3348,7 +3348,7 @@
         "url": "/guides/how-to-set-dashboards-on-grafana-home-page/"
       },
       {
-        "title": "Ability to import Grafana dashboards, Alerts based on ClickHouse queries and more advanced features - SigNal 19",
+        "title": "Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
         "publishedOn": "2022-12-02",
         "url": "/blog/community-update-19/"
       },
@@ -5273,7 +5273,7 @@
         "url": "/guides/what-is-the-default-username-and-password-for-grafana-login-page/"
       },
       {
-        "title": "Ability to import Grafana dashboards, Alerts based on ClickHouse queries and more advanced features - SigNal 19",
+        "title": "Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19",
         "publishedOn": "2022-12-02",
         "url": "/blog/community-update-19/"
       },

--- a/data/blog/community-update-19.mdx
+++ b/data/blog/community-update-19.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ability to import Grafana dashboards, Alerts based on ClickHouse queries and more advanced features - SigNal 19
+title: Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19
 slug: community-update-19
 date: 2022-12-02
 tags: [Product Updates]

--- a/data/blog/community-update-19.mdx
+++ b/data/blog/community-update-19.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ability to import grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19
+title: Ability to import Grafana dashboards (deprecated), Alerts based on ClickHouse queries and more advanced features - SigNal 19
 slug: community-update-19
 date: 2022-12-02
 tags: [Product Updates]


### PR DESCRIPTION
## Summary
- update the SigNal 19 blog frontmatter title to note that Grafana dashboard imports are deprecated
- align related articles metadata with the new title text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69019245e53483268cc45018af41def5