### PR TITLE
chore: update frontend monitoring docs

### DIFF
--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -2189,17 +2189,17 @@ const docsSideNav = [
     items: [
       {
         type: 'doc',
-        route: '/docs/frontend-monitoring/sending-logs',
+        route: '/docs/frontend-monitoring/sending-logs-with-opentelemetry',
         label: 'Sending Logs',
       },
       {
         type: 'doc',
-        route: '/docs/frontend-monitoring/sending-traces',
+        route: '/docs/frontend-monitoring/sending-traces-with-opentelemetry',
         label: 'Sending Traces',
       },
       {
         type: 'doc',
-        route: '/docs/frontend-monitoring/sending-metrics',
+        route: '/docs/frontend-monitoring/sending-metrics-with-opentelemetry',
         label: 'Sending Metrics',
       },
       {

--- a/data/comparisons/best-frontend-cloud-logging-tools.mdx
+++ b/data/comparisons/best-frontend-cloud-logging-tools.mdx
@@ -423,8 +423,8 @@ SigNoz pricing is based on actual data ingested:
 
 
 **Learn More:**
-- [Frontend Logging with SigNoz](https://signoz.io/docs/frontend-monitoring/sending-logs/) - Complete guide to sending logs from your frontend application to SigNoz
-- [Frontend Tracing with SigNoz](https://signoz.io/docs/frontend-monitoring/sending-traces/) - Step-by-step instructions for sending traces and understanding user interactions
+- [Frontend Logging with SigNoz](https://signoz.io/docs/frontend-monitoring/sending-logs-with-opentelemetry/) - Complete guide to sending logs from your frontend application to SigNoz
+- [Frontend Tracing with SigNoz](https://signoz.io/docs/frontend-monitoring/sending-traces-with-opentelemetry/) - Step-by-step instructions for sending traces and understanding user interactions
 - [Web Vitals Monitoring](https://signoz.io/docs/frontend-monitoring/opentelemetry-web-vitals/) - Monitor Core Web Vitals (LCP, FID, CLS) using OpenTelemetry and SigNoz
 
 ## Getting Started with SigNoz

--- a/data/docs/frontend-monitoring.mdx
+++ b/data/docs/frontend-monitoring.mdx
@@ -2,6 +2,8 @@
 date: 2025-11-11
 id: frontend-monitoring
 title: Monitor your Frontend applications
+tags: [SigNoz Cloud, Self-Host]
+description: Learn how to instrument your frontend application with OpenTelemetry.
 ---
 
 

--- a/data/docs/frontend-monitoring.mdx
+++ b/data/docs/frontend-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-08-17
+date: 2025-11-11
 id: frontend-monitoring
 title: Monitor your Frontend applications
 ---

--- a/data/docs/frontend-monitoring.mdx
+++ b/data/docs/frontend-monitoring.mdx
@@ -16,19 +16,19 @@ title: Monitor your Frontend applications
 <DocCard
     title="📄️ Sending Traces"
     description="Send traces from your frontend application using SigNoz"
-    href="/docs/frontend-monitoring/sending-traces"
+    href="/docs/frontend-monitoring/sending-traces-with-opentelemetry"
 />
 
 <DocCard
     title="📄️ Sending Metrics"
     description="Send metrics from your frontend application using SigNoz"
-    href="/docs/frontend-monitoring/sending-metrics"
+    href="/docs/frontend-monitoring/sending-metrics-with-opentelemetry"
 />
 
 <DocCard
     title="📄️ Sending Logs"
     description="Send logs from your frontend application using SigNoz"
-    href="/docs/frontend-monitoring/sending-logs"
+    href="/docs/frontend-monitoring/sending-logs-with-opentelemetry"
 />
 
 <DocCard

--- a/data/docs/frontend-monitoring.mdx
+++ b/data/docs/frontend-monitoring.mdx
@@ -10,9 +10,9 @@ description: Learn how to instrument your frontend application with OpenTelemetr
 <DocCardContainer>
 
 <DocCard
-    title="📄️ Web Vitals"
-    description="Monitor your application's web vitals using SigNoz"
-    href="/docs/frontend-monitoring/opentelemetry-web-vitals"
+    title="📄️ Sending Logs"
+    description="Send logs from your frontend application using SigNoz"
+    href="/docs/frontend-monitoring/sending-logs-with-opentelemetry"
 />
 
 <DocCard
@@ -28,9 +28,9 @@ description: Learn how to instrument your frontend application with OpenTelemetr
 />
 
 <DocCard
-    title="📄️ Sending Logs"
-    description="Send logs from your frontend application using SigNoz"
-    href="/docs/frontend-monitoring/sending-logs-with-opentelemetry"
+    title="📄️ Web Vitals"
+    description="Monitor your application's web vitals using SigNoz"
+    href="/docs/frontend-monitoring/opentelemetry-web-vitals"
 />
 
 <DocCard

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -136,23 +136,23 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
   config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
+
+  ```yaml:config.yaml
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+          cors:
+            allowed_origins:
+              - <YOUR_FRONTEND_URL>
+            allowed_headers: ['*']
+  ```
+
+  - `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 </Admonition>
-
-```yaml:config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-        cors:
-          allowed_origins:
-            - <YOUR_FRONTEND_URL>
-          allowed_headers: ['*']
-```
-
-- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 
 ### Step 3: Importing the instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -509,7 +509,7 @@ To do so, you need to write a custom implementation on top of `LogRecordProcesso
 
 <Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
-    ```ts
+    ```ts:custom-processor.ts
     import type { LogRecordProcessor, SdkLogRecord } from '@opentelemetry/sdk-logs';
     import { UAParser } from 'ua-parser-js';
 
@@ -559,7 +559,7 @@ To do so, you need to write a custom implementation on top of `LogRecordProcesso
 
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
-    ```js
+    ```js:custom-processor.js
     import { UAParser } from 'ua-parser-js';
 
     function getBrowserInfo() {
@@ -706,6 +706,6 @@ These captured logs can then also be viewed in the [Logs Explorer](https://signo
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-logs) that demonstrates sending logs to SigNoz.
 
 ## Next Steps
-- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
+- [Sending metrics](/docs/frontend-monitoring/sending-metrics-with-opentelemetry)
 - [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
 - [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -704,3 +704,8 @@ These captured logs can then also be viewed in the [Logs Explorer](https://signo
 ## Demo Application
 
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-logs) that demonstrates sending logs to SigNoz.
+
+## Next Steps
+- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
+- [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
+- [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -152,6 +152,8 @@ receivers:
           allowed_headers: ['*']
 ```
 
+- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
+
 ### Step 3: Importing the instrumentation file
 
 <Admonition type="info">
@@ -182,21 +184,6 @@ receivers:
   <TabItem value="nextjs-app" label="Next.js (App Router)">
     Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
 
-    Create `instrumentation.ts` (or `.js`) at the project root:
-
-    ```ts:instrumentation.ts
-    export async function register() {
-      if (process.env.NEXT_RUNTIME === 'nodejs') {
-        // This runs on the server - you can optionally skip client instrumentation here
-        // We'll handle client-side instrumentation separately
-      }
-
-      if (process.env.NEXT_RUNTIME === 'edge') {
-        // This runs on edge runtime
-      }
-    }
-    ```
-
     For **client-side instrumentation**, create a separate file and import it in your root layout:
 
     ```ts:app/instrumentation-client.ts
@@ -218,7 +205,7 @@ receivers:
     }
     ```
 
-    **Note:** Make sure to enable instrumentation in `next.config.js`:
+    **Note:** Make sure to enable instrumentation in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -227,11 +214,6 @@ receivers:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
-
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -257,7 +239,7 @@ receivers:
     }
     ```
 
-    And enable it in `next.config.js`:
+    And enable it in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -266,10 +248,6 @@ receivers:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
 
   </TabItem>
 

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -46,7 +46,7 @@ Install the following dependencies.
 <summary> Read more about the dependencies </summary>
   - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish logs from different services in your SigNoz dashboard.
 
-  - **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `SimpleLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
+  - **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `BatchLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
 
   - **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
 
@@ -62,7 +62,7 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
     ```ts:instrumentation.ts
     import {
       LoggerProvider,
-      SimpleLogRecordProcessor,
+      BatchLogRecordProcessor,
     } from '@opentelemetry/sdk-logs';
     import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
     import { logs } from '@opentelemetry/api-logs';
@@ -73,11 +73,12 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
         'service.name': '<SERVICE_NAME>',
       }),
       processors: [
-        new SimpleLogRecordProcessor(
+        new BatchLogRecordProcessor(
           new OTLPLogExporter({
             // For self-hosted version, please use the collector url instead.
             url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
             headers: {
+              // Optional for the self-hosted version
               'signoz-ingestion-key': '<INGESTION_KEY>',
             },
           }),
@@ -97,7 +98,7 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
     ```js:instrumentation.js
     import {
       LoggerProvider,
-      SimpleLogRecordProcessor,
+      BatchLogRecordProcessor,
     } from '@opentelemetry/sdk-logs';
     import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
     import { logs } from '@opentelemetry/api-logs';
@@ -108,11 +109,12 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
         'service.name': '<SERVICE_NAME>',
       }),
       processors: [
-        new SimpleLogRecordProcessor(
+        new BatchLogRecordProcessor(
           new OTLPLogExporter({
             // For self-hosted version, please use the collector url instead.
             url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
             headers: {
+              // Optional for the self-hosted version
               'signoz-ingestion-key': '<INGESTION_KEY>',
             },
           }),
@@ -132,10 +134,11 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
 
 <Admonition type="info">
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
-  config file to allow browser requests from your frontend domain:
+  config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
+  <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
 </Admonition>
 
-```yaml
+```yaml:config.yaml
 receivers:
   otlp:
     protocols:
@@ -151,7 +154,10 @@ receivers:
 
 ### Step 3: Importing the instrumentation file
 
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+<Admonition type="info">
+  Import the instrumentation file at the top level of your application. 
+  This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+</Admonition>
 
 <Tabs groupId="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
@@ -222,6 +228,10 @@ Import the instrumentation file at the top level of your application. This ensur
     };
     ```
 
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
+
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -256,6 +266,10 @@ Import the instrumentation file at the top level of your application. This ensur
       },
     };
     ```
+
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
 
   </TabItem>
 
@@ -597,16 +611,17 @@ To do so, you need to write a custom implementation on top of `LogRecordProcesso
 
 Update your `instrumentation` file to include this processor before the default one.
 
-```ts
+```ts:instrumentation.ts
 const loggerProvider = new LoggerProvider({
   resource: resourceFromAttributes({
     'service.name': '<SERVICE_NAME>',
   }),
   processors: [
     new CustomAttributesProcessor(),
-    new SimpleLogRecordProcessor(new OTLPLogExporter({
+    new BatchLogRecordProcessor(new OTLPLogExporter({
       url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
       headers: {
+        // Optional for the self-hosted version
         'signoz-ingestion-key': '<INGESTION_KEY>',
       },
     })),

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -1,9 +1,13 @@
 ---
 date: 2025-08-17
-tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
-title: Sending Logs from your frontend application
+tags: [SigNoz Cloud, Self-Host]
+title: Sending Logs from your frontend using OpenTelemetry
+
+
 id: sending-logs-frontend
-description: Send logs from your frontend application to SigNoz
+description: Learn how to send frontend logs to SigNoz using OpenTelemetry for complete visibility across your application.
+
+
 ---
 
 This documentation provides steps for sending logs from your frontend application to SigNoz.
@@ -25,32 +29,40 @@ Install the following dependencies.
 
 <Tabs entityName="logs-dependencies">
   <TabItem value="npm" label="Npm">
-    ```sh npm i \ @opentelemetry/resources \ @opentelemetry/sdk-logs \
-    @opentelemetry/exporter-logs-otlp-http \ @opentelemetry/api-logs ```
+    ```sh
+    npm install @opentelemetry/resources
+    npm install @opentelemetry/sdk-logs
+    npm install @opentelemetry/exporter-logs-otlp-http
+    npm install @opentelemetry/api-logs
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn" default>
-    ```sh yarn add \ @opentelemetry/resources \ @opentelemetry/sdk-logs \
-    @opentelemetry/exporter-logs-otlp-http \ @opentelemetry/api-logs ```
+    ```sh
+    yarn add @opentelemetry/resources
+    yarn add @opentelemetry/sdk-logs
+    yarn add @opentelemetry/exporter-logs-otlp-http
+    yarn add @opentelemetry/api-logs
+    ```
   </TabItem>
 </Tabs>
 
 <details>
 <summary> Read more about the dependencies </summary>
-- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish logs from different services in your SigNoz dashboard.
+  - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish logs from different services in your SigNoz dashboard.
 
-- **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `SimpleLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
+  - **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `SimpleLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
 
-- **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
+  - **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
 
-- **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
-  </details>
+  - **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
+</details>
 
 ### Step 2: Create an instrumentation file
 
 The instrumentation file is required to setup the `LoggerProvider` which is used to create custom logs within your application and export them to your collector.
 
 <Tabs entityName="plans">
-  <TabItem value="typescript" label="TypeScript" default>
+  <TabItem value="ts" label="TypeScript" default>
     ```ts:instrumentation.ts
     import {
       LoggerProvider,
@@ -62,15 +74,15 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
 
     const loggerProvider = new LoggerProvider({
       resource: resourceFromAttributes({
-        'service.name': '<<SERVICE_NAME>>',
+        'service.name': '<SERVICE_NAME>',
       }),
       processors: [
         new SimpleLogRecordProcessor(
           new OTLPLogExporter({
             // For self-hosted version, please use the collector url instead.
-            url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/logs`,
+            url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
             headers: {
-              'signoz-ingestion-key': <<INGESTION_KEY>>,
+              'signoz-ingestion-key': '<INGESTION_KEY>',
             },
           }),
         ),
@@ -80,12 +92,12 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
     logs.setGlobalLoggerProvider(loggerProvider);
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
-  <TabItem value="javascript" label="JavaScript">
+  <TabItem value="js" label="JavaScript">
     ```js:instrumentation.js
     import {
       LoggerProvider,
@@ -97,15 +109,15 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
 
     const loggerProvider = new LoggerProvider({
       resource: resourceFromAttributes({
-        'service.name': '<<SERVICE_NAME>>',
+        'service.name': '<SERVICE_NAME>',
       }),
       processors: [
         new SimpleLogRecordProcessor(
           new OTLPLogExporter({
             // For self-hosted version, please use the collector url instead.
-            url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/logs`,
+            url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
             headers: {
-              'signoz-ingestion-key': <<INGESTION_KEY>>,
+              'signoz-ingestion-key': '<INGESTION_KEY>',
             },
           }),
         ),
@@ -115,14 +127,17 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
     logs.setGlobalLoggerProvider(loggerProvider);
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
 </Tabs>
 
-**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
+<Admonition type="info">
+  For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
+  config file to allow browser requests from your frontend domain:
+</Admonition>
 
 ```sh
 receivers:
@@ -134,7 +149,7 @@ receivers:
         endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - <<YOUR_FRONTEND_URL>>
+            - <YOUR_FRONTEND_URL>
           allowed_headers: ['*']
 ```
 
@@ -449,14 +464,14 @@ The `utils` file will contain our utility functions for recording various kinds 
 Add logs at meaningful points in your application.
 
 ```ts
-function onNextClick() {
+async function onNextClick() {
   try {
-    const response = await fetch('/api/data')
-    const data = await response.json()
-    logInfo('Next button clicked!', { data })
-    return data
+    const response = await fetch('/api/data');
+    const data = await response.json();
+    logInfo('Next button clicked!', { data });
+    return data;
   } catch (error) {
-    logError('Failed to fetch data', { error: error.message })
+    logError('Failed to fetch data', { error: error.message });
   }
 }
 ```
@@ -589,11 +604,11 @@ Update your `instrumentation` file to include this processor before the default 
 ```ts
 const loggerProvider = new LoggerProvider({
   resource: resourceFromAttributes({
-    'service.name': '<<SERVICE_NAME>>',
+    'service.name': '<SERVICE_NAME>',
   }),
   processors: [
     new CustomAttributesProcessor(),
-    new SimpleLogRecordProcessor(new OTLPLogExporter({ url: '<<SIGNOZ_COLLECTOR_URL>>/v1/logs' })),
+    new SimpleLogRecordProcessor(new OTLPLogExporter({ url: '<SIGNOZ_COLLECTOR_URL>/v1/logs' })),
   ],
 })
 ```

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -43,7 +43,7 @@ Install the following dependencies.
 - **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
 
 - **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
-</details>
+  </details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -4,8 +4,6 @@ tags: [SigNoz Cloud, Self-Host]
 title: Sending Logs from your frontend using OpenTelemetry
 id: sending-logs-frontend
 description: Learn how to send frontend logs to SigNoz using OpenTelemetry for complete visibility across your application.
-
-
 ---
 
 This documentation provides steps for sending logs from your frontend application to SigNoz.

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-08-17
+date: 2025-11-06
 tags: [SigNoz Cloud, Self-Host]
 title: Sending Logs from your frontend using OpenTelemetry
 

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -43,7 +43,7 @@ Install the following dependencies.
 - **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
 
 - **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
-  </details>
+</details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -135,7 +135,7 @@ The instrumentation file is required to setup the `LoggerProvider` which is used
   config file to allow browser requests from your frontend domain:
 </Admonition>
 
-```sh
+```yaml
 receivers:
   otlp:
     protocols:
@@ -377,7 +377,7 @@ The `utils` file will contain our utility functions for recording various kinds 
 
 <Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
-    ```ts
+    ```ts:utils.ts
     import {
       logs,
       SeverityNumber,
@@ -416,7 +416,7 @@ The `utils` file will contain our utility functions for recording various kinds 
 
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
-    ```js
+    ```js:utils.js
     import {
       logs,
       SeverityNumber,
@@ -459,7 +459,7 @@ The `utils` file will contain our utility functions for recording various kinds 
 
 Add logs at meaningful points in your application.
 
-```ts
+```ts:func.ts
 async function onNextClick() {
   try {
     const response = await fetch('/api/data');
@@ -604,7 +604,12 @@ const loggerProvider = new LoggerProvider({
   }),
   processors: [
     new CustomAttributesProcessor(),
-    new SimpleLogRecordProcessor(new OTLPLogExporter({ url: '<SIGNOZ_COLLECTOR_URL>/v1/logs' })),
+    new SimpleLogRecordProcessor(new OTLPLogExporter({
+      url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/logs`,
+      headers: {
+        'signoz-ingestion-key': '<INGESTION_KEY>',
+      },
+    })),
   ],
 })
 ```

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -2,8 +2,6 @@
 date: 2025-11-06
 tags: [SigNoz Cloud, Self-Host]
 title: Sending Logs from your frontend using OpenTelemetry
-
-
 id: sending-logs-frontend
 description: Learn how to send frontend logs to SigNoz using OpenTelemetry for complete visibility across your application.
 

--- a/data/docs/frontend-monitoring/sending-logs.mdx
+++ b/data/docs/frontend-monitoring/sending-logs.mdx
@@ -1,8 +1,9 @@
 ---
 date: 2025-08-17
-tags : [SigNoz Cloud, Self-Host]
+tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
 title: Sending Logs from your frontend application
 id: sending-logs-frontend
+description: Send logs from your frontend application to SigNoz
 ---
 
 This documentation provides steps for sending logs from your frontend application to SigNoz.
@@ -18,11 +19,110 @@ Logs can be collected on the client side at meaningful points to capture various
 
 ## Setup
 
-### Step 1: Setup OTel Collector
+### Step 1: Install dependencies
 
-Install the OpenTelemetry Collector binary using [these instructions](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/). The Collector acts as an agent that receives, processes, and exports telemetry data. It is required to collect data from your application, including logs.
+Install the following dependencies.
 
-You would also need to update the collector config to whitelist the frontend domain. This is required to allow Cross-Origin Resource Sharing (CORS) requests from your frontend application to the OpenTelemetry collector.
+<Tabs entityName="logs-dependencies">
+  <TabItem value="npm" label="Npm">
+    ```sh npm i \ @opentelemetry/resources \ @opentelemetry/sdk-logs \
+    @opentelemetry/exporter-logs-otlp-http \ @opentelemetry/api-logs ```
+  </TabItem>
+  <TabItem value="yarn" label="Yarn" default>
+    ```sh yarn add \ @opentelemetry/resources \ @opentelemetry/sdk-logs \
+    @opentelemetry/exporter-logs-otlp-http \ @opentelemetry/api-logs ```
+  </TabItem>
+</Tabs>
+
+<details>
+<summary> Read more about the dependencies </summary>
+- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish logs from different services in your SigNoz dashboard.
+
+- **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `SimpleLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
+
+- **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
+
+- **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
+  </details>
+
+### Step 2: Create an instrumentation file
+
+The instrumentation file is required to setup the `LoggerProvider` which is used to create custom logs within your application and export them to your collector.
+
+<Tabs entityName="plans">
+  <TabItem value="typescript" label="TypeScript" default>
+    ```ts:instrumentation.ts
+    import {
+      LoggerProvider,
+      SimpleLogRecordProcessor,
+    } from '@opentelemetry/sdk-logs';
+    import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+    import { logs } from '@opentelemetry/api-logs';
+    import { resourceFromAttributes } from '@opentelemetry/resources';
+
+    const loggerProvider = new LoggerProvider({
+      resource: resourceFromAttributes({
+        'service.name': '<<SERVICE_NAME>>',
+      }),
+      processors: [
+        new SimpleLogRecordProcessor(
+          new OTLPLogExporter({
+            // For self-hosted version, please use the collector url instead.
+            url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/logs`,
+            headers: {
+              'signoz-ingestion-key': <<INGESTION_KEY>>,
+            },
+          }),
+        ),
+      ],
+    });
+
+    logs.setGlobalLoggerProvider(loggerProvider);
+    ```
+
+    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<<SERVICE_NAME>>` is the name of your service
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+    ```js:instrumentation.js
+    import {
+      LoggerProvider,
+      SimpleLogRecordProcessor,
+    } from '@opentelemetry/sdk-logs';
+    import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+    import { logs } from '@opentelemetry/api-logs';
+    import { resourceFromAttributes } from '@opentelemetry/resources';
+
+    const loggerProvider = new LoggerProvider({
+      resource: resourceFromAttributes({
+        'service.name': '<<SERVICE_NAME>>',
+      }),
+      processors: [
+        new SimpleLogRecordProcessor(
+          new OTLPLogExporter({
+            // For self-hosted version, please use the collector url instead.
+            url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/logs`,
+            headers: {
+              'signoz-ingestion-key': <<INGESTION_KEY>>,
+            },
+          }),
+        ),
+      ],
+    });
+
+    logs.setGlobalLoggerProvider(loggerProvider);
+    ```
+
+    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<<SERVICE_NAME>>` is the name of your service
+
+  </TabItem>
+</Tabs>
+
+**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
 
 ```sh
 receivers:
@@ -38,133 +138,233 @@ receivers:
           allowed_headers: ['*']
 ```
 
-### Step 2: Install dependencies
+### Step 3: Importing the instrumentation file
 
-Install the following dependencies.
+Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 
-<Tabs entityName="logs-dependencies">
-  <TabItem value="npm" label="Npm">
-    ```sh
-    npm i \
-      @opentelemetry/resources \
-      @opentelemetry/sdk-logs \
-      @opentelemetry/exporter-logs-otlp-http \
-      @opentelemetry/api-logs
+<Tabs groupId="framework-choice">
+  <TabItem value="react" label="React (Vite/CRA)" default>
+    In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
+
+    ```ts:src/main.tsx
+    import './instrumentation';
+    import { StrictMode } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import './index.css';
+    import App from './App';
+
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
     ```
+
   </TabItem>
-  <TabItem value="yarn" label="Yarn" default>
-    ```sh
-    yarn add \
-      @opentelemetry/resources \
-      @opentelemetry/sdk-logs \
-      @opentelemetry/exporter-logs-otlp-http \
-      @opentelemetry/api-logs
+  
+  <TabItem value="nextjs-app" label="Next.js (App Router)">
+    Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
+
+    Create `instrumentation.ts` (or `.js`) at the project root:
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (process.env.NEXT_RUNTIME === 'nodejs') {
+        // This runs on the server - you can optionally skip client instrumentation here
+        // We'll handle client-side instrumentation separately
+      }
+
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        // This runs on edge runtime
+      }
+    }
     ```
+
+    For **client-side instrumentation**, create a separate file and import it in your root layout:
+
+    ```ts:app/instrumentation-client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+    ```
+
+    Import it in your root layout:
+
+    ```tsx:app/layout.tsx
+    import './instrumentation-client';
+
+    export default function RootLayout({ children }: { children: React.ReactNode }) {
+      return (
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      );
+    }
+    ```
+
+    **Note:** Make sure to enable instrumentation in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
+    For Next.js with Pages Router, import the instrumentation in your `_app.tsx` file:
+
+    ```tsx:pages/_app.tsx
+    import '../instrumentation';
+    import type { AppProps } from 'next/app';
+
+    export default function App({ Component, pageProps }: AppProps) {
+      return <Component {...pageProps} />;
+    }
+    ```
+
+    Alternatively, you can use the `instrumentation.ts` file at the root (requires Next.js 13.2+):
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (typeof window !== 'undefined') {
+        // Client-side instrumentation
+        await import('./instrumentation-client');
+      }
+    }
+    ```
+
+    And enable it in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nuxt" label="Nuxt.js">
+    For Nuxt.js, create a plugin to initialize the instrumentation:
+
+    ```ts:plugins/instrumentation.client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+
+    export default defineNuxtPlugin(() => {
+      // Instrumentation is initialized when this plugin loads
+    });
+    ```
+
+    The `.client.ts` suffix ensures this only runs on the client side. Nuxt will automatically load this plugin during application initialization.
+
+    Alternatively, you can import it directly in `app.vue`:
+
+    ```vue:app.vue
+    <script setup>
+    import './instrumentation';
+    </script>
+
+    <template>
+      <NuxtPage />
+    </template>
+    ```
+
+  </TabItem>
+
+  <TabItem value="angular" label="Angular">
+    For Angular, import the instrumentation file at the very top of your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { bootstrapApplication } from '@angular/platform-browser';
+    import { appConfig } from './app/app.config';
+    import { AppComponent } from './app/app.component';
+
+    bootstrapApplication(AppComponent, appConfig)
+      .catch((err) => console.error(err));
+    ```
+
+    For older Angular versions using `platformBrowserDynamic`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    import { AppModule } from './app/app.module';
+
+    platformBrowserDynamic().bootstrapModule(AppModule)
+      .catch(err => console.error(err));
+    ```
+
+  </TabItem>
+
+  <TabItem value="vue" label="Vue.js">
+    For Vue.js, import the instrumentation file at the very top of your `main.ts` (or `main.js`):
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { createApp } from 'vue';
+    import App from './App.vue';
+
+    createApp(App).mount('#app');
+    ```
+
+    For Vue 2:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import Vue from 'vue';
+    import App from './App.vue';
+
+    new Vue({
+      render: h => h(App),
+    }).$mount('#app');
+    ```
+
+  </TabItem>
+
+  <TabItem value="svelte" label="Svelte/SvelteKit">
+    For **Svelte** (with Vite), import in your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import App from './App.svelte';
+
+    const app = new App({
+      target: document.getElementById('app')!,
+    });
+
+    export default app;
+    ```
+
+    For **SvelteKit**, create a hook in `src/hooks.client.ts`:
+
+    ```ts:src/hooks.client.ts
+    import './instrumentation';
+    ```
+
+    Or import it in your root layout:
+
+    ```svelte:src/routes/+layout.svelte
+    <script>
+      import '../instrumentation';
+    </script>
+
+    <slot />
+    ```
+
   </TabItem>
 </Tabs>
 
-<details>
-<summary> Read more about the dependencies </summary>
-- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish logs from different services in your SigNoz dashboard.
-
-- **`@opentelemetry/sdk-logs`**: Contains the core logging SDK implementation including `LoggerProvider` and `SimpleLogRecordProcessor`. This is the foundation for creating and processing log records in your application.
-
-- **`@opentelemetry/exporter-logs-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your logs to the SigNoz collector. This handles the actual transmission of log data over HTTP.
-
-- **`@opentelemetry/api-logs`**: Provides the logging API interface (`logs` object) that your application code uses to create log records. This is the main API you'll interact with when adding logging statements to your code.
-</details>
-
-### Step 3: Create an instrumentation file
-
-The instrumentation file is required to setup the `LoggerProvider` which is used to create custom logs within your application and export them to your collector.
-Inside your `src` directory, create a file named `instrument.js` (or `instrument.ts` for TypeScript):
-
-<Tabs entityName="logs-instrumentation">
-  <TabItem value="cloud" label="SigNoz Cloud" default>
-    ```ts:instrument.js
-      import {
-        LoggerProvider,
-        SimpleLogRecordProcessor,
-      } from '@opentelemetry/sdk-logs';
-      import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-      import { logs } from '@opentelemetry/api-logs';
-      import { resourceFromAttributes } from '@opentelemetry/resources';
-
-      const loggerProvider = new LoggerProvider({
-        resource: resourceFromAttributes({
-          'service.name': '<<SERVICE_NAME>>',
-        }),
-        processors: [
-          new SimpleLogRecordProcessor(
-            new OTLPLogExporter({
-              url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/logs`,
-              headers: {
-                'signoz-ingestion-key': <<INGESTION_KEY>>,
-              },
-            }),
-          ),
-        ],
-      });
-
-      logs.setGlobalLoggerProvider(loggerProvider);
-    ```
-
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
-  </TabItem>
-  <TabItem value="self-hosted" label="SigNoz Self-Hosted">
-    ```ts:instrument.js
-      import {
-        LoggerProvider,
-        SimpleLogRecordProcessor,
-      } from '@opentelemetry/sdk-logs';
-      import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-      import { logs } from '@opentelemetry/api-logs';
-      import { resourceFromAttributes } from '@opentelemetry/resources';
-
-      const loggerProvider = new LoggerProvider({
-        resource: resourceFromAttributes({
-          'service.name': '<<SERVICE_NAME>>',
-        }),
-        processors: [
-          new SimpleLogRecordProcessor(
-            new OTLPLogExporter({ url: '<<SIGNOZ_COLLECTOR_URL>>/v1/logs' })
-          ),
-        ],
-      });
-
-      logs.setGlobalLoggerProvider(loggerProvider);
-    ```
-
-    - `<<SERVICE_NAME>>` is the name of your service
-    - `<<SIGNOZ_COLLECTOR_URL>>` is the url where your collector is running
-  </TabItem>
-</Tabs>
-
-### Step 4: Importing the instrumentation file
-
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture logs from the very beginning of your application's execution.
-
-```ts
-import './instrument';
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App';
-
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
-```
-
-### Step 5: Create utility functions for Logging
+### Step 4: Create utility functions for Logging
 
 The `utils` file will contain our utility functions for recording various kinds of logs (`info`, `warning`, `error`).
 
-<Tabs entityName="logs-utilities">
+<Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
     ```ts
     import {
@@ -202,6 +402,7 @@ The `utils` file will contain our utility functions for recording various kinds 
       });
     }
     ```
+
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
     ```js
