### PR TITLE
Add Clarity priority tracking to 5 key pages

### DIFF
--- a/app/alerts-management/page.tsx
+++ b/app/alerts-management/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import AlertsPage from './AlertsPage'
 import { Metadata } from 'next'
+import ClarityPriority from '@/components/Analytics/ClarityPriority'
 
 export const metadata: Metadata = {
   title: {
@@ -8,18 +9,25 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Alerts with multiple thresholds and dynamic routing | SigNoz',
-    description: "Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.",
-    images:"/img/platform/AlertsManagementMeta.png"
+    description:
+      'Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.',
+    images: '/img/platform/AlertsManagementMeta.png',
   },
   description:
-    "Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.",
-  twitter:{
+    'Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.',
+  twitter: {
     title: 'Alerts with multiple thresholds and dynamic routing | SigNoz',
-    description: "Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.",
-    images:"/img/platform/AlertsManagementMeta.png",
-  }
+    description:
+      'Define warning and critical levels in a single rule. Automatically route to teams based on service, environment, or labels. Group notifications by deployment, customer, or any attribute.',
+    images: '/img/platform/AlertsManagementMeta.png',
+  },
 }
 
 export default function AlertsManagementPage() {
-  return <AlertsPage />
+  return (
+    <>
+      <ClarityPriority />
+      <AlertsPage />
+    </>
+  )
 }

--- a/app/distributed-tracing/page.tsx
+++ b/app/distributed-tracing/page.tsx
@@ -1,24 +1,33 @@
 import React from 'react'
 import DistributedTracingPage from './DistributedTracingPage'
 import { Metadata } from 'next'
+import ClarityPriority from '@/components/Analytics/ClarityPriority'
 
 export const metadata: Metadata = {
   title: {
     absolute: 'High-Performance Trace Analysis Powered by Columnar Storage | SigNoz',
   },
   openGraph: {
-    title: "High-Performance Trace Analysis Powered by Columnar Storage",
-    description: "Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.",
-    images: "/img/platform/DistributedTracingMeta.png"
+    title: 'High-Performance Trace Analysis Powered by Columnar Storage',
+    description:
+      'Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.',
+    images: '/img/platform/DistributedTracingMeta.png',
   },
-  description: "Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.",
-  twitter:{
-    title: "High-Performance Trace Analysis Powered by Columnar Storage",
-    description: "Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.",
-    images: "/img/platform/DistributedTracingMeta.png"
-  }
+  description:
+    'Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.',
+  twitter: {
+    title: 'High-Performance Trace Analysis Powered by Columnar Storage',
+    description:
+      'Aggregate and analyze millions of spans with ClickHouse performance. Correlate traces with logs and metrics to find root cause in distributed systems.',
+    images: '/img/platform/DistributedTracingMeta.png',
+  },
 }
 
 export default function DistributedTracing() {
-  return <DistributedTracingPage />
+  return (
+    <>
+      <ClarityPriority />
+      <DistributedTracingPage />
+    </>
+  )
 }

--- a/app/external-apis/page.tsx
+++ b/app/external-apis/page.tsx
@@ -1,24 +1,33 @@
 import React from 'react'
 import ExternalApisPage from './ExternalApisPage'
 import { Metadata } from 'next'
+import ClarityPriority from '@/components/Analytics/ClarityPriority'
 
 export const metadata: Metadata = {
   title: {
     absolute: 'Monitor External APIs With Built-In Service Correlation | SigNoz',
   },
   openGraph: {
-    title: "Monitor External APIs With Built-In Service Correlation",
-    description: "Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.",
-    images: "/img/platform/ExternalApisMeta.png"
+    title: 'Monitor External APIs With Built-In Service Correlation',
+    description:
+      'Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.',
+    images: '/img/platform/ExternalApisMeta.png',
   },
-  description: "Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.",
-  twitter:{
-    title: "Monitor External APIs With Built-In Service Correlation",
-    description: "Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.",
-    images: "/img/platform/ExternalApisMeta.png"
-  }
+  description:
+    'Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.',
+  twitter: {
+    title: 'Monitor External APIs With Built-In Service Correlation',
+    description:
+      'Automatically detect external API calls using OpenTelemetry semantic conventions. Click any metric to view the service making the call or the underlying trace.',
+    images: '/img/platform/ExternalApisMeta.png',
+  },
 }
 
 export default function TraceFunnels() {
-  return <ExternalApisPage />
+  return (
+    <>
+      <ClarityPriority />
+      <ExternalApisPage />
+    </>
+  )
 }

--- a/app/log-management/page.tsx
+++ b/app/log-management/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import LogManagement from './LogManagement'
 import { Metadata } from 'next'
