### PR TITLE
chore: Update OTel Demo Dashboards

### DIFF
--- a/public/dashboards/otel-demo-kafka-metrics.json
+++ b/public/dashboards/otel-demo-kafka-metrics.json
@@ -1,891 +1,926 @@
 {
-    "description": "",
-    "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
-    "layout": [
-      {
-        "h": 6,
-        "i": "ab5c8b0f-0562-42fd-a51e-dbba39100d07",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 0
+  "description": "",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
+  "layout": [
+    {
+      "h": 6,
+      "i": "ab5c8b0f-0562-42fd-a51e-dbba39100d07",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "9932812c-2d59-42f6-9289-7d5b27d29b2e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "ca4d9dc2-6150-4883-b034-81bfe10c9e1c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "d430460a-289a-4e40-aa8f-ffea1cd2f418",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "c00817ac-bd06-44bf-96bb-37d6f906f481",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "28c5429a-fcf5-4eff-b529-ad5f15a04b3d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 12
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "Oteldemo"
+  ],
+  "title": "Kafka Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "version": "v5",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
       },
-      {
-        "h": 6,
-        "i": "9932812c-2d59-42f6-9289-7d5b27d29b2e",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      {
-        "h": 6,
-        "i": "ca4d9dc2-6150-4883-b034-81bfe10c9e1c",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 6
-      },
-      {
-        "h": 6,
-        "i": "d430460a-289a-4e40-aa8f-ffea1cd2f418",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 6,
-        "y": 6
-      },
-      {
-        "h": 6,
-        "i": "c00817ac-bd06-44bf-96bb-37d6f906f481",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 12
-      },
-      {
-        "h": 6,
-        "i": "28c5429a-fcf5-4eff-b529-ad5f15a04b3d",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 6,
-        "y": 12
-      }
-    ],
-    "panelMap": {},
-    "tags": [
-      "Oteldemo"
-    ],
-    "title": "Kafka Monitoring Dashboard",
-    "uploadedGrafana": false,
-    "version": "v4",
-    "widgets": [
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "ab5c8b0f-0562-42fd-a51e-dbba39100d07",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_io_wait_ratio--float64--Gauge--true",
-                  "isColumn": true,
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "ab5c8b0f-0562-42fd-a51e-dbba39100d07",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.io_wait_ratio",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag",
+                  "isColumn": false,
                   "isJSON": false,
-                  "key": "kafka_consumer_io_wait_ratio",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "avg",
-                "stepInterval": 60,
-                "timeAggregation": "avg"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
               "legend": "",
-              "name": "A",
-              "query": ""
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
             }
           ],
-          "id": "f1edb6f7-877d-4ca2-9acf-ac7a9e7f11bb",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "selectedLogFields": [
+        "clickhouse_sql": [
           {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "selectedTracesFields": [
+        "id": "81ebaa77-fc36-452f-8cb5-233270d39cd5",
+        "promql": [
           {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Kafka IO wait",
-        "yAxisUnit": "none"
+        "queryType": "builder"
       },
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "9932812c-2d59-42f6-9289-7d5b27d29b2e",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_fetch_size_max--float64--Gauge--true",
-                  "isColumn": true,
-                  "isJSON": false,
-                  "key": "kafka_consumer_fetch_size_max",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "latest",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "avg",
-                "stepInterval": 60,
-                "timeAggregation": "latest"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "id": "5ba5ac54-8f87-4ffb-9d23-98af2d7b2807",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
         },
-        "selectedLogFields": [
-          {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
-          }
-        ],
-        "selectedTracesFields": [
-          {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
-          }
-        ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Consumer fetch size",
-        "yAxisUnit": "none"
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka IO wait",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
       },
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "ca4d9dc2-6150-4883-b034-81bfe10c9e1c",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_outgoing_byte_rate--float64--Gauge--true",
-                  "isColumn": true,
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "9932812c-2d59-42f6-9289-7d5b27d29b2e",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.fetch_size_max",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag",
+                  "isColumn": false,
                   "isJSON": false,
-                  "key": "kafka_consumer_outgoing_byte_rate",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "latest",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "max",
-                "stepInterval": 60,
-                "timeAggregation": "latest"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
               "legend": "",
-              "name": "A",
-              "query": ""
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
             }
           ],
-          "id": "21f378fb-b885-49b1-a848-ab12fc28911c",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "selectedLogFields": [
+        "clickhouse_sql": [
           {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "selectedTracesFields": [
+        "id": "bb77a011-a0ba-4a1b-b4a6-cb8e714e9a40",
+        "promql": [
           {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Kafka outgoing byte ratio",
-        "yAxisUnit": "none"
+        "queryType": "builder"
       },
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "d430460a-289a-4e40-aa8f-ffea1cd2f418",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_time_between_poll_max--float64--Gauge--true",
-                  "isColumn": true,
-                  "isJSON": false,
-                  "key": "kafka_consumer_time_between_poll_max",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "latest",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "max",
-                "stepInterval": 60,
-                "timeAggregation": "latest"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "id": "a28c6ea1-1dff-42d2-a918-460f6e20278d",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
         },
-        "selectedLogFields": [
-          {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
-          }
-        ],
-        "selectedTracesFields": [
-          {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
-          }
-        ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Kafka Time between poll [what causes lag]",
-        "yAxisUnit": "none"
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer fetch size",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
       },
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "c00817ac-bd06-44bf-96bb-37d6f906f481",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_response_rate--float64--Gauge--true",
-                  "isColumn": true,
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "ca4d9dc2-6150-4883-b034-81bfe10c9e1c",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.outgoing_byte_rate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag",
+                  "isColumn": false,
                   "isJSON": false,
-                  "key": "kafka_consumer_response_rate",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "latest",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "max",
-                "stepInterval": 60,
-                "timeAggregation": "latest"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
               "legend": "",
-              "name": "A",
-              "query": ""
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
             }
           ],
-          "id": "bb671b09-f33d-4092-8b25-ead6ec5f0974",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "selectedLogFields": [
+        "clickhouse_sql": [
           {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "selectedTracesFields": [
+        "id": "58d2c927-d41d-49dc-a44a-19e047b8fd02",
+        "promql": [
           {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Kafka consumer response rate",
-        "yAxisUnit": "decbytes"
+        "queryType": "builder"
       },
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": false,
-        "id": "28c5429a-fcf5-4eff-b529-ad5f15a04b3d",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "kafka_consumer_records_lag_avg--float64--Gauge--true",
-                  "isColumn": true,
-                  "isJSON": false,
-                  "key": "kafka_consumer_records_lag_avg",
-                  "type": "Gauge"
-                },
-                "aggregateOperator": "max",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "service_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "service_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "max",
-                "stepInterval": 60,
-                "timeAggregation": "max"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "id": "c5c62ed3-1219-4a15-be27-ae07be72d558",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
         },
-        "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka outgoing byte ratio",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "d430460a-289a-4e40-aa8f-ffea1cd2f418",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.time_between_poll_max",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
           {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "selectedTracesFields": [
+        "id": "eb5a1972-04a5-452e-8f29-d9dd56c1f906",
+        "promql": [
           {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
           }
         ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Consumer lag",
-        "yAxisUnit": "none"
-      }
-    ]
-  }
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka Time between poll [what causes lag]",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "c00817ac-bd06-44bf-96bb-37d6f906f481",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.response_rate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "",
+                  "id": "service.name----",
+                  "key": "service.name",
+                  "type": ""
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7134b419-79dd-43f9-869c-2e0be5681735",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka consumer response rate",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": false,
+      "id": "28c5429a-fcf5-4eff-b529-ad5f15a04b3d",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kafka.consumer.records_lag_avg",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5c6b64cf-0a7b-41f7-8894-a39d85f290f1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer lag",
+      "yAxisUnit": "none"
+    }
+  ],
+  "uuid": "019a823d-f141-7be0-a750-9fc509b4c470"
+}

--- a/public/dashboards/otel-demo-span-metrics.json
+++ b/public/dashboards/otel-demo-span-metrics.json
@@ -1,1213 +1,1193 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
-        }
-      ]
-    },
-    "description": "Spanmetrics way of demo application view.",
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 3,
-    "layout": [
-      {
-        "h": 6,
-        "i": "04a10958-e65d-4417-81c8-1b778570f4e0",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      }
-    ],
-    "links": [],
-    "panelMap": {},
-    "panels": [
-      {
-        "fieldConfig": {
-          "defaults": {},
-          "overrides": []
         },
-        "gridPos": {
-          "h": 2,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 26,
-        "options": {
-          "code": {
-            "language": "plaintext",
-            "showLineNumbers": false,
-            "showMiniMap": false
-          },
-          "content": "This dashboard uses RED metrics generated for all services by the spanmetrics connector configured in the OpenTelemetry Collector.\n<br>\nChart panels may require 5 minutes after the Demo is started before rendering data.",
-          "mode": "html"
-        },
-        "pluginVersion": "11.4.0",
-        "title": "",
-        "type": "text"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 2
-        },
-        "id": 24,
-        "panels": [],
-        "title": "Service Level - Throughput and Latencies",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "continuous-BlYlRd"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "blue",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 2
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 64
-                },
-                {
-                  "color": "orange",
-                  "value": 128
-                },
-                {
-                  "color": "red",
-                  "value": 256
-                }
-              ]
-            },
-            "unit": "ms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 20,
-          "w": 12,
-          "x": 0,
-          "y": 3
-        },
-        "id": 2,
-        "interval": "5m",
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,histogram_quantile(0.50, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
-            "format": "time_series",
-            "hide": true,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{service_name}}-quantile_0.50",
-            "range": true,
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,service_name)))",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{service_name}}",
-            "range": false,
-            "refId": "B"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "histogram_quantile(0.99, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
-            "hide": true,
-            "interval": "",
-            "legendFormat": "quantile99",
-            "range": true,
-            "refId": "C"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "histogram_quantile(0.999, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
-            "hide": true,
-            "interval": "",
-            "legendFormat": "quantile999",
-            "range": true,
-            "refId": "D"
-          }
-        ],
-        "title": "Top 3x3 - Service Latency - quantile95",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "continuous-BlYlRd"
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "super-light-blue",
-                  "value": 1
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 2
-                },
-                {
-                  "color": "red",
-                  "value": 10
-                }
-              ]
-            },
-            "unit": "reqps"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 13,
-          "w": 12,
-          "x": 12,
-          "y": 3
-        },
-        "id": 4,
-        "interval": "5m",
-        "options": {
-          "displayMode": "lcd",
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "maxVizHeight": 300,
-          "minVizHeight": 10,
-          "minVizWidth": 0,
-          "namePlacement": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "mean"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "sizing": "auto",
-          "text": {},
-          "valueMode": "color"
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,sum by (service_name) (rate(traces_span_metrics_calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])))",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{service_name}}",
-            "range": false,
-            "refId": "A"
-          }
-        ],
-        "title": "Top 7 Services Mean Rate over Range",
-        "type": "bargauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "continuous-reds"
-            },
-            "decimals": 4,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 1
-                },
-                {
-                  "color": "red",
-                  "value": 15
-                }
-              ]
-            },
-            "unit": "reqps"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 16
-        },
-        "id": 15,
-        "interval": "5m",
-        "options": {
-          "displayMode": "lcd",
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "maxVizHeight": 300,
-          "minVizHeight": 10,
-          "minVizWidth": 0,
-          "namePlacement": "auto",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "mean"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "sizing": "auto",
-          "text": {},
-          "valueMode": "color"
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,sum(rate(traces_span_metrics_calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (service_name))",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{service_name}}",
-            "range": false,
-            "refId": "A"
-          }
-        ],
-        "title": "Top 7 Services Mean ERROR Rate over Range",
-        "type": "bargauge"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 23
-        },
-        "id": 14,
-        "panels": [],
-        "title": "span_names Level - Throughput",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "reqps"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "bRate"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "mode": "lcd",
-                    "type": "gauge"
-                  }
-                },
-                {
-                  "id": "color",
-                  "value": {
-                    "mode": "continuous-BlYlRd"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "eRate"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "mode": "lcd",
-                    "type": "gauge"
-                  }
-                },
-                {
-                  "id": "color",
-                  "value": {
-                    "mode": "continuous-RdYlGr"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Error Rate"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 663
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Rate"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 667
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Service"
-              },
-              "properties": [
-                {
-                  "id": "custom.width"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 11,
-          "w": 24,
-          "x": 0,
-          "y": 24
-        },
-        "id": 22,
-        "interval": "5m",
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": []
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "exemplar": false,
-            "expr": "topk(7, sum(rate(traces_span_metrics_calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name)) ",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "Rate"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "exemplar": false,
-            "expr": "topk(7, sum(rate(traces_span_metrics_calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name))",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "Error Rate"
-          }
-        ],
-        "title": "Top 7 span_names and Errors  (APM Table)",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "span_name"
-            }
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time 1": true,
-                "Time 2": true
-              },
-              "indexByName": {},
-              "renameByName": {
-                "Value #Error Rate": "Error Rate",
-                "Value #Rate": "Rate",
-                "service_name 1": "Rate in Service",
-                "service_name 2": "Error Rate in Service"
-              }
-            }
-          },
-          {
-            "id": "calculateField",
-            "options": {
-              "alias": "bRate",
-              "mode": "reduceRow",
-              "reduce": {
-                "include": [
-                  "Rate"
-                ],
-                "reducer": "sum"
-              }
-            }
-          },
-          {
-            "id": "calculateField",
-            "options": {
-              "alias": "eRate",
-              "mode": "reduceRow",
-              "reduce": {
-                "include": [
-                  "Error Rate"
-                ],
-                "reducer": "sum"
-              }
-            }
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Error Rate": true,
-                "Rate": true,
-                "bRate": false
-              },
-              "indexByName": {
-                "Error Rate": 4,
-                "Error Rate in Service": 6,
-                "Rate": 1,
-                "Rate in Service": 5,
-                "bRate": 2,
-                "eRate": 3,
-                "span_name": 0
-              },
-              "renameByName": {
-                "Rate in Service": "Service",
-                "bRate": "Rate",
-                "eRate": "Error Rate",
-                "span_name": "span_name Name"
-              }
-            }
-          },
-          {
-            "id": "sortBy",
-            "options": {
-              "fields": {},
-              "sort": [
-                {
-                  "desc": true,
-                  "field": "Rate"
-                }
-              ]
-            }
-          }
-        ],
-        "type": "table"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 35
-        },
-        "id": 20,
-        "panels": [],
-        "title": "span_name Level - Latencies",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "continuous-BlYlRd"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "blue"
-                },
-                {
-                  "color": "green",
-                  "value": 2
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 64
-                },
-                {
-                  "color": "orange",
-                  "value": 128
-                },
-                {
-                  "color": "red",
-                  "value": 256
-                }
-              ]
-            },
-            "unit": "ms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 13,
-          "w": 12,
-          "x": 0,
-          "y": 36
-        },
-        "id": 25,
-        "interval": "5m",
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.3.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,histogram_quantile(0.50, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
-            "format": "time_series",
-            "hide": true,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{service_name}}-quantile_0.50",
-            "range": true,
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7,histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,span_name)))",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{span_name}}",
-            "range": false,
-            "refId": "B"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "histogram_quantile(0.99, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
-            "hide": true,
-            "interval": "",
-            "legendFormat": "quantile99",
-            "range": true,
-            "refId": "C"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "histogram_quantile(0.999, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
-            "hide": true,
-            "interval": "",
-            "legendFormat": "quantile999",
-            "range": true,
-            "refId": "D"
-          }
-        ],
-        "title": "Top 3x3 - span_name Latency - quantile95",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "continuous-BlYlRd"
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green"
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "ms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 13,
-          "w": 12,
-          "x": 12,
-          "y": 36
-        },
-        "id": 10,
-        "interval": "5m",
-        "options": {
-          "displayMode": "lcd",
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "maxVizHeight": 300,
-          "minVizHeight": 10,
-          "minVizWidth": 0,
-          "namePlacement": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "mean"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "sizing": "auto",
-          "valueMode": "color"
-        },
-        "pluginVersion": "11.3.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "topk(7, sum by (span_name,service_name)(increase(traces_span_metrics_duration_milliseconds_sum{service_name=~\"${service}\", span_name=~\"$span_name\"}[5m]) / increase(traces_span_metrics_duration_milliseconds_count{service_name=~\"${service}\",span_name=~\"$span_name\"}[5m\n])))",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{span_name}} [{{service_name}}]",
-            "range": false,
-            "refId": "A"
-          }
-        ],
-        "title": "Top 7 Highest Endpoint Latencies  Mean Over Range ",
-        "type": "bargauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "webstore-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 15,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "smooth",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green"
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "ms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 12,
-          "w": 24,
-          "x": 0,
-          "y": 49
-        },
-        "id": 16,
-        "interval": "5m",
-        "options": {
-          "legend": {
-            "calcs": [
-              "mean",
-              "logmin",
-              "max",
-              "delta"
-            ],
-            "displayMode": "table",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.3.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "webstore-metrics"
-            },
-            "editorMode": "code",
-            "exemplar": true,
-            "expr": "topk(7,sum by (span_name,service_name)(increase(traces_span_metrics_duration_milliseconds_sum{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval]) / increase(traces_span_metrics_duration_milliseconds_count{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])))",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "[{{service_name}}]  {{span_name}}",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Top 7 Latencies Over Range ",
-        "type": "timeseries"
-      }
-    ],
-    "preload": false,
-    "refresh": "5m",
-    "schemaVersion": 40,
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "allValue": ".*",
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "webstore-metrics"
-          },
-          "definition": "query_result(count by (service_name)(count_over_time(traces_span_metrics_calls_total[$__range])))",
-          "includeAll": true,
-          "multi": true,
-          "name": "service",
-          "options": [],
-          "query": {
-            "query": "query_result(count by (service_name)(count_over_time(traces_span_metrics_calls_total[$__range])))",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "/.*service_name=\"(.*)\".*/",
-          "sort": 1,
-          "type": "query"
-        },
-        {
-          "allValue": ".*",
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "webstore-metrics"
-          },
-          "definition": "query_result(sum ({__name__=~\".*traces_span_metrics_calls_total\",service_name=~\"$service\"})  by (span_name))",
-          "includeAll": true,
-          "multi": true,
-          "name": "span_name",
-          "options": [],
-          "query": {
-            "query": "query_result(sum ({__name__=~\".*traces_span_metrics_calls_total\",service_name=~\"$service\"})  by (span_name))",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "/.*span_name=\"(.*)\".*/",
-          "type": "query"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-15m",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Spanmetrics Demo Dashboard",
-    "uid": "W2gX2zHVk48",
-    "uploadedGrafana": false,
-    "version": 2,
-    "weekStart": "",
-    "widgets": [
-      {
-        "bucketCount": 30,
-        "bucketWidth": 0,
-        "columnUnits": {},
-        "description": "",
-        "fillSpans": true,
-        "id": "04a10958-e65d-4417-81c8-1b778570f4e0",
-        "isStacked": false,
-        "mergeAllActiveQueries": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "traces_span_metrics_calls--float64--Sum--true",
-                  "isColumn": true,
-                  "isJSON": false,
-                  "key": "traces_span_metrics_calls",
-                  "type": "Sum"
-                },
-                "aggregateOperator": "count",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "186b2d58",
-                      "key": {
-                        "dataType": "string",
-                        "id": "service_name--string--tag--false",
-                        "isColumn": false,
-                        "isJSON": false,
-                        "key": "service_name",
-                        "type": "tag"
-                      },
-                      "op": "=",
-                      "value": "frontend"
-                    },
-                    {
-                      "id": "ba223df5",
-                      "key": {
-                        "dataType": "string",
-                        "id": "status_code--string--tag--false",
-                        "isColumn": false,
-                        "isJSON": false,
-                        "key": "status_code",
-                        "type": "tag"
-                      },
-                      "op": "=",
-                      "value": "STATUS_CODE_ERROR"
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "functions": [],
-                "groupBy": [
-                  {
-                    "dataType": "string",
-                    "id": "span_name--string--tag--false",
-                    "isColumn": false,
-                    "isJSON": false,
-                    "key": "span_name",
-                    "type": "tag"
-                  }
-                ],
-                "having": [],
-                "legend": "",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "avg",
-                "spaceAggregation": "sum",
-                "stepInterval": 60,
-                "timeAggregation": "rate"
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "id": "b5e5c058-ec76-4870-b075-416255939092",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
-        },
-        "selectedLogFields": [
-          {
-            "dataType": "string",
-            "name": "body",
-            "type": ""
-          },
-          {
-            "dataType": "string",
-            "name": "timestamp",
-            "type": ""
-          }
-        ],
-        "selectedTracesFields": [
-          {
-            "dataType": "string",
-            "id": "serviceName--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "serviceName",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "name--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "name",
-            "type": "tag"
-          },
-          {
-            "dataType": "float64",
-            "id": "durationNano--float64--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "durationNano",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "httpMethod--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "httpMethod",
-            "type": "tag"
-          },
-          {
-            "dataType": "string",
-            "id": "responseStatusCode--string--tag--true",
-            "isColumn": true,
-            "isJSON": false,
-            "key": "responseStatusCode",
-            "type": "tag"
-          }
-        ],
-        "softMax": 0,
-        "softMin": 0,
-        "stackedBarChart": false,
-        "thresholds": [],
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Span metrics by service",
-        "yAxisUnit": "none"
+        "type": "dashboard"
       }
     ]
