### PR TITLE
fix:getting started image in es vs splunk article

### DIFF
--- a/data/blog/elasticsearch-vs-splunk.mdx
+++ b/data/blog/elasticsearch-vs-splunk.mdx
@@ -34,9 +34,6 @@ If you don’t want to go through the entire article, here are the quick takeawa
 - **Integrated Security Analytics and Advanced Correlation:**<br></br>
     Choose **Splunk** for advanced security analytics, including robust features for event correlation and threat detection, making it a strong choice for organizations with a significant focus on security and compliance.
 
-
-[![Get Started - Free CTA](/img/blog/2024/01/elasticsearch-vs-splunk-try-signoz-cloud.webp)](https://signoz.io/teams/)
-
 Before we deep-dive into key differences between Elasticsearch and Splunk, let's us have a brief overview of Elasticsearch and Splunk.
 
 ## What is Elasticsearch?


### PR DESCRIPTION
Removed the Getting Started with SigNoz image, which I feel is breaking the flow of the article:

<img width="753" height="779" alt="image" src="https://github.com/user-attachments/assets/f219a3dc-b37e-4017-bd3a-72a65af47ad2" />

cc - @ankit01-oss @yuvraajsj18 