### PR TITLE
Fix issues with OpenAPI spec

### DIFF
--- a/public/openAPISpec/api.yaml
+++ b/public/openAPISpec/api.yaml
@@ -182,7 +182,7 @@ paths:
         - name: Authorization
           in: header
           required: false
-          description: Bearer token for authentication (alternative to API key). Format: "Bearer <token>"
+          description: 'Bearer token for authentication (alternative to API key). Format: "Bearer <token>"'
           schema:
             type: string
           example: 'Bearer eyJhbGc...'
@@ -598,7 +598,7 @@ paths:
         * `builder` - Query builder for logs, traces, and metrics
         * `clickhouse_sql` - Raw SQL queries (recommended to use this only when you need to use complex queries that are not supported by the query builder)
         * `promql` - PromQL queries (uses Prometheus remote read with ClickHouse as the backend, slower than the query builder)
-      operationId: queryRange
+      operationId: queryRangeV4
       parameters:
         - name: SIGNOZ-API-KEY
           in: header
@@ -1085,7 +1085,7 @@ components:
       properties:
         target:
           description: Target value for the condition. The "Alert Threshold" from the alert configuration UI.
-          type: float
+          type: number
         matchType:
           description: Type of the match
           oneOf:
@@ -2565,30 +2565,21 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - description: Field object that needs to be added to the system
-                title: Field
-              - $ref: '#/components/schemas/Field'
+            $ref: '#/components/schemas/Field'
       description: Field object that needs to be added to the system
       required: true
     Alert:
       content:
         application/json:
           schema:
-            allOf:
-              - description: Alert object that needs to be added to the system
-                title: Alert
-              - $ref: '#/components/schemas/Alert'
+            $ref: '#/components/schemas/Alert'
       description: Alert object that needs to be added to the system
       required: true
     Dashboard:
       content:
         application/json:
           schema:
-            allOf:
-              - description: Dashboard object that needs to be added to the system
-                title: Dashboard
-              - $ref: '#/components/schemas/Dashboard'
+            $ref: '#/components/schemas/Dashboard'
       description: Dashboard object that needs to be added to the system
       required: true
   securitySchemes:


### PR DESCRIPTION
We're using the OpenAPI spec to generate a typed client in our golang backend using https://github.com/oapi-codegen/oapi-codegen and we have identified several issues with the spec that we had to patch locally and we would like to contribute back.

* Updated the description formatting for the `Authorization` header to fix invalid YAML.
* Changed the `target` property type in alert conditions from `float` to `number` following OpenAPI standards.
* Simplified the schema references for `Field`, `Alert`, and `Dashboard` objects in the request bodies by removing unnecessary `allOf` wrappers and using direct `$ref` references. Since the `allOf` are the same as the child type it generates duplicated schemas.
* Renamed the `operationId` for range queries from `queryRange` to `queryRangeV4` to avoid type name clashes with V5.
