### PR TITLE
fix: otel go article slug

### DIFF
--- a/data/opentelemetry/go.mdx
+++ b/data/opentelemetry/go.mdx
@@ -1,5 +1,6 @@
 ---
 title: Complete Guide to Implementing OpenTelemetry in Go Applications
+slug: go
 date: 2025-12-05
 tags: [opentelemetry, golang]
 authors: [aayush_sharma, ankit_anand]


### PR DESCRIPTION
I think the slug for this article was removed in one of the recent commits: https://github.com/SigNoz/signoz.io/commit/97a51bd43c2a79cee70c3693dc247967270ca350#diff-03df35b7507612e6df79497b547bcfc30aae8050ecbdff332aa472455866b6dcL3

I am raising this PR to fix the slug.

cc - @manika-signoz @yuvraajsj18