### PR TITLE
docs: update docker docs

### DIFF
--- a/data/docs/userguide/collect_docker_logs.mdx
+++ b/data/docs/userguide/collect_docker_logs.mdx
@@ -48,8 +48,8 @@ service:
 ```
 
 <Admonition type="note">
-If your logs are coming from Kubernetes Pod log file paths (for example, /var/log/pods/... or /var/log/containers/...), rather than directly from Docker container log files on the host, then set
-add_metadata_from_filepath: true, in the container parser operator so that Kubernetes metadata (such as pod name, namespace, and container name) can be automatically extracted from the file path.
+If your logs originate from Kubernetes pod log file paths (for example, `/var/log/pods/...` or `/var/log/containers/...`) instead of Docker container log files on the host, set `add_metadata_from_filepath: true` in the container parser operator. 
+This enables automatic extraction of Kubernetes metadata such as pod name, namespace, and container name from the log file path.
 </Admonition>
 
 ### Step 3: Update Docker Run Command

--- a/data/docs/userguide/collect_docker_logs.mdx
+++ b/data/docs/userguide/collect_docker_logs.mdx
@@ -2,6 +2,7 @@
 date: 2024-12-17
 title: Collecting Docker Container Logs
 tags : [SigNoz Cloud, Self-Host]
+description: Collecting Docker Container Logs using OpenTelemetry Collector
 id: collect_docker_logs
 ---
 
@@ -48,7 +49,7 @@ service:
 
 <Admonition type="note">
 If your logs are coming from Kubernetes Pod log file paths (for example, /var/log/pods/... or /var/log/containers/...), rather than directly from Docker container log files on the host, then set
-add_metadata_from_filepath: true , in the container parser operator so that Kubernetes metadata (such as pod name, namespace, and container name) can be automatically extracted from the file path.
+add_metadata_from_filepath: true, in the container parser operator so that Kubernetes metadata (such as pod name, namespace, and container name) can be automatically extracted from the file path.
 </Admonition>
 
 ### Step 3: Update Docker Run Command

--- a/data/docs/userguide/collect_docker_logs.mdx
+++ b/data/docs/userguide/collect_docker_logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2024-12-17
+date: 2025-11-07
 title: Collecting Docker Container Logs
 tags : [SigNoz Cloud, Self-Host]
 description: Collecting Docker Container Logs using OpenTelemetry Collector

--- a/data/docs/userguide/collect_docker_logs.mdx
+++ b/data/docs/userguide/collect_docker_logs.mdx
@@ -35,6 +35,7 @@ receivers:
       - id: container-parser
         type: container
         format: docker
+        add_metadata_from_filepath: false
 
 service:
   pipelines:
@@ -44,6 +45,11 @@ service:
       processors: [batch]
       exporters: [otlp]
 ```
+
+<Admonition type="note">
+If your logs are coming from Kubernetes Pod log file paths (for example, /var/log/pods/... or /var/log/containers/...), rather than directly from Docker container log files on the host, then set
+add_metadata_from_filepath: true , in the container parser operator so that Kubernetes metadata (such as pod name, namespace, and container name) can be automatically extracted from the file path.
+</Admonition>
 
 ### Step 3: Update Docker Run Command
 


### PR DESCRIPTION
Updated documentation to set `add_metadata_from_filepath: true` in the operator configuration, as most logs originate from Docker paths rather than Kubernetes.