@@ -239,27 +440,28 @@ The `utils` file will contain our utility functions for recording various kinds 
       });
     }
     ```
+
   </TabItem>
 </Tabs>
 
-### Step 6: Setting up Logs within your Application
+### Step 5: Setting up Logs within your Application
 
 Add logs at meaningful points in your application.
 
 ```ts
 function onNextClick() {
   try {
-    const response = await fetch('/api/data');
-    const data = await response.json();
-    logInfo('Next button clicked!', { data });
-    return data;
+    const response = await fetch('/api/data')
+    const data = await response.json()
+    logInfo('Next button clicked!', { data })
+    return data
   } catch (error) {
-    logError('Failed to fetch data', { error: error.message });
+    logError('Failed to fetch data', { error: error.message })
   }
 }
 ```
 
-### Step 7: Viewing Captured Logs in SigNoz
+### Step 6: Viewing Captured Logs in SigNoz
 
 The captured logs can then be viewed in the [Logs Explorer](https://signoz.io/docs/userguide/logs/).
 
@@ -274,13 +476,13 @@ The captured logs can then be viewed in the [Logs Explorer](https://signoz.io/do
   </figcaption>
 </figure>
 
-## Attaching additional identifiers to your Logs
+### Attaching additional identifiers to your Logs
 
 You can enrich logs with additional metadata like browser type, user ID etc. to enable real user monitoring (RUM)-like insights.
 
 To do so, you need to write a custom implementation on top of `LogRecordProcessor` which will intercept all your exported logs and attach additional attributes to them.
 
-<Tabs entityName="logs-processor">
+<Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
     ```ts
     import type { LogRecordProcessor, SdkLogRecord } from '@opentelemetry/sdk-logs';
