### PR TITLE
docs: clarify exponential histogram support

### DIFF
--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -19,13 +19,12 @@ SigNoz supports the following types of metrics:
 
 - **Exponential Histogram**: An exponential histogram is a metric that represents the distribution of a set of values on a logarithmic scale. Exponential histograms are used to track the distribution of values that span several orders of magnitude. For example, the latency of a network request.
 
-<Admonition type="info">
-Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them:
+<Admonition type="info">Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them:
 1. Set `enable_exp_hist: true` in the `clickhousemetricswrite` and `signozclickhousemetrics` exporters.
 2. Ensure your metrics use delta temporality.
 Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them in your OTel Collector configuration:
 1. Set `enable_exp_hist: true` in both the `clickhousemetricswrite` and `signozclickhousemetrics` exporters in your collector config.
-2. Ensure your metrics use delta temporality.
+2. Ensu Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.re your metrics use delta temporality.
 For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
 </Admonition>
 

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -19,6 +19,14 @@ SigNoz supports the following types of metrics:
 
 - **Exponential Histogram**: An exponential histogram is a metric that represents the distribution of a set of values on a logarithmic scale. Exponential histograms are used to track the distribution of values that span several orders of magnitude. For example, the latency of a network request.
 
+<Admonition type="info">
+Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them:
+1. Set `enable_exp_hist: true` in the `clickhousemetricswrite` and `signozclickhousemetrics` exporters.
+2. Ensure your metrics use delta temporality.
+
+For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
+</Admonition>
+
 ### Temporality of Metrics
 
 The temporality of a metric determines how the measurement is reported over time. SigNoz supports the following types of temporality:

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -23,7 +23,9 @@ SigNoz supports the following types of metrics:
 Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them:
 1. Set `enable_exp_hist: true` in the `clickhousemetricswrite` and `signozclickhousemetrics` exporters.
 2. Ensure your metrics use delta temporality.
-
+Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them in your OTel Collector configuration:
+1. Set `enable_exp_hist: true` in both the `clickhousemetricswrite` and `signozclickhousemetrics` exporters in your collector config.
+2. Ensure your metrics use delta temporality.
 For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
 </Admonition>
 

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -19,12 +19,10 @@ SigNoz supports the following types of metrics:
 
 - **Exponential Histogram**: An exponential histogram is a metric that represents the distribution of a set of values on a logarithmic scale. Exponential histograms are used to track the distribution of values that span several orders of magnitude. For example, the latency of a network request.
 
-<Admonition type="info">Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them:
-1. Set `enable_exp_hist: true` in the `clickhousemetricswrite` and `signozclickhousemetrics` exporters.
-2. Ensure your metrics use delta temporality.
+<Admonition type="info">
 Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them in your OTel Collector configuration:
 1. Set `enable_exp_hist: true` in both the `clickhousemetricswrite` and `signozclickhousemetrics` exporters in your collector config.
-2. Ensu Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.re your metrics use delta temporality.
+2. Ensure your metrics use delta temporality. Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.
 For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
 </Admonition>
 


### PR DESCRIPTION
### Motivation
- Clarify that Exponential Histograms are supported only for self-hosted SigNoz (not SigNoz Cloud) and document how to enable them and the required temporality because the existing page implied broader support.

### Description
- Add an `Admonition` to `data/docs/metrics-management/types-and-aggregation.mdx` that states Exponential Histograms are self-hosted only, instructs to set `enable_exp_hist: true` in the `clickhousemetricswrite` and `signozclickhousemetrics` exporters, requires metrics use `delta` temporality, and links to the collector issue for background.

### Testing
- No CI or automated tests were run for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970609824d88326954a187e4335dc63)