### PR TITLE
fix: remove links to localhost

### DIFF
--- a/data/blog/opentelemetry-django.mdx
+++ b/data/blog/opentelemetry-django.mdx
@@ -169,7 +169,7 @@ If you are running SigNoz in self-hosted mode, use the localhost endpoint:
     <figcaption><i>Ingestion details for your SigNoz Cloud account</i></figcaption>
 </figure>
 
-After running the command, visit [http://localhost:8000/admin](http://localhost:8000/admin) to open the admin panel and validate your app is running. Generate some telemetry to be captured by adding a few questions through the app interface.
+After running the command, visit `http://localhost:8000/admin` to open the admin panel and validate your app is running. Generate some telemetry to be captured by adding a few questions through the app interface.
 
 The following video guides you on how the exported application data flows through and is visualized by SigNoz:
 

--- a/data/opentelemetry/python.mdx
+++ b/data/opentelemetry/python.mdx
@@ -127,7 +127,7 @@ Verify whether the application is now accessible by running
 python3 app.py
 ```
 
-You will be greeted by the following UI upon visiting [http://localhost:5002/](http://localhost:5002/). With this, we have completed the initial application setup.
+You will be greeted by the following UI upon visiting `http://localhost:5002/`. With this, we have completed the initial application setup.
 
 <figure data-zoomable align='center'>
     <img src="/img/blog/2025/11/flask-todo-app-view.webp" alt="Sample Flask application running locally"/>
@@ -169,7 +169,7 @@ If you are running SigNoz in self-hosted mode, use the localhost endpoint:
     <figcaption><i>Ingestion details for your SigNoz Cloud account</i></figcaption>
 </figure>
 
-After running the command, play around with the application at [http://localhost:5002/](http://localhost:5002/) to generate telemetry data. You can add a few TODOs, mark them as completed, or delete them. Now open the `Services` from the side bar to see your application being observed, and SigNoz visualizing key metrics with pre-built monitoring dashboards.
+After running the command, play around with the application at `http://localhost:5002/` to generate telemetry data. You can add a few TODOs, mark them as completed, or delete them. Now open the `Services` from the side bar to see your application being observed, and SigNoz visualizing key metrics with pre-built monitoring dashboards.
 
 <figure data-zoomable align='center'>
     <video className="box-shadowed-image" src="/img/blog/2025/11/flask-prebuilt-dashboard.mp4" width="100%" controls={true}>


### PR DESCRIPTION
Converts markdown-linked localhost references to code-based:
eg. [http://localhost:5002/](http://localhost:5002/) -> `http://localhost:5002/`
for all blogs where I'm the author