### PR TITLE
Remove VPC Peering mentions from observability component and security FAQ

### DIFF
--- a/components/observability/index.tsx
+++ b/components/observability/index.tsx
@@ -39,12 +39,6 @@ const Observability = () => {
                     Advanced Security
                   </span>
                 </li>
-                <li className="flex flex-row items-center gap-3">
-                  <ArrowRightSolid />
-                  <span className="text-base font-normal leading-9 text-signoz_vanilla-400">
-                    VPC Peering
-                  </span>
-                </li>
               </ul>
             </div>
           </div>

--- a/data/faqs/how-signoz-ensures-data-security-and-privacy.mdx
+++ b/data/faqs/how-signoz-ensures-data-security-and-privacy.mdx
@@ -26,7 +26,6 @@ related_faqs:
 
 - **Single Sign-On (SSO) and SAML Support**: SigNoz offers secure login with SSO and SAML, ensuring only authorized users access the platform.
 - **API Key Management**: Provides secure control over API keys, letting you manage access to observability data effectively.
-- **VPC Peering**: Enhances security by enabling private, secure connections between SigNoz and your cloud environment, reducing public exposure.
 
 ## Data Privacy Measures
 


### PR DESCRIPTION
### Motivation
- Remove the incorrect claim that SigNoz provides VPC Peering/PrivateLink so pricing and security pages do not advertise unsupported features.

### Description
- Deleted the `VPC Peering` list item from `components/observability/index.tsx` so the enterprise observability feature list no longer mentions peering.
- Removed the `VPC Peering` bullet from `data/faqs/how-signoz-ensures-data-security-and-privacy.mdx` to keep the FAQ consistent with product capabilities.
- Committed the updates and prepared the PR with a concise message describing the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970afea0c28832685858912f8d3d378)