### PR TITLE
Fix typo in SMTP TLS insecure skip verify variable

### DIFF
--- a/data/docs/manage/administrator-guide/configuration/smtp-email-invitations.mdx
+++ b/data/docs/manage/administrator-guide/configuration/smtp-email-invitations.mdx
@@ -24,7 +24,7 @@ SigNoz allows you to configure email settings for sending email Invitations. Dep
 | **`SIGNOZ_EMAILING_SMTP_AUTH_SECRET`**              | Secret to use for the SMTP server                                                                                                          |
 | **`SIGNOZ_EMAILING_SMTP_AUTH_IDENTITY`**            | Identity to use for the SMTP server                                                                                                        |
 | **`SIGNOZ_EMAILING_SMTP_TLS_ENABLED`**              | To enable TLS. It should be false in most cases since the authentication mechanism should use the STARTTLS extension instead.              |
-| **`SIGNOZ_EMAILING_SMTP_TLS_INSECURE_SKIP_VERIFY`** | Whether to skip TLS verification                                                                                                           |
+| **`SIGNOZ_EMAILING_SMTP_TLS_INSECURE__SKIP__VERIFY`** | Whether to skip TLS verification                                                                                                           |
 | **`SIGNOZ_EMAILING_SMTP_TLS_CA_FILE_PATH`**         | Path to CA file                                                                                                                            |
 | **`SIGNOZ_EMAILING_SMTP_TLS_KEY_FILE_PATH`**        | Path to Key file                                                                                                                           |
 | **`SIGNOZ_EMAILING_SMTP_TLS_CERT_FILE_PATH`**       | Path to the Certificate file                                                                                                               |


### PR DESCRIPTION
After a long time debugging to get email sending working, I realized the DOC was wrong.

Another link in the DOC talks about underscores, and that's when I discovered I had to change them. Then it worked and stopped returning the message:

failed to send STARTTLS command

The correct code is: SIGNOZ_EMAILING_SMTP_TLS_INSECURE__SKIP__VERIFY=true
instead of
SIGNOZ_EMAILING_SMTP_TLS_INSECURE_SKIP_VERIFY=true