### PR TITLE
Add TextTooltip Component for MDX Use

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -72,6 +72,7 @@ import CICDMonitoringListicle from './CICD/CICDMonitoringListicle'
 import ToggleHeading from './Headings/ToggleHeading'
 import AWSMonitoringListicle from './AWS/AWSMonitoringListicle'
 import AWSOneClickListicle from './AWS/AWSOneClickListicle'
+import TextTooltip from './TextTooltip/TextTooltip'
 
 export const components: MDXComponents = {
   ToggleHeading,
@@ -144,4 +145,5 @@ export const components: MDXComponents = {
   CICDMonitoringListicle,
   AWSMonitoringListicle,
   AWSOneClickListicle,
+  TextTooltip,
 }

--- a/components/TextTooltip/TextTooltip.tsx
+++ b/components/TextTooltip/TextTooltip.tsx
@@ -12,10 +12,13 @@ const TextTooltip: React.FC<TextTooltipProps> = ({ content, children, position =
   const [isVisible, setIsVisible] = useState(false)
 
   const positionClasses = {
-    top: 'bottom-full mb-2',
-    bottom: 'top-full mt-2',
-    left: 'right-full mr-2',
-    right: 'left-full ml-2',
+    // 'left-1/2 transform -translate-x-1/2' to center horizontally
+    top: 'bottom-full mb-2 left-1/2 transform -translate-x-1/2',
+    bottom: 'top-full mt-2 left-1/2 transform -translate-x-1/2',
+
+    // 'top-1/2 transform -translate-y-1/2' to center vertically
+    left: 'right-full mr-2 top-1/2 transform -translate-y-1/2',
+    right: 'left-full ml-2 top-1/2 transform -translate-y-1/2',
   }
 
   const arrowClasses = {
@@ -28,22 +31,25 @@ const TextTooltip: React.FC<TextTooltipProps> = ({ content, children, position =
   }
 
   return (
-    <span
-      className="relative inline-block cursor-help border-b border-dashed border-blue-400"
-      onMouseEnter={() => setIsVisible(true)}
-      onMouseLeave={() => setIsVisible(false)}
-    >
-      {children}
+    <>
+      <span
+        // `inline` ensures browser search and find the wrapped text
+        className="relative inline cursor-help border-b border-dashed border-blue-400"
+        onMouseEnter={() => setIsVisible(true)}
+        onMouseLeave={() => setIsVisible(false)}
+      >
+        {children}
 
-      {isVisible && (
-        <div
-          className={`absolute z-50 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white shadow-lg ${positionClasses[position]}`}
-        >
-          {content}
-          <div className={`absolute h-0 w-0 border-4 ${arrowClasses[position]}`} />
-        </div>
-      )}
-    </span>
+        {isVisible && (
+          <div
+            className={`pointer-events-none absolute z-50 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white shadow-lg ${positionClasses[position]}`}
+          >
+            {content}
+            <div className={`absolute h-0 w-0 border-4 ${arrowClasses[position]}`} />
+          </div>
+        )}
+      </span>
+    </>
   )
 }
 

--- a/components/TextTooltip/TextTooltip.tsx
+++ b/components/TextTooltip/TextTooltip.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import React, { useState } from 'react'
+
+interface TextTooltipProps {
+  content: string
+  children: React.ReactNode
+  position?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+const TextTooltip: React.FC<TextTooltipProps> = ({ content, children, position = 'top' }) => {
+  const [isVisible, setIsVisible] = useState(false)
+
+  const positionClasses = {
+    top: 'bottom-full mb-2',
+    bottom: 'top-full mt-2',
+    left: 'right-full mr-2',
+    right: 'left-full ml-2',
+  }
+
+  const arrowClasses = {
+    top: 'top-full left-1/2 transform -translate-x-1/2 border-t-gray-900 border-l-transparent border-r-transparent border-b-transparent',
+    bottom:
+      'bottom-full left-1/2 transform -translate-x-1/2 border-b-gray-900 border-l-transparent border-r-transparent border-t-transparent',
+    left: 'left-full top-1/2 transform -translate-y-1/2 border-l-gray-900 border-t-transparent border-b-transparent border-r-transparent',
+    right:
+      'right-full top-1/2 transform -translate-y-1/2 border-r-gray-900 border-t-transparent border-b-transparent border-l-transparent',
+  }
+
+  return (
+    <span
+      className="relative inline-block cursor-help border-b border-dashed border-blue-400"
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+    >
+      {children}
+
+      {isVisible && (
+        <div
+          className={`absolute z-50 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white shadow-lg ${positionClasses[position]}`}
+        >
+          {content}
+          <div className={`absolute h-0 w-0 border-4 ${arrowClasses[position]}`} />
+        </div>
+      )}
+    </span>
+  )
+}
+
+export default TextTooltip


### PR DESCRIPTION
This component enables tooltips in MDX to highlight information without breaking the flow of the article.
Eg., consider a case where a concise explanation is needed, but a callout might be overkill.

Content is searchable within browser, tooltip renders vertically over the text on hover.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5b355dca-e6a9-4364-8f3e-24d72217d413" />

MDX content:
`After running the <TextTooltip content="gunicorn --mysite app.py">command</TextTooltip>, visit`