@@ -329,6 +531,7 @@ To do so, you need to write a custom implementation on top of `LogRecordProcesso
       }
     }
     ```
+
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
     ```js
@@ -377,6 +580,7 @@ To do so, you need to write a custom implementation on top of `LogRecordProcesso
       }
     }
     ```
+
   </TabItem>
 </Tabs>
 
@@ -389,11 +593,9 @@ const loggerProvider = new LoggerProvider({
   }),
   processors: [
     new CustomAttributesProcessor(),
-    new SimpleLogRecordProcessor(
-      new OTLPLogExporter({ url: '<<SIGNOZ_COLLECTOR_URL>>/v1/logs' })
-    ),
+    new SimpleLogRecordProcessor(new OTLPLogExporter({ url: '<<SIGNOZ_COLLECTOR_URL>>/v1/logs' })),
   ],
-});
+})
 ```
 
 Now every log exported will include these additional contextual attributes.
@@ -468,5 +670,6 @@ These captured logs can then also be viewed in the [Logs Explorer](https://signo
   </figcaption>
 </figure>
 
-## Demo Application  
+## Demo Application
+
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-logs) that demonstrates sending logs to SigNoz.

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -467,6 +467,6 @@ The captured metrics can then be viewed in the [Metrics Explorer](https://signoz
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-metrics) that demonstrates sending metrics to SigNoz.
 
 ## Next Steps
-- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
+- [Sending logs](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
 - [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
 - [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -166,6 +166,8 @@ receivers:
           allowed_headers: ['*']
 ```
 
+- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
+
 ### Step 3: Importing the instrumentation file
 
 <Admonition type="info">
@@ -196,21 +198,6 @@ receivers:
   <TabItem value="nextjs-app" label="Next.js (App Router)">
     Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
 
-    Create `instrumentation.ts` (or `.js`) at the project root:
-
-    ```ts:instrumentation.ts
-    export async function register() {
-      if (process.env.NEXT_RUNTIME === 'nodejs') {
-        // This runs on the server - you can optionally skip client instrumentation here
-        // We'll handle client-side instrumentation separately
-      }
-
-      if (process.env.NEXT_RUNTIME === 'edge') {
-        // This runs on edge runtime
-      }
-    }
-    ```
-
     For **client-side instrumentation**, create a separate file and import it in your root layout:
 
     ```ts:app/instrumentation-client.ts
@@ -232,7 +219,7 @@ receivers:
     }
     ```
 
-    **Note:** Make sure to enable instrumentation in `next.config.js`:
+    **Note:** Make sure to enable instrumentation in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -241,11 +228,6 @@ receivers:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
-
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -271,7 +253,7 @@ receivers:
     }
     ```
 
-    And enable it in `next.config.js`:
+    And enable it in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -280,11 +262,6 @@ receivers:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
-
   </TabItem>
 
   <TabItem value="nuxt" label="Nuxt.js">

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -150,23 +150,23 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
   config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
+
+  ```yaml:config.yaml
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+          cors:
+            allowed_origins:
+              - <YOUR_FRONTEND_URL>
+            allowed_headers: ['*']
+  ```
+
+  - `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 </Admonition>
-
-```yaml:config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-        cors:
-          allowed_origins:
-            - <YOUR_FRONTEND_URL>
-          allowed_headers: ['*']
-```
-
-- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 
 ### Step 3: Importing the instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -465,3 +465,8 @@ The captured metrics can then be viewed in the [Metrics Explorer](https://signoz
 ## Demo Application
 
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-metrics) that demonstrates sending metrics to SigNoz.
+
+## Next Steps
+- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
+- [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
+- [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -8,7 +8,7 @@ description: Learn how to send frontend metrics to SigNoz using OpenTelemetry fo
 
 This documentation provides steps for sending metrics from your frontend application to SigNoz.
 
-SigNoz natively supports OpenTelemetry for collecting metrics, so you can lift-and-shift existing log libraries or build new pipelines, all with the same unified model as your traces and logs.
+SigNoz natively supports OpenTelemetry for collecting metrics, so you can lift-and-shift existing metric instrumentation, all with the same unified model as your traces and logs.
 
 Metrics can be collected on the client side at meaningful points to capture various events and state changes.
 
@@ -79,6 +79,7 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
         // For self-hosted version, please use the collector url instead.
         url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/metrics`,
         headers: {
+          // Optional for the self-hosted version
           'signoz-ingestion-key': '<INGESTION_KEY>',
         },
       }),
