### PR TITLE
Fix Minor Issues with OTel Blogs & Document Yarn Setup Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,26 @@
    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
    ```
 
-2. Install and use the correct Node.js version by running the following commands in the project directory:
+2. Install Yarn if you haven't already:
+
+   ```bash
+   npm install -g yarn
+   ```
+
+3. Install and use the correct Node.js version by running the following commands in the project directory:
 
    ```bash
    nvm install
    nvm use
    ```
 
-3. Install dependencies:
+4. Install dependencies:
 
    ```bash
    yarn install
    ```
 
-4. Build the project to ensure there are no errors:
+5. Build the project to ensure there are no errors:
 
    ```bash
    yarn build
@@ -35,13 +41,13 @@
 
    This will create a `build` directory with the production build of the website. Check the output for any errors.
 
-5. Start the development server:
+6. Start the development server:
 
    ```bash
    yarn dev
    ```
 
-6. Open your browser and navigate to `http://localhost:3000` to view the website locally.
+7. Open your browser and navigate to `http://localhost:3000` to view the website locally.
 
 ### Git Hooks
 

--- a/data/blog/opentelemetry-collector-complete-guide.mdx
+++ b/data/blog/opentelemetry-collector-complete-guide.mdx
@@ -1,43 +1,65 @@
 ---
-title: "OpenTelemetry Collector from A to Z: A Production-Ready Guide"
+title: 'OpenTelemetry Collector from A to Z: A Production-Ready Guide'
 slug: opentelemetry-collector-complete-guide
 date: 2025-09-04
 tags: [OpenTelemetry]
 authors: [ankit_anand]
-description: "A complete guide to the OpenTelemetry Collector. Learn about agent vs. gateway patterns, YAML configuration, tail sampling, and production best practices for 2025."
+description: 'A complete guide to the OpenTelemetry Collector. Learn about agent vs. gateway patterns, YAML configuration, tail sampling, and production best practices for 2025.'
 image: /img/blog/2023/01/opentelemetry_collector_guide_cover-min.jpg
 hide_table_of_contents: false
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-keywords: [opentelemetry, opentelemetry collector, opentelemetry collector configuration, opentelemetry agent vs collector, opentelemetry collector tutorial, opentelemetry collector processors, opentelemetry collector use cases, opentelemetry collector best practices, signoz]
+keywords:
+  [
+    opentelemetry,
+    opentelemetry collector,
+    opentelemetry collector configuration,
+    opentelemetry agent vs collector,
+    opentelemetry collector tutorial,
+    opentelemetry collector processors,
+    opentelemetry collector use cases,
+    opentelemetry collector best practices,
+    signoz,
+  ]
 ---
 
 The OpenTelemetry Collector is a stand-alone service that acts as a powerful, vendor-neutral pipeline for your telemetry data. It can receive, process, and export logs, metrics, and traces, giving you full control over your observability data before it reaches a backend.
 
 This guide will provide a comprehensive overview of the OpenTelemetry Collector, its architecture, deployment patterns, and how to configure it for production use.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture"/>
-    <figcaption><i>High-level application architecture with an OpenTelemetry Collector.</i></figcaption>
+<figure data-zoomable align="center">
+  <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture" />
+  <figcaption>
+    <i>High-level application architecture with an OpenTelemetry Collector.</i>
+  </figcaption>
 </figure>
 
 ## What is OpenTelemetry?
 
-<a href="https://opentelemetry.io/" rel="noopener noreferrer">OpenTelemetry</a> is an open-source observability framework, incubated by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/" rel="noopener noreferrer">CNCF</a>), that standardizes how telemetry data (logs, metrics, traces) is generated and collected. After instrumenting your applications with OpenTelemetry SDKs, the Collector is the next critical piece for managing that data.
-
-Check out the video for a quick walkthrough of OpenTelemetry Collector.
-
-<YouTube id="KFesgjzK3gk" mute={false}/>
+<a href="https://opentelemetry.io/" rel="noopener noreferrer">
+  OpenTelemetry
+</a> is an open-source observability framework, incubated by the Cloud Native Computing Foundation (
+<a href="https://www.cncf.io/" rel="noopener noreferrer">
+  CNCF
+</a>
+), that standardizes how telemetry data (logs, metrics, traces) is generated and collected. After
+instrumenting your applications with OpenTelemetry SDKs, the Collector is the next critical piece
+for managing that data.
 
 ## What is the OpenTelemetry Collector?
 
 In very simple words, the collector is an agent that sits between your instrumented services, collects the telemetry data that is emitted by the services, processes it and sends it to an observability backend.  
-The most textbook definition of this [and what’s present in the official docs] is that the OpenTelemetry Collector offers a *vendor-agnostic implementation of how to receive, process and export telemetry data*. Vendor-agnostic means you can plug into any observability backend of your choice and switch it up as you prefer, without changing your application code. No vendor lock-in. 
+The most textbook definition of this [and what’s present in the official docs] is that the OpenTelemetry Collector offers a _vendor-agnostic implementation of how to receive, process and export telemetry data_. Vendor-agnostic means you can plug into any observability backend of your choice and switch it up as you prefer, without changing your application code. No vendor lock-in.
 
 The below animation shows the flow of data through the collector. You can try the SigNoz mode, to see where SigNoz comes into the picture.
+
 <OtelCollectorFlow />
 
