### PR TITLE
Update high-cardinality blog title to mention interactive examples

### DIFF
--- a/data/blog/high-cardinality-data.mdx
+++ b/data/blog/high-cardinality-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: What is High Cardinality? Explained with Examples
+title: What is High Cardinality? Explained with Interactive Examples
 slug: high-cardinality-data
 date: 2026-01-15
 tags: [Observability, Databases]


### PR DESCRIPTION
### Motivation
- Make the blog post title accurately indicate the presence of interactive examples by updating the frontmatter title for the high-cardinality article.

### Description
- Changed the `title` frontmatter in `data/blog/high-cardinality-data.mdx` from `What is High Cardinality? Explained with Examples` to `What is High Cardinality? Explained with Interactive Examples`.

### Testing
- Content-only change; no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ff7517ec83238526e4fefa829acf)