### PR TITLE
Remove self-referential links from Temporal doc

### DIFF
--- a/data/docs/integrations/temporal-typescript-opentelemetry.mdx
+++ b/data/docs/integrations/temporal-typescript-opentelemetry.mdx
@@ -30,7 +30,9 @@ You should open the repo and browse the code and files as we go through the doc 
     "@temporalio/workflow": "^1.11.6",
 ```
 
-### Step 2: Configure OpenTelemetry SDK ([link](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/instrumentation.ts))
+### Step 2: Configure OpenTelemetry SDK
+
+Source code reference: [instrumentation.ts](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/instrumentation.ts).
 Create `src/instrumentation.ts` to configure the OpenTelemetry SDK and initialize tracing and metrics for your Temporal application:
 ```typescript:src/instrumentation.ts
 // OpenTelemetry's Node.js documentation recommends to setup instrumentation from a
@@ -177,7 +179,9 @@ try {
 This interceptor enables automatic tracing and metrics collection for your Temporal workflows.
 
 
-### Step 3: Add OpenTelemetry Interceptor to the client code ([link](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/client.ts))
+### Step 3: Add OpenTelemetry Interceptor to the client code
+
+Source code reference: [client.ts](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/client.ts).
 
 Add the OpenTelemetry interceptor to your Temporal client configuration:
 
@@ -210,7 +214,9 @@ finally {
 This interceptor enables automatic tracing and metrics collection for your Temporal workflows.
 
 
-### Step 4: Configure Temporal Worker Code ([link](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/worker.ts))
+### Step 4: Configure Temporal Worker Code
+
+Source code reference: [worker.ts](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/worker.ts).
 
 Add OpenTelemetry instrumentation to your worker:
 
@@ -285,7 +291,9 @@ Make sure to import `instrumentation.ts` as the first line in your imports else 
 This configuration enables OpenTelemetry instrumentation for both workflow and activity telemetry in your Temporal worker.
 
 
-### Step 5: Configure Temporal Workflow Code ([link](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/workflows.ts))
+### Step 5: Configure Temporal Workflow Code
+
+Source code reference: [workflows.ts](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/workflows.ts).
 
 Add OpenTelemetry interceptors to your workflow code:
 
@@ -310,7 +318,9 @@ These interceptors enable telemetry collection for inbound signals, outbound act
 
 
 
-### Step 6: Configure logger ([link](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/logger.ts))
+### Step 6: Configure logger
+
+Source code reference: [logger.ts](https://github.com/SigNoz/temporal-typescript-opentelemetry/blob/main/src/logger.ts).
 
 Connect winston logger with temporal logger and otel logger
 

--- a/data/docs/integrations/temporal-typescript-opentelemetry.mdx
+++ b/data/docs/integrations/temporal-typescript-opentelemetry.mdx
@@ -1,8 +1,9 @@
 ---
 date: 2025-04-23
 id: temporal-typescript-opentelemetry
-tags : [SigNoz Cloud, Self-Host]
+tags: [SigNoz Cloud, Self-Host]
 title: Instrumenting a Temporal application in typescript with OpenTelemetry
+description: Learn how to instrument a Temporal TypeScript application with OpenTelemetry and export data to SigNoz.
 ---
 
 


### PR DESCRIPTION
## Summary
- remove the self-referential published guide notes under each step heading in the Temporal TypeScript integration doc to address review feedback

------
https://chatgpt.com/codex/tasks/task_e_690881eada788326a28fc092e237c7b8