### PR TITLE
Update linux.mdx

### DIFF
--- a/data/docs/install/linux.mdx
+++ b/data/docs/install/linux.mdx
@@ -37,7 +37,7 @@ sudo apt install default-jdk -y
 2. Get and extract the latest release of Zookeeper from the [releases page](https://zookeeper.apache.org/releases.html)
 
 ```bash
-curl -L https://dlcdn.apache.org/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4-bin.tar.gz -o zookeeper.tar.gz
+curl -L https://dlcdn.apache.org/zookeeper/zookeeper-3.8.5/apache-zookeeper-3.8.5-bin.tar.gz -o zookeeper.tar.gz
 tar -xzf zookeeper.tar.gz
 ```
 
@@ -47,7 +47,7 @@ tar -xzf zookeeper.tar.gz
 sudo mkdir -p /opt/zookeeper
 sudo mkdir -p /var/lib/zookeeper
 sudo mkdir -p /var/log/zookeeper
-sudo cp -r apache-zookeeper-3.8.4-bin/* /opt/zookeeper
+sudo cp -r apache-zookeeper-3.8.5-bin/* /opt/zookeeper
 ```
 
 4. Create the zookeeper config file:


### PR DESCRIPTION
updated zookeeper version from 3.8.4 to 3.8.5 due to the 3.8.4 no longer being available on the official apache mirror.