### PR TITLE
fix: remove unused attribute from required list

### DIFF
--- a/app/external-apis/ExternalApisPage.tsx
+++ b/app/external-apis/ExternalApisPage.tsx
@@ -272,8 +272,7 @@ const FilterAndAutomaticDetectionSection: React.FC = () => {
               <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
                 External API calls are automatically identified using OpenTelemetry's span.kind
                 attribute to detect client spans. API details like domain, endpoint, and URL are
-                extracted from semantic convention attributes (net.peer.name, http.url,
-                http.target).
+                extracted from semantic convention attributes (server.address, url.full).
               </p>
             </div>
           </div>

--- a/data/docs/external-api-monitoring/overview.mdx
+++ b/data/docs/external-api-monitoring/overview.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2025-05-12
+date: 2026-02-02
 title: External API Monitoring
 id: overview
+description: External API Monitoring Overview
 
 hide_table_of_contents: false
 ---
@@ -33,9 +34,8 @@ feature works by using the span attributes mentioned below:
 
 | Attribute | Description | Example |
 |-----------|-------------|---------|
-| `net.peer.name` | Domain or host of the external service | `api.stripe.com` |
-| `http.url` | Complete URL of the request | `https://api.stripe.com/v1/charges` |
-| `http.target` | Path portion of the URL | `/v1/charges` |
+| `server.address` or `net.peer.name` | Domain or host of the external service | `api.stripe.com` |
+| `http.url` or `url.full` | Complete URL of the request | `https://api.stripe.com/v1/charges` |
 
 These attributes are used to automatically derive API calls, identify external domains, extract important metadata, and correlate them with your internal services.
 
@@ -235,12 +235,3 @@ This tab will help you quickly identify the most problematic endpoints and under
 - [API Monitoring Launchweek video](https://www.youtube.com/watch?v=ODUFMrfPdpI)
 - [API Monitoring Demo](https://www.youtube.com/watch?v=4NnMcks62YY)
 - [External API Monitoring Blog Post](https://signoz.io/blog/third-party-api-monitoring/)
-
-
-
-
-
-
-
-
-

--- a/data/docs/external-api-monitoring/setup.mdx
+++ b/data/docs/external-api-monitoring/setup.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2025-05-12
+date: 2026-02-02
 title: Setup External API Monitoring
 id: setup
+description: External API Monitoring Setup
 
 hide_table_of_contents: false
 ---
@@ -17,9 +18,8 @@ To enable API monitoring, make sure that your application is instrumented correc
 
 For every external call, spans must include the below [attributes](https://signoz.io/blog/opentelemetry-spans/#what-are-span-attributes):
 
-- `net.peer.name`
-- `http.url`
-- `http.target`
+- `server.address` or `net.peer.name`
+- `url.full` or `http.url`
 
 These span attributes are used to automatically derive API calls.
 


### PR DESCRIPTION
We are not using http.target to power the external API monitoring. Also, newer version of required attributes are supported, so they are also added.