### PR TITLE
chore: bump next-mdx-remote to mitigate CVE-2026-0969

### DIFF
--- a/components/ArticleSeries/ArticleSeriesBottom.tsx
+++ b/components/ArticleSeries/ArticleSeriesBottom.tsx
@@ -11,10 +11,14 @@ type ArticleLink = {
 type ArticleSeriesProps = {
   seriesName: string
   seriesOverviewHref?: string
-  currentPart: number
-  totalParts: number
+  currentPart: number | string
+  totalParts: number | string
   previous?: ArticleLink | null
   next?: ArticleLink | null
+  previousTitle?: string
+  previousHref?: string
+  nextTitle?: string
+  nextHref?: string
   className?: string
 }
 
@@ -25,10 +29,20 @@ export default function ArticleSeriesBottom({
   totalParts,
   previous,
   next,
+  previousTitle,
+  previousHref,
+  nextTitle,
+  nextHref,
   className,
 }: ArticleSeriesProps) {
-  const showPrevious = Boolean(previous)
-  const showNext = Boolean(next)
+  const part = Number(currentPart)
+  const total = Number(totalParts)
+  const prevLink =
+    previous ??
+    (previousTitle && previousHref ? { title: previousTitle, href: previousHref } : null)
+  const nextLink = next ?? (nextTitle && nextHref ? { title: nextTitle, href: nextHref } : null)
+  const showPrevious = Boolean(prevLink)
+  const showNext = Boolean(nextLink)
 
   return (
     <div
@@ -38,18 +52,18 @@ export default function ArticleSeriesBottom({
       )}
     >
       {/* Next Article Section */}
-      {showNext && next ? (
+      {showNext && nextLink ? (
         <Link
-          href={next.href}
+          href={nextLink.href}
           className="group block p-4 no-underline transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50 sm:p-6"
         >
           <div className="flex items-center justify-between">
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                Next in "{seriesName}" (Part {currentPart + 1} of {totalParts})
+                Next in "{seriesName}" (Part {part + 1} of {total})
               </p>
               <h3 className="mt-1 line-clamp-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
-                {next.title}
+                {nextLink.title}
               </h3>
             </div>
             <ArrowRight className="ml-4 h-5 w-5 flex-shrink-0 text-gray-400 transition-transform group-hover:translate-x-1 group-hover:text-blue-500 dark:group-hover:text-blue-400" />
@@ -68,9 +82,9 @@ export default function ArticleSeriesBottom({
 
       {/* Footer for Previous & Full Series */}
       <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50/50 px-4 py-3 text-sm dark:border-gray-600 dark:bg-gray-700/30 sm:px-6">
-        {showPrevious && previous ? (
+        {showPrevious && prevLink ? (
           <Link
-            href={previous.href}
+            href={prevLink.href}
             className="group flex items-center font-medium text-gray-600 no-underline transition-colors hover:text-blue-500 dark:text-gray-400 dark:hover:text-blue-400"
           >
             <ArrowLeft className="mr-2 h-4 w-4 transition-transform group-hover:-translate-x-0.5" />

--- a/components/ArticleSeries/ArticleSeriesTop.tsx
+++ b/components/ArticleSeries/ArticleSeriesTop.tsx
@@ -12,10 +12,14 @@ type ArticleLink = {
 type ArticleSeriesTopProps = {
   seriesName: string
   seriesOverviewHref?: string
-  currentPart: number
-  totalParts: number
+  currentPart: number | string
+  totalParts: number | string
   previous?: ArticleLink | null
   next?: ArticleLink | null
+  previousTitle?: string
+  previousHref?: string
+  nextTitle?: string
+  nextHref?: string
   className?: string
 }
 
@@ -26,10 +30,20 @@ export default function ArticleSeriesTop({
   totalParts,
   previous,
   next,
+  previousTitle,
+  previousHref,
+  nextTitle,
+  nextHref,
   className,
 }: ArticleSeriesTopProps) {
-  const showPrevious = Boolean(previous)
-  const showNext = Boolean(next)
+  const part = Number(currentPart)
+  const total = Number(totalParts)
+  const prevLink =
+    previous ??
+    (previousTitle && previousHref ? { title: previousTitle, href: previousHref } : null)
+  const nextLink = next ?? (nextTitle && nextHref ? { title: nextTitle, href: nextHref } : null)
+  const showPrevious = Boolean(prevLink)
+  const showNext = Boolean(nextLink)
 
   return (
     <div
@@ -57,12 +71,12 @@ export default function ArticleSeriesTop({
 
       {/* Right: Prev/Current Position/Next */}
       <div className="flex items-center space-x-4">
-        {showPrevious && previous ? (
-          <Tooltip content={`Previous: ${previous.title}`} delay={150}>
+        {showPrevious && prevLink ? (
+          <Tooltip content={`Previous: ${prevLink.title}`} delay={150}>
             <Link
-              href={previous.href}
+              href={prevLink.href}
               className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 no-underline transition-all hover:bg-gray-200 hover:text-blue-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:hover:text-blue-400"
-              aria-label={`Previous article: ${previous.title}`}
+              aria-label={`Previous article: ${prevLink.title}`}
             >
               <ArrowLeft className="h-4 w-4" />
             </Link>
@@ -72,15 +86,15 @@ export default function ArticleSeriesTop({
         )}
 
         <span className="whitespace-nowrap text-gray-500 dark:text-gray-500">
-          Part {currentPart} of {totalParts}
+          Part {part} of {total}
         </span>
 
-        {showNext && next ? (
-          <Tooltip content={`Next: ${next.title}`} delay={150}>
+        {showNext && nextLink ? (
+          <Tooltip content={`Next: ${nextLink.title}`} delay={150}>
             <Link
-              href={next.href}
+              href={nextLink.href}
               className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 no-underline transition-all hover:bg-gray-200 hover:text-blue-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:hover:text-blue-400"
-              aria-label={`Next article: ${next.title}`}
+              aria-label={`Next article: ${nextLink.title}`}
             >
               <ArrowRight className="h-4 w-4" />
             </Link>

--- a/components/KeyPointCallout/KeyPointCallout.tsx
+++ b/components/KeyPointCallout/KeyPointCallout.tsx
@@ -5,11 +5,12 @@ import { ChevronDown } from 'lucide-react'
 interface KeyPointCalloutProps {
   title?: string
   children: React.ReactNode
-  defaultCollapsed?: boolean
+  defaultCollapsed?: boolean | 'true' | 'false'
 }
 
 const KeyPointCallout: React.FC<KeyPointCalloutProps> = ({ title, children, defaultCollapsed }) => {
-  const [isCollapsed, setIsCollapsed] = React.useState(Boolean(defaultCollapsed))
+  const isDefaultCollapsed = defaultCollapsed === true || defaultCollapsed === 'true'
+  const [isCollapsed, setIsCollapsed] = React.useState(isDefaultCollapsed)
 
   return (
     <div className="my-8 w-full rounded-2xl border border-white/10 bg-white/5 text-gray-100 shadow-lg shadow-black/10 backdrop-blur-sm transition-all duration-300 hover:border-white/20 hover:bg-white/10">

--- a/data/blog/golang-monitoring.mdx
+++ b/data/blog/golang-monitoring.mdx
@@ -84,7 +84,7 @@ go get go.opentelemetry.io/otel/sdk/log@latest
 go get go.opentelemetry.io/otel/sdk/trace@latest
 ```
 
-<KeyPointCallout title="Core Packages Explained" defaultCollapsed={true}> 
+<KeyPointCallout title="Core Packages Explained" defaultCollapsed="true"> 
 These packages define the core OpenTelemetry structure in Go:
 - `otel`: Core OpenTelemetry API for Go.
 - `otel/attribute`: Attribute key-value system used for spans, metrics, and logs.
@@ -100,7 +100,7 @@ go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@latest
 go get go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc@latest
 ```
 
-<KeyPointCallout title="Exporter Packages Explained" defaultCollapsed={true}> 
+<KeyPointCallout title="Exporter Packages Explained" defaultCollapsed="true"> 
 These enable the application to send data to an OTLP-compliant backend using the gRPC transport layer:
 - `otlptracegrpc`: gRPC exporter that sends traces to the OTLP backend.
 - `otlpmetricgrpc`: gRPC exporter that sends metrics to the OTLP backend.
@@ -113,7 +113,7 @@ go get go.opentelemetry.io/contrib/bridges/otellogrus@latest
 go get go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin@latest
 ```
 
-<KeyPointCallout title="Integration Packages Explained" defaultCollapsed={true}> 
+<KeyPointCallout title="Integration Packages Explained" defaultCollapsed="true"> 
 These are for automating instrumentation and bridging existing libraries:
 - `otellogrus`: Bridge for converting Logrus structured logs into OTEL logs, automatically including trace context.
 - `otelgin`: Gin middleware for automatic request tracing of HTTP endpoints. 
@@ -177,7 +177,7 @@ func InitTracer() func(context.Context) error {
 
 The function above initialises distributed tracing for the Golang application. It configures the trace exporter, sets up the tracing pipeline, and ensures all traces include service metadata for backend identification. It also handles secure/insecure modes depending on the environment and returns a shutdown handler that flushes buffered spans on exit. With this in place, the application can produce traces, including nested spans, and request timings. Flamegraphs and timelines become available inside your tracing UI.
 
-<KeyPointCallout title="Tracing Function Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Tracing Function Breakdown" defaultCollapsed="true">
 - `otlptracegrpc.New()`: creates a gRPC OTLP trace exporter for sending spans.
 - **Security Mode**
   - When `config.Insecure == "false"`: communication is encrypted using TLS.
@@ -241,7 +241,7 @@ func InitMeter() func(context.Context) error {
 
 The function above configures metric exporting for your Go service. It creates a gRPC-based OTLP metrics exporter, sets up a periodic reader to push data every 10s, registers application-level counters for business logic and HTTP requests, and exposes Go runtime telemetry such as memory allocation and goroutine count. It gives you both business-level telemetry and Go runtime behaviour in real time.
 
-<KeyPointCallout title="Metrics Function Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Metrics Function Breakdown" defaultCollapsed="true">
 - `otlpmetricgrpc.New()`: initializes the OTLP metric exporter over gRPC.
 - `sdkmetric.NewMeterProvider()`: central engine for emitting and managing metrics.
 - `sdkmetric.WithPeriodicReader(...10s)`: batches and exports metrics every 10 seconds.
@@ -283,7 +283,7 @@ func InitLogger() func(context.Context) error {
 
 The function above wires OpenTelemetry logging into the application. It configures an OTLP log exporter, creates a LoggerProvider that batches logs, and attaches a Logrus hook so log statements automatically include trace and span metadata.
 
-<KeyPointCallout title="Logging Function Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Logging Function Breakdown" defaultCollapsed="true">
 - `otlploggrpc.New()`: creates gRPC exporter for logs.
 - **Security Mode**
   - When `config.Insecure == "false"`: communication is encrypted using TLS.
@@ -392,7 +392,7 @@ Now that you have your credentials, start the application with the environment v
 OTEL_SERVICE_NAME=goApp INSECURE_MODE=false REDIS_ADDR=<REDIS-ADDRESS>  OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<SIGNOZ-INGESTION-KEY>" OTEL_EXPORTER_OTLP_ENDPOINT=ingest.{region}.signoz.cloud:443 go run main.go
 ```
 
-<KeyPointCallout title="Configuration Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Configuration Breakdown" defaultCollapsed="true">
 
 * **`OTEL_EXPORTER_OTLP_HEADERS`**: Replace `<SIGNOZ_INGESTION_KEY>` with the key you retrieved from the settings page.
 * **`OTEL_EXPORTER_OTLP_ENDPOINT`**: Update `{region}` to match your account location:

--- a/data/blog/opentelemetry-demo.mdx
+++ b/data/blog/opentelemetry-demo.mdx
@@ -26,7 +26,7 @@ What appears to be a *simple astronomy online shop* to purchase stargazing tools
 
 ## Architecture Overview for OpenTelemetry Example App
 
-<KeyPointCallout title="Skip to Setup" defaultCollapsed={false}>
+<KeyPointCallout title="Skip to Setup" defaultCollapsed="false">
 If you want to jump directly to the implementation, skip to the [Send OpenTelemetry Demo App Telemetry to SigNoz](#send-opentelemetry-demo-app-telemetry-to-signoz) section.
 </KeyPointCallout>
 

--- a/data/blog/opentelemetry-nextjs-logging.mdx
+++ b/data/blog/opentelemetry-nextjs-logging.mdx
@@ -24,16 +24,12 @@ keywords:
 <ArticleSeriesTop
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={4}
-  totalParts={5}
-  previous={{
-    title: 'Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-web-vitals',
-  }}
-  next={{
-    title: 'Deploying and Scaling OpenTelemetry in Production NextJS Apps',
-    href: '/blog/opentelemetry-nextjs-production',
-  }}
+  currentPart="4"
+  totalParts="5"
+  previousTitle="Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry"
+  previousHref="/blog/opentelemetry-nextjs-web-vitals"
+  nextTitle="Deploying and Scaling OpenTelemetry in Production NextJS Apps"
+  nextHref="/blog/opentelemetry-nextjs-production"
 />
 
 Traces tell you **what** happened and **when**. Logs tell you **why**. When something breaks, logs are often your first clue, and if they’re correlated with traces, they can cut debugging time down from hours to minutes.
@@ -867,14 +863,10 @@ With instrumentation, metrics, and logging in place, you're ready for production
 <ArticleSeriesBottom
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={4}
-  totalParts={5}
-  previous={{
-    title: 'Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-web-vitals',
-  }}
-  next={{
-    title: 'Deploying and Scaling OpenTelemetry in Production NextJS Apps',
-    href: '/blog/opentelemetry-nextjs-production',
-  }}
+  currentPart="4"
+  totalParts="5"
+  previousTitle="Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry"
+  previousHref="/blog/opentelemetry-nextjs-web-vitals"
+  nextTitle="Deploying and Scaling OpenTelemetry in Production NextJS Apps"
+  nextHref="/blog/opentelemetry-nextjs-production"
 />

--- a/data/blog/opentelemetry-nextjs-production.mdx
+++ b/data/blog/opentelemetry-nextjs-production.mdx
@@ -14,12 +14,10 @@ keywords: [nextjs, opentelemetry, production monitoring, collector vs exporter, 
 <ArticleSeriesTop
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={5}
-  totalParts={5}
-  previous={{
-    title: 'Structured Logging in NextJS with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-logging',
-  }}
+  currentPart="5"
+  totalParts="5"
+  previousTitle="Structured Logging in NextJS with OpenTelemetry"
+  previousHref="/blog/opentelemetry-nextjs-logging"
 />
 
 
@@ -657,10 +655,8 @@ This guide wasn’t just about tracing code—it’s about **building smarter sy
 <ArticleSeriesBottom
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={5}
-  totalParts={5}
-  previous={{
-    title: 'Structured Logging in NextJS with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-logging',
-  }}
+  currentPart="5"
+  totalParts="5"
+  previousTitle="Structured Logging in NextJS with OpenTelemetry"
+  previousHref="/blog/opentelemetry-nextjs-logging"
 />

--- a/data/blog/opentelemetry-nextjs-use-cases.mdx
+++ b/data/blog/opentelemetry-nextjs-use-cases.mdx
@@ -14,16 +14,12 @@ keywords: [nextjs observability, 404 monitoring, exception tracing, external api
 <ArticleSeriesTop
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={2}
-  totalParts={5}
-  previous={{
-    title: 'Monitor NextJS with OpenTelemetry - Traces, Metrics, and Logs',
-    href: '/blog/opentelemetry-nextjs',
-  }}
-  next={{
-    title: 'Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-web-vitals',
-  }}
+  currentPart="2"
+  totalParts="5"
+  previousTitle="Monitor NextJS with OpenTelemetry - Traces, Metrics, and Logs"
+  previousHref="/blog/opentelemetry-nextjs"
+  nextTitle="Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry"
+  nextHref="/blog/opentelemetry-nextjs-web-vitals"
 />
 
 
@@ -395,14 +391,10 @@ In the upcoming articles, we'll explore how to actually use SigNoz to track web 
 <ArticleSeriesBottom
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={2}
-  totalParts={5}
-  previous={{
-    title: 'Monitor NextJS with OpenTelemetry - Traces, Metrics, and Logs',
-    href: '/blog/opentelemetry-nextjs',
-  }}
-  next={{
-    title: 'Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-web-vitals',
-  }}
+  currentPart="2"
+  totalParts="5"
+  previousTitle="Monitor NextJS with OpenTelemetry - Traces, Metrics, and Logs"
+  previousHref="/blog/opentelemetry-nextjs"
+  nextTitle="Tracking Web Vitals & Widget Performance in Next.js with OpenTelemetry"
+  nextHref="/blog/opentelemetry-nextjs-web-vitals"
 />

--- a/data/blog/opentelemetry-nextjs-web-vitals.mdx
+++ b/data/blog/opentelemetry-nextjs-web-vitals.mdx
@@ -14,16 +14,12 @@ keywords: [web vitals, nextjs, frontend monitoring, opentelmetry browser, widget
 <ArticleSeriesTop
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={3}
-  totalParts={5}
-  previous={{
-    title: 'NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More',
-    href: '/blog/opentelemetry-nextjs-use-cases',
-  }}
-  next={{
-    title: 'Structured Logging in NextJS with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-logging',
-  }}
+  currentPart="3"
+  totalParts="5"
+  previousTitle="NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More"
+  previousHref="/blog/opentelemetry-nextjs-use-cases"
+  nextTitle="Structured Logging in NextJS with OpenTelemetry"
+  nextHref="/blog/opentelemetry-nextjs-logging"
 />
 
 Web vitals are critical to understanding real-world user experience. Metrics like loading time, layout stability, and interactivity directly impact how users perceive your app—and they influence SEO rankings too.
@@ -242,14 +238,10 @@ While metrics tell you **what** is happening, logs tell you **why**. In the next
 <ArticleSeriesBottom
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={3}
-  totalParts={5}
-  previous={{
-    title: 'NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More',
-    href: '/blog/opentelemetry-nextjs-use-cases',
-  }}
-  next={{
-    title: 'Structured Logging in NextJS with OpenTelemetry',
-    href: '/blog/opentelemetry-nextjs-logging',
-  }}
+  currentPart="3"
+  totalParts="5"
+  previousTitle="NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More"
+  previousHref="/blog/opentelemetry-nextjs-use-cases"
+  nextTitle="Structured Logging in NextJS with OpenTelemetry"
+  nextHref="/blog/opentelemetry-nextjs-logging"
 />

--- a/data/blog/opentelemetry-nextjs.mdx
+++ b/data/blog/opentelemetry-nextjs.mdx
@@ -14,12 +14,10 @@ keywords: [opentelemetry,nextjs,opentelemetry nextjs,javascript,apm tools,applic
 <ArticleSeriesTop
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={1}
-  totalParts={5}
-  next={{
-    title: 'NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More',
-    href: '/blog/opentelemetry-nextjs-use-cases',
-  }}
+  currentPart="1"
+  totalParts="5"
+  nextTitle="NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More"
+  nextHref="/blog/opentelemetry-nextjs-use-cases"
 />
 
 Vercel gives you some observability out of the box for your NextJS application: function logs, perf insights, basic metrics. But as your app grows, the cracks start showing.
@@ -762,10 +760,8 @@ Let’s observe!
 <ArticleSeriesBottom
   seriesName="OpenTelemetry NextJS Tutorial"
   seriesOverviewHref="/blog/opentelemetry-nextjs"
-  currentPart={1}
-  totalParts={5}
-  next={{
-    title: 'NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More',
-    href: '/blog/opentelemetry-nextjs-use-cases',
-  }}
+  currentPart="1"
+  totalParts="5"
+  nextTitle="NextJS OpenTelemetry Use Cases - Monitoring 404s, External APIs, Exceptions & More"
+  nextHref="/blog/opentelemetry-nextjs-use-cases"
 />

--- a/data/blog/what-is-opentelemetry.mdx
+++ b/data/blog/what-is-opentelemetry.mdx
@@ -74,7 +74,7 @@ Beginners often confuse these two, but the distinction is vital for stability.
 - **The SDK (Implementation):** The SDK plugs into the API to actually handle the data. It applies sampling rules, adds resource attributes (like `service.name` or `k8s.pod.name`), batches the data, and sends it to an exporter.
 
 
-<KeyPointCallout title="Why did OTel separate the API and SDK?" defaultCollapsed={true}> 
+<KeyPointCallout title="Why did OTel separate the API and SDK?" defaultCollapsed="true"> 
 The primary reason for separating the API from the SDK is that it makes it easier to embed native instrumentation into open-source library code. OpenTelemetry's API is designed to be lightweight and safe to depend on. The signal's implementation provided by the SDK is significantly more complex and likely contains dependencies on other software. Forcing these dependencies on users could lead to conflicts with their particular software stack. Furthermore, it allows us to ship software with built-in observability without forcing the runtime cost of instrumentation onto users that don't need it.
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/elb.mdx
+++ b/data/docs/aws-monitoring/elb.mdx
@@ -25,7 +25,7 @@ SigNoz allows you to monitor your AWS Elastic Load Balancers (Classic) by collec
 
 This logs setup uses an AWS Lambda function to forward ELB logs from S3 to SigNoz.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/lambda/lambda-logs.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-logs.mdx
@@ -20,7 +20,7 @@ SigNoz. By integrating with SigNoz, you can efficiently collect, monitor, and an
 
 - AWS account with administrative privilege.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/lambda/lambda-metrics.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-metrics.mdx
@@ -44,7 +44,7 @@ This covers:
 Manual setup works for both **SigNoz Cloud** and **Self-Hosted**.
 </Admonition>
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/lambda/lambda-traces.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-traces.mdx
@@ -12,7 +12,7 @@ This documentation provides a detailed walkthrough on how to set up an AWS Lambd
 using OpenTelemetry auto-instrumentation. This will enable you to automatically sends your Lambda traces to SigNoz, 
 enabling you to trace the activities of your Lambda function.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/rds.mdx
+++ b/data/docs/aws-monitoring/rds.mdx
@@ -83,7 +83,7 @@ These guides cover:
 
 If your RDS logs are exported to S3, use a Lambda function to forward them to SigNoz.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/aws-monitoring/sqs.mdx
+++ b/data/docs/aws-monitoring/sqs.mdx
@@ -102,7 +102,7 @@ Verify these values:
 - `<your-secret-key>`: Your AWS secret access key.
 - `<aws-region>`: Your AWS region where SQS queues are deployed (e.g., `us-east-1`, `eu-west-1`, `ap-south-1`).
 
-<KeyPointCallout title="Optional: Filter specific queues" defaultCollapsed={true}>
+<KeyPointCallout title="Optional: Filter specific queues" defaultCollapsed="true">
 By default, the exporter monitors all SQS queues visible to the AWS account. To filter specific queues, use one of these environment variables:
 - `SQS_QUEUE_NAMES`: Comma-separated list of queue names (e.g., `queue1,queue2`)
 - `SQS_QUEUE_NAME_PREFIX`: A single queue name prefix to match

--- a/data/docs/aws-monitoring/vpc.mdx
+++ b/data/docs/aws-monitoring/vpc.mdx
@@ -14,7 +14,7 @@ This documentation provides a detailed walkthrough on how to set up an AWS Lambd
 
 - AWS account with administrative privilege.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/cloud/quickstart.mdx
+++ b/data/docs/cloud/quickstart.mdx
@@ -13,7 +13,6 @@ start sending logs, metrics, and traces to SigNoz Cloud in minutes.
 <video
   src="/img/docs/otel-demo-quickstart.mp4"
   alt="OpenTelemetry Demo App"
-  controls={false}
   muted
   autoPlay
   loop

--- a/data/docs/infrastructure-monitoring/hostmetrics.mdx
+++ b/data/docs/infrastructure-monitoring/hostmetrics.mdx
@@ -13,7 +13,7 @@ Host metrics are fundamental performance indicators collected directly from a sy
 
 The OpenTelemetry hostmetrics receiver collects metrics on CPU, memory, disk, network, paging, and system performance.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -25,7 +25,7 @@ The OpenTelemetry hostmetrics receiver collects metrics on CPU, memory, disk, ne
 
 <TabItem value="vm" label="Virtual Machine" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -192,7 +192,7 @@ If you are running the binary manually (e.g., for testing):
 </TabItem>
 <TabItem value="docker" label="Docker">
 
-<KeyPointCallout title="Want to monitor Docker container metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Want to monitor Docker container metrics?" defaultCollapsed="true">
   This section explains how to run the collector as a Docker container to collect **Host Metrics** (like CPU/Memory of the underlying Node).
 
   If you want to monitor the performance of your Docker containers themselves (e.g. CPU/Memory usage per container), please refer to the [Docker Container Metrics](https://signoz.io/docs/metrics-management/docker-container-metrics/) documentation.

--- a/data/docs/instrumentation/dotnet/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/dotnet/manual-instrumentation.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 Manual instrumentation gives you programmatic control over OpenTelemetry in your .NET application. Use this approach when you need to create custom spans, add business-specific attributes, or when zero-code automatic instrumentation doesn't cover your use case.
 
-<KeyPointCallout title="Activity and Span in .NET" defaultCollapsed={true}>
+<KeyPointCallout title="Activity and Span in .NET" defaultCollapsed="true">
 OpenTelemetry uses the terms "Tracer" and "Span", but .NET has its own tracing API that predates OpenTelemetry. In .NET:
 - **ActivitySource** = Tracer
 - **Activity** = Span
@@ -97,7 +97,7 @@ builder.Services.AddOpenTelemetry()
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint) .
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Update the endpoint and remove the headers:
 ```csharp
 options.Endpoint = new Uri("http://<collector-host>:4317");

--- a/data/docs/instrumentation/dotnet/nuget-instrumentation.mdx
+++ b/data/docs/instrumentation/dotnet/nuget-instrumentation.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to add OpenTelemetry to your .NET application by installing NuGet packages and configuring the SDK in your code. Use this approach when you need more control over instrumentation than zero-code provides, or when zero-code instrumentation isn't available for your deployment.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/java/opentelemetry-java.mdx
+++ b/data/docs/instrumentation/java/opentelemetry-java.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide walks you through instrumenting your Java or Spring Boot application with OpenTelemetry and sending traces to SigNoz. The Java agent handles most popular libraries and frameworks automatically—Spring, JDBC, HTTP clients, message queues, and more.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -23,7 +23,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -48,7 +48,7 @@ export OTEL_METRICS_EXPORTER="none"
 export OTEL_LOGS_EXPORTER="none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -83,7 +83,7 @@ java -javaagent:./opentelemetry-javaagent.jar \
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 For centralized instrumentation management or auto-injection without code changes, see the OTel Operator tab.
 </KeyPointCallout>
 
@@ -118,7 +118,7 @@ env:
   value: 'none'
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -162,7 +162,7 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to your collector.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -201,7 +201,7 @@ $env:OTEL_METRICS_EXPORTER = "none"
 $env:OTEL_LOGS_EXPORTER = "none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -250,7 +250,7 @@ ENV OTEL_LOGS_EXPORTER="none"
 ENTRYPOINT ["java", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.

--- a/data/docs/instrumentation/java/opentelemetry-jboss.mdx
+++ b/data/docs/instrumentation/java/opentelemetry-jboss.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide walks you through instrumenting your JBoss EAP or WildFly application server with OpenTelemetry and sending traces to SigNoz. JBoss and WildFly use `standalone.conf` (Linux/Mac) or `standalone.conf.bat` (Windows) to configure JVM options, making it straightforward to attach the OpenTelemetry Java agent.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -24,7 +24,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -56,7 +56,7 @@ JAVA_OPTS="$JAVA_OPTS -Dotel.metrics.exporter=none"
 JAVA_OPTS="$JAVA_OPTS -Dotel.logs.exporter=none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the line entirely.
@@ -77,7 +77,7 @@ Verify these values:
 /opt/wildfly/bin/standalone.sh
 ```
 
-<KeyPointCallout title="Running in background mode" defaultCollapsed={true}>
+<KeyPointCallout title="Running in background mode" defaultCollapsed="true">
 To run JBoss/WildFly in the background with logs:
 ```bash
 /opt/jboss-eap-7.x/bin/standalone.sh > /opt/jboss/nohup.out 2>&1 &
@@ -100,7 +100,7 @@ tail -f /opt/jboss/nohup.out
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 For centralized instrumentation management or auto-injection without code changes, see the OTel Operator tab.
 </KeyPointCallout>
 
@@ -144,7 +144,7 @@ env:
   value: 'none'
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -188,7 +188,7 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to your collector.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -264,7 +264,7 @@ set "JAVA_OPTS=%JAVA_OPTS% -Dotel.metrics.exporter=none"
 set "JAVA_OPTS=%JAVA_OPTS% -Dotel.logs.exporter=none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the line entirely.
@@ -310,7 +310,7 @@ EXPOSE 8080
 CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0"]
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.

--- a/data/docs/instrumentation/java/opentelemetry-quarkus.mdx
+++ b/data/docs/instrumentation/java/opentelemetry-quarkus.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide walks you through instrumenting your Quarkus application with OpenTelemetry and sending traces to SigNoz. Quarkus uses built-in OpenTelemetry extensions rather than the Java agent, making it well-suited for both JVM and native builds.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud to Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -142,7 +142,7 @@ This configuration reads values from environment variables, making it easy to co
 java -jar target/quarkus-app/quarkus-run.jar
 ```
 
-<KeyPointCallout title="Native builds" defaultCollapsed={true}>
+<KeyPointCallout title="Native builds" defaultCollapsed="true">
 Quarkus OpenTelemetry works with native builds too. The extension is designed to compile to native code:
 
 ```bash

--- a/data/docs/instrumentation/java/opentelemetry-tomcat.mdx
+++ b/data/docs/instrumentation/java/opentelemetry-tomcat.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows how to instrument your Apache Tomcat application server with OpenTelemetry and send traces to SigNoz. Tomcat uses `setenv.sh` (Linux/Mac) or `setenv.bat` (Windows) to configure JVM options, making it straightforward to attach the OpenTelemetry Java agent.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud -> Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -24,7 +24,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -54,7 +54,7 @@ export OTEL_METRICS_EXPORTER="none"
 export OTEL_LOGS_EXPORTER="none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the line entirely.
@@ -90,7 +90,7 @@ sudo systemctl restart tomcat
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 For centralized instrumentation management or auto-injection without code changes, see the OTel Operator tab.
 </KeyPointCallout>
 
@@ -132,7 +132,7 @@ env:
   value: 'none'
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -176,7 +176,7 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to your collector.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.
@@ -252,7 +252,7 @@ set "OTEL_METRICS_EXPORTER=none"
 set "OTEL_LOGS_EXPORTER=none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the line entirely.
@@ -309,7 +309,7 @@ EXPOSE 8080
 CMD ["catalina.sh", "run"]
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry Java agent enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.

--- a/data/docs/instrumentation/javascript/nodejs-manual-instrumentation.mdx
+++ b/data/docs/instrumentation/javascript/nodejs-manual-instrumentation.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 Manual instrumentation lets you trace business operations that auto-instrumentation misses. Use it to capture checkout flows, payment processing, or any code path where you need visibility into what happened and why.
 
-<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed={true}>
+<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed="true">
 These steps work the same way regardless of deployment. Only your OTLP endpoint and ingestion key differ.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/javascript/nodejs-selective-instrumentation.mdx
+++ b/data/docs/instrumentation/javascript/nodejs-selective-instrumentation.mdx
@@ -11,7 +11,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 Auto-instrumentation enables many libraries by default. Use environment variables or code to enable only what you need.
 
-<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed={true}>
+<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed="true">
 These steps work the same way regardless of deployment. Only your OTLP endpoint and ingestion key differ.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/javascript/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/javascript/opentelemetry-nextjs.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to instrument your Next.js application with OpenTelemetry and send traces to SigNoz. You will use the `@vercel/otel` package for instrumentation of both server and edge runtime.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud to Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -24,7 +24,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -131,7 +131,7 @@ npm run dev
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 If you're managing multiple services or want automatic instrumentation injection, consider using the [OTel Operator](#otel-operator) tab instead.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/javascript/opentelemetry-nodejs.mdx
+++ b/data/docs/instrumentation/javascript/opentelemetry-nodejs.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to instrument your Node.js or NestJS application with OpenTelemetry and send traces to SigNoz. You can use either zero-code automatic instrumentation or code-level setup depending on your needs.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud to Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -23,7 +23,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -71,7 +71,7 @@ Need to enable or disable instrumentation for specific libraries? Check out our 
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 Consider using the [OTel Operator](#otel-operator) for centralized instrumentation management across your cluster.
 </KeyPointCallout>
 
@@ -307,7 +307,7 @@ await sdk.shutdown();
 ## Code-Based Setup (Optional)
 </ToggleHeading>
 
-<KeyPointCallout title="When is this needed?" defaultCollapsed={true}>
+<KeyPointCallout title="When is this needed?" defaultCollapsed="true">
 Unlike env vars, code-based setup gives you full control over SDK initialization, like custom processors, advanced sampling, or pulling config from your app. This replaces the env var setup above. If switching from env vars, remove the `NODE_OPTIONS` line to avoid duplicate instrumentation.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/javascript/opentelemetry-nuxtjs.mdx
+++ b/data/docs/instrumentation/javascript/opentelemetry-nuxtjs.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to instrument your Nuxt.js application with OpenTelemetry and send traces to SigNoz. You can use either zero-code auto-instrumentation or code-level setup for more control.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud to Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -24,7 +24,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -72,7 +72,7 @@ Need to enable or disable instrumentation for specific libraries? Check out our 
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 Consider the [OTel Operator](#otel-operator) tab for automatic instrumentation injection without modifying your application image.
 </KeyPointCallout>
 
@@ -288,7 +288,7 @@ await trace.getTracerProvider().forceFlush();
 ## Code-Based Setup (Optional)
 </ToggleHeading>
 
-<KeyPointCallout title="When is this needed?" defaultCollapsed={true}>
+<KeyPointCallout title="When is this needed?" defaultCollapsed="true">
 Unlike env vars, code-based setup gives you full control over SDK initialization, like custom processors, advanced sampling, or pulling config from your app. This replaces the env var setup above. If switching from env vars, remove the `NODE_OPTIONS` line to avoid duplicate instrumentation.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/javascript/opentelemetry-react-native.mdx
+++ b/data/docs/instrumentation/javascript/opentelemetry-react-native.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 ---
 This guide shows you how to instrument your React Native application with OpenTelemetry and send traces to SigNoz. Your app will automatically capture network requests (fetch and XMLHttpRequest) plus any custom spans you create.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud to Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -179,7 +179,7 @@ After running your instrumented application, verify traces appear in SigNoz:
     caption="Traces from your React Native app appearing in SigNoz"
 />
 
-<KeyPointCallout title="Trailing slash - 404 from self-hosted collector" defaultCollapsed={true}>
+<KeyPointCallout title="Trailing slash - 404 from self-hosted collector" defaultCollapsed="true">
 React Native's iOS networking layer (NSURLSession) appends a trailing slash to URLs, which is a known behavior in certain React Native versions. The OTLP exporter sends to `/v1/traces/` instead of `/v1/traces`, and the collector returns 404.
 
 **Fix:** Set `traces_url_path: /v1/traces/` in your collector's OTLP HTTP receiver config:

--- a/data/docs/instrumentation/manual-instrumentation/golang/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/manual-instrumentation/golang/manual-instrumentation.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 Manual instrumentation gives you fine-grained control when automatic instrumentation alone cannot express important business operations. Use it to capture steps that matter for debugging, to attach business-specific attributes, or to guarantee that failures surface with the right context in SigNoz.
 
-<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed={true}>
+<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed="true">
   Manual instrumentation steps are identical across deployments—only your OTLP endpoint and ingestion key differ.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/manual-instrumentation/ruby/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/manual-instrumentation/ruby/manual-instrumentation.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 Manual instrumentation gives you fine-grained control when automatic instrumentation alone cannot express important business operations. Use it to capture steps that matter for debugging, to attach business-specific attributes, or to guarantee that failures surface with the right context in SigNoz.
 
-<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed={true}>
+<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed="true">
   Manual instrumentation steps are identical across deployments—only your OTLP endpoint and ingestion key differ.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/opentelemetry-dotnet.mdx
+++ b/data/docs/instrumentation/opentelemetry-dotnet.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 
 This guide shows you how to instrument your .NET application with OpenTelemetry and send traces to SigNoz using zero-code automatic instrumentation. This approach requires no code changes to your application.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -21,7 +21,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -48,7 +48,7 @@ On macOS, install `coreutils` first: `brew install coreutils`
 
 ### Step 2. Run your application with zero-code instrumentation
 
-<KeyPointCallout title="What is zero-code instrumentation?" defaultCollapsed={true}>
+<KeyPointCallout title="What is zero-code instrumentation?" defaultCollapsed="true">
 Zero-code instrumentation uses an external agent to automatically instrument your application without any code changes. It works by injecting instrumentation at runtime via environment variables.
 
 If you prefer more control or need to configure OpenTelemetry directly in your code, see [NuGet based instrumentation](https://signoz.io/docs/instrumentation/dotnet/nuget-instrumentation/) which uses NuGet packages and `Program.cs` configuration.
@@ -78,7 +78,7 @@ Replace:
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 For centralized instrumentation management or auto-injection without code changes, see the OTel Operator tab.
 </KeyPointCallout>
 

--- a/data/docs/instrumentation/opentelemetry-golang.mdx
+++ b/data/docs/instrumentation/opentelemetry-golang.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 ---
 This guide shows you how to instrument your Go application with OpenTelemetry and send traces to SigNoz. Instrument your Go services with the OpenTelemetry Go SDK and send traces to SigNoz Cloud or a self-hosted collector.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -20,7 +20,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 ## Send traces to SigNoz
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-        <KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+        <KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
             A VM is a virtual computer that runs on physical hardware. This includes:
             - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
             - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/instrumentation/opentelemetry-php.mdx
+++ b/data/docs/instrumentation/opentelemetry-php.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 
 This guide shows you how to instrument your PHP application with OpenTelemetry and send traces to SigNoz. The auto-instrumentation approach works with Laravel, WordPress, Symfony, Slim, and other PHP frameworks.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -24,7 +24,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -45,7 +45,7 @@ export OTEL_EXPORTER_OTLP_HEADERS=signoz-ingestion-key=<your-ingestion-key>
 export OTEL_PROPAGATORS=baggage,tracecontext
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics and logs?" defaultCollapsed="true">
 The OpenTelemetry PHP SDK enables all three signals (traces, metrics, and logs) by default. Since this guide focuses on traces, we disable metrics and logs to avoid sending unwanted data to SigNoz.
 
 If you want to collect metrics or logs later, change the respective exporter to `otlp` or remove the variable entirely.

--- a/data/docs/instrumentation/opentelemetry-python.mdx
+++ b/data/docs/instrumentation/opentelemetry-python.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to instrument your Python application with OpenTelemetry and send traces to SigNoz. The auto-instrumentation approach works with Django, Flask, FastAPI, Falcon, Celery, and most Python libraries out of the box.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -25,7 +25,7 @@ Tested with Python 3.11 and OpenTelemetry Python SDK v1.27.0.
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -44,7 +44,7 @@ export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
 export OTEL_METRICS_EXPORTER="none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed="true">
 The bootstrap command (Step 3) installs instrumentations for all detected libraries, including HTTP clients like `requests`, `urllib3`, and `httpx`. These libraries generate metrics such as request duration histograms and optionally request/response body sizes for every outgoing HTTP call.
 
 Since `opentelemetry-distro` enables metrics by default, these HTTP metrics would be sent to SigNoz even though this guide only covers traces. For apps that make frequent HTTP calls, this can add up quickly.
@@ -89,7 +89,7 @@ See [Framework instrumentation](#framework-instrumentation) below for framework-
 <Tabs entityName="k8s-method">
 <TabItem value="direct" label="Direct" default>
 
-<KeyPointCallout title="Managing multiple services?" defaultCollapsed={true}>
+<KeyPointCallout title="Managing multiple services?" defaultCollapsed="true">
 For centralized instrumentation management or auto-injection without code changes, see the OTel Operator tab.
 </KeyPointCallout>
 
@@ -111,7 +111,7 @@ env:
   value: 'none'
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed="true">
 The bootstrap command (Step 3) installs instrumentations for all detected libraries, including HTTP clients like `requests`, `urllib3`, and `httpx`. These libraries generate metrics such as request duration histograms and optionally request/response body sizes for every outgoing HTTP call.
 
 Since `opentelemetry-distro` enables metrics by default, these HTTP metrics would be sent to SigNoz even though this guide only covers traces. For apps that make frequent HTTP calls, this can add up quickly.
@@ -181,7 +181,7 @@ spec:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed="true">
 The OTel Operator's Python auto-instrumentation image includes instrumentations for HTTP clients like `requests`, `urllib3`, and `httpx`. These libraries generate metrics such as request duration histograms for every outgoing HTTP call.
 
 Since metrics are enabled by default, these HTTP metrics would be sent to your collector even though this guide only covers traces. For apps that make frequent HTTP calls, this can add up quickly.
@@ -216,7 +216,7 @@ $env:OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
 $env:OTEL_METRICS_EXPORTER = "none"
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed="true">
 The bootstrap command (Step 3) installs instrumentations for all detected libraries, including HTTP clients like `requests`, `urllib3`, and `httpx`. These libraries generate metrics such as request duration histograms and optionally request/response body sizes for every outgoing HTTP call.
 
 Since `opentelemetry-distro` enables metrics by default, these HTTP metrics would be sent to SigNoz even though this guide only covers traces. For apps that make frequent HTTP calls, this can add up quickly.
@@ -279,7 +279,7 @@ docker run -e OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>" \
     your-image:latest
 ```
 
-<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable metrics?" defaultCollapsed="true">
 The bootstrap command (Step 3) installs instrumentations for all detected libraries, including HTTP clients like `requests`, `urllib3`, and `httpx`. These libraries generate metrics such as request duration histograms and optionally request/response body sizes for every outgoing HTTP call.
 
 Since `opentelemetry-distro` enables metrics by default, these HTTP metrics would be sent to SigNoz even though this guide only covers traces. For apps that make frequent HTTP calls, this can add up quickly.
@@ -354,7 +354,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         Always use `--noreload` with Django. The auto-reload mechanism spawns child processes that break OpenTelemetry instrumentation.
         </Admonition>
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "python", "manage.py", "runserver", "0.0.0.0:8000", "--noreload"]
         ```
@@ -379,7 +379,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         Always use `--no-reload` with Flask. The reloader spawns a child process that breaks OpenTelemetry instrumentation. Also avoid `FLASK_ENV=development` as it enables the reloader.
         </Admonition>
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "flask", "run", "--host=0.0.0.0", "--no-reload"]
         ```
@@ -408,7 +408,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         Uvicorn's `--workers` flag is not supported with `opentelemetry-instrument`. Use Gunicorn with Uvicorn workers instead: `gunicorn -k uvicorn.workers.UvicornWorker main:app`
         </Admonition>
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
         ```
@@ -429,7 +429,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         opentelemetry-instrument waitress-serve --port=8000 app:api
         ```
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "gunicorn", "app:api", "--bind", "0.0.0.0:8000"]
         ```
@@ -446,7 +446,7 @@ Choose your framework below to see the specific run command. The setup steps abo
 
         Replace `tasks` with your Celery app module name.
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "celery", "-A", "tasks", "worker", "--loglevel=info"]
         ```
@@ -456,7 +456,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         Celery instrumentation captures task execution spans, including task name, arguments, and status. Both the worker and the code that enqueues tasks should be instrumented for full trace propagation.
         </Admonition>
 
-        <KeyPointCallout title="Celery with prefork workers (advanced)" defaultCollapsed={true}>
+        <KeyPointCallout title="Celery with prefork workers (advanced)" defaultCollapsed="true">
         Celery uses the prefork worker model by default. The OpenTelemetry SDK is not fork-safe, so you must initialize it in each worker process using the `worker_process_init` signal. Add this to your Celery app file:
 
         ```python
@@ -501,7 +501,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         opentelemetry-instrument gunicorn -k uvicorn.workers.UvicornWorker main:app --bind 0.0.0.0:8000
         ```
 
-        <KeyPointCallout title="For Docker users" defaultCollapsed={true}>
+        <KeyPointCallout title="For Docker users" defaultCollapsed="true">
         ```dockerfile
         CMD ["opentelemetry-instrument", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "main:app", "--bind", "0.0.0.0:8000"]
         ```
@@ -525,7 +525,7 @@ Choose your framework below to see the specific run command. The setup steps abo
 - Add `lazy-apps = true` to your uWSGI config (recommended, simplest fix)
 - Or implement a post_fork hook (see <a href="https://opentelemetry-python.readthedocs.io/en/latest/examples/fork-process-model/README.html" target="_blank" rel="noopener noreferrer nofollow">example</a>)
 
-<KeyPointCallout title="Why do some setups need extra config?" defaultCollapsed={true}>
+<KeyPointCallout title="Why do some setups need extra config?" defaultCollapsed="true">
 OpenTelemetry's span exporter uses a background thread. When a server forks worker processes, this thread doesn't copy over correctly, causing spans to get stuck.
 
 **Gunicorn** loads your app in each worker after forking (so the thread starts fresh). With `--preload`, it loads before forking, causing the same issue.

--- a/data/docs/instrumentation/opentelemetry-ruby.mdx
+++ b/data/docs/instrumentation/opentelemetry-ruby.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 ---
 This guide shows you how to instrument your Ruby application including Rails, Sinatra, Sidekiq, Resque, Redis, and PostgreSQL with OpenTelemetry and send traces to SigNoz. The `opentelemetry-instrumentation-all` gem provides automatic instrumentation for 53+ popular Ruby libraries.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -20,7 +20,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 ## Send traces to SigNoz
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-        <KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+        <KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
             A VM is a virtual computer that runs on physical hardware. This includes:
             - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
             - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/instrumentation/overview.mdx
+++ b/data/docs/instrumentation/overview.mdx
@@ -14,7 +14,6 @@ SigNoz APM uses OpenTelemetry to instrument your applications, providing service
     <video 
         className="box-shadowed-image" 
         src="/img/docs/apm-and-distributed-tracing/apm-traces-overview.mp4" 
-        controls={false}
         width="100%" 
         autoPlay 
         muted 

--- a/data/docs/instrumentation/php/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/php/manual-instrumentation.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 
 Manual instrumentation gives you fine-grained control when automatic instrumentation alone cannot express important business operations. Use it to capture steps that matter for debugging, attach business-specific attributes, or ensure failures surface with the right context in SigNoz.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/integrations/aws-elasticache-redis.mdx
+++ b/data/docs/integrations/aws-elasticache-redis.mdx
@@ -36,7 +36,7 @@ Before you begin, ensure you have:
 
 4. To collect Redis native metrics, the collector must be able to access the Redis server as a client (optional).
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/integrations/aws-rds-mysql.mdx
+++ b/data/docs/integrations/aws-rds-mysql.mdx
@@ -36,7 +36,7 @@ Before you begin, ensure you have:
 
 4. OTEL collector access to the MySQL server (optional, for MySQL engine metrics)
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/integrations/aws-rds-postgres.mdx
+++ b/data/docs/integrations/aws-rds-postgres.mdx
@@ -39,7 +39,7 @@ Before you begin, ensure you have the following:
 4. **PostgreSQL Server Access**: 
   - The OTEL collector must have client access to the Postgres server (optional if only collecting CloudWatch metrics).
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/logs-management/send-logs-to-signoz.mdx
+++ b/data/docs/logs-management/send-logs-to-signoz.mdx
@@ -7,7 +7,7 @@ description: Learn how to send logs to SigNoz from various platforms, languages,
 
 SigNoz provides multiple ways to collect and ingest logs from your applications and infrastructure. You can send logs from container platforms, various programming languages, log collectors, and cloud services.
 
-<KeyPointCallout title="Not sure which log collection method to use?" defaultCollapsed={true}>
+<KeyPointCallout title="Not sure which log collection method to use?" defaultCollapsed="true">
   Check out our [Log Export Methods](https://signoz.io/docs/logs-management/send-logs/log-export-methods/) guide to understand the trade-offs between SDK, Agents, and other approaches.
 </KeyPointCallout>
 

--- a/data/docs/logs-management/send-logs/application-logs.mdx
+++ b/data/docs/logs-management/send-logs/application-logs.mdx
@@ -7,7 +7,7 @@ title: Send Application logs to SigNoz
 
 There are multiple ways in which you can send application logs to SigNoz
 
-<KeyPointCallout title="Not sure which log collection method to use?" defaultCollapsed={true}>
+<KeyPointCallout title="Not sure which log collection method to use?" defaultCollapsed="true">
   Check out our [Log Export Methods](https://signoz.io/docs/logs-management/send-logs/log-export-methods/) guide to understand the trade-offs between SDK, Agents, and other approaches.
 </KeyPointCallout>
 

--- a/data/docs/logs-management/send-logs/collect-systemd-logs.mdx
+++ b/data/docs/logs-management/send-logs/collect-systemd-logs.mdx
@@ -33,7 +33,7 @@ Jun 25 10:30:46 hostname myapp[1234]: Application started successfully
 
 Follow the [installation guide](https://signoz.io/docs/tutorial/opentelemetry-binary-usage-in-virtual-machine/) to install the OpenTelemetry Collector. The <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/journaldreceiver/README.md" target="_blank" rel="noopener noreferrer nofollow">journald receiver</a> is available in the OpenTelemetry Collector Contrib distribution.
 
-<KeyPointCallout title="Running the Collector in a container?" defaultCollapsed={true}>
+<KeyPointCallout title="Running the Collector in a container?" defaultCollapsed="true">
 The `journald` receiver shells out to `journalctl`, so the Collector needs access to the `journalctl` binary (in `$PATH`) and the host journal files. The simplest setup is running the OTel Collector on the host. If you run the Collector in a container, ensure you mount the journal directory and make `journalctl` available in the container. See the <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/journaldreceiver/README.md" target="_blank" rel="noopener noreferrer nofollow">journald receiver documentation</a> for container-specific requirements and examples.
 
 **Note:** The official `otelcol` images don't include `journalctl`, so you must provide it (for example, by bundling it into a custom image or mounting a compatible `journalctl` binary). See the <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/journaldreceiver/README.md#docker--kubernetes" target="_blank" rel="noopener noreferrer nofollow">Docker & Kubernetes notes</a>.
@@ -79,7 +79,7 @@ Replace the placeholders:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint) (e.g., `us`, `eu`, or `in`)
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/logs-management/send-logs/convex-log-streams-signoz.mdx
+++ b/data/docs/logs-management/send-logs/convex-log-streams-signoz.mdx
@@ -16,7 +16,7 @@ Convex log streaming sends logs as JSON or JSONL webhooks with HMAC-SHA256 signa
 2. Transforms Convex log events for SigNoz
 3. Forwards them to SigNoz Cloud
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/logs-management/send-logs/java-logs.mdx
+++ b/data/docs/logs-management/send-logs/java-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Java application to SigNoz using OpenTe
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -51,7 +51,7 @@ wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releas
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -297,7 +297,7 @@ dependencies {
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/logs-management/send-logs/log-export-methods.mdx
+++ b/data/docs/logs-management/send-logs/log-export-methods.mdx
@@ -138,7 +138,7 @@ The OpenTelemetry Collector has native receivers for many log sources. These rec
 | **Kafka** | `kafka` | <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver" target="_blank" rel="noopener noreferrer nofollow">Receives logs from Kafka topics</a> |
 | **MongoDB Atlas** | `mongodb_atlas` | [Collects MongoDB Atlas logs](https://signoz.io/docs/integrations/mongodb-atlas/) |
 
-<KeyPointCallout title="More OTel Collector Receivers" defaultCollapsed={false}>
+<KeyPointCallout title="More OTel Collector Receivers" defaultCollapsed="false">
 
 The OpenTelemetry Collector supports many more receivers. See the full list in the <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry Collector Contrib repository</a>.
 

--- a/data/docs/logs-management/send-logs/nodejs-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Node.js default console logger to SigNo
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
@@ -104,7 +104,7 @@ yarn add @opentelemetry/api-logs \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Node.js Pino logger to SigNoz using the
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
@@ -58,7 +58,7 @@ yarn add @opentelemetry/api \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -249,7 +249,7 @@ yarn add @opentelemetry/sdk-node@^0.208.0 \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Node.js Winston logger to SigNoz using 
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
@@ -60,7 +60,7 @@ yarn add @opentelemetry/api \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -254,7 +254,7 @@ yarn add @opentelemetry/sdk-node@^0.208.0 \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/logs-management/send-logs/opentelemetry-nodejs-bunyan-logs.mdx
+++ b/data/docs/logs-management/send-logs/opentelemetry-nodejs-bunyan-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Node.js Bunyan logger to SigNoz using t
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
@@ -58,7 +58,7 @@ yarn add @opentelemetry/api \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -254,7 +254,7 @@ yarn add @opentelemetry/auto-instrumentations-node@^0.67.2 \
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/logs-management/send-logs/python-logs.mdx
+++ b/data/docs/logs-management/send-logs/python-logs.mdx
@@ -8,7 +8,7 @@ description: Learn how to send logs from Python to SigNoz using the OpenTelemetr
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
@@ -45,7 +45,7 @@ opentelemetry-bootstrap -a install
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -214,7 +214,7 @@ pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-prot
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/metrics-management/fly-metrics.mdx
+++ b/data/docs/metrics-management/fly-metrics.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This document explains how to monitor Fly.io application metrics in SigNoz by scraping Fly’s Prometheus federation endpoint with the OpenTelemetry Collector.
 
-<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed={true}>
+<KeyPointCallout title="Works for both SigNoz Cloud and Self-Hosted" defaultCollapsed="true">
 If using Self-hosted SigNoz, most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -71,7 +71,7 @@ echo '<RAW_TOKEN_AFTER_FlyV1>' > fly_federate_token
 
 <Tabs>
 <TabItem value="vm" label="VM" default>
-        <KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+        <KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
             A VM is a virtual computer that runs on physical hardware. This includes:
             - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
             - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -132,7 +132,7 @@ service:
       exporters: [otlphttp]
 ```
 
-<KeyPointCallout title="Important Configuration" defaultCollapsed={false}>
+<KeyPointCallout title="Important Configuration" defaultCollapsed="false">
   Fly's `/federate` endpoint doesn't expose metric types, so all metrics are mapped as Gauge by
   default. To override this, we use the transform processor `convert_gauge_to_sum`. If you want to
   convert any other metrics, add them to the transform processor.
@@ -205,7 +205,7 @@ service:
       exporters: [otlphttp]
 ```
 
-<KeyPointCallout title="Important Configuration" defaultCollapsed={false}>
+<KeyPointCallout title="Important Configuration" defaultCollapsed="false">
   Fly's `/federate` endpoint doesn't expose metric types, so all metrics are mapped as Gauge by
   default. To override this, we use the transform processor `convert_gauge_to_sum`. If you want to
   convert any other metrics, add them to the transform processor.
@@ -329,7 +329,7 @@ otelAgent:
       readOnly: true
 ```
 
-<KeyPointCallout title="Important Configuration" defaultCollapsed={false}>
+<KeyPointCallout title="Important Configuration" defaultCollapsed="false">
   Fly's `/federate` endpoint doesn't expose metric types, so all metrics are mapped as Gauge by
   default. To override this, we use the transform processor `convert_gauge_to_sum`. If you want to
   convert any other metrics, add them to the transform processor.

--- a/data/docs/metrics-management/send-metrics/applications/golang.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/golang.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to instrument your Go application with OpenTelemetry to send metrics to SigNoz. You will learn how to collect runtime metrics, auto-instrument libraries, and create custom metrics.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
     Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -23,7 +23,7 @@ This guide shows you how to instrument your Go application with OpenTelemetry to
 
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
     A VM is a virtual computer that runs on physical hardware. This includes:
     - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
     - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-dotnet.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-dotnet.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to send custom and runtime metrics from your .NET application to SigNoz using OpenTelemetry automatic instrumentation.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -23,7 +23,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -57,7 +57,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 
-<KeyPointCallout title="Why disable traces and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why disable traces and logs?" defaultCollapsed="true">
 The automatic instrumentation generates traces for HTTP requests by default. Since traces and logs export is enabled by default, these would be sent to SigNoz even though this guide only covers metrics.
 
 Setting `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `none` disables them while keeping metrics working. If you want traces or logs later, change them to `otlp` or remove these variables.

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to send custom and JVM runtime metrics from your Java application to SigNoz using the OpenTelemetry Java agent.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -18,7 +18,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 - Java 8 or later (Java 17+ recommended for enhanced JVM metrics)
 - A SigNoz Cloud account or self-hosted SigNoz instance
 
-<KeyPointCallout title="Why Java 17+ for enhanced metrics?" defaultCollapsed={true}>
+<KeyPointCallout title="Why Java 17+ for enhanced metrics?" defaultCollapsed="true">
 Java 17+ enables **JFR-based (Java Flight Recorder) metrics** collection, providing deeper runtime insights with lower overhead. JFR captures detailed GC events, memory allocation patterns, thread contention, and CPU profiling data that aren't available through standard JMX/MBeans on Java 8.
 </KeyPointCallout>
 
@@ -27,7 +27,7 @@ Java 17+ enables **JFR-based (Java Flight Recorder) metrics** collection, provid
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -59,7 +59,7 @@ Replace the following:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 
-<KeyPointCallout title="Why disable traces and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why disable traces and logs?" defaultCollapsed="true">
 The Java agent auto-instruments web frameworks like Spring Boot, JAX-RS, and Servlet containers, generating traces for every HTTP request. Since traces and logs export is enabled by default, these would be sent to SigNoz even though this guide only covers metrics.
 
 For applications handling many requests, this can generate significant data volume and costs. Setting `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `none` disables them while keeping metrics working. If you want traces or logs later, change them to `otlp` or remove these variables.

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-java/jmx-metrics.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-java/jmx-metrics.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to collect JMX (Java Management Extensions) metrics from any Java application using the OpenTelemetry Collector's JMX receiver. This approach works with any JVM-based application including Kafka, Cassandra, Tomcat, and custom Java services.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to send metrics from your Node.js application (Express, Fastify, Koa, NestJS, Runtime) to SigNoz using OpenTelemetry.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
     Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -22,7 +22,7 @@ This guide shows you how to send metrics from your Node.js application (Express,
 
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
     A VM is a virtual computer that runs on physical hardware. This includes:
     - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
     - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -142,7 +142,7 @@ Verify these values:
 </TabItem>
 </Tabs>
 
-<KeyPointCallout title="Why explicitly disable traces and logs?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable traces and logs?" defaultCollapsed="true">
 The auto-instrumentation package (`@opentelemetry/auto-instrumentations-node`) includes instrumentations for web frameworks like Express, Fastify, and Koa. These instrumentations generate traces (spans) for every incoming HTTP request.
 
 Since OpenTelemetry Node.js enables traces and logs export by default, these would be sent to SigNoz even though this guide only covers metrics. For apps handling many requests, this can generate significant volume and costs.

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
@@ -9,7 +9,7 @@ doc_type: howto
 
 This guide shows you how to send metrics from your Python application (Flask, Django, FastAPI, Celery, Runtime) to SigNoz using OpenTelemetry.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
     Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
@@ -22,7 +22,7 @@ This guide shows you how to send metrics from your Python application (Flask, Dj
 
 <Tabs entityName="deployment">
 <TabItem value="vm" label="VM" default>
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
     A VM is a virtual computer that runs on physical hardware. This includes:
     - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
     - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -130,7 +130,7 @@ Verify these values:
 </TabItem>
 </Tabs>
 
-<KeyPointCallout title="Why explicitly disable traces?" defaultCollapsed={true}>
+<KeyPointCallout title="Why explicitly disable traces?" defaultCollapsed="true">
 The bootstrap command (Step 3) installs instrumentations for all detected libraries, including web frameworks like Flask, Django, and FastAPI. These instrumentations generate traces (spans) for every incoming HTTP request.
 
 Since `opentelemetry-distro` enables traces by default, these traces would be sent to SigNoz even though this guide only covers metrics. For apps handling many requests, this can generate significant trace volume and costs.
@@ -235,7 +235,7 @@ Library instrumentation automatically collects metrics from supported frameworks
         Always use `--no-reload` with Flask. The reloader spawns a child process that breaks OpenTelemetry instrumentation.
         </Admonition>
 
-        <KeyPointCallout title="Exported metrics" defaultCollapsed={true}>
+        <KeyPointCallout title="Exported metrics" defaultCollapsed="true">
         - `http.server.request.duration` - Duration of HTTP server requests (histogram, seconds)
         - `http.server.active_requests` - Number of active HTTP server requests (up-down counter)
 
@@ -261,7 +261,7 @@ Library instrumentation automatically collects metrics from supported frameworks
         Always use `--noreload` with Django. The auto-reload mechanism spawns child processes that break OpenTelemetry instrumentation.
         </Admonition>
 
-        <KeyPointCallout title="Exported metrics" defaultCollapsed={true}>
+        <KeyPointCallout title="Exported metrics" defaultCollapsed="true">
         - `http.server.request.duration` - Duration of HTTP server requests (histogram, seconds)
         - `http.server.active_requests` - Number of active HTTP server requests (up-down counter)
 
@@ -279,7 +279,7 @@ Library instrumentation automatically collects metrics from supported frameworks
         Do not use `--reload` with Uvicorn when instrumenting. The reload mode spawns new processes that break instrumentation.
         </Admonition>
 
-        <KeyPointCallout title="Exported metrics" defaultCollapsed={true}>
+        <KeyPointCallout title="Exported metrics" defaultCollapsed="true">
         - `http.server.request.duration` - Duration of HTTP server requests (histogram, seconds)
         - `http.server.active_requests` - Number of active HTTP server requests (up-down counter)
         - `http.server.request.body.size` - Size of HTTP request body (histogram, bytes)
@@ -297,7 +297,7 @@ Library instrumentation automatically collects metrics from supported frameworks
 
         Replace `tasks` with your Celery app module name.
 
-        <KeyPointCallout title="Exported metrics" defaultCollapsed={true}>
+        <KeyPointCallout title="Exported metrics" defaultCollapsed="true">
         - `flower.task.runtime.seconds` - The time it took to run the task (histogram, seconds)
 
         <a href="https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/celery/celery.html" target="_blank" rel="noopener noreferrer nofollow">Instrumentation docs</a>

--- a/data/docs/migration/migrate-from-datadog/logs.mdx
+++ b/data/docs/migration/migrate-from-datadog/logs.mdx
@@ -15,7 +15,7 @@ This guide walks you through migrating logs from Datadog to SigNoz. You will:
 3. Configure log parsing to match your formats
 4. Validate logs are flowing correctly to SigNoz
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -17,7 +17,7 @@ This guide walks you through migrating metrics from Datadog to SigNoz. You will:
 
 You cannot import historical metrics from Datadog. This guide focuses on redirecting your metric streams to SigNoz going forward.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-datadog/opentelemetry-datadog-receiver.mdx
+++ b/data/docs/migration/migrate-from-datadog/opentelemetry-datadog-receiver.mdx
@@ -18,7 +18,7 @@ The OpenTelemetry Datadog Receiver allows you to receive metrics from Datadog Ag
 This approach is a bridge solution. For long-term use, we recommend migrating to native OpenTelemetry instrumentation for better integration and standardization.
 </Admonition>
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-datadog/traces.mdx
+++ b/data/docs/migration/migrate-from-datadog/traces.mdx
@@ -17,7 +17,7 @@ This guide walks you through migrating distributed tracing and APM from Datadog 
 
 SigNoz is built natively on OpenTelemetry, so migration involves replacing Datadog tracing libraries with OTel instrumentation.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-elk/logs.mdx
+++ b/data/docs/migration/migrate-from-elk/logs.mdx
@@ -16,7 +16,7 @@ This guide walks you through migrating logs from the ELK Stack (Elasticsearch, L
 3. Configure log parsing to match your formats
 4. Validate logs are flowing correctly to SigNoz
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-elk/metrics.mdx
+++ b/data/docs/migration/migrate-from-elk/metrics.mdx
@@ -15,7 +15,7 @@ This guide walks you through migrating metrics from the ELK Stack (specifically 
 3. Map Metricbeat modules to OpenTelemetry receivers
 4. Validate metrics are flowing correctly to SigNoz
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-elk/traces.mdx
+++ b/data/docs/migration/migrate-from-elk/traces.mdx
@@ -17,7 +17,7 @@ This guide walks you through migrating distributed tracing and APM from the ELK 
 
 SigNoz is built natively on OpenTelemetry, so migration involves replacing proprietary Elastic APM agents with standard OpenTelemetry SDKs.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-grafana/logs.mdx
+++ b/data/docs/migration/migrate-from-grafana/logs.mdx
@@ -18,7 +18,7 @@ This guide walks you through migrating logs from Loki (LGTM Stack) to SigNoz. Yo
 
 SigNoz uses the OpenTelemetry Collector for log collection, which provides a more robust and standard-compliant alternative to Promtail.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-grafana/metrics.mdx
+++ b/data/docs/migration/migrate-from-grafana/metrics.mdx
@@ -17,7 +17,7 @@ This guide walks you through migrating metrics from Prometheus, Mimir, or Grafan
 
 SigNoz supports Prometheus metrics natively, so migration typically involves pointing your existing exporters to the OpenTelemetry Collector or using the Collector to scrape your targets.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-grafana/traces.mdx
+++ b/data/docs/migration/migrate-from-grafana/traces.mdx
@@ -18,7 +18,7 @@ This guide walks you through migrating distributed tracing and APM from Tempo (L
 
 SigNoz is built natively on OpenTelemetry, making it compatible with most existing instrumentation used with Tempo (OpenTelemetry, Jaeger, Zipkin).
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-honeycomb/data.mdx
+++ b/data/docs/migration/migrate-from-honeycomb/data.mdx
@@ -27,7 +27,7 @@ Once you have switched to OpenTelemetry, proceed with the configuration below.
 
 Since both Honeycomb and SigNoz use OpenTelemetry, migrating involves pointing your OTLP endpoint to SigNoz.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-newrelic/logs.mdx
+++ b/data/docs/migration/migrate-from-newrelic/logs.mdx
@@ -15,7 +15,7 @@ This guide walks you through migrating logs from New Relic to SigNoz. You will:
 3. Configure log parsing to match your formats
 4. Validate logs are flowing correctly to SigNoz
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-newrelic/metrics.mdx
+++ b/data/docs/migration/migrate-from-newrelic/metrics.mdx
@@ -17,7 +17,7 @@ This guide walks you through migrating metrics from New Relic to SigNoz. You wil
 
 You cannot import historical metrics from New Relic. This guide focuses on redirecting your metric streams to SigNoz going forward.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-newrelic/traces.mdx
+++ b/data/docs/migration/migrate-from-newrelic/traces.mdx
@@ -18,7 +18,7 @@ This guide walks you through migrating distributed tracing and APM from New Reli
 
 SigNoz is built natively on OpenTelemetry, so migration involves replacing New Relic agents with OTel instrumentation.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/migration/migrate-from-opentelemetry-to-signoz.mdx
+++ b/data/docs/migration/migrate-from-opentelemetry-to-signoz.mdx
@@ -17,7 +17,7 @@ If you already have OpenTelemetry instrumentation in your applications, you can 
 
 ## Configuration
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/switch-to-collector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/switch-to-collector.mdx
@@ -11,7 +11,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 This guide shows you how to switch from sending telemetry data directly from your application to SigNoz to routing it through an OpenTelemetry Collector.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#quick-differences).
 </KeyPointCallout>
 

--- a/data/docs/userguide/collect_logs_from_file.mdx
+++ b/data/docs/userguide/collect_logs_from_file.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 
 import GetHelp from '@/components/shared/get-help.md'
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
 header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
@@ -46,7 +46,7 @@ The following steps guide you through configuring the `filelog` receiver on diff
 <Tabs>
 <TabItem value="vm" label="VM" default>
 
-<KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>
+<KeyPointCallout title="What classifies as VM?" defaultCollapsed="true">
 A VM is a virtual computer that runs on physical hardware. This includes:
 - **Cloud VMs**: AWS EC2, Google Compute Engine, Azure VMs, DigitalOcean Droplets
 - **On-premise VMs**: VMware, VirtualBox, Hyper-V, KVM
@@ -112,7 +112,7 @@ The [SigNoz Kubernetes Infra Chart](https://signoz.io/docs/opentelemetry-collect
 The default configuration collects logs from all pods in the cluster. To filter specific namespaces or pods, you'll need to customize the filelog receiver configuration.
 </Admonition>
 
-<KeyPointCallout title="Collecting from custom file paths" defaultCollapsed={true}>
+<KeyPointCallout title="Collecting from custom file paths" defaultCollapsed="true">
 
 If your application writes logs to a specific file instead of `stdout` or `stderr`, you have two options:
 
@@ -272,7 +272,7 @@ Go to the **SigNoz UI** -> **Logs** tab. You should see your new log entries app
 
 ## Advanced Configuration
 
-<KeyPointCallout title="Storage extension for production deployments" defaultCollapsed={true}>
+<KeyPointCallout title="Storage extension for production deployments" defaultCollapsed="true">
 
 For production use, especially when using `start_at: beginning`, configure a <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/storage/filestorage/README.md" target="_blank" rel="noopener noreferrer nofollow">storage extension</a> to prevent log duplication on collector restarts. The storage extension saves the read position for each file to disk.
 

--- a/data/docs/userguide/drop-metrics.mdx
+++ b/data/docs/userguide/drop-metrics.mdx
@@ -34,7 +34,7 @@ metrics:
 ```
 </Admonition>
 
-<KeyPointCallout title="Dropping labels does not reduce sample count" defaultCollapsed={true}>
+<KeyPointCallout title="Dropping labels does not reduce sample count" defaultCollapsed="true">
 If you are trying to drop specific labels (attributes) to reduce cardinality, simply removing them may not work as expected and does not reduce ingest volume. See [Dropping Metric Labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/) for details.
 </KeyPointCallout>
 

--- a/data/docs/userguide/envoy-metrics.mdx
+++ b/data/docs/userguide/envoy-metrics.mdx
@@ -13,7 +13,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 Envoy is a high-performance edge and service proxy. This guide will help you send metrics from Envoy to SigNoz using the OpenTelemetry (OTel) Collector.
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
   header as shown in [Cloud →
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).

--- a/data/docs/userguide/logs.mdx
+++ b/data/docs/userguide/logs.mdx
@@ -12,7 +12,6 @@ SigNoz natively supports OpenTelemetry for collecting logs, so you can lift-and-
     <video 
         className="box-shadowed-image" 
         src="/img/docs/logs-management/signoz-log-management-overview.mp4" 
-        controls={false}
         width="100%" 
         autoPlay 
         muted 

--- a/data/docs/userguide/query-builder-v5.mdx
+++ b/data/docs/userguide/query-builder-v5.mdx
@@ -37,7 +37,7 @@ Use the keyboard shortcut `CMD+ENTER` (Mac) or `CTRL+ENTER` (Windows/Linux) to q
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/query-builder-filtering-spans.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -88,7 +88,7 @@ Grouping transforms aggregations from single values into comparative datasets:
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/most-frequently-added-products.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -105,7 +105,7 @@ Grouping transforms aggregations from single values into comparative datasets:
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/bulk-quantity-buyers.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -121,7 +121,7 @@ Grouping transforms aggregations from single values into comparative datasets:
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/cart-additions-over-one-day.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -137,7 +137,7 @@ Grouping transforms aggregations from single values into comparative datasets:
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/per-product-avg-quantity.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -180,7 +180,7 @@ Fine-tune your query results with result manipulation options that help you focu
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/show-order-by.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -352,7 +352,7 @@ Combine multiple queries to perform sophisticated analysis that single queries c
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/error-percentage.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -369,7 +369,7 @@ Combine multiple queries to perform sophisticated analysis that single queries c
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/sla-monitoring-with-duration.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>
@@ -408,7 +408,7 @@ Combine Multiple Trace Queries to perform sophisticated analysis within a trace 
         className="box-shadowed-image" 
         src="/img/docs/product-features/query-builder/direct-descedant-operator.mp4" 
         width="100%" 
-        controls={true}
+        controls
     >
         Your browser does not support the video tag.
     </video>

--- a/data/docs/userguide/send-cloudwatch-logs-to-signoz.mdx
+++ b/data/docs/userguide/send-cloudwatch-logs-to-signoz.mdx
@@ -10,7 +10,7 @@ doc_type: howto
 
 This guide walks you through forwarding AWS CloudWatch logs to SigNoz using the OpenTelemetry (OTel) Collector's `awscloudwatch` receiver. By the end, you'll have CloudWatch logs flowing into SigNoz where you can search, filter, and correlate them with traces and metrics.
 
-<KeyPointCallout title="What is the OpenTelemetry Collector?" defaultCollapsed={true}>
+<KeyPointCallout title="What is the OpenTelemetry Collector?" defaultCollapsed="true">
 The OpenTelemetry Collector is a vendor-agnostic agent that collects, processes, and exports telemetry data (logs, metrics, traces). In this setup, it pulls logs from CloudWatch and forwards them to SigNoz. Learn more in the [OTel Collector documentation](https://signoz.io/docs/opentelemetry-collection-agents/opentelemetry-collector/why-to-use-collector/).
 </KeyPointCallout>
 
@@ -45,7 +45,7 @@ Replace the placeholders:
 - `<YOUR_AWS_ACCESS_KEY_ID>`: Your AWS access key ID
 - `<YOUR_AWS_SECRET_ACCESS_KEY>`: Your AWS secret access key
 
-<KeyPointCallout title="Using named profiles?" defaultCollapsed={true}>
+<KeyPointCallout title="Using named profiles?" defaultCollapsed="true">
 If you use multiple AWS profiles, you can specify a named profile like this:
 
 ```bash:~/.aws/credentials
@@ -172,7 +172,7 @@ Replace:
 - `<your-ingestion-key>`: Your ingestion key from [SigNoz Settings](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
 </Admonition>
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 

--- a/data/guides/aws-elb-logs.mdx
+++ b/data/guides/aws-elb-logs.mdx
@@ -13,12 +13,10 @@ keywords: [aws elb logs, alb access logs, query alb logs athena, alb logs to clo
 <ArticleSeriesTop
   seriesName="AWS Elastic Load Balancing (ELB) Monitoring Series"
   seriesOverviewHref="/guides/aws-elb-monitoring"
-  currentPart={3}
-  totalParts={3}
-  previous={{
-    title: 'How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide',
-    href: '/guides/aws-elb-metrics',
-  }}
+  currentPart="3"
+  totalParts="3"
+  previousTitle="How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide"
+  previousHref="/guides/aws-elb-metrics"
 />
 
 In the previous parts of this series, we covered the fundamentals of AWS Elastic Load Balancer (ELB) monitoring, focusing on what to monitor and why it matters in production systems. We also covered the core ELB metrics and demonstrated how to collect and visualize these metrics using a centralized observability backend instead of relying solely on native tooling.

--- a/data/guides/aws-elb-metrics.mdx
+++ b/data/guides/aws-elb-metrics.mdx
@@ -13,16 +13,12 @@ keywords: [aws elb monitoring, aws load balancer monitoring, alb monitoring, elb
 <ArticleSeriesTop
   seriesName="AWS Elastic Load Balancing (ELB) Monitoring Series"
   seriesOverviewHref="/guides/aws-elb-monitoring"
-  currentPart={2}
-  totalParts={3}
-  previous={{
-    title: 'AWS ELB Monitoring - Key Metrics for Availability, Performance, and Capacity',
-    href: '/guides/aws-elb-monitoring',
-  }}
-  next={{
-    title: 'How to Monitor AWS ELB Logs using CloudWatch and Athena?',
-    href: '/guides/aws-elb-logs',
-  }}
+  currentPart="2"
+  totalParts="3"
+  previousTitle="AWS ELB Monitoring - Key Metrics for Availability, Performance, and Capacity"
+  previousHref="/guides/aws-elb-monitoring"
+  nextTitle="How to Monitor AWS ELB Logs using CloudWatch and Athena?"
+  nextHref="/guides/aws-elb-logs"
 />
 
 The first part of this series covered AWS ELB fundamentals, load balancer types, why monitoring matters, and which metrics indicate real user impact.
@@ -213,14 +209,10 @@ The next part of this series covers ALB access logs, how to enable them, stream 
 <ArticleSeriesBottom
   seriesName="AWS Elastic Load Balancing (ELB) Monitoring Series"
   seriesOverviewHref="/guides/aws-elb-logs"
-  currentPart={2}
-  totalParts={3}
-  previous={{
-    title: 'AWS ELB Monitoring - Key Metrics for Availability, Performance, and Capacity',
-    href: '/guides/aws-elb-monitoring',
-  }}
-  next={{
-    title: 'How to Monitor AWS ELB Logs using CloudWatch and Athena',
-    href: '/guides/aws-elb-logs',
-  }}
+  currentPart="2"
+  totalParts="3"
+  previousTitle="AWS ELB Monitoring - Key Metrics for Availability, Performance, and Capacity"
+  previousHref="/guides/aws-elb-monitoring"
+  nextTitle="How to Monitor AWS ELB Logs using CloudWatch and Athena"
+  nextHref="/guides/aws-elb-logs"
 />

--- a/data/guides/aws-elb-monitoring.mdx
+++ b/data/guides/aws-elb-monitoring.mdx
@@ -13,12 +13,10 @@ keywords: [aws elb monitoring, aws load balancer monitoring, alb monitoring, nlb
 <ArticleSeriesTop
   seriesName="AWS Elastic Load Balancing (ELB) Monitoring Series"
   seriesOverviewHref="/guides/aws-elb-monitoring"
-  currentPart={1}
-  totalParts={3}
-  next={{
-    title: 'How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide',
-    href: '/guides/aws-elb-metrics',
-  }}
+  currentPart="1"
+  totalParts="3"
+  nextTitle="How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide"
+  nextHref="/guides/aws-elb-metrics"
 />
 
 AWS Elastic Load Balancing (ELB) distributes traffic across backend targets, like EC2 instances, containers, and IP addresses. As the entry point for all application traffic, load balancer failures directly impact user experience. Effective monitoring addresses this by identifying which metrics signal real issues, separating load balancer failures from backend problems, and understanding CloudWatch's blind spots.
@@ -135,6 +133,7 @@ At this point, you know what AWS ELB is, which metrics actually reflect user imp
 
 <ArticleSeriesBottom seriesName="AWS Elastic Load Balancing (ELB) Monitoring Series"
 seriesOverviewHref="/guides/aws-elb-monitoring"
-currentPart={1}
-totalParts={3}
-next={{ title: "How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide", href: '/guides/aws-elb-metrics' }} />
+currentPart="1"
+totalParts="3"
+nextTitle="How to Monitor AWS ELB Metrics with SigNoz - A Step-by-Step Guide"
+nextHref="/guides/aws-elb-metrics" />

--- a/data/guides/prometheus-node-exporter-metrics.mdx
+++ b/data/guides/prometheus-node-exporter-metrics.mdx
@@ -13,12 +13,10 @@ keywords: [prometheus node exporter, linux monitoring, node exporter, kubernetes
 <ArticleSeriesTop
   seriesName="Prometheus Node Exporter Tutorial"
   seriesOverviewHref="/guides/prometheus-node-exporter"
-  currentPart={2}
-  totalParts={2}
-  previous={{
-    title: 'Prometheus Node Exporter - Install, Run & Visualize',
-    href: '/guides/prometheus-node-exporter',
-  }}
+  currentPart="2"
+  totalParts="2"
+  previousTitle="Prometheus Node Exporter - Install, Run & Visualize"
+  previousHref="/guides/prometheus-node-exporter"
 />
 
 In earlier part, [Prometheus Node Exporter: Install, Run & Visualize](/guides/prometheus-node-exporter/), you set up Prometheus Node Exporter, configured Prometheus to scrape host-level metrics, and verified that your system was emitting and collecting data correctly. While this setup works well for learning and small environments, production systems demand a more deliberate approach.

--- a/data/guides/prometheus-node-exporter.mdx
+++ b/data/guides/prometheus-node-exporter.mdx
@@ -18,12 +18,10 @@ keywords:
 <ArticleSeriesTop
   seriesName="Prometheus Node Exporter Tutorial"
   seriesOverviewHref="/guides/prometheus-node-exporter"
-  currentPart={1}
-  totalParts={2}
-  next={{
-    title: 'Prometheus Node Exporter - Metrics Configuration & Alerting',
-    href: '/guides/prometheus-node-exporter-metrics',
-  }}
+  currentPart="1"
+  totalParts="2"
+  nextTitle="Prometheus Node Exporter - Metrics Configuration & Alerting"
+  nextHref="/guides/prometheus-node-exporter-metrics"
 />
 
 Prometheus Node Exporter is a lightweight monitoring agent that runs on Linux and Unix-based systems to collect and expose host-level metrics. These metrics help you detect critical system issues such as CPU throttling, memory leaks, disk I/O saturation, network bottlenecks, and more, making Node Exporter a foundational component in the infrastructure monitoring stack.
@@ -242,4 +240,4 @@ Hope we answered all your questions about setting up Prometheus Node Exporter an
 
 You can also subscribe to our [newsletter](https://newsletter.signoz.io/) for insights from observability nerds at SigNoz, get open source, OpenTelemetry, and devtool building stories straight to your inbox.
 
-<ArticleSeriesBottom seriesName="Prometheus Node Exporter Tutorial" seriesOverviewHref="/guides/prometheus-node-exporter" currentPart={1} totalParts={2} next={{ title: "Prometheus Node Exporter - Metrics Configuration & Alerting", href: '/guides/prometheus-node-exporter-metrics' }} />
+<ArticleSeriesBottom seriesName="Prometheus Node Exporter Tutorial" seriesOverviewHref="/guides/prometheus-node-exporter" currentPart="1" totalParts="2" nextTitle="Prometheus Node Exporter - Metrics Configuration & Alerting" nextHref="/guides/prometheus-node-exporter-metrics" />

--- a/data/guides/ssh-logs.mdx
+++ b/data/guides/ssh-logs.mdx
@@ -416,7 +416,6 @@ iptables -A INPUT -p tcp --dport 2222 -m recent --name ssh --rcheck --seconds 60
     <video 
         className="box-shadowed-image" 
         src="/img/docs/logs-management/signoz-log-management-overview.mp4" 
-        controls={false}
         width="100%" 
         autoPlay 
         muted 

--- a/data/opentelemetry/go.mdx
+++ b/data/opentelemetry/go.mdx
@@ -56,7 +56,7 @@ Run the commands below after navigating to the application source folder:
   go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 ```
 
-<KeyPointCallout title="Dependencies Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Dependencies Breakdown" defaultCollapsed="true">
 - **`otel`**: Core OpenTelemetry APIs for Go
 - **`otel/trace`**: Tracing interfaces and utilities
 - **`otel/sdk`**: SDK implementation for telemetry
@@ -103,7 +103,7 @@ import (
 )
 ```
 
-<KeyPointCallout title="Dependencies Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Dependencies Breakdown" defaultCollapsed="true">
 - **`attribute`**: Used to attach useful descriptive data to spans, like `user_id`, `region`, and `request_type`, making traces meaningful and searchable.
 - **`resource`**: Stores information about what is producing telemetry, such as `service name`, `environment (prod/staging)`, `version`, and `container ID`, etc.
 - **`sdktrace`**: Used to create, manage and sample spans, and sends them to the tracing backend.
@@ -165,7 +165,7 @@ func initTracer() func(context.Context) error {
 
 The function above configures OpenTelemetry tracing for your Go service. It creates the OTLP exporter that pushes traces to your collector and assigns metadata. Hence, the backend knows which service the traces belong to and configures the tracer provider to sample, batch, and manage spans efficiently. It also returns a shutdown function that flushes all pending traces when the app stops.
 
-<KeyPointCallout title="Keyword glossary for the above function" defaultCollapsed={true}>
+<KeyPointCallout title="Keyword glossary for the above function" defaultCollapsed="true">
 - **`otlptrace.New`**: creates the OTLP trace exporter
 - **`resource.WithAttributes`**: defines service metadata (`service.name`, etc.)
 - **`sdktrace.NewTracerProvider`**: main engine for tracing in the app
@@ -404,7 +404,7 @@ Now that you have your credentials, restart the application with the environment
 OTEL_SERVICE_NAME=goApp INSECURE_MODE=false OTEL_EXPORTER_OTLP_HEADERS=signoz-ingestion-key=<SIGNOZ-INGESTION-KEY> OTEL_EXPORTER_OTLP_ENDPOINT=ingest.{region}.signoz.cloud:443 go run main.go
 ```
 
-<KeyPointCallout title="Configuration Breakdown" defaultCollapsed={true}>
+<KeyPointCallout title="Configuration Breakdown" defaultCollapsed="true">
 
 * **`OTEL_EXPORTER_OTLP_HEADERS`**: Replace `<SIGNOZ_INGESTION_KEY>` with the key you retrieved from the settings page.
 * **`OTEL_EXPORTER_OTLP_ENDPOINT`**: Update `{region}` to match your account location:

--- a/data/opentelemetry/python.mdx
+++ b/data/opentelemetry/python.mdx
@@ -172,7 +172,7 @@ If you are running SigNoz in self-hosted mode, use the localhost endpoint:
 After running the command, play around with the application at `http://localhost:5002/` to generate telemetry data. You can add a few TODOs, mark them as completed, or delete them. Now open the `Services` from the side bar to see your application being observed, and SigNoz visualizing key metrics with pre-built monitoring dashboards.
 
 <figure data-zoomable align='center'>
-    <video className="box-shadowed-image" src="/img/blog/2025/11/flask-prebuilt-dashboard.mp4" width="100%" controls={true}>
+    <video className="box-shadowed-image" src="/img/blog/2025/11/flask-prebuilt-dashboard.mp4" width="100%" controls>
         Your browser does not support the video tag.
     </video>
     <figcaption><i>An overview of SigNoz's APM capabilities</i></figcaption>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "next": "14.2.35",
     "next-contentlayer2": "0.5.5",
     "next-image-zoom": "^1.1.7",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.3.0",
     "pliny": "0.4.1",
     "postcss": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11531,15 +11531,16 @@ next-image-zoom@^1.1.7:
   resolved "https://registry.npmjs.org/next-image-zoom/-/next-image-zoom-1.1.7.tgz"
   integrity sha512-dSXA/c7z6SZQQvwoCP+JK9s0A5Nx1ZtGwIM7p/j7dP2gsLhdkwrTlShkQw+SvXDKgU5iVB2XoUKS+DFBGm49og==
 
-next-mdx-remote@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz"
-  integrity sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==
+next-mdx-remote@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/next-mdx-remote/-/next-mdx-remote-6.0.0.tgz#75b18bbdeda807ddb73fa07fdb7ef2620500bf59"
+  integrity sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==
   dependencies:
     "@babel/code-frame" "^7.23.5"
     "@mdx-js/mdx" "^3.0.1"
     "@mdx-js/react" "^3.0.1"
-    unist-util-remove "^3.1.0"
+    unist-util-remove "^4.0.0"
+    unist-util-visit "^5.1.0"
     vfile "^6.0.1"
     vfile-matter "^5.0.0"
 
@@ -14441,14 +14442,14 @@ unist-util-remove-position@^5.0.0:
     "@types/unist" "^3.0.0"
     unist-util-visit "^5.0.0"
 
-unist-util-remove@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz"
-  integrity sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==
+unist-util-remove@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-4.0.0.tgz#94b7d6bbd24e42d2f841e947ed087be5c82b222e"
+  integrity sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==
   dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^5.0.0"
-    unist-util-visit-parents "^5.0.0"
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 unist-util-select@^4.0.0, unist-util-select@^4.0.1:
   version "4.0.3"
@@ -14497,7 +14498,7 @@ unist-util-visit-parents@^4.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
+unist-util-visit-parents@^5.1.1:
   version "5.1.3"
   resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz"
   integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
@@ -14535,6 +14536,15 @@ unist-util-visit@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz"
   integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
+unist-util-visit@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
+  integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
   dependencies:
     "@types/unist" "^3.0.0"
     unist-util-is "^6.0.0"


### PR DESCRIPTION
## Summary
Upgrades next-mdx-remote from 5.0.0 to 6.0.0 to address https://www.cve.org/CVERecord?id=CVE-2026-0969 and updates MDX usage so it works with the new default blockJS: true behavior due to breaking changes in v6.

## Code changes and content changes
with blockJS: true (default), JS expressions like {variable} and JSX attribute expressions like defaultCollapsed={true} are removed during MDX compilation so the component and consumption have to be updated

### Component updates
KeyPointCallout: Accepts both boolean and string props (defaultCollapsed="true" / defaultCollapsed="false").
ArticleSeriesTop / ArticleSeriesBottom: Accept string props (currentPart="1", totalParts="2") and previousTitle/previousHref/nextTitle/nextHref instead of object props.

MDX content updates
KeyPointCallout: defaultCollapsed={true} → defaultCollapsed="true", defaultCollapsed={false} → defaultCollapsed="false" in most files
Video controls: controls={false} removed; controls={true} replaced with controls to avoid {} syntax
ArticleSeries: Object props replaced with string props in guides and blog series.
Updated areas:
data/docs/ – instrumentation, migration, logs, metrics, AWS, integrations, etc.
data/guides/ – Prometheus Node Exporter, AWS ELB, SSH logs
data/blog/ – OpenTelemetry Next.js series (5 articles), golang-monitoring, opentelemetry-demo, what-is-opentelemetry
data/opentelemetry/ – go.mdx, python.mdx
data/faqs/ – no changes needed
data/case-study/ – no changes needed
data/comparisons/ – no changes needed

## Post change
Do not use {} syntax in mdx files to print / evaluate variables / call methods

Avoid: 
```
Next page {nextPage.title} ->
Result is {2 + 2}
{someFunction()}
{new Date().toISOString()}
```

If the above functionality needs to be enabled - please create a component and use via props

to do `Next page {nextPage.title} ->`
use something like `<NextPageComponent title="Title for next page" />` in mdx