### PR TITLE
Enhance docs search bar prominence

### DIFF
--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -72,18 +72,20 @@ const SearchBar: React.FC<SearchBarProps> = ({
   return (
     <>
       <div
-        className={`relative flex w-full max-w-lg cursor-pointer items-center rounded-lg border border-signoz_slate-400 bg-signoz_ink-500 px-4 py-3 transition-all duration-200 focus-within:border-signoz_robin-500 focus-within:ring-2 focus-within:ring-signoz_robin-500/20 hover:border-signoz_robin-500 hover:shadow-md ${className}`}
+        className={`group relative flex w-full cursor-pointer items-center gap-3 rounded-2xl border border-signoz_slate-200/80 bg-gradient-to-r from-signoz_ink-500/95 via-signoz_ink-400 to-signoz_ink-300/90 px-5 py-4 shadow-[0_18px_50px_-32px_rgba(0,0,0,0.95)] transition-all duration-200 hover:-translate-y-0.5 hover:border-signoz_robin-400/80 hover:shadow-[0_22px_60px_-34px_rgba(0,0,0,1)] focus-within:border-signoz_robin-400 focus-within:ring-4 focus-within:ring-signoz_robin-500/25 ${className}`}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         tabIndex={0}
         role="button"
         aria-label="Open search and chat interface"
       >
-        <SparklesIcon className="mr-3 h-5 w-5 flex-shrink-0 text-signoz_vanilla-400" />
-        <span className="flex-1 text-left text-sm text-signoz_vanilla-400 transition-all duration-300">
+        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-signoz_slate-100/20 text-signoz_vanilla-200 shadow-inner shadow-signoz_ink-500/60 transition-all duration-200 group-hover:bg-signoz_slate-100/30 group-focus-within:bg-signoz_slate-100/30">
+          <SparklesIcon className="h-5 w-5" />
+        </div>
+        <span className="flex-1 text-left text-base font-medium text-signoz_vanilla-200 transition-all duration-300">
           {currentPlaceholder}
         </span>
-        <kbd className="rounded border border-signoz_slate-300 bg-signoz_slate-500 px-2 py-1 font-mono text-xs text-signoz_vanilla-500">
+        <kbd className="rounded-md border border-signoz_slate-100/60 bg-signoz_slate-300/60 px-2.5 py-1 font-mono text-xs font-semibold text-signoz_vanilla-100 shadow-sm shadow-signoz_ink-300/40">
           /
         </kbd>
       </div>


### PR DESCRIPTION
## Summary
- restyled the docs introduction search bar with a richer background, border, and shadow to make it stand out
- added a dedicated icon capsule and stronger placeholder/shortcut styling for better contrast

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2eda8d0c8323b0cd7a38556c47e2)