### PR TITLE
[DOCS] Missing DELETE section in Dashboards API

### DIFF
--- a/public/openAPISpec/api.yaml
+++ b/public/openAPISpec/api.yaml
@@ -521,9 +521,9 @@ paths:
           schema:
             type: string
           example: '<TOKEN>'
-        - name: id
+        - name: uuid
           in: path
-          description: ID of dashboard to return
+          description: UUID of dashboard to return
           required: true
           schema:
             type: string
@@ -552,9 +552,9 @@ paths:
             type: string
           example: '<TOKEN>'
 
-        - name: id
+        - name: uuid
           in: path
-          description: ID of dashboard to update
+          description: UUID of dashboard to update
           required: true
           schema:
             type: string
@@ -566,9 +566,9 @@ paths:
     delete:
       tags:
         - dashboards
-      summary: Deletes a alert rule
+      summary: Delete a dashboard
       description: ''
-      operationId: deleteRule
+      operationId: deleteDashboard
       parameters:
         - name: SIGNOZ-API-KEY
           in: header
@@ -576,9 +576,9 @@ paths:
           schema:
             type: string
           example: '<TOKEN>'
-        - name: id
+        - name: uuid
           in: path
-          description: Alert rule id to delete
+          description: UUID of dashboard to delete
           required: true
           schema:
             type: string


### PR DESCRIPTION
## Summary
- add a dashboard-specific DELETE operation in the OpenAPI spec instead of referencing alert rules
- align dashboard path parameters with the UUID used in the endpoint

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258cb9f2a483269cf8f9f94734c316)