+import ClarityPriority from '@/components/Analytics/ClarityPriority'
 
 export const metadata: Metadata = {
   title: {
@@ -8,18 +9,25 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: 'Log Management | SigNoz',
-    description: 'Ingest logs from anywhere, quickly search and analyze with a powerful query builder, and correlate your logs with other signals. Logs at SigNoz is powered by ClickHouse - a lightning-fast columnar datastore suited for storing logs at scale.',
-    images:"/img/platform/LogsManagementHero.webp"
+    description:
+      'Ingest logs from anywhere, quickly search and analyze with a powerful query builder, and correlate your logs with other signals. Logs at SigNoz is powered by ClickHouse - a lightning-fast columnar datastore suited for storing logs at scale.',
+    images: '/img/platform/LogsManagementHero.webp',
   },
   description:
     'Ingest logs from anywhere, quickly search and analyze with a powerful query builder, and correlate your logs with other signals. Logs at SigNoz is powered by ClickHouse - a lightning-fast columnar datastore suited for storing logs at scale.',
-  twitter:{
+  twitter: {
     title: 'Log Management | SigNoz',
-    description: 'Ingest logs from anywhere, quickly search and analyze with a powerful query builder, and correlate your logs with other signals. Logs at SigNoz is powered by ClickHouse - a lightning-fast columnar datastore suited for storing logs at scale.',
-    images:"/img/platform/LogsManagementHero.webp",
-  }
+    description:
+      'Ingest logs from anywhere, quickly search and analyze with a powerful query builder, and correlate your logs with other signals. Logs at SigNoz is powered by ClickHouse - a lightning-fast columnar datastore suited for storing logs at scale.',
+    images: '/img/platform/LogsManagementHero.webp',
+  },
 }
 
 export default function LogManagementPage() {
-  return <LogManagement />
+  return (
+    <>
+      <ClarityPriority />
+      <LogManagement />
+    </>
+  )
 }

--- a/app/trace-funnels/page.tsx
+++ b/app/trace-funnels/page.tsx
@@ -1,24 +1,33 @@
 import React from 'react'
 import TraceFunnelsPage from './TraceFunnelsPage'
 import { Metadata } from 'next'
+import ClarityPriority from '@/components/Analytics/ClarityPriority'
 
 export const metadata: Metadata = {
   title: {
     absolute: 'Create Visual Funnels from Traces to Track Step-by-Step Completion | SigNoz',
   },
   openGraph: {
-    title: "Create Visual Funnels from Traces to Track Step-by-Step Completion",
-    description: "The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.",
-    images: "/img/platform/TraceFunnelsMeta.png"
+    title: 'Create Visual Funnels from Traces to Track Step-by-Step Completion',
+    description:
+      'The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.',
+    images: '/img/platform/TraceFunnelsMeta.png',
   },
-  description: "The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.",
-  twitter:{
-    title: "Create Visual Funnels from Traces to Track Step-by-Step Completion",
-    description: "The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.",
-    images: "/img/platform/TraceFunnelsMeta.png"
-  }
+  description:
+    'The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.',
+  twitter: {
+    title: 'Create Visual Funnels from Traces to Track Step-by-Step Completion',
+    description:
+      'The only distributed tracing tool that tracks multi-step request flows. See where traces succeed, where they fail, and where they drop off in multi-step processes.',
+    images: '/img/platform/TraceFunnelsMeta.png',
+  },
 }
 
 export default function TraceFunnels() {
-  return <TraceFunnelsPage />
+  return (
+    <>
+      <ClarityPriority />
+      <TraceFunnelsPage />
+    </>
+  )
 }

--- a/components/Analytics/ClarityPriority.tsx
+++ b/components/Analytics/ClarityPriority.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function ClarityPriority() {
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.clarity) {
+      window.clarity('set', 'priority', 'high')
+    }
+  }, [])
+
+  return null
+}
+
+declare global {
+  interface Window {
+    clarity?: (action: string, key: string, value: string) => void
+  }
+}


### PR DESCRIPTION
Added Clarity priority tracking to 5 product pages to increase heatmap data collection and session recording priority.

Pages updated:

- /log-management/
- /distributed-tracing/
- /alerts-management/
- /trace-funnels/
- /external-apis/

Implementation:

1. Created ClarityPriority component that calls clarity("set", "priority", "high") on mount
2. Added component to all 5 target pages

How I tested

- Ran npm run dev and visited http://localhost:3000/log-management/
- Opened DevTools Console 
- Verified Clarity is loaded: typeof clarity returned "function" 
- Priority tracking fires automatically on page load via useEffect