### PR TITLE
Update page type classification for OpenTelemetry landing

### DIFF
--- a/utils/getPageType.ts
+++ b/utils/getPageType.ts
@@ -46,11 +46,12 @@ export const getPageType = (pathname: string): string => {
   if (normalizedPath.match(/^\/guides\/page\/\d+$/)) return 'Guide Listing Page'
 
   // OTel listing pages
-  if (normalizedPath === '/resource-center/opentelemetry' || normalizedPath === '/opentelemetry')
-    return 'OTel Listing Page'
+  if (normalizedPath === '/resource-center/opentelemetry') return 'OTel Listing Page'
   if (normalizedPath.match(/^\/resource-center\/opentelemetry\/page\/\d+$/))
     return 'OTel Listing Page'
   if (normalizedPath.match(/^\/opentelemetry\/page\/\d+$/)) return 'OTel Listing Page'
+
+  if (normalizedPath === '/opentelemetry') return 'Blog Page'
 
   // Content pages (ensure they are not listing pages)
   if (normalizedPath.startsWith('/blog/') && !normalizedPath.match(/^\/blog\/page\/\d+$/))


### PR DESCRIPTION
## Summary
- classify /opentelemetry as a blog page instead of an OTel listing
- keep other OpenTelemetry listing routes unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69280e443afc83238b9d83c9c94e172e)