@@ -121,6 +122,7 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
         // For self-hosted version, please use the collector url instead.
         url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/metrics`,
         headers: {
+          // Optional for the self-hosted version
           'signoz-ingestion-key': '<INGESTION_KEY>',
         },
       }),
@@ -146,10 +148,11 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
 
 <Admonition type="info">
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
-  config file to allow browser requests from your frontend domain:
+  config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
+  <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
 </Admonition>
 
-```yaml
+```yaml:config.yaml
 receivers:
   otlp:
     protocols:
@@ -165,7 +168,10 @@ receivers:
 
 ### Step 3: Importing the instrumentation file
 
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+<Admonition type="info">
+  Import the instrumentation file at the top level of your application. 
+  This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+</Admonition>
 
 <Tabs groupId="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
@@ -236,6 +242,10 @@ Import the instrumentation file at the top level of your application. This ensur
     };
     ```
 
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
+
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -270,6 +280,10 @@ Import the instrumentation file at the top level of your application. This ensur
       },
     };
     ```
+
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
 
   </TabItem>
 

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -149,7 +149,7 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
   config file to allow browser requests from your frontend domain:
 </Admonition>
 
-```sh
+```yaml
 receivers:
   otlp:
     protocols:
@@ -389,7 +389,7 @@ Import the instrumentation file at the top level of your application. This ensur
 
 Now you can create and record metrics in your application. Here's an example of how to create and use metrics.
 
-```ts
+```ts:meter.ts
 import { metrics } from '@opentelemetry/api'
 
 // Get a meter from the global meter provider

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -43,7 +43,7 @@ Install the following dependencies.
 - **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
 
 - **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
-  </details>
+</details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -50,7 +50,7 @@ Install the following dependencies.
 
   - **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
 
-  - **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
+  - **`@opentelemetry/api`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
 </details>
 
 ### Step 2: Create an instrumentation file

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -1,8 +1,9 @@
 ---
 date: 2025-08-24
-tags : [SigNoz Cloud, Self-Host]
+tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
 title: Sending Metrics from your frontend application
 id: sending-metrics-frontend
+description: Send metrics from your frontend application to SigNoz
 ---
 
 This documentation provides steps for sending metrics from your frontend application to SigNoz.
@@ -18,11 +19,124 @@ Metrics can be collected on the client side at meaningful points to capture vari
 
 ## Setup
 
-### Step 1: Setup OTel Collector
+### Step 1: Install dependencies
 
-Install the OpenTelemetry Collector binary using [these instructions](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/). The Collector acts as an agent that receives, processes, and exports telemetry data. It is required to collect data from your application, including metrics.
+Install the following dependencies.
 
-You would also need to update the collector config to whitelist the frontend domain. This is required to allow Cross-Origin Resource Sharing (CORS) requests from your frontend application to the OpenTelemetry collector.
+<Tabs entityName="metrics-dependencies">
+  <TabItem value="npm" label="Npm">
+    ```sh npm i \ @opentelemetry/resources \ @opentelemetry/sdk-metrics \
+    @opentelemetry/exporter-metrics-otlp-http \ @opentelemetry/api ```
+  </TabItem>
+  <TabItem value="yarn" label="Yarn" default>
+    ```sh yarn add \ @opentelemetry/resources \ @opentelemetry/sdk-metrics \
+    @opentelemetry/exporter-metrics-otlp-http \ @opentelemetry/api ```
+  </TabItem>
+</Tabs>
+
+<details>
+<summary> Read more about the dependencies </summary>
+- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish metrics from different services in your SigNoz dashboard.
+
+- **`@opentelemetry/sdk-metrics`**: Contains the core metrics SDK implementation including `MeterProvider` and `PeriodicExportingMetricReader`. This is the foundation for creating and sending metrics from your application.
+
+- **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
+
+- **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
+  </details>
+
+### Step 2: Create an instrumentation file
+
+The instrumentation file is required to setup the `MeterProvider` which is used to create custom metrics within your application and export them to your collector.
+
+<Tabs entityName="plans">
+  <TabItem value="typescript" label="TypeScript" default>
+    ```ts:instrumentation.ts
+    import {
+      MeterProvider,
+      PeriodicExportingMetricReader,
+    } from '@opentelemetry/sdk-metrics';
+    import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+    import { resourceFromAttributes } from '@opentelemetry/resources';
+    import { metrics } from '@opentelemetry/api';
+
+    // Define your resource, e.g., service name, environment.
+    const resource = resourceFromAttributes({
+      'service.name': '<<SERVICE_NAME>>',
+    });
+
+    // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
+    const metricReader = new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        // For self-hosted version, please use the collector url instead.
+        url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/metrics`,
+        headers: {
+          'signoz-ingestion-key': <<INGESTION_KEY>>,
+        },
+      }),
+      exportIntervalMillis: 10000, // Export metrics every 10 seconds.
+    });
+
+    // Initialize a MeterProvider with the above configurations.
+    const myServiceMeterProvider = new MeterProvider({
+      resource,
+      readers: [metricReader],
+    });
+
+    // Set the initialized MeterProvider as global to enable metric collection across the app.
+    metrics.setGlobalMeterProvider(myServiceMeterProvider);
+    ```
+
+    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<<SERVICE_NAME>>` is the name of your service
+
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+    ```js:instrumentation.js
+    import {
+      MeterProvider,
+      PeriodicExportingMetricReader,
+    } from '@opentelemetry/sdk-metrics';
+    import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+    import { resourceFromAttributes } from '@opentelemetry/resources';
+    import { metrics } from '@opentelemetry/api';
+
+    // Define your resource, e.g., service name, environment.
+    const resource = resourceFromAttributes({
+      'service.name': '<<SERVICE_NAME>>',
+    });
+
+    // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
+    const metricReader = new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        // For self-hosted version, please use the collector url instead.
+        url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/metrics`,
+        headers: {
+          'signoz-ingestion-key': <<INGESTION_KEY>>,
+        },
+      }),
+      exportIntervalMillis: 10000, // Export metrics every 10 seconds.
+    });
+
+    // Initialize a MeterProvider with the above configurations.
+    const myServiceMeterProvider = new MeterProvider({
+      resource,
+      readers: [metricReader],
+    });
+
+    // Set the initialized MeterProvider as global to enable metric collection across the app.
+    metrics.setGlobalMeterProvider(myServiceMeterProvider);
+    ```
+
+    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<<SERVICE_NAME>>` is the name of your service
+
+  </TabItem>
+</Tabs>
+
+**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
 
 ```sh
 receivers:
@@ -38,193 +152,277 @@ receivers:
           allowed_headers: ['*']
 ```
 
-### Step 2: Install dependencies
+### Step 3: Importing the instrumentation file
 
-Install the following dependencies.
+Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 
-<Tabs entityName="metrics-dependencies">
-  <TabItem value="npm" label="Npm">
-    ```sh
-    npm i \
-      @opentelemetry/resources \
-      @opentelemetry/sdk-metrics \
-      @opentelemetry/exporter-metrics-otlp-http \
-      @opentelemetry/api
+<Tabs groupId="framework-choice">
+  <TabItem value="react" label="React (Vite/CRA)" default>
+    In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
+
+    ```ts:src/main.tsx
+    import './instrumentation';
+    import { StrictMode } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import './index.css';
+    import App from './App';
+
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
     ```
+
   </TabItem>
-  <TabItem value="yarn" label="Yarn" default>
-    ```sh
-    yarn add \
-      @opentelemetry/resources \
-      @opentelemetry/sdk-metrics \
-      @opentelemetry/exporter-metrics-otlp-http \
-      @opentelemetry/api
+  
+  <TabItem value="nextjs-app" label="Next.js (App Router)">
+    Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
+
+    Create `instrumentation.ts` (or `.js`) at the project root:
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (process.env.NEXT_RUNTIME === 'nodejs') {
+        // This runs on the server - you can optionally skip client instrumentation here
+        // We'll handle client-side instrumentation separately
+      }
+
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        // This runs on edge runtime
+      }
+    }
     ```
+
+    For **client-side instrumentation**, create a separate file and import it in your root layout:
+
+    ```ts:app/instrumentation-client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+    ```
+
+    Import it in your root layout:
+
+    ```tsx:app/layout.tsx
+    import './instrumentation-client';
+
+    export default function RootLayout({ children }: { children: React.ReactNode }) {
+      return (
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      );
+    }
+    ```
+
+    **Note:** Make sure to enable instrumentation in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
+    For Next.js with Pages Router, import the instrumentation in your `_app.tsx` file:
+
+    ```tsx:pages/_app.tsx
+    import '../instrumentation';
+    import type { AppProps } from 'next/app';
+
+    export default function App({ Component, pageProps }: AppProps) {
+      return <Component {...pageProps} />;
+    }
+    ```
+
+    Alternatively, you can use the `instrumentation.ts` file at the root (requires Next.js 13.2+):
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (typeof window !== 'undefined') {
+        // Client-side instrumentation
+        await import('./instrumentation-client');
+      }
+    }
+    ```
+
+    And enable it in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nuxt" label="Nuxt.js">
+    For Nuxt.js, create a plugin to initialize the instrumentation:
+
+    ```ts:plugins/instrumentation.client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+
+    export default defineNuxtPlugin(() => {
+      // Instrumentation is initialized when this plugin loads
+    });
+    ```
+
+    The `.client.ts` suffix ensures this only runs on the client side. Nuxt will automatically load this plugin during application initialization.
+
+    Alternatively, you can import it directly in `app.vue`:
+
+    ```vue:app.vue
+    <script setup>
+    import './instrumentation';
+    </script>
+
+    <template>
+      <NuxtPage />
+    </template>
+    ```
+
+  </TabItem>
+
+  <TabItem value="angular" label="Angular">
+    For Angular, import the instrumentation file at the very top of your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { bootstrapApplication } from '@angular/platform-browser';
+    import { appConfig } from './app/app.config';
+    import { AppComponent } from './app/app.component';
+
+    bootstrapApplication(AppComponent, appConfig)
+      .catch((err) => console.error(err));
+    ```
+
+    For older Angular versions using `platformBrowserDynamic`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    import { AppModule } from './app/app.module';
+
+    platformBrowserDynamic().bootstrapModule(AppModule)
+      .catch(err => console.error(err));
+    ```
+
+  </TabItem>
+
+  <TabItem value="vue" label="Vue.js">
+    For Vue.js, import the instrumentation file at the very top of your `main.ts` (or `main.js`):
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { createApp } from 'vue';
+    import App from './App.vue';
+
+    createApp(App).mount('#app');
+    ```
+
+    For Vue 2:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import Vue from 'vue';
+    import App from './App.vue';
+
+    new Vue({
+      render: h => h(App),
+    }).$mount('#app');
+    ```
+
+  </TabItem>
+
+  <TabItem value="svelte" label="Svelte/SvelteKit">
+    For **Svelte** (with Vite), import in your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import App from './App.svelte';
+
+    const app = new App({
+      target: document.getElementById('app')!,
+    });
+
+    export default app;
+    ```
+
+    For **SvelteKit**, create a hook in `src/hooks.client.ts`:
+
+    ```ts:src/hooks.client.ts
+    import './instrumentation';
+    ```
+
+    Or import it in your root layout:
+
+    ```svelte:src/routes/+layout.svelte
+    <script>
+      import '../instrumentation';
+    </script>
+
+    <slot />
+    ```
+
   </TabItem>
 </Tabs>
 
