### PR TITLE
chore: refine GitHub workflows for PR handling and tool updates

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -35,7 +35,9 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: ${{ vars.APP_ID && secrets.APP_PRIVATE_KEY }}
+        # Run when an App is configured AND we're not in a forked PR context
+        # (secrets are unavailable for forked pull_request events).
+        if: ${{ vars.APP_ID && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b
         with:
           app-id: ${{ vars.APP_ID }}
@@ -122,7 +124,6 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number || github.event.issue.number }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          web_search: enabled
           track_progress: true # ✨ Enables tracking comments
           prompt: |
             REPO: ${{ github.repository }}
@@ -148,4 +149,4 @@ jobs:
             - Do not paste large fetched content into comments; instead summarize and cite the canonical link.
 
           claude_args: |
-            --allowedTools "web_search,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cat:*),Bash(curl:*),Bash(grep:*),Bash(head:*),Bash(tail:*)"
+            --allowedTools "WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cat:*),Bash(curl:*),Bash(grep:*),Bash(head:*),Bash(tail:*)"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -33,11 +33,25 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Check GitHub App private key
+        id: check_app_private_key
+        # Only runs when the workflow has access to secrets (non-fork contexts).
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        run: |
+          set -euo pipefail
+          if [ -n "${APP_PRIVATE_KEY}" ]; then
+            echo "has_private_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_private_key=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Mint identity token
         id: mint_identity_token
         # Run when an App is configured AND we're not in a forked PR context
         # (secrets are unavailable for forked pull_request events).
-        if: ${{ vars.APP_ID && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        if: ${{ vars.APP_ID && steps.check_app_private_key.outputs.has_private_key == 'true' }}
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b
         with:
           app-id: ${{ vars.APP_ID }}

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -7,19 +7,6 @@ on:
   pull_request_review:
     types:
       - 'submitted'
-  pull_request:
-    types:
-      - 'opened'
-      - 'synchronize'
-      - 'reopened'
-      - 'ready_for_review'
-    paths:
-      - 'data/docs/**'
-      - 'public/img/docs/**'
-      - 'constants/docsSideNav.ts'
-      - 'next.config.js'
-      - 'scripts/check-doc-redirects.js'
-      - 'scripts/check-docs-metadata.js'
   issue_comment:
     types:
       - 'created'
@@ -49,17 +36,11 @@ jobs:
           env | grep '^DEBUG_'
 
   dispatch:
-    # For PRs: only if not from a fork
-    # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
+    # Only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
     if: |-
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false
-      ) || (
-        github.event.sender.type == 'User' &&
-        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
-      )
+      github.event.sender.type == 'User' &&
+      startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -91,24 +72,14 @@ jobs:
           REQUEST: '${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}'
         with:
           script: |
-            const eventType = process.env.EVENT_TYPE;
             const request = process.env.REQUEST;
             core.setOutput('request', request);
 
-            const prAutoReviewEvents = new Set([
-              'pull_request.opened',
-              'pull_request.synchronize',
-              'pull_request.reopened',
-              'pull_request.ready_for_review',
-            ]);
-
-            if (prAutoReviewEvents.has(eventType)) {
-              core.setOutput('command', 'review');
-            } else if (request.startsWith("@gemini-cli /review")) {
+            if (request && request.startsWith("@gemini-cli /review")) {
               core.setOutput('command', 'review');
               const additionalContext = request.replace(/^@gemini-cli \/review/, '').trim();
               core.setOutput('additional_context', additionalContext);
-            } else if (request.startsWith("@gemini-cli")) {
+            } else if (request && request.startsWith("@gemini-cli")) {
               const additionalContext = request.replace(/^@gemini-cli/, '').trim();
               core.setOutput('command', 'invoke');
               core.setOutput('additional_context', additionalContext);

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -19,7 +19,6 @@ defaults:
 jobs:
   review:
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 7
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
- Update claude-pr-review.yaml to conditionally mint identity tokens only for non-forked PRs, remove web_search enablement, and rename tools to WebSearch/WebFetch
- Simplify gemini-dispatch.yml by removing PR auto-review triggers and logic, focusing solely on @gemini-cli comment-based dispatching for authorized users