### PR TITLE
fix: wrong phrase

### DIFF
--- a/data/opentelemetry/go.mdx
+++ b/data/opentelemetry/go.mdx
@@ -456,12 +456,13 @@ caption="Flamegraphs and Gantt charts on SigNoz dashboard"
 
 ## Adding OpenTelemetry Custom Attributes and Events in Go Applications
 
-Auto-instrumentation captures technical details like latency, HTTP methods, and status codes. However, effective debugging often requires business context. For example, knowing that a request took 2 seconds is useful; knowing it took 2 seconds for user_id: 105 while processing book_id: 88 allows you to reproduce and fix the issue.
+Auto-instrumentation captures technical details like latency, HTTP methods, and status codes. However, effective debugging often requires business context. 
+
+For example: Knowing that a request took 2 seconds is useful, but knowing it took 2 seconds for `user_id: 105` while processing `book_id: 88` allows you to reproduce and fix the issue.
 
 OpenTelemetry allows you to attach this context using **Attributes** and **Events**:
 - Attributes: Key-value pairs representing state (e.g., `user_id`, `region`, `app_version`). These are indexed by backends like SigNoz, enabling you to filter traces (e.g., "Show me all failed requests for `book_id: 88`").
-- Events: Time-stamped logs attached to a span. Use these to record specific moments in the execution flow, such as "Cache miss" or "Validation failed".
-
+- Events: Time-stamped logs attached to a span. Use these to record specific moments in the execution flow, such as *Cache miss* or **Validation failed**.
 
 Here’s how you can add **custom attributes** and **custom events** to spans in your Go application:
 
@@ -651,12 +652,6 @@ Once you've updated your application, restart it and generate new telemetry data
   alt="Events"
   caption="Events can be seen under the Events section on the SigNoz trace detail page"
 />
-
-Yes, that is a great idea. A "Next Steps" section is often more high-value for technical tutorials because it keeps the reader in an "action-oriented" mindset rather than signalling "the end."
-
-Here is the replacement section:
-
----
 
 ## Next Steps
 


### PR DESCRIPTION
A phrase came up in the previous PR that does not cater to the article. Making this PR to remove the phrases.
<img width="758" height="133" alt="image" src="https://github.com/user-attachments/assets/7c29cf6b-f7c5-4f22-a603-904ed2cc48e3" />