-<details>
-<summary> Read more about the dependencies </summary>
-- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish metrics from different services in your SigNoz dashboard.
-
-- **`@opentelemetry/sdk-metrics`**: Contains the core metrics SDK implementation including `MeterProvider` and `PeriodicExportingMetricReader`. This is the foundation for creating and sending metrics from your application.
-
-- **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
-
-- **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
-</details>
-
-### Step 3: Create an instrumentation file
-
-The instrumentation file is required to setup the `MeterProvider` which is used to create custom metrics within your application and export them to your collector.
-Inside your `src` directory, create a file named `instrument.js` (or `instrument.ts` for TypeScript):
-
-<Tabs entityName="logs-instrumentation">
-  <TabItem value="cloud" label="SigNoz Cloud" default>
-    ```ts:instrument.js
-      import {
-        MeterProvider,
-        PeriodicExportingMetricReader,
-      } from '@opentelemetry/sdk-metrics';
-      import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
-      import { resourceFromAttributes } from '@opentelemetry/resources';
-      import { metrics } from '@opentelemetry/api';
-
-      // Define your resource, e.g., service name, environment.
-      const resource = resourceFromAttributes({
-        'service.name': <<SERVICE_NAME>>,
-      });
-
-      // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
-      const metricReader = new PeriodicExportingMetricReader({
-        exporter: new OTLPMetricExporter({
-          url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/metrics`,
-          headers: {
-            'signoz-ingestion-key': <<INGESTION_KEY>>,
-          },
-        }),
-        exportIntervalMillis: 10000, // Export metrics every 10 seconds.
-      });
-
-      // Initialize a MeterProvider with the above configurations.
-      const myServiceMeterProvider = new MeterProvider({
-        resource,
-        readers: [metricReader],
-      });
-
-      // Set the initialized MeterProvider as global to enable metric collection across the app.
-      metrics.setGlobalMeterProvider(myServiceMeterProvider);
-    ```
-
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
-  </TabItem>
-  <TabItem value="self-hosted" label="SigNoz Self-Hosted">
-    ```ts:instrument.js
-      import {
-        MeterProvider,
-        PeriodicExportingMetricReader,
-      } from '@opentelemetry/sdk-metrics';
-      import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
-      import { resourceFromAttributes } from '@opentelemetry/resources';
-      import { metrics } from '@opentelemetry/api';
-
-      // Define your resource, e.g., service name, environment.
-      const resource = resourceFromAttributes({
-        'service.name': <<SERVICE_NAME>>,
-      });
-
-      // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
-      const metricReader = new PeriodicExportingMetricReader({
-        exporter: new OTLPMetricExporter({
-          url: '<<SIGNOZ_COLLECTOR_URL>>/v1/metrics',
-        }),
-        exportIntervalMillis: 10000, // Export metrics every 10 seconds.
-      });
-
-      // Initialize a MeterProvider with the above configurations.
-      const myServiceMeterProvider = new MeterProvider({
-        resource,
-        readers: [metricReader],
-      });
-
-      // Set the initialized MeterProvider as global to enable metric collection across the app.
-      metrics.setGlobalMeterProvider(myServiceMeterProvider);
-    ```
-
-    - `<<SERVICE_NAME>>` is the name of your service
-    - `<<SIGNOZ_COLLECTOR_URL>>` is the url where your collector is running
-  </TabItem>
-</Tabs>
-
-### Step 4: Importing the instrumentation file
-
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture metrics from the very beginning of your application's execution.
-
-```ts
-import './instrument';
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App';
-
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
-```
-
-### Step 5: Setting up Metrics within your Application
+### Step 4: Setting up Metrics within your Application
 
 Now you can create and record metrics in your application. Here's an example of how to create and use metrics.
 
 ```ts
-import { metrics } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api'
 
 // Get a meter from the global meter provider
-const meter = metrics.getMeter('my-app-metrics');
+const meter = metrics.getMeter('my-app-metrics')
 
 // Create a histogram metric for measuring request duration (also gives count & sum)
 const requestDuration = meter.createHistogram('http.client.request.duration', {
   description: 'Duration of HTTP requests',
   unit: 's', // seconds
-});
+})
 
 // Record metrics in your application
 async function handleRequest() {
-  const startTime = performance.now();
-  
+  const startTime = performance.now()
+
   try {
-    const response = await fetch('/api/data', { method: 'GET' });
+    const response = await fetch('/api/data', { method: 'GET' })
 
     // Record the request duration
-    const duration = (performance.now() - startTime) / 1000; // Convert to seconds
+    const duration = (performance.now() - startTime) / 1000 // Convert to seconds
     requestDuration.record(duration, {
       'http.request.method': 'GET',
       'http.response.status_code': response.status,
       'http.route': '/api/data',
       'url.path': '/api/data',
       'url.scheme': window.location.protocol.replace(':', ''),
-    });
+    })
 
-    return await response.json();
+    return await response.json()
   } catch (err) {
-    const duration = (performance.now() - startTime) / 1000; // Convert to seconds
+    const duration = (performance.now() - startTime) / 1000 // Convert to seconds
     requestDuration.record(duration, {
       'http.request.method': 'GET',
       'http.response.status_code': 0,
       'http.route': '/api/data',
       'url.path': '/api/data',
       'url.scheme': window.location.protocol.replace(':', ''),
-    });
-    throw err;
+    })
+    throw err
   }
 }
 ```
 
-### Step 6: Viewing Captured Metrics in SigNoz
+### Step 5: Viewing Captured Metrics in SigNoz
 
 The captured metrics can then be viewed in the [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/).
 
@@ -239,5 +437,6 @@ The captured metrics can then be viewed in the [Metrics Explorer](https://signoz
   </figcaption>
 </figure>
 
-## Demo Application  
+## Demo Application
+
 Check out this [Sample React Application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-metrics) that demonstrates sending metrics to SigNoz.

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -1,9 +1,9 @@
 ---
 date: 2025-08-24
-tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
-title: Sending Metrics from your frontend application
+tags: [SigNoz Cloud, Self-Host]
+title: Sending Metrics from your frontend using OpenTelemetry
 id: sending-metrics-frontend
-description: Send metrics from your frontend application to SigNoz
+description: Learn how to send frontend metrics to SigNoz using OpenTelemetry for complete visibility across your application.
 ---
 
 This documentation provides steps for sending metrics from your frontend application to SigNoz.
@@ -25,25 +25,33 @@ Install the following dependencies.
 
 <Tabs entityName="metrics-dependencies">
   <TabItem value="npm" label="Npm">
-    ```sh npm i \ @opentelemetry/resources \ @opentelemetry/sdk-metrics \
-    @opentelemetry/exporter-metrics-otlp-http \ @opentelemetry/api ```
+    ```sh
+    npm install @opentelemetry/resources
+    npm install @opentelemetry/sdk-metrics
+    npm install @opentelemetry/exporter-metrics-otlp-http
+    npm install @opentelemetry/api
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn" default>
-    ```sh yarn add \ @opentelemetry/resources \ @opentelemetry/sdk-metrics \
-    @opentelemetry/exporter-metrics-otlp-http \ @opentelemetry/api ```
+    ```sh
+    yarn add @opentelemetry/resources
+    yarn add @opentelemetry/sdk-metrics
+    yarn add @opentelemetry/exporter-metrics-otlp-http
+    yarn add @opentelemetry/api
+    ```
   </TabItem>
 </Tabs>
 
 <details>
 <summary> Read more about the dependencies </summary>
-- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish metrics from different services in your SigNoz dashboard.
+  - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish metrics from different services in your SigNoz dashboard.
 
-- **`@opentelemetry/sdk-metrics`**: Contains the core metrics SDK implementation including `MeterProvider` and `PeriodicExportingMetricReader`. This is the foundation for creating and sending metrics from your application.
+  - **`@opentelemetry/sdk-metrics`**: Contains the core metrics SDK implementation including `MeterProvider` and `PeriodicExportingMetricReader`. This is the foundation for creating and sending metrics from your application.
 
-- **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
+  - **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
 
-- **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
-  </details>
+  - **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
+</details>
 
 ### Step 2: Create an instrumentation file
 
@@ -62,16 +70,16 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
 
     // Define your resource, e.g., service name, environment.
     const resource = resourceFromAttributes({
-      'service.name': '<<SERVICE_NAME>>',
+      'service.name': '<SERVICE_NAME>',
     });
 
     // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
     const metricReader = new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
         // For self-hosted version, please use the collector url instead.
-        url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/metrics`,
+        url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/metrics`,
         headers: {
-          'signoz-ingestion-key': <<INGESTION_KEY>>,
+          'signoz-ingestion-key': '<INGESTION_KEY>',
         },
       }),
       exportIntervalMillis: 10000, // Export metrics every 10 seconds.
@@ -87,9 +95,9 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
     metrics.setGlobalMeterProvider(myServiceMeterProvider);
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
   <TabItem value="javascript" label="JavaScript">
@@ -104,16 +112,16 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
 
     // Define your resource, e.g., service name, environment.
     const resource = resourceFromAttributes({
-      'service.name': '<<SERVICE_NAME>>',
+      'service.name': '<SERVICE_NAME>',
     });
 
     // Create a metric reader with OTLP exporter configured to send metrics to a local collector.
     const metricReader = new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
         // For self-hosted version, please use the collector url instead.
-        url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/metrics`,
+        url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/metrics`,
         headers: {
-          'signoz-ingestion-key': <<INGESTION_KEY>>,
+          'signoz-ingestion-key': <INGESTION_KEY>,
         },
       }),
       exportIntervalMillis: 10000, // Export metrics every 10 seconds.
@@ -129,14 +137,17 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
     metrics.setGlobalMeterProvider(myServiceMeterProvider);
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
 </Tabs>
 
-**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
+<Admonition type="info">
+  For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
+  config file to allow browser requests from your frontend domain:
+</Admonition>
 
 ```sh
 receivers:
@@ -148,7 +159,7 @@ receivers:
         endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - <<YOUR_FRONTEND_URL>>
+            - <YOUR_FRONTEND_URL>
           allowed_headers: ['*']
 ```
 

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -43,7 +43,7 @@ Install the following dependencies.
 - **`@opentelemetry/exporter-metrics-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your metrics to the SigNoz collector. This handles the actual transmission of metrics data over HTTP.
 
 - **`@opentelemetry/api-metrics`**: Provides the API interface that your application code uses to create metrics. This is the main API you'll interact with when adding metrics to your code.
-</details>
+  </details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -121,7 +121,7 @@ The instrumentation file is required to setup the `MeterProvider` which is used 
         // For self-hosted version, please use the collector url instead.
         url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/metrics`,
         headers: {
-          'signoz-ingestion-key': <INGESTION_KEY>,
+          'signoz-ingestion-key': '<INGESTION_KEY>',
         },
       }),
       exportIntervalMillis: 10000, // Export metrics every 10 seconds.

--- a/data/docs/frontend-monitoring/sending-metrics.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-08-24
+date: 2025-11-06
 tags: [SigNoz Cloud, Self-Host]
 title: Sending Metrics from your frontend using OpenTelemetry
 id: sending-metrics-frontend

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -521,7 +521,7 @@ To do so, you need to write a custom implementation of `SpanProcessor` which wil
 
 <Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
-    ```ts
+    ```ts:custom-processor.ts
     import { SpanProcessor } from '@opentelemetry/sdk-trace-web';
     import { UAParser } from 'ua-parser-js';
 