-  }
+  },
+  "description": "Spanmetrics way of demo application view.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "layout": [
+    {
+      "h": 6,
+      "i": "04a10958-e65d-4417-81c8-1b778570f4e0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    }
+  ],
+  "links": [],
+  "panelMap": {},
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 26,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "This dashboard uses RED metrics generated for all services by the spanmetrics connector configured in the OpenTelemetry Collector.\n<br>\nChart panels may require 5 minutes after the Demo is started before rendering data.",
+        "mode": "html"
+      },
+      "pluginVersion": "11.4.0",
+      "title": "",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Service Level - Throughput and Latencies",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 2
+              },
+              {
+                "color": "#EAB839",
+                "value": 64
+              },
+              {
+                "color": "orange",
+                "value": 128
+              },
+              {
+                "color": "red",
+                "value": 256
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "interval": "5m",
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,histogram_quantile(0.50, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+          "format": "time_series",
+          "hide": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{service_name}}-quantile_0.50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,service_name)))",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{service_name}}",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.99, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "quantile99",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.999, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "quantile999",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Top 3x3 - Service Latency - quantile95",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "super-light-blue",
+                "value": 1
+              },
+              {
+                "color": "#EAB839",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 4,
+      "interval": "5m",
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,sum by (service_name) (rate(traces_span_metrics_calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{service_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 7 Services Mean Rate over Range",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-reds"
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 15,
+      "interval": "5m",
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,sum(rate(traces_span_metrics_calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (service_name))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{service_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 7 Services Mean ERROR Rate over Range",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 14,
+      "panels": [],
+      "title": "span_names Level - Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bRate"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "lcd",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlYlRd"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "eRate"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "lcd",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-RdYlGr"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error Rate"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 663
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 667
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 22,
+      "interval": "5m",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "exemplar": false,
+          "expr": "topk(7, sum(rate(traces_span_metrics_calls_total{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name)) ",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Rate"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "exemplar": false,
+          "expr": "topk(7, sum(rate(traces_span_metrics_calls_total{status_code=\"STATUS_CODE_ERROR\",service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (span_name,service_name))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Error Rate"
+        }
+      ],
+      "title": "Top 7 span_names and Errors  (APM Table)",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "span_name"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #Error Rate": "Error Rate",
+              "Value #Rate": "Rate",
+              "service_name 1": "Rate in Service",
+              "service_name 2": "Error Rate in Service"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "bRate",
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "Rate"
+              ],
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "eRate",
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "Error Rate"
+              ],
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Error Rate": true,
+              "Rate": true,
+              "bRate": false
+            },
+            "indexByName": {
+              "Error Rate": 4,
+              "Error Rate in Service": 6,
+              "Rate": 1,
+              "Rate in Service": 5,
+              "bRate": 2,
+              "eRate": 3,
+              "span_name": 0
+            },
+            "renameByName": {
+              "Rate in Service": "Service",
+              "bRate": "Rate",
+              "eRate": "Error Rate",
+              "span_name": "span_name Name"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Rate"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 20,
+      "panels": [],
+      "title": "span_name Level - Latencies",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 2
+              },
+              {
+                "color": "#EAB839",
+                "value": 64
+              },
+              {
+                "color": "orange",
+                "value": 128
+              },
+              {
+                "color": "red",
+                "value": 256
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 25,
+      "interval": "5m",
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,histogram_quantile(0.50, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name)))",
+          "format": "time_series",
+          "hide": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{service_name}}-quantile_0.50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7,histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__range])) by (le,span_name)))",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{span_name}}",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.99, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "quantile99",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.999, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])) by (le,service_name))",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "quantile999",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Top 3x3 - span_name Latency - quantile95",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 10,
+      "interval": "5m",
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(7, sum by (span_name,service_name)(increase(traces_span_metrics_duration_milliseconds_sum{service_name=~\"${service}\", span_name=~\"$span_name\"}[5m]) / increase(traces_span_metrics_duration_milliseconds_count{service_name=~\"${service}\",span_name=~\"$span_name\"}[5m\n])))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{span_name}} [{{service_name}}]",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 7 Highest Endpoint Latencies  Mean Over Range ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "webstore-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 16,
+      "interval": "5m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "logmin",
+            "max",
+            "delta"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "webstore-metrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "topk(7,sum by (span_name,service_name)(increase(traces_span_metrics_duration_milliseconds_sum{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval]) / increase(traces_span_metrics_duration_milliseconds_count{service_name=~\"$service\", span_name=~\"$span_name\"}[$__rate_interval])))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "[{{service_name}}]  {{span_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 7 Latencies Over Range ",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "webstore-metrics"
+        },
+        "definition": "query_result(count by (service_name)(count_over_time(traces_span_metrics_calls_total[$__range])))",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "query_result(count by (service_name)(count_over_time(traces_span_metrics_calls_total[$__range])))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*service_name=\"(.*)\".*/",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "webstore-metrics"
+        },
+        "definition": "query_result(sum ({__name__=~\".*traces_span_metrics_calls_total\",service_name=~\"$service\"})  by (span_name))",
+        "includeAll": true,
+        "multi": true,
+        "name": "span_name",
+        "options": [],
+        "query": {
+          "query": "query_result(sum ({__name__=~\".*traces_span_metrics_calls_total\",service_name=~\"$service\"})  by (span_name))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*span_name=\"(.*)\".*/",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spanmetrics Demo Dashboard",
+  "uid": "W2gX2zHVk48",
+  "uploadedGrafana": false,
+  "version": "v5",
+  "weekStart": "",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "",
+      "fillSpans": true,
+      "id": "04a10958-e65d-4417-81c8-1b778570f4e0",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "traces.span.metrics.calls",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "(service.name = 'frontend' AND status.code = 'STATUS_CODE_ERROR')"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "span.name--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "span.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c05ec7cd-a427-4dc5-96c8-d2c72359e17b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Span metrics by service",
+      "yAxisUnit": "none"
+    }
+  ],
+  "uuid": "019a8269-afee-704d-8496-c03ce9376019"
+}


### PR DESCRIPTION
Updates the dashboards used in the [OTel Demo](https://signoz.io/blog/opentelemetry-demo/) article, to use `.` based separators (`kafka.consumer.io_wait_ratio`) instead of underscores (`kafka_consumer_time_between_poll_max`).

kafka dashboard view
<img width="1512" height="804" alt="image" src="https://github.com/user-attachments/assets/b9c1730d-485f-41d7-a578-21b5ce298d6d" />

metrics dashboard view
<img width="1512" height="789" alt="image" src="https://github.com/user-attachments/assets/62ea72d9-713a-439c-ab0d-83551753eb44" />
