### PR TITLE
Interlink LLM observability docs in related content

### DIFF
--- a/data/blog/langchain-observability-with-opentelemetry.mdx
+++ b/data/blog/langchain-observability-with-opentelemetry.mdx
@@ -309,6 +309,8 @@ By pairing OpenTelemetry’s vendor-neutral instrumentation with SigNoz’s powe
 
 In AI-powered apps, guesswork is the enemy. Observability is how you replace it with clarity, and that’s how you build LangChain systems you can trust.
 
+If you want the docs version of this walkthrough, see the [LangChain/LangGraph observability guide](/docs/langchain-observability/).
+
 ## Coming Next: Using SigNoz to monitor a LangChain agent that queries SigNoz MCP
 
 In the [next part](/blog/monitoring-langchain-agent-querying-signoz-mcp-server/) of this series, we’ll go deeper into observability by looking at a LangChain agent that integrates with an MCP (Model Context Protocol) server. This opens up richer interactions, but also more moving parts where observability becomes even more critical.

--- a/data/blog/llm-observability-opentelemetry.mdx
+++ b/data/blog/llm-observability-opentelemetry.mdx
@@ -99,7 +99,7 @@ We’re continuing to invest in OpenTelemetry-native LLM observability so teams 
 
 * Clear dashboards and traces when LLM calls are modeled using OTel spans/attributes. You can find examples and dashboards in our  [LLM observability](https://signoz.io/docs/llm-observability/) docs. Though we have also use LLM specific libraries like OpenInference in our docs (as they are still the easiest way for ppl to get started), we have kept the dashboards as close to OTel standards as possible. We also plan to actively update this as OTel GenAI semantic conventions become more mature.
 
-* Guidance and examples for popular frameworks (LangChain, LlamaIndex, etc.) on emitting OTel-friendly telemetry.
+* Guidance and examples for popular frameworks on emitting OTel-friendly telemetry, including [LangChain/LangGraph](/docs/langchain-observability/), [LlamaIndex](/docs/llamaindex-observability/), [LiteLLM](/docs/litellm-observability/), [Vercel AI SDK](/docs/vercel-ai-sdk-observability/), and [Pydantic AI](/docs/pydantic-ai-observability/).
 
 * Build features leveraging OpenTelemetry semantic conventions so that you get great out-of-box experience in SigNoz and adhere to thoughtful defaults that keep your services, DBs, queues, and LLM agents—in one coherent picture. 
 

--- a/data/blog/llm-observability.mdx
+++ b/data/blog/llm-observability.mdx
@@ -315,6 +315,13 @@ Several tools can help you implement effective LLM Observability:
 
 When choosing a tool, consider factors such as integration capabilities, scalability, and support for LLM-specific metrics. SigNoz stands out for its balance of features, ease of use, and cost-effectiveness, especially for teams already working with open-source technologies.
 
+### Framework and provider guides
+
+SigNoz has step-by-step docs for common LLM stacks. Pick the one that matches your app:
+
+- Providers: [OpenAI](/docs/openai-monitoring/), [Azure OpenAI API](/docs/azure-openai-monitoring/), [Anthropic API](/docs/anthropic-monitoring/), [Amazon Bedrock](/docs/amazon-bedrock-monitoring/), [Google Gemini](/docs/google-gemini-monitoring/), [Grok](/docs/grok-monitoring/), [DeepSeek API](/docs/deepseek-monitoring/), [Claude Code](/docs/claude-code-monitoring/).
+- Frameworks and SDKs: [LangChain/LangGraph](/docs/langchain-observability/), [LlamaIndex](/docs/llamaindex-observability/), [LiteLLM](/docs/litellm-observability/), [Vercel AI SDK](/docs/vercel-ai-sdk-observability/), [Pydantic AI](/docs/pydantic-ai-observability/), [AutoGen](/docs/autogen-observability/), [Crew AI](/docs/crewai-observability/), [Semantic Kernel](/docs/semantic-kernel-observability/), [Temporal](/docs/temporal-observability/), [LiveKit](/docs/livekit-observability/), [Pipecat](/docs/pipecat-monitoring/), [Mastra](/docs/mastra-observability/), [Agno](/docs/agno-monitoring/), [Inkeep](/docs/inkeep-monitoring/).
+
 Let's see how we can implement LLM Observability with SigNoz and OpenTelemetry &rarr;
 
 ## Implementing LLM Observability with SigNoz and OpenTelemetry

--- a/data/blog/monitoring-langchain-agent-querying-signoz-mcp-server.mdx
+++ b/data/blog/monitoring-langchain-agent-querying-signoz-mcp-server.mdx
@@ -221,3 +221,5 @@ LangChain agents integrated with MCP servers open the door to powerful new workf
 By pairing OpenTelemetry with SigNoz, you get full visibility into the agent lifecycle: where time is spent, which tools are bottlenecks, and what errors are occurring. Whether it’s a slow external API, a looping agent, or a rate limit error, you can see exactly what happened and where.
 
 With this clarity, debugging becomes faster, scaling becomes smoother, and users get more reliable experiences even as your agents grow more complex.
+
+If you want a step-by-step setup guide, start with the [LangChain/LangGraph observability docs](/docs/langchain-observability/) and the [LLM observability overview](/docs/llm-observability/).

--- a/data/blog/opentelemetry-llamaindex.mdx
+++ b/data/blog/opentelemetry-llamaindex.mdx
@@ -403,3 +403,5 @@ Building LlamaIndex‑based RAG applications is exciting. There’s something ma
 By pairing OpenTelemetry’s vendor‑neutral instrumentation with SigNoz’s powerful observability platform, you can follow every step of your RAG workflow—chunking, embedding, retrieval, generation—and even capture user feedback to drive improvements. With this visibility, debugging becomes faster, performance tuning becomes data‑driven, and your users get consistently great experiences.
 
 In AI‑powered apps, guesswork is the enemy. Observability is how you replace it with clarity, and that’s how you build RAG systems you can trust. In the race to build smarter AI, the real edge isn’t just better models—it’s better observability.
+
+If you want the docs version of this guide, see the [LlamaIndex observability docs](/docs/llamaindex-observability/) and the [LLM observability overview](/docs/llm-observability/).

--- a/data/comparisons/axiom-alternatives.mdx
+++ b/data/comparisons/axiom-alternatives.mdx
@@ -46,7 +46,7 @@ SigNoz offers greater deployment flexibility than Axiom, with managed cloud for 
 
 For pricing, SigNoz offers a free open-source version or ingest-based cloud plans (\$0.10 per million metric samples, \$0.30 per GB for logs/traces), avoiding Axiom's variable query costs associated with heavy usage. 
 
-In feature breadth, SigNoz goes beyond Axiom's logs/traces core by adding built-in APM with RED metrics, anomaly-based alerts, and service maps for fuller observability. SigNoz also offers a collection of pre-built integrations and configurations for [monitoring popular LLM frameworks](https://signoz.io/docs/llm-observability/).
+In feature breadth, SigNoz goes beyond Axiom's logs/traces core by adding built-in APM with RED metrics, anomaly-based alerts, and service maps for fuller observability. SigNoz also offers a collection of pre-built integrations and configurations for [LLM observability](/docs/llm-observability/), including guides for [LangChain](/docs/langchain-observability/), [LlamaIndex](/docs/llamaindex-observability/), [OpenAI](/docs/openai-monitoring/), and [Anthropic](/docs/anthropic-monitoring/).
 
 **Get Started with SigNoz**
 

--- a/data/guides/ai-observability.mdx
+++ b/data/guides/ai-observability.mdx
@@ -468,6 +468,8 @@ SigNoz is an open-source observability platform that provides full tracking and 
 
 Interested in doing LLM monitoring with SigNoz? Refer SigNoz’s [official doc on LLM Monitoring.](https://signoz.io/docs/llm-observability/)
 
+If you're instrumenting a specific stack, the dedicated guides for [OpenAI](/docs/openai-monitoring/), [Azure OpenAI API](/docs/azure-openai-monitoring/), [Anthropic](/docs/anthropic-monitoring/), and [Vercel AI SDK](/docs/vercel-ai-sdk-observability/) are a good starting point.
+
 ## Future Trends in AI Observability.
 
 The topic of AI observability is quickly evolving. Here are some emerging themes to monitor:

--- a/data/guides/claude-api-latency.mdx
+++ b/data/guides/claude-api-latency.mdx
@@ -323,6 +323,8 @@ Continuous monitoring is key to ensuring optimal Claude API performance. Impleme
 
 SigNoz offers a comprehensive solution for monitoring Claude API performance. Here's how to get started:
 
+For a step-by-step setup, see the [Anthropic (Claude) monitoring guide](/docs/anthropic-monitoring/).
+
 <GetStartedSigNoz />
 
 Once set up, configure SigNoz to track Claude API latency metrics:

--- a/data/guides/llmops.mdx
+++ b/data/guides/llmops.mdx
@@ -195,6 +195,8 @@ Through the resolution of these issues and the utilization of monitoring instrum
 
 Interested in doing LLM monitoring with SigNoz? Refer SigNoz’s [official doc on LLM Monitoring](https://signoz.io/docs/llm-observability/) for complete guide.
 
+For framework- and provider-specific setups, see the docs for [OpenAI](/docs/openai-monitoring/), [Anthropic](/docs/anthropic-monitoring/), [LangChain/LangGraph](/docs/langchain-observability/), and [LlamaIndex](/docs/llamaindex-observability/).
+
 ## Future Trends in LLMOps
 
 The need for increasingly advanced AI systems and technical developments is driving the ongoing evolution of the LLMOps area. Among the major new developments in LLMOps are the following:

--- a/data/guides/open-ai-api-latency.mdx
+++ b/data/guides/open-ai-api-latency.mdx
@@ -164,7 +164,7 @@ To measure API latency accurately:
 
 1. Use Built-in Timing Functions: Most programming languages offer built-in functions to measure time. For instance, in Python, you can use `time.time()` or the `timeit` module. This allows you to capture the duration of API calls easily, giving you precise insights into how long each request takes.
 2. Implement Server-side Logging: Setting up logging for your API calls helps you capture more than just response times. By logging the request and response details along with timestamps, you can analyze performance over time, identify patterns, and pinpoint any anomalies or delays. 
-3. Utilize [API Monitoring Tools](https://signoz.io/blog/api-monitoring-complete-guide/): Tools like [SigNoz](https://signoz.io/docs/introduction/) provide a comprehensive way to monitor your API performance. They can track metrics such as response times, error rates, and throughput, allowing you to visualize trends and identify bottlenecks in real-time. This [proactive monitoring](https://signoz.io/guides/proactive-monitoring/) helps you react quickly to any performance issues that arise.
+3. Utilize [API Monitoring Tools](https://signoz.io/blog/api-monitoring-complete-guide/): Tools like [SigNoz](https://signoz.io/docs/introduction/) provide a comprehensive way to monitor your API performance. They can track metrics such as response times, error rates, and throughput, allowing you to visualize trends and identify bottlenecks in real-time. This [proactive monitoring](https://signoz.io/guides/proactive-monitoring/) helps you react quickly to any performance issues that arise. For OpenAI-specific setup, see the [OpenAI monitoring guide](/docs/openai-monitoring/).
 
 ## Benchmarking OpenAI API Performance
 
@@ -199,7 +199,7 @@ for chunk in openai.ChatCompletion.create(
 ```
 
 - Fine-Tune Models: Consider customizing models to fit your specific needs by fine-tuning them with relevant data. This approach can greatly enhance inference times and ensure that the outputs align closely with your expectations, boosting both speed and accuracy.
-- Leverage Azure OpenAI: It can provide reduced latency, particularly in certain regions. Azure's robust infrastructure is designed to optimize connectivity and performance, making it an excellent choice for applications that demand low latency.
+- Leverage Azure OpenAI: It can provide reduced latency, particularly in certain regions. Azure's robust infrastructure is designed to optimize connectivity and performance, making it an excellent choice for applications that demand low latency. If you use Azure OpenAI, follow the [Azure OpenAI monitoring guide](/docs/azure-openai-monitoring/) for instrumentation steps.
 - Optimize Network Connectivity: Take steps to enhance your application's network performance by utilizing a Content Delivery Network (CDN). This will cache responses closer to your users, reducing load times. Additionally, consider deploying your application nearer to OpenAI’s servers to further minimize latency and create a smoother experience for your users.
 
 ## Best Practices for OpenAI API Integration


### PR DESCRIPTION
## Summary
- add LLM observability doc cross-links in LLM-focused blogs/guides
- centralize provider/framework doc links in LLM observability blog
- keep SigNoz doc links relative and flow at article ends

## Testing
- not run (content-only changes)