### PR TITLE
fix OTLP blog typo & add it to hub.json

### DIFF
--- a/constants/opentelemetry_hub.json
+++ b/constants/opentelemetry_hub.json
@@ -566,6 +566,9 @@
                 },
                 {
                   "url": "https://signoz.io/blog/opentelemetry-agent/"
+                },
+                {
+                  "url": "https://signoz.io/blog/what-is-otlp/"
                 }
               ]
             },

--- a/data/blog/what-is-otlp.mdx
+++ b/data/blog/what-is-otlp.mdx
@@ -62,7 +62,7 @@ If “data is sacred”, then “fire and forget” is not an option.
 
 OTLP uses a **strict request-response model** where it works on a simple handshake principle - the client sends a request, and the server must explicitly parse, queue and acknowledge it before the transaction is considered complete. In case of transmission failures, the client retries the request to prevent any intermittent data loss.
 
-Critically, OTLP limits this guarantee to one hop at a time- between a pair of nodes, such as an instrumented app and an observability backend. **To achieve end-to-end reliability across the entire observability pipeline, OTLP chains these acknowledgement hops together, creating a path of continuous delivery.
+Critically, OTLP limits this guarantee to one hop at a time- between a pair of nodes, such as an instrumented app and an observability backend. To achieve end-to-end reliability across the entire observability pipeline, OTLP chains these acknowledgement hops together, creating a path of continuous delivery.
 
 OTLP servers can return one of three response types, with each response affecting the client’s next action:
 


### PR DESCRIPTION
removes bold marks from OTLP blog and adds it to hub.json