@@ -579,7 +579,7 @@ To do so, you need to write a custom implementation of `SpanProcessor` which wil
 
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
-    ```js
+    ```js:custom-processor.js
     import { UAParser } from 'ua-parser-js';
 
     export const CONSTANTS = {
@@ -690,6 +690,6 @@ export async function eventHandler() {
 Check out this [full-stack application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-traces) that demonstrates sending traces from both frontend and backend to SigNoz.
 
 ## Next Steps
-- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
-- [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
+- [Sending metrics](/docs/frontend-monitoring/sending-metrics-with-opentelemetry)
+- [Sending logs](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
 - [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -688,3 +688,8 @@ export async function eventHandler() {
 ## Demo Application
 
 Check out this [full-stack application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-traces) that demonstrates sending traces from both frontend and backend to SigNoz.
+
+## Next Steps
+- [Sending metrics](/docs/frontend-monitoring/sending-logs-with-opentelemetry)
+- [Sending traces](/docs/frontend-monitoring/sending-traces-with-opentelemetry)
+- [Sending web vitals](/docs/frontend-monitoring/opentelemetry-web-vitals)

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -89,6 +89,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
     import { registerInstrumentations } from '@opentelemetry/instrumentation';
     import { resourceFromAttributes } from '@opentelemetry/resources';
+    import { ZoneContextManager } from '@opentelemetry/context-zone';
 
     const exporter = new OTLPTraceExporter({
       // For self-hosted version, please use the collector url instead.
@@ -106,7 +107,9 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
 
-    provider.register();
+    provider.register({
+      contextManager: new ZoneContextManager(),
+    });
 
     registerInstrumentations({
       instrumentations: [
@@ -141,6 +144,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
     import { registerInstrumentations } from '@opentelemetry/instrumentation';
     import { resourceFromAttributes } from '@opentelemetry/resources';
+    import { ZoneContextManager } from '@opentelemetry/context-zone';
 
     const exporter = new OTLPTraceExporter({
       // For self-hosted version, please use the collector url instead.
@@ -158,7 +162,9 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
 
-    provider.register();
+    provider.register({
+      contextManager: new ZoneContextManager(),
+    });
 
     registerInstrumentations({
       instrumentations: [
@@ -429,41 +435,6 @@ Going through each of the 3 instrumentations set up:
 
 To link your frontend and backend traces, you need to instrument your backend to send traces. Check out this [document](https://signoz.io/docs/instrumentation/overview/) to instrument your backend.
 Once done, your frontend traces should automatically get linked with your backend traces.
-
-For the purpose of this guide, we have setup a simple Node.js API with instrumentation.
-
-```ts:backend.ts
-import { NodeSDK } from '@opentelemetry/sdk-node'
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { resourceFromAttributes } from '@opentelemetry/resources'
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
-
-const sdk = new NodeSDK({
-  resource: resourceFromAttributes({
-    'service.name': '<SERVICE_NAME>',
-  }),
-  traceExporter: new OTLPTraceExporter({
-    url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
-    headers: {
-      // Optional for the self-hosted version
-      'signoz-ingestion-key': '<INGESTION_KEY>',
-    },
-  }),
-  instrumentations: [getNodeAutoInstrumentations()],
-})
-
-sdk.start()
-```
-
-```ts:backend.ts
-app.post('<api-endpoint>', (req, res) => {
-  try {
-    // Your api logic
-  } catch (error) {
-    // Your error handling logic
-  }
-})
-```
 
 ### Step 5: Viewing Captured Traces in SigNoz
 

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -191,7 +191,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
 </Admonition>
 
-```yaml
+```yaml:config.yaml
 receivers:
   otlp:
     protocols:
@@ -204,6 +204,8 @@ receivers:
             - <YOUR_FRONTEND_URL>
           allowed_headers: ['*']
 ```
+
+- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 
 Going through each of the 3 instrumentations set up:
 
@@ -244,21 +246,6 @@ Going through each of the 3 instrumentations set up:
   <TabItem value="nextjs-app" label="Next.js (App Router)">
     Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
 
-    Create `instrumentation.ts` (or `.js`) at the project root:
-
-    ```ts:instrumentation.ts
-    export async function register() {
-      if (process.env.NEXT_RUNTIME === 'nodejs') {
-        // This runs on the server - you can optionally skip client instrumentation here
-        // We'll handle client-side instrumentation separately
-      }
-
-      if (process.env.NEXT_RUNTIME === 'edge') {
-        // This runs on edge runtime
-      }
-    }
-    ```
-
     For **client-side instrumentation**, create a separate file and import it in your root layout:
 
     ```ts:app/instrumentation-client.ts
@@ -280,7 +267,7 @@ Going through each of the 3 instrumentations set up:
     }
     ```
 
-    **Note:** Make sure to enable instrumentation in `next.config.js`:
+    **Note:** Make sure to enable instrumentation in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -289,11 +276,6 @@ Going through each of the 3 instrumentations set up:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
-
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -319,7 +301,7 @@ Going through each of the 3 instrumentations set up:
     }
     ```
 
-    And enable it in `next.config.js`:
+    And enable it in `next.config.js` (Only required when using NextJs 14 and below):
 
     ```js:next.config.js
     module.exports = {
@@ -328,10 +310,6 @@ Going through each of the 3 instrumentations set up:
       },
     };
     ```
-
-    <Admonition>
-    This step is only needed when using NextJs 14 and below
-    </Admonition>
 
   </TabItem>
 

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -94,6 +94,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
       // For self-hosted version, please use the collector url instead.
       url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
       headers: {
+        // Optional for the self-hosted version
         'signoz-ingestion-key': '<INGESTION_KEY>',
       },
     });
@@ -145,6 +146,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
       // For self-hosted version, please use the collector url instead.
       url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
       headers: {
+        // Optional for the self-hosted version
         'signoz-ingestion-key': '<INGESTION_KEY>',
       },
     });
@@ -185,7 +187,8 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
 
 <Admonition type="info">
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
-  config file to allow browser requests from your frontend domain:
+  config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
+  <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
 </Admonition>
 
 ```yaml
@@ -213,7 +216,10 @@ Going through each of the 3 instrumentations set up:
 
 ### Step 3: Importing the instrumentation file
 
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+<Admonition type="info">
+  Import the instrumentation file at the top level of your application. 
+  This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
+</Admonition>
 
 <Tabs groupId="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
@@ -284,6 +290,10 @@ Import the instrumentation file at the top level of your application. This ensur
     };
     ```
 
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
+
   </TabItem>
 
   <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
@@ -318,6 +328,10 @@ Import the instrumentation file at the top level of your application. This ensur
       },
     };
     ```
+
+    <Admonition>
+    This step is only needed when using NextJs 14 and below
+    </Admonition>
 
   </TabItem>
 
@@ -453,6 +467,7 @@ const sdk = new NodeSDK({
   traceExporter: new OTLPTraceExporter({
     url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
     headers: {
+      // Optional for the self-hosted version
       'signoz-ingestion-key': '<INGESTION_KEY>',
     },
   }),
@@ -650,8 +665,12 @@ Now every span exported will include these additional contextual attributes.
 
 If you need to create custom spans for capture activity, you can do so from any handler function in your code like this.
 
-```ts
-function eventHandler() {
+```ts:manual.js
+import { context, trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('<service-name>');
+
+export async function eventHandler() {
   const span = tracer.startSpan('<span-name>');
   try {
     await context.with(trace.setSpan(context.active(), span), async () => {

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -195,23 +195,23 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
   For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
   config file to allow browser requests from your frontend domain. Also, update the endpoint and remove the ingestion key header as shown in  
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>. 
+
+  ```yaml:config.yaml
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+          cors:
+            allowed_origins:
+              - <YOUR_FRONTEND_URL>
+            allowed_headers: ['*']
+  ```
+
+  - `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 </Admonition>
-
-```yaml:config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-        cors:
-          allowed_origins:
-            - <YOUR_FRONTEND_URL>
-          allowed_headers: ['*']
-```
-
-- `<YOUR_FRONTEND_URL>` is the url pointing to your frontend application
 
 Going through each of the 3 instrumentations set up:
 

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -1,11 +1,12 @@
 ---
 date: 2025-08-17
-tags : [SigNoz Cloud, Self-Host]
+tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
 title: Sending Traces from your frontend application
 id: sending-traces-frontend
+description: Send traces from your frontend application to SigNoz
 ---
 
-This documentation provides steps for sending traces from your frontend application to SigNoz.  
+This documentation provides steps for sending traces from your frontend application to SigNoz.
 
 SigNoz natively supports OpenTelemetry for collecting traces, so you can instrument your frontend applications with minimal setup and get deep visibility into user interactions and network activity.
 
@@ -18,58 +19,24 @@ Client side traces help you understand how user actions trigger requests, how lo
 
 ## Setup
 
-### Step 1: Setup OTel Collector
-
-Install the OpenTelemetry Collector binary using [these instructions](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/). The Collector acts as an agent that receives, processes, and exports telemetry data. It is required to collect data from your application, including traces.
-
-You would also need to update the collector config to whitelist the frontend domain. This is required to allow Cross-Origin Resource Sharing (CORS) requests from your frontend application to the OpenTelemetry collector.
-
-```sh
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-        cors:
-          allowed_origins:
-            - <<YOUR_FRONTEND_URL>>
-          allowed_headers: ['*']
-```
-
-### Step 2: Install dependencies
+### Step 1: Install dependencies
 
 Install the following dependencies.
 
 <Tabs groupId="traces-dependencies">
   <TabItem value="npm" label="Npm">
-    ```sh
-    npm i \
-      @opentelemetry/sdk-trace-base \
-      @opentelemetry/sdk-trace-web \
-      @opentelemetry/exporter-trace-otlp-http \
-      @opentelemetry/instrumentation \
-      @opentelemetry/instrumentation-fetch \
-      @opentelemetry/instrumentation-xml-http-request \
-      @opentelemetry/context-zone \
-      @opentelemetry/resources \
-      @opentelemetry/instrumentation-user-interaction
-    ```
+    ```sh npm i \ @opentelemetry/sdk-trace-base \ @opentelemetry/sdk-trace-web \
+    @opentelemetry/exporter-trace-otlp-http \ @opentelemetry/instrumentation \
+    @opentelemetry/instrumentation-fetch \ @opentelemetry/instrumentation-xml-http-request \
+    @opentelemetry/context-zone \ @opentelemetry/resources \
+    @opentelemetry/instrumentation-user-interaction ```
   </TabItem>
   <TabItem value="yarn" label="Yarn" default>
-    ```sh
-    yarn add \
-      @opentelemetry/sdk-trace-base \
-      @opentelemetry/sdk-trace-web \
-      @opentelemetry/exporter-trace-otlp-http \
-      @opentelemetry/instrumentation \
-      @opentelemetry/instrumentation-fetch \
-      @opentelemetry/instrumentation-xml-http-request \
-      @opentelemetry/context-zone \
-      @opentelemetry/resources \
-      @opentelemetry/instrumentation-user-interaction
-    ```
+    ```sh yarn add \ @opentelemetry/sdk-trace-base \ @opentelemetry/sdk-trace-web \
+    @opentelemetry/exporter-trace-otlp-http \ @opentelemetry/instrumentation \
+    @opentelemetry/instrumentation-fetch \ @opentelemetry/instrumentation-xml-http-request \
+    @opentelemetry/context-zone \ @opentelemetry/resources \
+    @opentelemetry/instrumentation-user-interaction ```
   </TabItem>
 </Tabs>
 
@@ -92,23 +59,26 @@ Install the following dependencies.
 - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish traces from different services in your SigNoz dashboard.
 
 - **`@opentelemetry/instrumentation-user-interaction`**: Automatically instruments user interactions like clicks, inputs, and form submissions. This helps correlate user actions with resulting operations and provides insights into user behavior.
-</details>
+  </details>
 
-### Step 3: Create an instrumentation file
+### Step 2: Create an instrumentation file
 
 The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTracerProvider` which are used to capture traces within your application and export them to your collector.
 
 <Tabs entityName="plans">
-  <TabItem value="cloud" label="SigNoz Cloud" default>
-    ```ts
+  <TabItem value="typescript" label="TypeScript" default>
+    ```ts:instrumentation.ts
     import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
     import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
     import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
     import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+    import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
+    import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
     import { registerInstrumentations } from '@opentelemetry/instrumentation';
     import { resourceFromAttributes } from '@opentelemetry/resources';
 
     const exporter = new OTLPTraceExporter({
+      // For self-hosted version, please use the collector url instead.
       url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/traces`,
       headers: {
         'signoz-ingestion-key': <<INGESTION_KEY>>,
@@ -145,18 +115,25 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
     - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
     - `<<SERVICE_NAME>>` is the name of your service
+
   </TabItem>
-  <TabItem value="self-hosted" label="SigNoz Self-Hosted">
-    ```ts
+  <TabItem value="javascript" label="JavaScript">
+    ```js:instrumentation.js
     import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
     import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
     import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
     import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+    import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
+    import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
     import { registerInstrumentations } from '@opentelemetry/instrumentation';
     import { resourceFromAttributes } from '@opentelemetry/resources';
 
     const exporter = new OTLPTraceExporter({
-      url: '<<SIGNOZ_COLLECTOR_URL>>/v1/traces',
+      // For self-hosted version, please use the collector url instead.
+      url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/traces`,
+      headers: {
+        'signoz-ingestion-key': <<INGESTION_KEY>>,
+      },
     });
 
     const provider = new WebTracerProvider({
@@ -186,10 +163,29 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     });
     ```
 
+    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
     - `<<SERVICE_NAME>>` is the name of your service
     - `<<SIGNOZ_COLLECTOR_URL>>` is the url where your collector is running
+
   </TabItem>
 </Tabs>
+
+**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
+
+```sh
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - <<YOUR_FRONTEND_URL>>
+          allowed_headers: ['*']
+```
 
 Going through each of the 3 instrumentations set up:
 
@@ -200,37 +196,240 @@ Going through each of the 3 instrumentations set up:
 - `UserInteractionInstrumentation` – Tracks meaningful user actions like clicks, form inputs, and submissions. This helps correlate user intent with resulting operations like network requests or page changes.  
   For example, you can trace that a backend request was triggered by a button click.
 
+### Step 3: Importing the instrumentation file
 
-### Step 4: Importing the instrumentation file
+Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 
-Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture logs from the very beginning of your application's execution.
+<Tabs groupId="framework-choice">
+  <TabItem value="react" label="React (Vite/CRA)" default>
+    In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
 
-```ts
-import './instrument';
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App';
+    ```ts:src/main.tsx
+    import './instrumentation';
+    import { StrictMode } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import './index.css';
+    import App from './App';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
-```
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+    ```
 
-### Step 5: Linking frontend traces with backend
+  </TabItem>
+  
+  <TabItem value="nextjs-app" label="Next.js (App Router)">
+    Next.js (App Router) supports instrumentation through a special `instrumentation.ts` file at the root of your project (or inside `src/` if using the `src` directory).
 
-To link your frontend and backend traces, you need to instrument your backend to send traces. Check out this [document](https://signoz.io/docs/instrumentation/overview/) to instrument your backend. 
-Once done, your frontend traces should automatically get linked with your backend traces.  
+    Create `instrumentation.ts` (or `.js`) at the project root:
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (process.env.NEXT_RUNTIME === 'nodejs') {
+        // This runs on the server - you can optionally skip client instrumentation here
+        // We'll handle client-side instrumentation separately
+      }
+
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        // This runs on edge runtime
+      }
+    }
+    ```
+
+    For **client-side instrumentation**, create a separate file and import it in your root layout:
+
+    ```ts:app/instrumentation-client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+    ```
+
+    Import it in your root layout:
+
+    ```tsx:app/layout.tsx
+    import './instrumentation-client';
+
+    export default function RootLayout({ children }: { children: React.ReactNode }) {
+      return (
+        <html lang="en">
+          <body>{children}</body>
+        </html>
+      );
+    }
+    ```
+
+    **Note:** Make sure to enable instrumentation in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nextjs-pages" label="Next.js (Pages Router)">
+    For Next.js with Pages Router, import the instrumentation in your `_app.tsx` file:
+
+    ```tsx:pages/_app.tsx
+    import '../instrumentation';
+    import type { AppProps } from 'next/app';
+
+    export default function App({ Component, pageProps }: AppProps) {
+      return <Component {...pageProps} />;
+    }
+    ```
+
+    Alternatively, you can use the `instrumentation.ts` file at the root (requires Next.js 13.2+):
+
+    ```ts:instrumentation.ts
+    export async function register() {
+      if (typeof window !== 'undefined') {
+        // Client-side instrumentation
+        await import('./instrumentation-client');
+      }
+    }
+    ```
+
+    And enable it in `next.config.js`:
+
+    ```js:next.config.js
+    module.exports = {
+      experimental: {
+        instrumentationHook: true,
+      },
+    };
+    ```
+
+  </TabItem>
+
+  <TabItem value="nuxt" label="Nuxt.js">
+    For Nuxt.js, create a plugin to initialize the instrumentation:
+
+    ```ts:plugins/instrumentation.client.ts
+    // Your OpenTelemetry instrumentation code here
+    // (the code from Step 2)
+
+    export default defineNuxtPlugin(() => {
+      // Instrumentation is initialized when this plugin loads
+    });
+    ```
+
+    The `.client.ts` suffix ensures this only runs on the client side. Nuxt will automatically load this plugin during application initialization.
+
+    Alternatively, you can import it directly in `app.vue`:
+
+    ```vue:app.vue
+    <script setup>
+    import './instrumentation';
+    </script>
+
+    <template>
+      <NuxtPage />
+    </template>
+    ```
+
+  </TabItem>
+
+  <TabItem value="angular" label="Angular">
+    For Angular, import the instrumentation file at the very top of your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { bootstrapApplication } from '@angular/platform-browser';
+    import { appConfig } from './app/app.config';
+    import { AppComponent } from './app/app.component';
+
+    bootstrapApplication(AppComponent, appConfig)
+      .catch((err) => console.error(err));
+    ```
+
+    For older Angular versions using `platformBrowserDynamic`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    import { AppModule } from './app/app.module';
+
+    platformBrowserDynamic().bootstrapModule(AppModule)
+      .catch(err => console.error(err));
+    ```
+
+  </TabItem>
+
+  <TabItem value="vue" label="Vue.js">
+    For Vue.js, import the instrumentation file at the very top of your `main.ts` (or `main.js`):
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import { createApp } from 'vue';
+    import App from './App.vue';
+
+    createApp(App).mount('#app');
+    ```
+
+    For Vue 2:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import Vue from 'vue';
+    import App from './App.vue';
+
+    new Vue({
+      render: h => h(App),
+    }).$mount('#app');
+    ```
+
+  </TabItem>
+
+  <TabItem value="svelte" label="Svelte/SvelteKit">
+    For **Svelte** (with Vite), import in your `main.ts`:
+
+    ```ts:src/main.ts
+    import './instrumentation';
+    import App from './App.svelte';
+
+    const app = new App({
+      target: document.getElementById('app')!,
+    });
+
+    export default app;
+    ```
+
+    For **SvelteKit**, create a hook in `src/hooks.client.ts`:
+
+    ```ts:src/hooks.client.ts
+    import './instrumentation';
+    ```
+
+    Or import it in your root layout:
+
+    ```svelte:src/routes/+layout.svelte
+    <script>
+      import '../instrumentation';
+    </script>
+
+    <slot />
+    ```
+
+  </TabItem>
+</Tabs>
+
+### Step 4: Linking frontend traces with backend
+
+To link your frontend and backend traces, you need to instrument your backend to send traces. Check out this [document](https://signoz.io/docs/instrumentation/overview/) to instrument your backend.
+Once done, your frontend traces should automatically get linked with your backend traces.
 
 For the purpose of this guide, we have setup a simple Node.js API with instrumentation.
 
 ```ts
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
@@ -240,9 +439,9 @@ const sdk = new NodeSDK({
     url: '<<SIGNOZ_COLLECTOR_URL>>/v1/traces',
   }),
   instrumentations: [getNodeAutoInstrumentations()],
-});
+})
 
-sdk.start();
+sdk.start()
 ```
 
 ```ts
@@ -252,10 +451,10 @@ app.post('<<api-endpoint>>', (req, res) => {
   } catch (error) {
     // Your error handling logic
   }
-});
+})
 ```
 
-### Step 6: Viewing Captured Traces in SigNoz
+### Step 5: Viewing Captured Traces in SigNoz
 
 The captured traces can then be viewed in the [Traces Explorer](https://signoz.io/docs/product-features/trace-explorer/).
 
@@ -281,13 +480,13 @@ The captured traces can then be viewed in the [Traces Explorer](https://signoz.i
   </figcaption>
 </figure>
 
-## Attaching additional identifiers to your Traces
+### Attaching additional identifiers to your Traces
 
 You can enrich traces with additional metadata like browser type, user ID etc. to enable real user monitoring (RUM)-like insights.
 
 To do so, you need to write a custom implementation of `SpanProcessor` which will intercept all your exported spans and attach additional attributes to them.
 
-<Tabs groupId="traces-processor">
+<Tabs entityName="plans">
   <TabItem value="ts" label="TypeScript">
     ```ts
     import { SpanProcessor } from '@opentelemetry/sdk-trace-web';
@@ -344,6 +543,7 @@ To do so, you need to write a custom implementation of `SpanProcessor` which wil
 
     export default CustomSpanProcessor;
     ```
+
   </TabItem>
   <TabItem value="js" label="JavaScript" default>
     ```js
@@ -400,6 +600,7 @@ To do so, you need to write a custom implementation of `SpanProcessor` which wil
 
     export default CustomSpanProcessor;
     ```
+
   </TabItem>
 </Tabs>
 
@@ -411,7 +612,7 @@ const provider = new WebTracerProvider({
     'service.name': 'text-generator',
   }),
   spanProcessors: [new BatchSpanProcessor(exporter), CustomSpanProcessor],
-});
+})
 ```
 
 Now every span exported will include these additional contextual attributes.
@@ -427,25 +628,26 @@ Now every span exported will include these additional contextual attributes.
   </figcaption>
 </figure>
 
-## Manual Instrumentation
+### Manual Instrumentation
 
 If you need to create custom spans for capture activity, you can do so from any handler function in your code like this.
 
 ```ts
 function eventHandler() {
-  const span = tracer.startSpan('<<span-name>>');
+  const span = tracer.startSpan('<<span-name>>')
   try {
     await context.with(trace.setSpan(context.active(), span), async () => {
       // Your data fetching logic
-    });
+    })
   } catch (err) {
     // Your error fetching log
   } finally {
     // Close the span
-    span.end();
+    span.end()
   }
-};
+}
 ```
-## Demo Application  
 
-Check out this [full-stack application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-traces) that demonstrates sending traces from both frontend and backend to SigNoz. 
+## Demo Application
+
+Check out this [full-stack application](https://github.com/SigNoz/frontend-monitoring-examples/tree/main/sending-traces) that demonstrates sending traces from both frontend and backend to SigNoz.

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -59,7 +59,7 @@ Install the following dependencies.
 - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish traces from different services in your SigNoz dashboard.
 
 - **`@opentelemetry/instrumentation-user-interaction`**: Automatically instruments user interactions like clicks, inputs, and form submissions. This helps correlate user actions with resulting operations and provides insights into user behavior.
-  </details>
+</details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -188,7 +188,7 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
   config file to allow browser requests from your frontend domain:
 </Admonition>
 
-```sh
+```yaml
 receivers:
   otlp:
     protocols:
@@ -440,7 +440,7 @@ Once done, your frontend traces should automatically get linked with your backen
 
 For the purpose of this guide, we have setup a simple Node.js API with instrumentation.
 
-```ts
+```ts:backend.ts
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
@@ -451,7 +451,10 @@ const sdk = new NodeSDK({
     'service.name': '<SERVICE_NAME>',
   }),
   traceExporter: new OTLPTraceExporter({
-    url: '<SIGNOZ_COLLECTOR_URL>/v1/traces',
+    url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
+    headers: {
+      'signoz-ingestion-key': '<INGESTION_KEY>',
+    },
   }),
   instrumentations: [getNodeAutoInstrumentations()],
 })
@@ -459,7 +462,7 @@ const sdk = new NodeSDK({
 sdk.start()
 ```
 
-```ts
+```ts:backend.ts
 app.post('<api-endpoint>', (req, res) => {
   try {
     // Your api logic

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -59,7 +59,7 @@ Install the following dependencies.
 - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish traces from different services in your SigNoz dashboard.
 
 - **`@opentelemetry/instrumentation-user-interaction`**: Automatically instruments user interactions like clicks, inputs, and form submissions. This helps correlate user actions with resulting operations and provides insights into user behavior.
-</details>
+  </details>
 
 ### Step 2: Create an instrumentation file
 

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -183,7 +183,10 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
   </TabItem>
 </Tabs>
 
-**Note:** Please make sure to whitelist your frontend domain when using the self-hosted version
+<Admonition type="info">
+  For self-hosted deployments, add the following CORS configuration to your OpenTelemetry Collector
+  config file to allow browser requests from your frontend domain:
+</Admonition>
 
 ```sh
 receivers:

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-08-17
+date: 2025-11-06
 tags: [SigNoz Cloud, Self-Host]
 title: Sending Traces from your frontend application using OpenTelemetry
 id: sending-traces-frontend

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -1,9 +1,9 @@
 ---
 date: 2025-08-17
-tags: [SigNoz Cloud, Self-Host, Frontend, JavaScript]
-title: Sending Traces from your frontend application
+tags: [SigNoz Cloud, Self-Host]
+title: Sending Traces from your frontend application using OpenTelemetry
 id: sending-traces-frontend
-description: Send traces from your frontend application to SigNoz
+description: Learn how to send frontend traces to SigNoz using OpenTelemetry for complete visibility across your application.
 ---
 
 This documentation provides steps for sending traces from your frontend application to SigNoz.
@@ -25,18 +25,30 @@ Install the following dependencies.
 
 <Tabs groupId="traces-dependencies">
   <TabItem value="npm" label="Npm">
-    ```sh npm i \ @opentelemetry/sdk-trace-base \ @opentelemetry/sdk-trace-web \
-    @opentelemetry/exporter-trace-otlp-http \ @opentelemetry/instrumentation \
-    @opentelemetry/instrumentation-fetch \ @opentelemetry/instrumentation-xml-http-request \
-    @opentelemetry/context-zone \ @opentelemetry/resources \
-    @opentelemetry/instrumentation-user-interaction ```
+    ```sh
+    npm install @opentelemetry/sdk-trace-base
+    npm install @opentelemetry/sdk-trace-web
+    npm install @opentelemetry/exporter-trace-otlp-http
+    npm install @opentelemetry/instrumentation
+    npm install @opentelemetry/instrumentation-fetch
+    npm install @opentelemetry/instrumentation-xml-http-request
+    npm install @opentelemetry/context-zone
+    npm install @opentelemetry/resources
+    npm install @opentelemetry/instrumentation-user-interaction
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn" default>
-    ```sh yarn add \ @opentelemetry/sdk-trace-base \ @opentelemetry/sdk-trace-web \
-    @opentelemetry/exporter-trace-otlp-http \ @opentelemetry/instrumentation \
-    @opentelemetry/instrumentation-fetch \ @opentelemetry/instrumentation-xml-http-request \
-    @opentelemetry/context-zone \ @opentelemetry/resources \
-    @opentelemetry/instrumentation-user-interaction ```
+    ```sh
+    yarn add @opentelemetry/sdk-trace-base
+    yarn add @opentelemetry/sdk-trace-web
+    yarn add @opentelemetry/exporter-trace-otlp-http
+    yarn add @opentelemetry/instrumentation
+    yarn add @opentelemetry/instrumentation-fetch
+    yarn add @opentelemetry/instrumentation-xml-http-request
+    yarn add @opentelemetry/context-zone
+    yarn add @opentelemetry/resources
+    yarn add @opentelemetry/instrumentation-user-interaction
+    ```
   </TabItem>
 </Tabs>
 
@@ -79,15 +91,15 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
 
     const exporter = new OTLPTraceExporter({
       // For self-hosted version, please use the collector url instead.
-      url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/traces`,
+      url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
       headers: {
-        'signoz-ingestion-key': <<INGESTION_KEY>>,
+        'signoz-ingestion-key': '<INGESTION_KEY>',
       },
     });
 
     const provider = new WebTracerProvider({
       resource: resourceFromAttributes({
-        'service.name': '<<SERVICE_NAME>>',
+        'service.name': '<SERVICE_NAME>',
       }),
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
@@ -112,9 +124,9 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     });
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
   <TabItem value="javascript" label="JavaScript">
@@ -130,15 +142,15 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
 
     const exporter = new OTLPTraceExporter({
       // For self-hosted version, please use the collector url instead.
-      url: `https://ingest.<<INGESTION_REGION>>.signoz.cloud:443/v1/traces`,
+      url: `https://ingest.<INGESTION_REGION>.signoz.cloud:443/v1/traces`,
       headers: {
-        'signoz-ingestion-key': <<INGESTION_KEY>>,
+        'signoz-ingestion-key': '<INGESTION_KEY>',
       },
     });
 
     const provider = new WebTracerProvider({
       resource: resourceFromAttributes({
-        'service.name': '<<SERVICE_NAME>>',
+        'service.name': '<SERVICE_NAME>',
       }),
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
@@ -163,10 +175,9 @@ The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTr
     });
     ```
 
-    - Set the `<<INGESTION_REGION>>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-    - Replace `<<INGESTION_KEY>>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
-    - `<<SERVICE_NAME>>` is the name of your service
-    - `<<SIGNOZ_COLLECTOR_URL>>` is the url where your collector is running
+    - Set the `<INGESTION_REGION>` to match your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+    - Replace `<INGESTION_KEY>` with your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+    - `<SERVICE_NAME>` is the name of your service
 
   </TabItem>
 </Tabs>
@@ -183,7 +194,7 @@ receivers:
         endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - <<YOUR_FRONTEND_URL>>
+            - <YOUR_FRONTEND_URL>
           allowed_headers: ['*']
 ```
 
@@ -433,10 +444,10 @@ import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentation
 
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
-    'service.name': '<<SERVICE_NAME>>',
+    'service.name': '<SERVICE_NAME>',
   }),
   traceExporter: new OTLPTraceExporter({
-    url: '<<SIGNOZ_COLLECTOR_URL>>/v1/traces',
+    url: '<SIGNOZ_COLLECTOR_URL>/v1/traces',
   }),
   instrumentations: [getNodeAutoInstrumentations()],
 })
@@ -445,7 +456,7 @@ sdk.start()
 ```
 
 ```ts
-app.post('<<api-endpoint>>', (req, res) => {
+app.post('<api-endpoint>', (req, res) => {
   try {
     // Your api logic
   } catch (error) {
@@ -634,16 +645,16 @@ If you need to create custom spans for capture activity, you can do so from any 
 
 ```ts
 function eventHandler() {
-  const span = tracer.startSpan('<<span-name>>')
+  const span = tracer.startSpan('<span-name>');
   try {
     await context.with(trace.setSpan(context.active(), span), async () => {
       // Your data fetching logic
-    })
+    });
   } catch (err) {
     // Your error fetching log
   } finally {
     // Close the span
-    span.end()
+    span.end();
   }
 }
 ```

--- a/data/docs/frontend-monitoring/sending-traces.mdx
+++ b/data/docs/frontend-monitoring/sending-traces.mdx
@@ -53,25 +53,26 @@ Install the following dependencies.
 </Tabs>
 
 <details>
-<summary> Read more about the dependencies </summary>
-- **`@opentelemetry/sdk-trace-base`**: Contains the core tracing SDK implementation including `BatchSpanProcessor` and base classes. This provides the foundation for creating and processing trace spans.
+  <summary> Read more about the dependencies </summary>
 
-- **`@opentelemetry/sdk-trace-web`**: Provides the `WebTracerProvider` specifically designed for browser environments. This is essential for web applications as it handles browser-specific tracing requirements.
+  - **`@opentelemetry/sdk-trace-base`**: Contains the core tracing SDK implementation including `BatchSpanProcessor` and base classes. This provides the foundation for creating and processing trace spans.
 
-- **`@opentelemetry/exporter-trace-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your traces to the SigNoz collector. This handles the actual transmission of trace data over HTTP.
+  - **`@opentelemetry/sdk-trace-web`**: Provides the `WebTracerProvider` specifically designed for browser environments. This is essential for web applications as it handles browser-specific tracing requirements.
 
-- **`@opentelemetry/instrumentation`**: Provides the `registerInstrumentations` function that allows you to register multiple instrumentations at once. This is the main API for setting up automatic instrumentation.
+  - **`@opentelemetry/exporter-trace-otlp-http`**: Implements the OTLP (OpenTelemetry Protocol) HTTP exporter that sends your traces to the SigNoz collector. This handles the actual transmission of trace data over HTTP.
 
-- **`@opentelemetry/instrumentation-fetch`**: Automatically instruments `fetch()` API calls to capture spans for network requests. This is crucial for tracking HTTP requests from your frontend to backend services.
+  - **`@opentelemetry/instrumentation`**: Provides the `registerInstrumentations` function that allows you to register multiple instrumentations at once. This is the main API for setting up automatic instrumentation.
 
-- **`@opentelemetry/instrumentation-xml-http-request`**: Instruments legacy XMLHttpRequest calls for older code or libraries that don't use `fetch`. This ensures all network requests are captured regardless of the HTTP client used.
+  - **`@opentelemetry/instrumentation-fetch`**: Automatically instruments `fetch()` API calls to capture spans for network requests. This is crucial for tracking HTTP requests from your frontend to backend services.
 
-- **`@opentelemetry/context-zone`**: Provides context propagation for browser environments using Zone.js. This is essential for maintaining trace context across async operations and ensuring proper distributed tracing.
+  - **`@opentelemetry/instrumentation-xml-http-request`**: Instruments legacy XMLHttpRequest calls for older code or libraries that don't use `fetch`. This ensures all network requests are captured regardless of the HTTP client used.
 
-- **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish traces from different services in your SigNoz dashboard.
+  - **`@opentelemetry/context-zone`**: Provides context propagation for browser environments using Zone.js. This is essential for maintaining trace context across async operations and ensuring proper distributed tracing.
 
-- **`@opentelemetry/instrumentation-user-interaction`**: Automatically instruments user interactions like clicks, inputs, and form submissions. This helps correlate user actions with resulting operations and provides insights into user behavior.
-  </details>
+  - **`@opentelemetry/resources`**: Provides resource attributes that identify your service (like service name, version, etc.). This helps distinguish traces from different services in your SigNoz dashboard.
+
+  - **`@opentelemetry/instrumentation-user-interaction`**: Automatically instruments user interactions like clicks, inputs, and form submissions. This helps correlate user actions with resulting operations and provides insights into user behavior.
+</details>
 
 ### Step 2: Create an instrumentation file
 

--- a/next.config.js
+++ b/next.config.js
@@ -441,6 +441,21 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/docs/frontend-monitoring/sending-logs/',
+          destination: '/docs/frontend-monitoring/sending-logs-with-opentelemetry/',
+          permanent: true,
+        },
+        {
+          source: '/docs/frontend-monitoring/sending-metrics/',
+          destination: '/docs/frontend-monitoring/sending-metrics-with-opentelemetry/',
+          permanent: true,
+        },
+        {
+          source: '/docs/frontend-monitoring/sending-traces/',
+          destination: '/docs/frontend-monitoring/sending-traces-with-opentelemetry/',
+          permanent: true,
+        },
+        {
           source: '/guides/unified-observability/',
           destination: '/unified-observability/',
           permanent: true,


### PR DESCRIPTION
- Update the other frontend monitoring docs to follow the same conventions that were discussed in https://github.com/SigNoz/signoz.io/pull/1796
- Update the doc to ensure that users using different frameworks (next, nuxt angular) can use the docs reliably. Our docs for sending logs, traces, metric are already framework agnostic. Just added another section in the end to handle special cases for Nextjs and Nuxt. Added code examples for all popular frameworks
- All docs using ES2020 code snippets