### PR TITLE
Update setup-alerts-notification.mdx

### DIFF
--- a/data/docs/setup-alerts-notification.mdx
+++ b/data/docs/setup-alerts-notification.mdx
@@ -25,8 +25,7 @@ Click the **`+ New Alert Channel`** button at the top right corner and fill in t
 |------------|-------------|
 | **Name** | Provide a clear and descriptive name for the notification channel so it can be easily identified when configuring alerts. |
 | **Send Resolved Alerts** | Use this toggle to choose whether a notification should be sent when an alert is resolved. It is enabled by default. |
-| **Type** | Choose the notification channel type using the options provided in the [Available Notification Channel Types](#available-notification-channel-types)
- table.|
+| **Type** | Choose the notification channel type using the options provided in the [Available Notification Channel Types](#available-notification-channel-types).|
 
 ---
 

--- a/data/docs/setup-alerts-notification.mdx
+++ b/data/docs/setup-alerts-notification.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2024-06-28
+date: 2026-02-11
 id: setup-alerts-notification
 title: Setup Alerts Notifications Channel
 description: Set a notification channel for the alerts

--- a/data/docs/setup-alerts-notification.mdx
+++ b/data/docs/setup-alerts-notification.mdx
@@ -44,7 +44,7 @@ Click the **`+ New Alert Channel`** button at the top right corner and fill in t
 | **[Email](https://signoz.io/docs/alerts-management/notification-channel/email/)** | Sends alert notifications via email. You can specify one or more email addresses to receive alerts. |
 | **[Microsoft Teams](https://signoz.io/docs/alerts-management/notification-channel/ms-teams/)** | Sends alert notifications to Microsoft Teams, a collaboration platform. |
 
-3. Test and Save
+### Test and Save
  - Click **Test** to send a test notification and confirm that the channel is configured correctly and working as expected.
  - Click **Save** to save the newly created notification channel.
 

--- a/data/docs/setup-alerts-notification.mdx
+++ b/data/docs/setup-alerts-notification.mdx
@@ -7,39 +7,49 @@ title: Setup Alerts Notifications Channel
 
 ## Setting a Notification Channel
 
+<Admonition>
+Only a workspace `Admin` can create a notification channel.
+</Admonition>
+
 As a first step before creating a new alert, you should set up a notification channel where you want to send your alert. There are multiple notification channels available to send your alerts. Here's how you can set the notification channel:
 
-### Step 1: Open the Notification Channel Settings
+1. Open the Notification Channel Settings
 To configure the appropriate notification channel, navigate to the Notification Channel settings (`Settings -> Notification Channels`). This section contains a list of available channels that you have created.
 
-### Step 2: Create a New Alert Channel
+2. Create a New Alert Channel
 Click the **`+ New Alert Channel`** button at the top right corner and fill in the details
 
-#### Name
-Assign a descriptive name to the notification channel in the "Name" field. This helps identify the channel when selecting it for alerts.
+## Notification Channel Fields
 
-#### Send Resolved Alerts
-The "Send Resolved Alerts" toggle lets you decide whether to send notifications when alerts are resolved. By default it is enabled.
+| Field Name | Description |
+|------------|-------------|
+| **Name** | Provide a clear and descriptive name for the notification channel so it can be easily identified when configuring alerts. |
+| **Send Resolved Alerts** | Use this toggle to choose whether a notification should be sent when an alert is resolved. It is enabled by default. |
+| **Type** | Choose the notification channel type using the options provided in the [Available Notification Channel Types](#available-notification-channel-types)
+ table.|
 
-#### Type
-The "Type" dropdown menu lets you choose the type of notification channel. The following types are available:
+---
 
-- **[Slack](https://signoz.io/docs/alerts-management/notification-channel/slack/)**: Sends alert notifications to Slack. You can select a specific Slack channel for alert notifications.
-- **[Webhook](https://signoz.io/docs/alerts-management/notification-channel/webhook/)**: Sends alert notifications to a custom webhook endpoint for integration with third-party systems or custom applications.
-- **[Incident.io](https://signoz.io/docs/alerts-management/notification-channel/incident-io/)**: Sends alert notifications to Incident.io for incident management.
-- **[Rootly](https://signoz.io/docs/alerts-management/notification-channel/rootly/)**: Sends alert notifications to Rootly for incident management.
-- **[Zenduty](https://signoz.io/docs/alerts-management/notification-channel/zenduty/)**: Sends alert notifications to Zenduty for incident management.
-- **[PagerDuty](https://signoz.io/docs/alerts-management/notification-channel/pagerduty/)**: Sends alert notifications to PagerDuty for advanced incident management. 
-- **[Opsgenie](https://signoz.io/docs/alerts-management/notification-channel/opsgenie/)**: Sends alert notifications to Opsgenie, an incident management platform.
-- **[Email](https://signoz.io/docs/alerts-management/notification-channel/email/)**: Sends alert notifications via email. You can specify one or more email addresses to receive alerts.
-- **[Microsoft Teams](https://signoz.io/docs/alerts-management/notification-channel/ms-teams/)**: Sends alert notifications to Microsoft Teams, a collaboration platform. 
+## Available Notification Channel Types
+
+| Type | Description |
+|------|-------------|
+| **[Slack](https://signoz.io/docs/alerts-management/notification-channel/slack/)** | Sends alert notifications to Slack. You can select a specific Slack channel for alert notifications. |
+| **[Webhook](https://signoz.io/docs/alerts-management/notification-channel/webhook/)** | Sends alert notifications to a custom webhook endpoint for integration with third-party systems or custom applications. |
+| **[Incident.io](https://signoz.io/docs/alerts-management/notification-channel/incident-io/)** | Sends alert notifications to Incident.io for incident management. |
+| **[Rootly](https://signoz.io/docs/alerts-management/notification-channel/rootly/)** | Sends alert notifications to Rootly for incident management. |
+| **[Zenduty](https://signoz.io/docs/alerts-management/notification-channel/zenduty/)** | Sends alert notifications to Zenduty for incident management. |
+| **[PagerDuty](https://signoz.io/docs/alerts-management/notification-channel/pagerduty/)** | Sends alert notifications to PagerDuty for advanced incident management. |
+| **[Opsgenie](https://signoz.io/docs/alerts-management/notification-channel/opsgenie/)** | Sends alert notifications to Opsgenie, an incident management platform. |
+| **[Email](https://signoz.io/docs/alerts-management/notification-channel/email/)** | Sends alert notifications via email. You can specify one or more email addresses to receive alerts. |
+| **[Microsoft Teams](https://signoz.io/docs/alerts-management/notification-channel/ms-teams/)** | Sends alert notifications to Microsoft Teams, a collaboration platform. |
+
+3. Test and Save
+ - Click **Test** to send a test notification and confirm that the channel is configured correctly and working as expected.
+ - Click **Save** to save the newly created notification channel.
 
 
-### Step 3: Test and Save
-- **Test**: The "Test" button sends a test notification to verify that the channel is set up correctly and is functioning as expected.
-- **Save**: This button saves the new notification channel.
-
-Once the Notification Channel is saved, you should be able to select it when creating an Alert.
+After saving the notification channel, it becomes available for selection when creating an alert.
 
 
 <figure data-zoomable align='center'>

--- a/data/docs/setup-alerts-notification.mdx
+++ b/data/docs/setup-alerts-notification.mdx
@@ -1,8 +1,9 @@
 ---
 date: 2024-06-28
 id: setup-alerts-notification
-
 title: Setup Alerts Notifications Channel
+description: Set a notification channel for the alerts
+tags: ["SigNoz Cloud", "Self-Host", "alerts", "notification channel"]
 ---
 
 ## Setting a Notification Channel


### PR DESCRIPTION
Added a note about only Admins being able to create a notification channel.

I tested that  `+ New Alert Channel ` is available only if you are logged in as Admin

- rewrote the content for consistency.
<img width="995" height="241" alt="Screenshot 2026-02-12 at 8 59 44 AM" src="https://github.com/user-attachments/assets/74d1d853-2add-4e04-b00f-5736454df5d6" />
