### PR TITLE
fix: correct Android network security config file path

### DIFF
--- a/data/docs/instrumentation/mobile-instrumentation/opentelemetry-java.mdx
+++ b/data/docs/instrumentation/mobile-instrumentation/opentelemetry-java.mdx
@@ -40,9 +40,9 @@ implementation 'io.opentelemetry:opentelemetry-semconv'
 
 ### Step 2: Configure network settings
 
-Create `app/res/xml/network_security_config.xml`:
+Create `app/src/main/res/xml/network_security_config.xml`:
 
-```xml:app/res/xml/network_security_config.xml
+```xml:app/src/main/res/xml/network_security_config.xml
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">

--- a/data/docs/instrumentation/mobile-instrumentation/opentelemetry-kotlin.mdx
+++ b/data/docs/instrumentation/mobile-instrumentation/opentelemetry-kotlin.mdx
@@ -40,9 +40,9 @@ implementation("io.opentelemetry:opentelemetry-semconv")
 
 ### Step 2: Configure network settings
 
-`app/res/xml/network_security_config.xml`:
+`app/src/main/res/xml/network_security_config.xml`:
 
-```xml:app/res/xml/network_security_config.xml
+```xml:app/src/main/res/xml/network_security_config.xml
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">


### PR DESCRIPTION
The [Android app in Java instrumentation](https://signoz.io/docs/instrumentation/mobile-instrumentation/opentelemetry-java/) documentation incorrectly states that `network_security_config.xml` should be located at `app/res/xml/network_security_config.xml`. However, Android resource files must be located under `app/src/main/res/`, as shown in [the sample app](https://github.com/SigNoz/mobile-monitoring-sample-apps/blob/main/android-java/app/src/main/res/xml/network_security_config.xml).