### PR TITLE
Remove AWS Private Link mentions from pricing, observability and security FAQ

### DIFF
--- a/app/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -605,17 +605,6 @@ const ALL_FEATURES_DATA = {
           ),
         },
         {
-          feature: 'AWS Private link',
-          inCommunity: <CrossSolid />,
-          inTeams: <CrossSolid />,
-          inEnterprise: (
-            <div className="flex items-center">
-              <CloudSolid />
-              <span className="ml-1.5 text-[8px] sm:text-xs">ENTERPRISE CLOUD</span>
-            </div>
-          ),
-        },
-        {
           feature: 'Audit Logs',
           inCommunity: <CrossSolid />,
           inTeams: <CrossSolid />,

--- a/components/observability/index.tsx
+++ b/components/observability/index.tsx
@@ -42,12 +42,6 @@ const Observability = () => {
                 <li className="flex flex-row items-center gap-3">
                   <ArrowRightSolid />
                   <span className="text-base font-normal leading-9 text-signoz_vanilla-400">
-                    AWS Private Link
-                  </span>
-                </li>
-                <li className="flex flex-row items-center gap-3">
-                  <ArrowRightSolid />
-                  <span className="text-base font-normal leading-9 text-signoz_vanilla-400">
                     VPC Peering
                   </span>
                 </li>

--- a/data/faqs/how-signoz-ensures-data-security-and-privacy.mdx
+++ b/data/faqs/how-signoz-ensures-data-security-and-privacy.mdx
@@ -26,7 +26,7 @@ related_faqs:
 
 - **Single Sign-On (SSO) and SAML Support**: SigNoz offers secure login with SSO and SAML, ensuring only authorized users access the platform.
 - **API Key Management**: Provides secure control over API keys, letting you manage access to observability data effectively.
-- **VPC Peering and AWS Private Link**: Enhances security by enabling private, secure connections between SigNoz and your cloud environment, reducing public exposure.
+- **VPC Peering**: Enhances security by enabling private, secure connections between SigNoz and your cloud environment, reducing public exposure.
 
 ## Data Privacy Measures
 


### PR DESCRIPTION
### Motivation
- Remove inaccurate references to "AWS Private Link" across the public site so the product pages do not advertise a feature that is not offered.
- Ensure consistency across the pricing features list, observability feature list, and the security FAQ.

### Description
- Removed the `AWS Private link` entry from the pricing features list in `app/pricing/pricingv1/components/ExploreAllFeatures.tsx` so it no longer appears under "Why select SigNoz?".
- Deleted the `AWS Private Link` list item from `components/observability/index.tsx` so the enterprise observability feature list no longer includes Private Link.
- Updated the security FAQ `data/faqs/how-signoz-ensures-data-security-and-privacy.mdx` to replace the combined "VPC Peering and AWS Private Link" line with just `VPC Peering`.

### Testing
- No automated tests were executed for this change.
- An automated Playwright screenshot attempt failed due to a Chromium crash in the container, so no visual E2E snapshot was produced.
- The local Next.js dev server was started with `yarn dev` as a manual verification step (server startup succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb812fef883269099acb97dd756ac)