### PR TITLE
Update CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const defaultFrameAncestors =
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app https://www.googletagmanager.com https://js.hsforms.net https://f.vimeocdn.com https://embed.lu.ma https://www.clarity.ms https://*.contentsquare.net http://*.contentsquare.net https://www.chatbase.co https://static.reo.dev https://*.clarity.ms;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app https://www.googletagmanager.com https://js.hsforms.net https://f.vimeocdn.com https://embed.lu.ma https://www.clarity.ms https://*.contentsquare.net http://*.contentsquare.net https://www.chatbase.co https://static.reo.dev https://*.clarity.ms https://snap.licdn.com;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://embed.lu.ma;
   img-src * blob: data:;
   media-src *;


### PR DESCRIPTION
## Summary
- add https://snap.licdn.com to script-src in CSP
- unblock LinkedIn Insight tag loading via Google Tag Manager

## Why
The LinkedIn retargeting tag script (https://snap.licdn.com/li.lms-analytics/insight.min.js) was blocked by the current Content Security Policy.

## Validation
- verified CSP now includes https://snap.licdn.com in script-src
- this addresses the console CSP violation for the LinkedIn Insight script host