-Apart from acting as a buffer, the collector also acts as a *translation layer;* it supports the native OpenTelemetry Protocol [OTLP] for ingesting data, but can also accept other formats [like Jaeger trace data or [Prometheus metrics](https://signoz.io/guides/what-are-the-4-types-of-metrics-in-prometheus/)] and translate them on the fly.
+Apart from acting as a buffer, the collector also acts as a _translation layer;_ it supports the native OpenTelemetry Protocol [OTLP] for ingesting data, but can also accept other formats [like Jaeger trace data or [Prometheus metrics](https://signoz.io/guides/what-are-the-4-types-of-metrics-in-prometheus/)] and translate them on the fly.
+
+Check out the video for a quick walkthrough of OpenTelemetry Collector.
+
+<YouTube id="KFesgjzK3gk" mute={false} />
 
 ## Why Use an OpenTelemetry Collector?
 
@@ -53,43 +75,60 @@ Using a Collector is a best practice for several key reasons:
 
 The Collector's functionality is defined by pipelines, which are composed of three types of components:
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2022/09/collector_pipeline.webp" alt="Architecture of OpenTelemetry Collector"/>
-    <figcaption><i>A pipeline consists of receivers, processors, and exporters.</i></figcaption>
+<figure data-zoomable align="center">
+  <img
+    src="/img/blog/2022/09/collector_pipeline.webp"
+    alt="Architecture of OpenTelemetry Collector"
+  />
+  <figcaption>
+    <i>A pipeline consists of receivers, processors, and exporters.</i>
+  </figcaption>
 </figure>
 
 ### Receivers
+
 Receivers are how data gets into the Collector. They can be push-based (listening for data on an endpoint) or pull-based (scraping a target). A single collector can have multiple receivers for different formats, such as:
+
 - **OTLP (OpenTelemetry Protocol):** The native and recommended protocol.
 - **Jaeger:** For trace data in Jaeger formats.
 - **Prometheus:** To scrape Prometheus metrics endpoints.
 
 ### Processors
+
 Processors transform the data as it flows through the pipeline. This is one of the most powerful features of the Collector. Common processors include:
+
 - **Batch Processor:** Groups telemetry into batches for more efficient export.
 - **Memory Limiter Processor:** Prevents the Collector from consuming too much memory and crashing.
 - **Attributes Processor:** Adds, modifies, or deletes attributes (metadata) on spans, logs, or metrics.
-- **[Tail Sampling](https://signoz.io/docs/traces-management/guides/drop-spans/) Processor:** Samples traces based on decisions made *after* all spans for a trace have arrived.
+- **[Tail Sampling](https://signoz.io/docs/traces-management/guides/drop-spans/) Processor:** Samples traces based on decisions made _after_ all spans for a trace have arrived.
 
- Previously, a `queued_retry` processor was used to handle retries and queuing. This functionality is now built into most exporters, which is the recommended approach. You can configure `retry_on_failure` and `sending_queue` directly on the exporter to prevent data loss.
+Previously, a `queued_retry` processor was used to handle retries and queuing. This functionality is now built into most exporters, which is the recommended approach. You can configure `retry_on_failure` and `sending_queue` directly on the exporter to prevent data loss.
 
 ### Exporters
-Exporters send the processed data to a destination. This can be an observability backend like [SigNoz](https://signoz.io/), an open-source tool, or even another Collector. You can configure multiple exporters to send the same data to different backends or send different signals (e.g., traces to SigNoz, metrics to Prometheus) to different places.
 
+Exporters send the processed data to a destination. This can be an observability backend like [SigNoz](https://signoz.io/), an open-source tool, or even another Collector. You can configure multiple exporters to send the same data to different backends or send different signals (e.g., traces to SigNoz, metrics to Prometheus) to different places.
 
 ## OpenTelemetry Agent vs. Gateway: Which Deployment Pattern Should You Choose?
 
 There are two primary patterns for deploying the Collector. Choosing the right one depends on your scale and requirements.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/otel-deployment.webp" alt="OpenTelemetry Collector Deployment Patterns: Agent and Gateway"/>
-    <figcaption><i>The Agent pattern deploys a collector with each application, while the Gateway pattern uses a central collector service.</i></figcaption>
+<figure data-zoomable align="center">
+  <img
+    src="/img/blog/2025/09/otel-deployment.webp"
+    alt="OpenTelemetry Collector Deployment Patterns: Agent and Gateway"
+  />
+  <figcaption>
+    <i>
+      The Agent pattern deploys a collector with each application, while the Gateway pattern uses a
+      central collector service.
+    </i>
+  </figcaption>
 </figure>
 
-| Pattern | Description | Pros | Cons |
-| :--- | :--- | :--- | :--- |
-| **Agent** | A Collector instance is deployed on the same host as the application (e.g., as a sidecar in Kubernetes or a local process). | - Enriches data with host-level metadata.<br />- Collects host metrics (CPU, memory).<br />- Can perform early filtering/sampling. | - Higher resource consumption across all hosts.<br />- Managing many individual configs can be complex. |
-| **Gateway** | A standalone, centralized Collector service (or cluster of services) that receives telemetry from many sources (applications or agents). | - Centralized management of processing and exporting.<br />- Reduces the number of egress points.<br />- Better for heavy, cross-signal processing. | - Single point of failure (requires HA setup).<br />- Cannot easily add host-specific metadata. |
+| Pattern     | Description                                                                                                                              | Pros                                                                                                                                                | Cons                                                                                                    |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| **Agent**   | A Collector instance is deployed on the same host as the application (e.g., as a sidecar in Kubernetes or a local process).              | - Enriches data with host-level metadata.<br />- Collects host metrics (CPU, memory).<br />- Can perform early filtering/sampling.                  | - Higher resource consumption across all hosts.<br />- Managing many individual configs can be complex. |
+| **Gateway** | A standalone, centralized Collector service (or cluster of services) that receives telemetry from many sources (applications or agents). | - Centralized management of processing and exporting.<br />- Reduces the number of egress points.<br />- Better for heavy, cross-signal processing. | - Single point of failure (requires HA setup).<br />- Cannot easily add host-specific metadata.         |
 
 A **Hybrid Pattern** is very common: Agents are deployed on hosts for local collection and metadata enrichment, and they forward their data to a central Gateway for aggregation, heavy processing, and exporting.
 
@@ -103,6 +142,7 @@ You can run it via Docker:
 Here’s how to build your `config.yaml`:
 
 ### Step 1: Define Receivers
+
 We'll accept data using the standard OTLP protocol over gRPC and HTTP.
 
 ```yaml
@@ -116,19 +156,21 @@ receivers:
 ```
 
 ### Step 2: Define Exporters
+
 We'll configure an exporter to send data to SigNoz Cloud. This same OTLP exporter can be configured to send data to any OTLP-compatible backend.
 
 ```yaml
 exporters:
   otlp:
     # Replace with your backend endpoint
-    endpoint: "ingest.us.signoz.cloud:443" 
+    endpoint: 'ingest.us.signoz.cloud:443'
     headers:
       # Replace with your ingestion key
-      "signoz-ingestion-key": "${SIGNOZ_INGESTION_KEY}"
+      'signoz-ingestion-key': '${SIGNOZ_INGESTION_KEY}'
 ```
 
 ### Step 3: Add Processors for Stability and Efficiency
+
 It's a best practice to always include `memory_limiter` and `batch` processors.
 
 ```yaml
@@ -146,6 +188,7 @@ processors:
 ```
 
 ### Step 4: Enable Components with Pipelines
+
 Pipelines connect the receivers, processors, and exporters. The order of processors matters: they are executed in the order they are listed.
 
 ```yaml
@@ -181,7 +224,7 @@ Running a Collector in production requires a few more considerations:
 exporters:
   # ... (your otlp exporter)
   prometheus:
-    endpoint: "0.0.0.0:8889"
+    endpoint: '0.0.0.0:8889'
 
 extensions:
   health_check: {}
@@ -193,7 +236,7 @@ service:
       receivers: [otlp]
       processors: [memory_limiter, batch]
       # Export to your backend AND to a local prometheus endpoint
-      exporters: [otlp, prometheus] 
+      exporters: [otlp, prometheus]
     # ... other pipelines
 ```
 
@@ -216,7 +259,7 @@ Processors unlock powerful capabilities. Here are a few examples:
     attributes:
       actions:
         - key: environment
-          value: "production"
+          value: 'production'
           action: insert
   ```
 - **Reducing Cardinality:** Use the `span` processor to rename a high-cardinality span name (e.g., involving a user ID) to a generic name.
@@ -225,21 +268,25 @@ Processors unlock powerful capabilities. Here are a few examples:
     span:
       name:
         # From attribute "http.route"
-        from_attributes: ["http.route"]
+        from_attributes: ['http.route']
   ```
 
 ## OpenTelemetry Collector FAQs
 
 ### What is the difference between OpenTelemetry Agent and Collector?
+
 They are the same software, just deployed differently. "Agent" refers to a Collector deployed on the same host as an application (the Agent pattern). "Collector" or "Gateway" typically refers to a centralized, standalone Collector service (the Gateway pattern).
 
 ### What is the difference between OpenTelemetry Collector and Jaeger/Prometheus?
-The OpenTelemetry Collector is a pipeline; it receives, processes, and exports data. Jaeger is a backend specifically for storing and visualizing traces. Prometheus is a backend for storing and querying time-series metrics. The Collector can *receive* data in Jaeger/Prometheus formats and *export* data to Jaeger/Prometheus backends.
+
+The OpenTelemetry Collector is a pipeline; it receives, processes, and exports data. Jaeger is a backend specifically for storing and visualizing traces. Prometheus is a backend for storing and querying time-series metrics. The Collector can _receive_ data in Jaeger/Prometheus formats and _export_ data to Jaeger/Prometheus backends.
 
 ### What is OpenTelemetry collector-contrib vs. core?
+
 The **core** distribution contains a minimal, stable set of components. The **collector-contrib** distribution is a much larger set that includes core components plus many more contributed by the community. For most use cases, you should start with `collector-contrib` to have more capabilities available.
 
 ### How do I monitor the OpenTelemetry Collector itself?
+
 Use the `prometheus` exporter within the Collector's own `metrics` pipeline to expose its internal operational metrics. Then, scrape that endpoint (`:8889` in our example) with a Prometheus server to monitor the Collector's health and performance.
 
 ## Getting Started with OpenTelemetry and SigNoz
@@ -248,9 +295,17 @@ The OpenTelemetry Collector provides a powerful, vendor-agnostic way to manage y
 
 With SigNoz, you can visualize all your logs, metrics, and traces in a single pane of glass, helping you resolve issues faster.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/common/signoz_charts_application_metrics.webp" alt="SigNoz dashboard showing overview metrics like RPS"/>
-    <figcaption><i>SigNoz UI showing application overview metrics like RPS, 50th/90th/99th Percentile latencies, and Error Rate</i></figcaption>
+<figure data-zoomable align="center">
+  <img
+    src="/img/blog/common/signoz_charts_application_metrics.webp"
+    alt="SigNoz dashboard showing overview metrics like RPS"
+  />
+  <figcaption>
+    <i>
+      SigNoz UI showing application overview metrics like RPS, 50th/90th/99th Percentile latencies,
+      and Error Rate
+    </i>
+  </figcaption>
 </figure>
 
 <GetStartedSigNoz />

--- a/data/blog/opentelemetry-collector-complete-guide.mdx
+++ b/data/blog/opentelemetry-collector-complete-guide.mdx
@@ -1,65 +1,43 @@
 ---
-title: 'OpenTelemetry Collector from A to Z: A Production-Ready Guide'
+title: "OpenTelemetry Collector from A to Z: A Production-Ready Guide"
 slug: opentelemetry-collector-complete-guide
 date: 2025-09-04
 tags: [OpenTelemetry]
 authors: [ankit_anand]
-description: 'A complete guide to the OpenTelemetry Collector. Learn about agent vs. gateway patterns, YAML configuration, tail sampling, and production best practices for 2025.'
+description: "A complete guide to the OpenTelemetry Collector. Learn about agent vs. gateway patterns, YAML configuration, tail sampling, and production best practices for 2025."
 image: /img/blog/2023/01/opentelemetry_collector_guide_cover-min.jpg
 hide_table_of_contents: false
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-keywords:
-  [
-    opentelemetry,
-    opentelemetry collector,
-    opentelemetry collector configuration,
-    opentelemetry agent vs collector,
-    opentelemetry collector tutorial,
-    opentelemetry collector processors,
-    opentelemetry collector use cases,
-    opentelemetry collector best practices,
-    signoz,
-  ]
+keywords: [opentelemetry, opentelemetry collector, opentelemetry collector configuration, opentelemetry agent vs collector, opentelemetry collector tutorial, opentelemetry collector processors, opentelemetry collector use cases, opentelemetry collector best practices, signoz]
 ---
 
 The OpenTelemetry Collector is a stand-alone service that acts as a powerful, vendor-neutral pipeline for your telemetry data. It can receive, process, and export logs, metrics, and traces, giving you full control over your observability data before it reaches a backend.
 
 This guide will provide a comprehensive overview of the OpenTelemetry Collector, its architecture, deployment patterns, and how to configure it for production use.
 
-<figure data-zoomable align="center">
-  <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture" />
-  <figcaption>
-    <i>High-level application architecture with an OpenTelemetry Collector.</i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture"/>
+    <figcaption><i>High-level application architecture with an OpenTelemetry Collector.</i></figcaption>
 </figure>
 
 ## What is OpenTelemetry?
 
-<a href="https://opentelemetry.io/" rel="noopener noreferrer">
-  OpenTelemetry
-</a> is an open-source observability framework, incubated by the Cloud Native Computing Foundation (
-<a href="https://www.cncf.io/" rel="noopener noreferrer">
-  CNCF
-</a>
-), that standardizes how telemetry data (logs, metrics, traces) is generated and collected. After
-instrumenting your applications with OpenTelemetry SDKs, the Collector is the next critical piece
-for managing that data.
+<a href="https://opentelemetry.io/" rel="noopener noreferrer">OpenTelemetry</a> is an open-source observability framework, incubated by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/" rel="noopener noreferrer">CNCF</a>), that standardizes how telemetry data (logs, metrics, traces) is generated and collected. After instrumenting your applications with OpenTelemetry SDKs, the Collector is the next critical piece for managing that data.
 
 ## What is the OpenTelemetry Collector?
 
 In very simple words, the collector is an agent that sits between your instrumented services, collects the telemetry data that is emitted by the services, processes it and sends it to an observability backend.  
-The most textbook definition of this [and what’s present in the official docs] is that the OpenTelemetry Collector offers a _vendor-agnostic implementation of how to receive, process and export telemetry data_. Vendor-agnostic means you can plug into any observability backend of your choice and switch it up as you prefer, without changing your application code. No vendor lock-in.
+The most textbook definition of this [and what’s present in the official docs] is that the OpenTelemetry Collector offers a *vendor-agnostic implementation of how to receive, process and export telemetry data*. Vendor-agnostic means you can plug into any observability backend of your choice and switch it up as you prefer, without changing your application code. No vendor lock-in. 
 
 The below animation shows the flow of data through the collector. You can try the SigNoz mode, to see where SigNoz comes into the picture.
-
 <OtelCollectorFlow />
 
-Apart from acting as a buffer, the collector also acts as a _translation layer;_ it supports the native OpenTelemetry Protocol [OTLP] for ingesting data, but can also accept other formats [like Jaeger trace data or [Prometheus metrics](https://signoz.io/guides/what-are-the-4-types-of-metrics-in-prometheus/)] and translate them on the fly.
+Apart from acting as a buffer, the collector also acts as a *translation layer;* it supports the native OpenTelemetry Protocol [OTLP] for ingesting data, but can also accept other formats [like Jaeger trace data or [Prometheus metrics](https://signoz.io/guides/what-are-the-4-types-of-metrics-in-prometheus/)] and translate them on the fly.
 
 Check out the video for a quick walkthrough of OpenTelemetry Collector.
 
-<YouTube id="KFesgjzK3gk" mute={false} />
+<YouTube id="KFesgjzK3gk" mute={false}/>
 
 ## Why Use an OpenTelemetry Collector?
 
@@ -75,60 +53,43 @@ Using a Collector is a best practice for several key reasons:
 
 The Collector's functionality is defined by pipelines, which are composed of three types of components:
 
-<figure data-zoomable align="center">
-  <img
-    src="/img/blog/2022/09/collector_pipeline.webp"
-    alt="Architecture of OpenTelemetry Collector"
-  />
-  <figcaption>
-    <i>A pipeline consists of receivers, processors, and exporters.</i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2022/09/collector_pipeline.webp" alt="Architecture of OpenTelemetry Collector"/>
+    <figcaption><i>A pipeline consists of receivers, processors, and exporters.</i></figcaption>
 </figure>
 
 ### Receivers
-
 Receivers are how data gets into the Collector. They can be push-based (listening for data on an endpoint) or pull-based (scraping a target). A single collector can have multiple receivers for different formats, such as:
-
 - **OTLP (OpenTelemetry Protocol):** The native and recommended protocol.
 - **Jaeger:** For trace data in Jaeger formats.
 - **Prometheus:** To scrape Prometheus metrics endpoints.
 
 ### Processors
-
 Processors transform the data as it flows through the pipeline. This is one of the most powerful features of the Collector. Common processors include:
-
 - **Batch Processor:** Groups telemetry into batches for more efficient export.
 - **Memory Limiter Processor:** Prevents the Collector from consuming too much memory and crashing.
 - **Attributes Processor:** Adds, modifies, or deletes attributes (metadata) on spans, logs, or metrics.
-- **[Tail Sampling](https://signoz.io/docs/traces-management/guides/drop-spans/) Processor:** Samples traces based on decisions made _after_ all spans for a trace have arrived.
+- **[Tail Sampling](https://signoz.io/docs/traces-management/guides/drop-spans/) Processor:** Samples traces based on decisions made *after* all spans for a trace have arrived.
 
-Previously, a `queued_retry` processor was used to handle retries and queuing. This functionality is now built into most exporters, which is the recommended approach. You can configure `retry_on_failure` and `sending_queue` directly on the exporter to prevent data loss.
+ Previously, a `queued_retry` processor was used to handle retries and queuing. This functionality is now built into most exporters, which is the recommended approach. You can configure `retry_on_failure` and `sending_queue` directly on the exporter to prevent data loss.
 
 ### Exporters
-
 Exporters send the processed data to a destination. This can be an observability backend like [SigNoz](https://signoz.io/), an open-source tool, or even another Collector. You can configure multiple exporters to send the same data to different backends or send different signals (e.g., traces to SigNoz, metrics to Prometheus) to different places.
+
 
 ## OpenTelemetry Agent vs. Gateway: Which Deployment Pattern Should You Choose?
 
 There are two primary patterns for deploying the Collector. Choosing the right one depends on your scale and requirements.
 
-<figure data-zoomable align="center">
-  <img
-    src="/img/blog/2025/09/otel-deployment.webp"
-    alt="OpenTelemetry Collector Deployment Patterns: Agent and Gateway"
-  />
-  <figcaption>
-    <i>
-      The Agent pattern deploys a collector with each application, while the Gateway pattern uses a
-      central collector service.
-    </i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/otel-deployment.webp" alt="OpenTelemetry Collector Deployment Patterns: Agent and Gateway"/>
+    <figcaption><i>The Agent pattern deploys a collector with each application, while the Gateway pattern uses a central collector service.</i></figcaption>
 </figure>
 
-| Pattern     | Description                                                                                                                              | Pros                                                                                                                                                | Cons                                                                                                    |
-| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
-| **Agent**   | A Collector instance is deployed on the same host as the application (e.g., as a sidecar in Kubernetes or a local process).              | - Enriches data with host-level metadata.<br />- Collects host metrics (CPU, memory).<br />- Can perform early filtering/sampling.                  | - Higher resource consumption across all hosts.<br />- Managing many individual configs can be complex. |
-| **Gateway** | A standalone, centralized Collector service (or cluster of services) that receives telemetry from many sources (applications or agents). | - Centralized management of processing and exporting.<br />- Reduces the number of egress points.<br />- Better for heavy, cross-signal processing. | - Single point of failure (requires HA setup).<br />- Cannot easily add host-specific metadata.         |
+| Pattern | Description | Pros | Cons |
+| :--- | :--- | :--- | :--- |
+| **Agent** | A Collector instance is deployed on the same host as the application (e.g., as a sidecar in Kubernetes or a local process). | - Enriches data with host-level metadata.<br />- Collects host metrics (CPU, memory).<br />- Can perform early filtering/sampling. | - Higher resource consumption across all hosts.<br />- Managing many individual configs can be complex. |
+| **Gateway** | A standalone, centralized Collector service (or cluster of services) that receives telemetry from many sources (applications or agents). | - Centralized management of processing and exporting.<br />- Reduces the number of egress points.<br />- Better for heavy, cross-signal processing. | - Single point of failure (requires HA setup).<br />- Cannot easily add host-specific metadata. |
 
 A **Hybrid Pattern** is very common: Agents are deployed on hosts for local collection and metadata enrichment, and they forward their data to a central Gateway for aggregation, heavy processing, and exporting.
 
@@ -142,7 +103,6 @@ You can run it via Docker:
 Here’s how to build your `config.yaml`:
 
 ### Step 1: Define Receivers
-
 We'll accept data using the standard OTLP protocol over gRPC and HTTP.
 
 ```yaml
@@ -156,21 +116,19 @@ receivers:
 ```
 
 ### Step 2: Define Exporters
-
 We'll configure an exporter to send data to SigNoz Cloud. This same OTLP exporter can be configured to send data to any OTLP-compatible backend.
 
 ```yaml
 exporters:
   otlp:
     # Replace with your backend endpoint
-    endpoint: 'ingest.us.signoz.cloud:443'
+    endpoint: "ingest.us.signoz.cloud:443" 
     headers:
       # Replace with your ingestion key
-      'signoz-ingestion-key': '${SIGNOZ_INGESTION_KEY}'
+      "signoz-ingestion-key": "${SIGNOZ_INGESTION_KEY}"
 ```
 
 ### Step 3: Add Processors for Stability and Efficiency
-
 It's a best practice to always include `memory_limiter` and `batch` processors.
 
 ```yaml
@@ -188,7 +146,6 @@ processors:
 ```
 
 ### Step 4: Enable Components with Pipelines
-
 Pipelines connect the receivers, processors, and exporters. The order of processors matters: they are executed in the order they are listed.
 
 ```yaml
@@ -224,7 +181,7 @@ Running a Collector in production requires a few more considerations:
 exporters:
   # ... (your otlp exporter)
   prometheus:
-    endpoint: '0.0.0.0:8889'
+    endpoint: "0.0.0.0:8889"
 
 extensions:
   health_check: {}
@@ -236,7 +193,7 @@ service:
       receivers: [otlp]
       processors: [memory_limiter, batch]
       # Export to your backend AND to a local prometheus endpoint
-      exporters: [otlp, prometheus]
+      exporters: [otlp, prometheus] 
     # ... other pipelines
 ```
 
@@ -259,7 +216,7 @@ Processors unlock powerful capabilities. Here are a few examples:
     attributes:
       actions:
         - key: environment
-          value: 'production'
+          value: "production"
           action: insert
   ```
 - **Reducing Cardinality:** Use the `span` processor to rename a high-cardinality span name (e.g., involving a user ID) to a generic name.
@@ -268,25 +225,21 @@ Processors unlock powerful capabilities. Here are a few examples:
     span:
       name:
         # From attribute "http.route"
-        from_attributes: ['http.route']
+        from_attributes: ["http.route"]
   ```
 
 ## OpenTelemetry Collector FAQs
 
 ### What is the difference between OpenTelemetry Agent and Collector?
-
 They are the same software, just deployed differently. "Agent" refers to a Collector deployed on the same host as an application (the Agent pattern). "Collector" or "Gateway" typically refers to a centralized, standalone Collector service (the Gateway pattern).
 
 ### What is the difference between OpenTelemetry Collector and Jaeger/Prometheus?
-
-The OpenTelemetry Collector is a pipeline; it receives, processes, and exports data. Jaeger is a backend specifically for storing and visualizing traces. Prometheus is a backend for storing and querying time-series metrics. The Collector can _receive_ data in Jaeger/Prometheus formats and _export_ data to Jaeger/Prometheus backends.
+The OpenTelemetry Collector is a pipeline; it receives, processes, and exports data. Jaeger is a backend specifically for storing and visualizing traces. Prometheus is a backend for storing and querying time-series metrics. The Collector can *receive* data in Jaeger/Prometheus formats and *export* data to Jaeger/Prometheus backends.
 
 ### What is OpenTelemetry collector-contrib vs. core?
-
 The **core** distribution contains a minimal, stable set of components. The **collector-contrib** distribution is a much larger set that includes core components plus many more contributed by the community. For most use cases, you should start with `collector-contrib` to have more capabilities available.
 
 ### How do I monitor the OpenTelemetry Collector itself?
-
 Use the `prometheus` exporter within the Collector's own `metrics` pipeline to expose its internal operational metrics. Then, scrape that endpoint (`:8889` in our example) with a Prometheus server to monitor the Collector's health and performance.
 
 ## Getting Started with OpenTelemetry and SigNoz
@@ -295,17 +248,9 @@ The OpenTelemetry Collector provides a powerful, vendor-agnostic way to manage y
 
 With SigNoz, you can visualize all your logs, metrics, and traces in a single pane of glass, helping you resolve issues faster.
 
-<figure data-zoomable align="center">
-  <img
-    src="/img/blog/common/signoz_charts_application_metrics.webp"
-    alt="SigNoz dashboard showing overview metrics like RPS"
-  />
-  <figcaption>
-    <i>
-      SigNoz UI showing application overview metrics like RPS, 50th/90th/99th Percentile latencies,
-      and Error Rate
-    </i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/common/signoz_charts_application_metrics.webp" alt="SigNoz dashboard showing overview metrics like RPS"/>
+    <figcaption><i>SigNoz UI showing application overview metrics like RPS, 50th/90th/99th Percentile latencies, and Error Rate</i></figcaption>
 </figure>
 
 <GetStartedSigNoz />

--- a/data/blog/opentelemetry-logs.mdx
+++ b/data/blog/opentelemetry-logs.mdx
@@ -266,16 +266,16 @@ from its SDK.
   Here's an example of using OpenTelemetry's [LoggingInstrumentor](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html) to instrument the logging library to automatically add trace context in a Python application.
 
   ```python 
-      import logging
-      from opentelemetry.instrumentation.logging import LoggingInstrumentor
-      
-      # Instrument the logging library to automatically add trace context
-      LoggingInstrumentor().instrument(set_logging_format=True)
-      
-      # Now, any log created within an active trace will automatically
-      # include trace_id and span_id in its record.
-      logging.basicConfig(level=logging.INFO)
-      logging.info("User login successful.")
+  import logging
+  from opentelemetry.instrumentation.logging import LoggingInstrumentor
+  
+  # Instrument the logging library to automatically add trace context
+  LoggingInstrumentor().instrument(set_logging_format=True)
+  
+  # Now, any log created within an active trace will automatically
+  # include trace_id and span_id in its record.
+  logging.basicConfig(level=logging.INFO)
+  logging.info("User login successful.")
   ```
 
   **Example 2. Instrumenting in Java with a Log Appender**

--- a/data/blog/opentelemetry-logs.mdx
+++ b/data/blog/opentelemetry-logs.mdx
@@ -7,11 +7,20 @@ authors: [ankit_anand]
 description: Unlike traces and metrics, OpenTelemetry logs take a different approach. In order to be successful, OpenTelemetry needs to support the existing legacy of logs and logging libraries. And this is the main design philosophy of OpenTelemetry logs....
 image: /img/blog/2023/10/single-pane-of-glass-cover-min.jpg
 hide_table_of_contents: false
-keywords: [opentelemetry logs,opentelemetry log,opentelemetry,logs correlation,opentelemetry logging,telemetry signals,observability,signoz]
+keywords:
+  [
+    opentelemetry logs,
+    opentelemetry log,
+    opentelemetry,
+    logs correlation,
+    opentelemetry logging,
+    telemetry signals,
+    observability,
+    signoz,
+  ]
 ---
+
 OpenTelemetry is a Cloud Native Computing Foundation(<a href = "https://www.cncf.io/" rel="noopener noreferrer nofollow" target="_blank" >CNCF</a>) incubating project aimed at standardizing the way we instrument applications for generating telemetry data(logs, metrics, and traces). OpenTelemetry aims to provide a vendor-agnostic observability framework that provides a set of tools, APIs, and SDKs to instrument applications.
-
-
 
 ![Cover Image](/img/blog/2023/10/otel-logs-cover.webp)
 
@@ -37,11 +46,15 @@ Before deep diving into OpenTelemetry logs, let's briefly overview OpenTelemetry
 
 OpenTelemetry provides instrumentation libraries for your application. The development of these libraries is guided by the <a href = "https://github.com/open-telemetry/opentelemetry-specification" rel="noopener noreferrer nofollow" target="_blank" >OpenTelemetry specification</a>. The OpenTelemetry specification describes the cross-language requirements and design expectations for all OpenTelemetry implementations in various programming languages.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture"/>
-    <figcaption><i>How OpenTelemetry fits in an application architecture. OTel collector refers to OpenTelemetry Collector</i></figcaption>
+<figure data-zoomable align="center">
+  <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture" />
+  <figcaption>
+    <i>
+      How OpenTelemetry fits in an application architecture. OTel is the convenient short form for
+      OpenTelemtry
+    </i>
+  </figcaption>
 </figure>
-
 
 OpenTelemetry libraries can be used to generate logs, metrics, and traces. You can then collect these signals with OpenTelemetry Collector or send them to an observability backend of your choice. In this article, we will focus on [OpenTelemetry logs](https://signoz.io/comparisons/opentelemetry-events-vs-logs/). OpenTelemetry can be used to collect log data and process it. Let's explore OpenTelemetry logs further.
 
@@ -90,12 +103,12 @@ The primary goal of OpenTelemetry's log data model is to ensure a common underst
 
 **Trace Context Fields:** These include TraceId, SpanId, and TraceFlags which are essential for correlating logs with traces.
 
-**Severity Text:** This is a string that represents the original *log level* as it was written by the source system
-          (e.g., "INFO", "WARN", "DEBUG"). 
+**Severity Text:** This is a string that represents the original _log level_ as it was written by the source system
+(e.g., "INFO", "WARN", "DEBUG").
 
-**Severity Number:** This is a standardized, enumerated integer that represents the level's severity. This is an important field 
+**Severity Number:** This is a standardized, enumerated integer that represents the level's severity. This is an important field
 for programmatic use cases like filtering and alerting. For example, you can reliably
-         create an alert for all logs where SeverityNumber >= 17 (the ERROR range).
+create an alert for all logs where SeverityNumber >= 17 (the ERROR range).
 
 **Body:** Contains the main content of the log record. It can be a human-readable string message or structured data.
 
@@ -151,7 +164,7 @@ Existing logging solutions also don’t have any standardized way to propagate a
 
 **Holistic View:** Correlation provides a complete picture of the system, allowing developers and operators to understand how different components interact and affect each other.
 
-{/* <!-- ## Correlation in OpenTelemetry
+{/\* <!-- ## Correlation in OpenTelemetry
 
 Let's see through a code example how correlation works in OpenTelemetry. Consider a hypothetical scenario where a web service processes user requests. We'll showcase how to correlate logs, metrics, and traces using OpenTelemetry:
 
@@ -203,7 +216,7 @@ If there's an exception during processing, we log an error message, set error at
 
 With OpenTelemetry's correlation capabilities, when analyzing the data, you can link the log entries, metrics, and trace spans together. This allows you to see, for instance, the specific log messages associated with a particular trace or the metrics associated with a specific operation.
 
-Now let's talk about how to collect log data with OpenTelmetry. --> */}
+Now let's talk about how to collect log data with OpenTelmetry. --> \*/}
 
 ## Collecting log data with OpenTelemetry
 
@@ -211,7 +224,7 @@ OpenTelemetry provides various receivers and processors for collecting first-par
 
 ### Collecting legacy first-party application logs
 
-These applications are built in-house and use existing logging libraries. The logs from these applications can be pushed to OpenTelemetry with little to no changes in the application code. 
+These applications are built in-house and use existing logging libraries. The logs from these applications can be pushed to OpenTelemetry with little to no changes in the application code.
 OpenTelemetry provides a `trace_parser` with which you can add context IDs to your logs to correlate them with other signals.
 
 In OpenTelemetry, there are two important context IDs for context propagation.
@@ -220,12 +233,17 @@ In OpenTelemetry, there are two important context IDs for context propagation.
   A trace is a complete breakdown of a transaction as it travels through different components of a distributed system. Each trace gets a [trace ID](https://signoz.io/comparisons/opentelemetry-trace-id-vs-span-id/) that helps to correlate all events connected with a single trace.
 
 - **Span IDs**<br></br>
-  A trace consists of multiple spans. Each span represents a single unit of logical work in the trace data. Spans have span ids that are used to represent the parent-child relationship.
-    <figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/otel-spans.webp" alt="Traces in SigNoz"/>
-    <figcaption><i>A trace graph broken down into individual spans visualized as Flamegraphs and Gantt charts in SigNoz dashboard</i></figcaption>
-    </figure>
-    
+  A trace consists of multiple spans. Each span represents a single unit of logical work in the trace data. Spans have span IDs that are used to represent the parent-child relationship.
+  {' '}
+  <figure data-zoomable align="center">
+    <img src="/img/blog/2025/09/otel-spans.webp" alt="Traces in SigNoz" />
+    <figcaption>
+      <i>
+        A trace graph broken down into individual spans visualized as Flamegraphs and Gantt charts
+        in SigNoz dashboard
+      </i>
+    </figcaption>
+  </figure>
 
 Correlating your logs with traces can help drive deeper insights. If you don’t have request context like **traceId** and **spanId** in your logs, you might want to add them for easier correlation with metrics and traces.
 
@@ -234,17 +252,18 @@ There are **two** ways to collect application logs:
 - **Via File or Stdout Logs**<br></br>
   Here, the logs of the application are directly collected by the OpenTelemetry receiver using collectors like **filelog receiver.** Then operators and processors are used for parsing them into the OpenTelemetry log data model.
 
-    <figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/log-pipeline.webp" alt="Collecting logs via file or Stdout logs"/>
-    <figcaption><i>Collecting logs via file or Stdout logs</i></figcaption>
-    </figure>
-    
+  {' '}
+  <figure data-zoomable align="center">
+    <img src="/img/blog/2025/09/log-pipeline.webp" alt="Collecting logs via file or Stdout logs" />
+    <figcaption>
+      <i>Collecting logs via file or Stdout logs</i>
+    </figcaption>
+  </figure>
 
-    
-    For advanced parsing and collecting capabilities, you can also use something like FluentBit or Logstash. The agents can push the logs to the OpenTelemetry collector using protocols like FluentForward/TCP/UDP, etc.
+  For advanced parsing and collecting capabilities, you can also use something like FluentBit or Logstash. The agents can push the logs to the OpenTelemetry collector using protocols like FluentForward/TCP/UDP, etc.
 
 - **Directly to OpenTelemetry Collector with SDK**<br></br>
-  In this approach, you can modify your logging library that is used by the application to use the logging SDK provided by OpenTelemetry and directly forward the logs from the application to OpenTelemetry. 
+  In this approach, you can modify your logging library that is used by the application to use the logging SDK provided by OpenTelemetry and directly forward the logs from the application to OpenTelemetry.
   This approach removes any need for agents/intermediary medium but loses the simplicity of having the log file locally. Let's explore it in greater detail.
 
 ### Generating Context Aware Logs with OpenTelemetry SDK
@@ -256,74 +275,67 @@ with full trace context, making correlation effortless.
 To understand how this works, you first need to know about OpenTelemetry's core design: the separation of its API
 from its SDK.
 
-   * The API: A set of abstract interfaces that library authors use to add instrumentation. It defines what can be done
-      (e.g., get a logger, emit a log) but has no real implementation. 
+- The API: A set of abstract interfaces that library authors use to add instrumentation. It defines what can be done
+  (e.g., get a logger, emit a log) but has no real implementation.
 
-   * The SDK: The concrete implementation of the API. You, the application developer, adds the SDK to your project to
-     **turn on** telemetry. The SDK is responsible for actually creating, processing, and exporting the logs.
+- The SDK: The concrete implementation of the API. You, the application developer, adds the SDK to your project to
+  **turn on** telemetry. The SDK is responsible for actually creating, processing, and exporting the logs.
 
-  Now, let's see how to use this combination in practice.
+Now, let's see how to use this combination in practice.
 
-  **Example 1. Instrumenting Python with a Logging Handler**
+**Example 1. Instrumenting Python with a Logging Handler**
 
-  Here's an example of using OpenTelemetry's [LoggingInstrumentor](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html) to instrument the logging library to automatically add trace context in a Python application.
+Here's an example of using OpenTelemetry's [LoggingInstrumentor](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html) to instrument the logging library to automatically add trace context in a Python application.
 
-  ```python 
+```python
+import logging
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
-      import logging
-        from opentelemetry.instrumentation.logging import LoggingInstrumentor
-        
-        # Instrument the logging library to automatically add trace context
-        LoggingInstrumentor().instrument(set_logging_format=True)
-        
-        # Now, any log created within an active trace will automatically
-        # include trace_id and span_id in its record.
-        logging.basicConfig(level=logging.INFO)
-        logging.info("User login successful.")
-  ```
+# Instrument the logging library to automatically add trace context
+LoggingInstrumentor().instrument(set_logging_format=True)
 
-  **Example 2. Instrumenting in Java with a Log Appender**
+# Now, any log created within an active trace will automatically
+# include trace_id and span_id in its record.
+logging.basicConfig(level=logging.INFO)
+logging.info("User login successful.")
+```
 
+**Example 2. Instrumenting in Java with a Log Appender**
 
-  For Java applications, which commonly use logging frameworks like Logback or Log4j, OpenTelemetry
-  integrates by providing a custom Log Appender.
+For Java applications, which commonly use logging frameworks like Logback or Log4j, OpenTelemetry
+integrates by providing a custom Log Appender.
 
-  An Appender is a component within these frameworks responsible for sending log events to a destination (like the
-  console or a file). The OpenTelemetryAppender is a special appender that captures all logs your application creates
-   and forwards them to the OpenTelemetry SDK (the destination). The SDK then automatically enriches them with the active TraceId and
-  SpanId before exporting them.
-
+An Appender is a component within these frameworks responsible for sending log events to a destination (like the
+console or a file). The OpenTelemetryAppender is a special appender that captures all logs your application creates
+and forwards them to the OpenTelemetry SDK (the destination). The SDK then automatically enriches them with the active TraceId and
+SpanId before exporting them.
 
 To configure it, you simply add the OpenTelemetryAppender to your log4j2.xml (or logback.xml) file, requiring no changes to your
 application's source code as shown in the below example.
 
-  ```xml 
-  <?xml version="1.0" encoding="UTF-8"?>
-  <Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.appender.v2_17">
-    <!-- The appender is configured via standard OpenTelemetry environment variables or system properties -->
-    <Appenders>
-        <OpenTelemetry name="OpenTelemetryAppender"/>
-    </Appenders>
-    <!-- Attach the OpenTelemetryAppender to the root logger -->
-    <Loggers>
-        <Root>
-            <AppenderRef ref="OpenTelemetryAppender" level="All"/>
-        </Root>
-    </Loggers>
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.appender.v2_17">
+  <!-- The appender is configured via standard OpenTelemetry environment variables or system properties -->
+  <Appenders>
+      <OpenTelemetry name="OpenTelemetryAppender"/>
+  </Appenders>
+  <!-- Attach the OpenTelemetryAppender to the root logger -->
+  <Loggers>
+      <Root>
+          <AppenderRef ref="OpenTelemetryAppender" level="All"/>
+      </Root>
+  </Loggers>
 </Configuration>
+```
 
-  ```
-
-  As you can see, while the mechanism differs by language ecosystem (Handlers in Python, Appenders in Java), the
-  underlying idea is the same, i.e, integrate the OpenTelemetry SDK with your existing logging framework to automatically enrich
-  all your logs with invaluable trace context.
-
-
-
+As you can see, while the mechanism differs by language ecosystem (Handlers in Python, Appenders in Java), the
+underlying idea is the same, i.e, integrate the OpenTelemetry SDK with your existing logging framework to automatically enrich
+all your logs with invaluable trace context.
 
 ### Collecting third-party application log data
 
-Logs emitted by third-party applications running on the system are known as third-party application logs. The logs are typically written to stdout, files, or other specialized mediums. 
+Logs emitted by third-party applications running on the system are known as third-party application logs. The logs are typically written to stdout, files, or other specialized mediums.
 For example, Windows event logs for applications.
 
 These logs can be collected using the OpenTelemetry file receiver and then processed.
@@ -339,7 +351,7 @@ You will need OpenTelemetry Collector (otel collector) to collect syslogs. In th
   receivers:
     syslog:
       tcp:
-        listen_address: "0.0.0.0:54527"
+        listen_address: '0.0.0.0:54527'
       protocol: rfc3164
       location: UTC
       operators:
@@ -423,21 +435,23 @@ Processors are also helpful when you have multiple receivers for logs and you wa
 ## Log Analytics - Querying and Visualising Logs
 
 Once you have configured OpenTelemetry to collect your logs, you need a backend to analyze, query, and
-visualize them. This is where the value of structured logging is truly unlocked. As an OpenTelemetry-native platform, SigNoz is designed to work  with the OTel data model. Let's explore
+visualize them. This is where the value of structured logging is truly unlocked. As an OpenTelemetry-native platform, SigNoz is designed to work with the OTel data model. Let's explore
 how you can perform log analytics. The logs tab in SigNoz has advanced features like a log query builder, search across multiple fields, structured table view, JSON view, etc.
 
 ### Searching and Filtering with the Query Builder
 
 Your key step in any investigation during an escalation is to find the right logs. Instead of manually searching through tons of logs,
-you can use a query builder to filter logs based on any field in the OpenTelemetry log data model. 
-We recently made some improvements to the query builder to make it more, you can read more about it [here](https://signoz.io/blog/query-builder-v5/).
+you can use a query builder to filter logs based on any field in the OpenTelemetry log data model.
+We have recently overhauled the Query Builder, you can read more about it [here](https://signoz.io/blog/query-builder-v5/).
 
 For example, you can quickly find all logs with `SeverityText = ERROR` from your web-backend service that occurred in
 the last hour as shown in the below screenshot.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/logs-query-error.webp" alt="Log Management in SigNoz"/>
-    <figcaption><i>Logs management in SigNoz</i></figcaption>
+<figure data-zoomable align="center">
+  <img src="/img/blog/2025/09/logs-query-error.webp" alt="Log Management in SigNoz" />
+  <figcaption>
+    <i>Logs management in SigNoz</i>
+  </figcaption>
 </figure>
 
 ### Real-Time Analysis with Live Tail
@@ -446,10 +460,11 @@ When you're debugging a live issue, you need to see logs as they happen. Live ta
 provides a real-time stream of logs from your applications, allowing you to see the immediate impact of your
 changes as demonstrated in the below screenshot.
 
-
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/live-tailing.webp" alt="Live tail logging in SigNoz"/>
-    <figcaption><i>Live tail logging in SigNoz</i></figcaption>
+<figure data-zoomable align="center">
+  <img src="/img/blog/2025/09/live-tailing.webp" alt="Live tail logging in SigNoz" />
+  <figcaption>
+    <i>Live tail logging in SigNoz</i>
+  </figcaption>
 </figure>
 
 ### Correlating Logs with Traces
@@ -459,16 +474,20 @@ As mentioned previously, this is an important benefit of using OpenTelemetry for
 
 In SigNoz, the `TraceId` in a log record is a clickable link. Meaning, when you find an interesting error log, you can click its
 `TraceId` to instantly pivot to the full distributed trace view for that specific request. This allows you to discover more important insights like:
-  - The exact user request that produced the error.
-  - The full journey of the request across all microservices.
-  - Latency breakdowns for each step, helping you pinpoint the root cause.
 
-<figure data-zoomable align='center'>
-    <img src="/img/blog/2025/09/otel-log-correlation.webp" alt="Correlating Logs with Traces in SigNoz"/>
-    <figcaption><i>Correlating Logs with Traces in SigNoz</i></figcaption>
+- The exact user request that produced the error.
+- The full journey of the request across all microservices.
+- Latency breakdowns for each step, helping you pinpoint the root cause.
+
+<figure data-zoomable align="center">
+  <img
+    src="/img/blog/2025/09/otel-log-correlation.webp"
+    alt="Correlating Logs with Traces in SigNoz"
+  />
+  <figcaption>
+    <i>Correlating Logs with Traces in SigNoz</i>
+  </figcaption>
 </figure>
-
-
 
 ## Getting started with SigNoz
 

--- a/data/blog/opentelemetry-logs.mdx
+++ b/data/blog/opentelemetry-logs.mdx
@@ -7,19 +7,8 @@ authors: [ankit_anand]
 description: Unlike traces and metrics, OpenTelemetry logs take a different approach. In order to be successful, OpenTelemetry needs to support the existing legacy of logs and logging libraries. And this is the main design philosophy of OpenTelemetry logs....
 image: /img/blog/2023/10/single-pane-of-glass-cover-min.jpg
 hide_table_of_contents: false
-keywords:
-  [
-    opentelemetry logs,
-    opentelemetry log,
-    opentelemetry,
-    logs correlation,
-    opentelemetry logging,
-    telemetry signals,
-    observability,
-    signoz,
-  ]
+keywords: [opentelemetry logs,opentelemetry log,opentelemetry,logs correlation,opentelemetry logging,telemetry signals,observability,signoz]
 ---
-
 OpenTelemetry is a Cloud Native Computing Foundation(<a href = "https://www.cncf.io/" rel="noopener noreferrer nofollow" target="_blank" >CNCF</a>) incubating project aimed at standardizing the way we instrument applications for generating telemetry data(logs, metrics, and traces). OpenTelemetry aims to provide a vendor-agnostic observability framework that provides a set of tools, APIs, and SDKs to instrument applications.
 
 ![Cover Image](/img/blog/2023/10/otel-logs-cover.webp)
@@ -46,14 +35,9 @@ Before deep diving into OpenTelemetry logs, let's briefly overview OpenTelemetry
 
 OpenTelemetry provides instrumentation libraries for your application. The development of these libraries is guided by the <a href = "https://github.com/open-telemetry/opentelemetry-specification" rel="noopener noreferrer nofollow" target="_blank" >OpenTelemetry specification</a>. The OpenTelemetry specification describes the cross-language requirements and design expectations for all OpenTelemetry implementations in various programming languages.
 
-<figure data-zoomable align="center">
-  <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture" />
-  <figcaption>
-    <i>
-      How OpenTelemetry fits in an application architecture. OTel is the convenient short form for
-      OpenTelemetry
-    </i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2022/09/opentelemetry_architecture.webp" alt="OpenTelemetry Architecture"/>
+    <figcaption><i>How OpenTelemetry fits in an application architecture. OTel is the convenient short form for OpenTelemetry</i></figcaption>
 </figure>
 
 OpenTelemetry libraries can be used to generate logs, metrics, and traces. You can then collect these signals with OpenTelemetry Collector or send them to an observability backend of your choice. In this article, we will focus on [OpenTelemetry logs](https://signoz.io/comparisons/opentelemetry-events-vs-logs/). OpenTelemetry can be used to collect log data and process it. Let's explore OpenTelemetry logs further.
@@ -103,12 +87,12 @@ The primary goal of OpenTelemetry's log data model is to ensure a common underst
 
 **Trace Context Fields:** These include TraceId, SpanId, and TraceFlags which are essential for correlating logs with traces.
 
-**Severity Text:** This is a string that represents the original _log level_ as it was written by the source system
-(e.g., "INFO", "WARN", "DEBUG").
+**Severity Text:** This is a string that represents the original *log level* as it was written by the source system
+          (e.g., "INFO", "WARN", "DEBUG"). 
 
-**Severity Number:** This is a standardized, enumerated integer that represents the level's severity. This is an important field
+**Severity Number:** This is a standardized, enumerated integer that represents the level's severity. This is an important field 
 for programmatic use cases like filtering and alerting. For example, you can reliably
-create an alert for all logs where SeverityNumber >= 17 (the ERROR range).
+         create an alert for all logs where SeverityNumber >= 17 (the ERROR range).
 
 **Body:** Contains the main content of the log record. It can be a human-readable string message or structured data.
 
@@ -164,7 +148,7 @@ Existing logging solutions also don’t have any standardized way to propagate a
 
 **Holistic View:** Correlation provides a complete picture of the system, allowing developers and operators to understand how different components interact and affect each other.
 
-{/\* <!-- ## Correlation in OpenTelemetry
+{/* <!-- ## Correlation in OpenTelemetry
 
 Let's see through a code example how correlation works in OpenTelemetry. Consider a hypothetical scenario where a web service processes user requests. We'll showcase how to correlate logs, metrics, and traces using OpenTelemetry:
 
@@ -216,7 +200,7 @@ If there's an exception during processing, we log an error message, set error at
 
 With OpenTelemetry's correlation capabilities, when analyzing the data, you can link the log entries, metrics, and trace spans together. This allows you to see, for instance, the specific log messages associated with a particular trace or the metrics associated with a specific operation.
 
-Now let's talk about how to collect log data with OpenTelmetry. --> \*/}
+Now let's talk about how to collect log data with OpenTelmetry. --> */}
 
 ## Collecting log data with OpenTelemetry
 
@@ -224,7 +208,7 @@ OpenTelemetry provides various receivers and processors for collecting first-par
 
 ### Collecting legacy first-party application logs
 
-These applications are built in-house and use existing logging libraries. The logs from these applications can be pushed to OpenTelemetry with little to no changes in the application code.
+These applications are built in-house and use existing logging libraries. The logs from these applications can be pushed to OpenTelemetry with little to no changes in the application code. 
 OpenTelemetry provides a `trace_parser` with which you can add context IDs to your logs to correlate them with other signals.
 
 In OpenTelemetry, there are two important context IDs for context propagation.
@@ -234,16 +218,11 @@ In OpenTelemetry, there are two important context IDs for context propagation.
 
 - **Span IDs**<br></br>
   A trace consists of multiple spans. Each span represents a single unit of logical work in the trace data. Spans have span IDs that are used to represent the parent-child relationship.
-  {' '}
-  <figure data-zoomable align="center">
-    <img src="/img/blog/2025/09/otel-spans.webp" alt="Traces in SigNoz" />
-    <figcaption>
-      <i>
-        A trace graph broken down into individual spans visualized as Flamegraphs and Gantt charts
-        in SigNoz dashboard
-      </i>
-    </figcaption>
-  </figure>
+    <figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/otel-spans.webp" alt="Traces in SigNoz"/>
+    <figcaption><i>A trace graph broken down into individual spans visualized as Flamegraphs and Gantt charts in SigNoz dashboard</i></figcaption>
+    </figure>
+    
 
 Correlating your logs with traces can help drive deeper insights. If you don’t have request context like **traceId** and **spanId** in your logs, you might want to add them for easier correlation with metrics and traces.
 
@@ -252,19 +231,17 @@ There are **two** ways to collect application logs:
 - **Via File or Stdout Logs**<br></br>
   Here, the logs of the application are directly collected by the OpenTelemetry receiver using collectors like **filelog receiver.** Then operators and processors are used for parsing them into the OpenTelemetry log data model.
 
-  {' '}
+    <figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/log-pipeline.webp" alt="Collecting logs via file or Stdout logs"/>
+    <figcaption><i>Collecting logs via file or Stdout logs</i></figcaption>
+    </figure>
+    
 
-  <figure data-zoomable align="center">
-    <img src="/img/blog/2025/09/log-pipeline.webp" alt="Collecting logs via file or Stdout logs" />
-    <figcaption>
-      <i>Collecting logs via file or Stdout logs</i>
-    </figcaption>
-  </figure>
-
-  For advanced parsing and collecting capabilities, you can also use something like FluentBit or Logstash. The agents can push the logs to the OpenTelemetry collector using protocols like FluentForward/TCP/UDP, etc.
+    
+    For advanced parsing and collecting capabilities, you can also use something like FluentBit or Logstash. The agents can push the logs to the OpenTelemetry collector using protocols like FluentForward/TCP/UDP, etc.
 
 - **Directly to OpenTelemetry Collector with SDK**<br></br>
-  In this approach, you can modify your logging library that is used by the application to use the logging SDK provided by OpenTelemetry and directly forward the logs from the application to OpenTelemetry.
+  In this approach, you can modify your logging library that is used by the application to use the logging SDK provided by OpenTelemetry and directly forward the logs from the application to OpenTelemetry. 
   This approach removes any need for agents/intermediary medium but loses the simplicity of having the log file locally. Let's explore it in greater detail.
 
 ### Generating Context Aware Logs with OpenTelemetry SDK
@@ -276,67 +253,69 @@ with full trace context, making correlation effortless.
 To understand how this works, you first need to know about OpenTelemetry's core design: the separation of its API
 from its SDK.
 
-- The API: A set of abstract interfaces that library authors use to add instrumentation. It defines what can be done
-  (e.g., get a logger, emit a log) but has no real implementation.
+   * The API: A set of abstract interfaces that library authors use to add instrumentation. It defines what can be done
+      (e.g., get a logger, emit a log) but has no real implementation. 
 
-- The SDK: The concrete implementation of the API. You, the application developer, adds the SDK to your project to
-  **turn on** telemetry. The SDK is responsible for actually creating, processing, and exporting the logs.
+   * The SDK: The concrete implementation of the API. You, the application developer, adds the SDK to your project to
+     **turn on** telemetry. The SDK is responsible for actually creating, processing, and exporting the logs.
 
-Now, let's see how to use this combination in practice.
+  Now, let's see how to use this combination in practice.
 
-**Example 1. Instrumenting Python with a Logging Handler**
+  **Example 1. Instrumenting Python with a Logging Handler**
 
-Here's an example of using OpenTelemetry's [LoggingInstrumentor](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html) to instrument the logging library to automatically add trace context in a Python application.
+  Here's an example of using OpenTelemetry's [LoggingInstrumentor](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html) to instrument the logging library to automatically add trace context in a Python application.
 
-```python
-import logging
-from opentelemetry.instrumentation.logging import LoggingInstrumentor
+  ```python 
+      import logging
+      from opentelemetry.instrumentation.logging import LoggingInstrumentor
+      
+      # Instrument the logging library to automatically add trace context
+      LoggingInstrumentor().instrument(set_logging_format=True)
+      
+      # Now, any log created within an active trace will automatically
+      # include trace_id and span_id in its record.
+      logging.basicConfig(level=logging.INFO)
+      logging.info("User login successful.")
+  ```
 
-# Instrument the logging library to automatically add trace context
-LoggingInstrumentor().instrument(set_logging_format=True)
+  **Example 2. Instrumenting in Java with a Log Appender**
 
-# Now, any log created within an active trace will automatically
-# include trace_id and span_id in its record.
-logging.basicConfig(level=logging.INFO)
-logging.info("User login successful.")
-```
 
-**Example 2. Instrumenting in Java with a Log Appender**
+  For Java applications, which commonly use logging frameworks like Logback or Log4j, OpenTelemetry
+  integrates by providing a custom Log Appender.
 
-For Java applications, which commonly use logging frameworks like Logback or Log4j, OpenTelemetry
-integrates by providing a custom Log Appender.
+  An Appender is a component within these frameworks responsible for sending log events to a destination (like the
+  console or a file). The OpenTelemetryAppender is a special appender that captures all logs your application creates
+   and forwards them to the OpenTelemetry SDK (the destination). The SDK then automatically enriches them with the active TraceId and
+  SpanId before exporting them.
 
-An Appender is a component within these frameworks responsible for sending log events to a destination (like the
-console or a file). The OpenTelemetryAppender is a special appender that captures all logs your application creates
-and forwards them to the OpenTelemetry SDK (the destination). The SDK then automatically enriches them with the active TraceId and
-SpanId before exporting them.
 
 To configure it, you simply add the OpenTelemetryAppender to your log4j2.xml (or logback.xml) file, requiring no changes to your
 application's source code as shown in the below example.
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.appender.v2_17">
-  <!-- The appender is configured via standard OpenTelemetry environment variables or system properties -->
-  <Appenders>
-      <OpenTelemetry name="OpenTelemetryAppender"/>
-  </Appenders>
-  <!-- Attach the OpenTelemetryAppender to the root logger -->
-  <Loggers>
-      <Root>
-          <AppenderRef ref="OpenTelemetryAppender" level="All"/>
-      </Root>
-  </Loggers>
+  ```xml 
+  <?xml version="1.0" encoding="UTF-8"?>
+  <Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.appender.v2_17">
+    <!-- The appender is configured via standard OpenTelemetry environment variables or system properties -->
+    <Appenders>
+        <OpenTelemetry name="OpenTelemetryAppender"/>
+    </Appenders>
+    <!-- Attach the OpenTelemetryAppender to the root logger -->
+    <Loggers>
+        <Root>
+            <AppenderRef ref="OpenTelemetryAppender" level="All"/>
+        </Root>
+    </Loggers>
 </Configuration>
-```
+  ```
 
-As you can see, while the mechanism differs by language ecosystem (Handlers in Python, Appenders in Java), the
-underlying idea is the same, i.e, integrate the OpenTelemetry SDK with your existing logging framework to automatically enrich
-all your logs with invaluable trace context.
+  As you can see, while the mechanism differs by language ecosystem (Handlers in Python, Appenders in Java), the
+  underlying idea is the same, i.e, integrate the OpenTelemetry SDK with your existing logging framework to automatically enrich
+  all your logs with invaluable trace context.
 
 ### Collecting third-party application log data
 
-Logs emitted by third-party applications running on the system are known as third-party application logs. The logs are typically written to stdout, files, or other specialized mediums.
+Logs emitted by third-party applications running on the system are known as third-party application logs. The logs are typically written to stdout, files, or other specialized mediums. 
 For example, Windows event logs for applications.
 
 These logs can be collected using the OpenTelemetry file receiver and then processed.
@@ -352,7 +331,7 @@ You will need OpenTelemetry Collector (otel collector) to collect syslogs. In th
   receivers:
     syslog:
       tcp:
-        listen_address: '0.0.0.0:54527'
+        listen_address: "0.0.0.0:54527"
       protocol: rfc3164
       location: UTC
       operators:
@@ -436,23 +415,21 @@ Processors are also helpful when you have multiple receivers for logs and you wa
 ## Log Analytics - Querying and Visualising Logs
 
 Once you have configured OpenTelemetry to collect your logs, you need a backend to analyze, query, and
-visualize them. This is where the value of structured logging is truly unlocked. As an OpenTelemetry-native platform, SigNoz is designed to work with the OTel data model. Let's explore
+visualize them. This is where the value of structured logging is truly unlocked. As an OpenTelemetry-native platform, SigNoz is designed to work  with the OTel data model. Let's explore
 how you can perform log analytics. The logs tab in SigNoz has advanced features like a log query builder, search across multiple fields, structured table view, JSON view, etc.
 
 ### Searching and Filtering with the Query Builder
 
 Your key step in any investigation during an escalation is to find the right logs. Instead of manually searching through tons of logs,
-you can use a query builder to filter logs based on any field in the OpenTelemetry log data model.
+you can use a query builder to filter logs based on any field in the OpenTelemetry log data model. 
 We have recently overhauled the Query Builder, you can read more about it [here](https://signoz.io/blog/query-builder-v5/).
 
 For example, you can quickly find all logs with `SeverityText = ERROR` from your web-backend service that occurred in
 the last hour as shown in the below screenshot.
 
-<figure data-zoomable align="center">
-  <img src="/img/blog/2025/09/logs-query-error.webp" alt="Log Management in SigNoz" />
-  <figcaption>
-    <i>Logs management in SigNoz</i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/logs-query-error.webp" alt="Log Management in SigNoz"/>
+    <figcaption><i>Logs management in SigNoz</i></figcaption>
 </figure>
 
 ### Real-Time Analysis with Live Tail
@@ -461,11 +438,10 @@ When you're debugging a live issue, you need to see logs as they happen. Live ta
 provides a real-time stream of logs from your applications, allowing you to see the immediate impact of your
 changes as demonstrated in the below screenshot.
 
-<figure data-zoomable align="center">
-  <img src="/img/blog/2025/09/live-tailing.webp" alt="Live tail logging in SigNoz" />
-  <figcaption>
-    <i>Live tail logging in SigNoz</i>
-  </figcaption>
+
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/live-tailing.webp" alt="Live tail logging in SigNoz"/>
+    <figcaption><i>Live tail logging in SigNoz</i></figcaption>
 </figure>
 
 ### Correlating Logs with Traces
@@ -475,19 +451,13 @@ As mentioned previously, this is an important benefit of using OpenTelemetry for
 
 In SigNoz, the `TraceId` in a log record is a clickable link. Meaning, when you find an interesting error log, you can click its
 `TraceId` to instantly pivot to the full distributed trace view for that specific request. This allows you to discover more important insights like:
+  - The exact user request that produced the error.
+  - The full journey of the request across all microservices.
+  - Latency breakdowns for each step, helping you pinpoint the root cause.
 
-- The exact user request that produced the error.
-- The full journey of the request across all microservices.
-- Latency breakdowns for each step, helping you pinpoint the root cause.
-
-<figure data-zoomable align="center">
-  <img
-    src="/img/blog/2025/09/otel-log-correlation.webp"
-    alt="Correlating Logs with Traces in SigNoz"
-  />
-  <figcaption>
-    <i>Correlating Logs with Traces in SigNoz</i>
-  </figcaption>
+<figure data-zoomable align='center'>
+    <img src="/img/blog/2025/09/otel-log-correlation.webp" alt="Correlating Logs with Traces in SigNoz"/>
+    <figcaption><i>Correlating Logs with Traces in SigNoz</i></figcaption>
 </figure>
 
 ## Getting started with SigNoz

--- a/data/blog/opentelemetry-logs.mdx
+++ b/data/blog/opentelemetry-logs.mdx
@@ -51,7 +51,7 @@ OpenTelemetry provides instrumentation libraries for your application. The devel
   <figcaption>
     <i>
       How OpenTelemetry fits in an application architecture. OTel is the convenient short form for
-      OpenTelemtry
+      OpenTelemetry
     </i>
   </figcaption>
 </figure>
@@ -253,6 +253,7 @@ There are **two** ways to collect application logs:
   Here, the logs of the application are directly collected by the OpenTelemetry receiver using collectors like **filelog receiver.** Then operators and processors are used for parsing them into the OpenTelemetry log data model.
 
   {' '}
+
   <figure data-zoomable align="center">
     <img src="/img/blog/2025/09/log-pipeline.webp" alt="Collecting logs via file or Stdout logs" />
     <figcaption>


### PR DESCRIPTION
Addresses several minor issues in the OTel Logs and Collector blogs, including pre-commit based formatting changes.

Also includes the `yarn` setup step in the readme file, as yarn docs suggest another library which causes problems with husky pre-commit integration.

<img width="1512" height="457" alt="image" src="https://github.com/user-attachments/assets/03fcb361-8bc8-46ca-8cd6-f04cd07eeacc" />
