### PR TITLE
style: add subtle rounded corners to Figure images

### DIFF
--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -26,10 +26,12 @@ export default function Figure({
   figureClassName,
   captionClassName,
 }: FigureProps) {
+  const imageClassName = ['rounded-md', className].filter(Boolean).join(' ')
+
   return (
     <Zoom>
       <figure className={figureClassName}>
-        <img src={src} alt={alt} className={className} />
+        <img src={src} alt={alt} className={imageClassName} />
         <figcaption className={captionClassName}>
           <i>
             {link && !sourceText ? (

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -5,6 +5,8 @@ import React from 'react'
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 
+import { cn } from 'app/lib/utils'
+
 interface FigureProps {
   src: string
   alt: string
@@ -29,7 +31,7 @@ export default function Figure({
   return (
     <Zoom>
       <figure className={figureClassName}>
-        <img src={src} alt={alt} className={`rounded-md ${className ?? ''}`.trim()} />
+        <img src={src} alt={alt} className={cn('rounded-md', className)} />
         <figcaption className={captionClassName}>
           <i>
             {link && !sourceText ? (

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -26,12 +26,10 @@ export default function Figure({
   figureClassName,
   captionClassName,
 }: FigureProps) {
-  const imageClassName = ['rounded-md', className].filter(Boolean).join(' ')
-
   return (
     <Zoom>
       <figure className={figureClassName}>
-        <img src={src} alt={alt} className={imageClassName} />
+        <img src={src} alt={alt} className={`rounded-md ${className ?? ''}`.trim()} />
         <figcaption className={captionClassName}>
           <i>
             {link && !sourceText ? (


### PR DESCRIPTION
Make images rendered via the shared `Figure` component visually consistent with a slight rounded corner by default so site images look a bit softer.