### PR TITLE
Fix wrong ns name #2590

### DIFF
--- a/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
@@ -35,7 +35,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: signoz-collector-daemonset-collector-role
-  namespace: opentelemetery-operator-system
+  namespace: opentelemetry-operator-system
 rules:
   - apiGroups: ['']
     resources: [pods, namespaces, nodes, persistentvolumeclaims]
@@ -67,7 +67,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: signoz-collector-daemonset-collector-binding
-  namespace: opentelemetery-operator-system
+  namespace: opentelemetry-operator-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -75,7 +75,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: signoz-collector-daemonset-collector
-    namespace: opentelemetery-operator-system
+    namespace: opentelemetry-operator-system
 ```
 
 ### Collector CR
@@ -88,6 +88,7 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: signoz-collector-daemonset
+  namespace: opentelemetry-operator-system
 spec:
   mode: daemonset
   image: docker.io/otel/opentelemetry-collector-contrib:0.139.0
@@ -408,6 +409,7 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: signoz-collector-daemonset
+  namespace: opentelemetry-operator-system
 spec:
   mode: daemonset
   image: docker.io/otel/opentelemetry-collector-contrib:0.139.0
@@ -756,7 +758,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: signoz-collector-deployment-collector-role
-  namespace: opentelemetery-operator-system
+  namespace: opentelemetry-operator-system
 rules:
   - apiGroups: ['']
     resources:
@@ -791,7 +793,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: signoz-collector-deployment-collector-binding
-  namespace: opentelemetery-operator-system
+  namespace: opentelemetry-operator-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -799,7 +801,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: signoz-collector-deployment-collector
-    namespace: opentelemetery-operator-system
+    namespace: opentelemetry-operator-system
 ```
 
 ### Collector CR
@@ -812,6 +814,7 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: signoz-collector-deployment
+  namespace: opentelemetry-operator-system
 spec:
   mode: deployment
   image: docker.io/otel/opentelemetry-collector-contrib:0.139.0
@@ -995,6 +998,7 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: signoz-collector-deployment
+  namespace: opentelemetry-operator-system
 spec:
   mode: deployment
   image: docker.io/otel/opentelemetry-collector-contrib:0.139.0


### PR DESCRIPTION
* Changed ns type from `opentelemetery-operator-system` to `opentelemetry-operator-system`
* Added  namespace in opentelemetrycollectors CR  to match the RBAC 

## Related issue
Fixes #2590