### PR TITLE
Add copy markdown button across additional pages

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -125,6 +125,7 @@ export default async function Page(props: { params: { slug: string[] } }) {
           content={mainContent}
           authorDetails={authorDetails}
           authors={authorList}
+          markdownContent={post.body?.raw}
           toc={post.toc}
           navItems={hubContext.items}
           currentHubPath={hubContext.pathKey}

--- a/app/comparisons/[...slug]/page.tsx
+++ b/app/comparisons/[...slug]/page.tsx
@@ -118,6 +118,7 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
           content={mainContent}
           authorDetails={authorDetails}
           authors={authorList}
+          markdownContent={post.body?.raw}
           toc={post.toc}
           navItems={hubContext.items}
           currentHubPath={hubContext.pathKey}

--- a/app/guides/[...slug]/page.tsx
+++ b/app/guides/[...slug]/page.tsx
@@ -135,6 +135,7 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
           content={mainContent}
           authorDetails={authorDetails}
           authors={authorList}
+          markdownContent={post.body?.raw}
           toc={post.toc}
           navItems={hubContext.items}
           currentHubPath={hubContext.pathKey}

--- a/app/opentelemetry/[...slug]/page.tsx
+++ b/app/opentelemetry/[...slug]/page.tsx
@@ -329,6 +329,7 @@ export default async function Page({ params }: { params: { slug: string[] } }) {
           content={mainContent}
           authorDetails={authorDetails}
           authors={content.authors?.map((author) => author?.key) || []}
+          markdownContent={content.content}
           toc={toc}
           navItems={hubContext.items}
           currentHubPath={hubContext.pathKey}

--- a/layouts/ArticleLayout.tsx
+++ b/layouts/ArticleLayout.tsx
@@ -4,7 +4,8 @@ import '../css/article-layout.css'
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog, Authors, Comparison, Guide } from 'contentlayer/generated'
 import { ExternalLink } from 'lucide-react'
@@ -20,8 +21,11 @@ import { ProgressBar } from '@/components/ProgressBar/ProgressBar'
 import NewsletterSubscription from '@/components/NewsletterSubscription/NewsletterSubscription'
 import authorsDirectory from '@/constants/authors.json'
 import { useScrollToHash } from '@/hooks/useScrollToHash'
+import OpenInAI from '@/components/OpenInAI'
+import { buildCopyMarkdownFromRendered } from '@/utils/docs/buildCopyMarkdownFromRendered'
 
 const MAIN_CONTENT_ID = 'article-main'
+const ARTICLE_COPY_SOURCE_ID = 'article-copy-source'
 
 export interface TocItemProps {
   url: string
@@ -119,6 +123,7 @@ export default function ArticleLayout({
   showRelatedArticles = true,
 }: LayoutProps) {
   const { title, relatedArticles } = content
+  const pathname = usePathname()
   const mainRef = useRef<HTMLElement | null>(null)
   const tocContainerRef = useRef<HTMLDivElement>(null)
   const [activeSection, setActiveSection] = useState<string>('')
@@ -162,10 +167,26 @@ export default function ArticleLayout({
   const readingTimeText = getReadingTimeText(content)
 
   const MAX_VISIBLE_TAGS = 2
-  const tagsArray = Array.isArray(content.tags) ? content.tags : []
+  const tagsArray = useMemo(() => (Array.isArray(content.tags) ? content.tags : []), [content.tags])
   const primaryTags = tagsArray.slice(0, MAX_VISIBLE_TAGS)
   const hiddenTags = tagsArray.slice(MAX_VISIBLE_TAGS)
   const hiddenTagsTitle = hiddenTags.length ? hiddenTags.join(', ') : undefined
+  const fallbackMarkdown = useMemo(() => {
+    const tagLine = tagsArray.length > 0 ? `Tags: ${tagsArray.join(', ')}` : ''
+    return [`# ${title}`, tagLine].filter(Boolean).join('\n\n')
+  }, [tagsArray, title])
+  const getMarkdownContent = useCallback(async () => {
+    const articleEl = document.getElementById(ARTICLE_COPY_SOURCE_ID)
+    if (!articleEl) {
+      return fallbackMarkdown
+    }
+
+    return buildCopyMarkdownFromRendered(articleEl, {
+      title,
+      tags: tagsArray,
+      includeTagDefinitions: true,
+    })
+  }, [fallbackMarkdown, tagsArray, title])
   const hasMetaInfo =
     renderedAuthors.length > 0 ||
     Boolean(readingTimeText) ||
@@ -192,8 +213,20 @@ export default function ArticleLayout({
           <div className="doc-content md:px-0 lg:px-4">
             {hasToc && <div className="mb-4 lg:hidden" />}
 
-            <article className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert">
-              <h1 className="text-3xl font-bold">{title}</h1>
+            <article
+              id={ARTICLE_COPY_SOURCE_ID}
+              className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert"
+            >
+              <div className="not-prose mb-4 flex items-start justify-between gap-2">
+                <h1 className="m-0 text-3xl font-bold leading-tight">{title}</h1>
+                <OpenInAI
+                  getMarkdownContent={getMarkdownContent}
+                  pageUrl={pathname}
+                  docSlug={content.slug}
+                  copyLabel="Copy markdown"
+                  className="shrink-0"
+                />
+              </div>
               {(formattedUpdatedDate || readingTimeText) && (
                 <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">
                   {formattedUpdatedDate && <span>Updated {formattedUpdatedDate}</span>}

--- a/layouts/OpenTelemetryHubLayout.tsx
+++ b/layouts/OpenTelemetryHubLayout.tsx
@@ -17,9 +17,11 @@ import type { HubPathMeta, LayoutProps } from './open-telemetry-hub/types'
 import { normalizeRoute } from './open-telemetry-hub/navigation'
 import { ExternalLink } from 'lucide-react'
 import { RegionProvider } from '@/components/Region/RegionContext'
+import OpenInAI from '@/components/OpenInAI'
 
 const LANGUAGES_CATEGORY_KEY = 'Language and Frameworks'
 const MAIN_CONTENT_ID = 'opentelemetry-hub-main'
+const ARTICLE_COPY_SOURCE_ID = 'opentelemetry-hub-copy-source'
 const MOBILE_TRIGGER_ID = 'ot-hub-mobile-trigger'
 const MOBILE_OVERLAY_ID = 'ot-hub-mobile-overlay'
 
@@ -99,6 +101,7 @@ export default function OpenTelemetryHubLayout({
   authorDetails,
   authors,
   children,
+  markdownContent,
   toc,
   navItems,
   currentHubPath,
@@ -209,8 +212,20 @@ export default function OpenTelemetryHubLayout({
             <div className="doc-content md:px-0 lg:px-4">
               {(showSidebar || hasToc) && <div id={MOBILE_TRIGGER_ID} className="mb-4 lg:hidden" />}
 
-              <article className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert">
-                <h1 className="text-3xl font-bold">{title}</h1>
+              <article
+                id={ARTICLE_COPY_SOURCE_ID}
+                className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert"
+              >
+                <div className="not-prose mb-4 flex items-start justify-between gap-2">
+                  <h1 className="m-0 text-3xl font-bold leading-tight">{title}</h1>
+                  <OpenInAI
+                    markdownContent={markdownContent}
+                    pageUrl={currentRoute}
+                    docSlug={content.slug}
+                    copyLabel="Copy markdown"
+                    className="shrink-0"
+                  />
+                </div>
                 {(formattedUpdatedDate || readingTimeText) && (
                   <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">
                     {formattedUpdatedDate && <span>Updated {formattedUpdatedDate}</span>}

--- a/layouts/open-telemetry-hub/types.ts
+++ b/layouts/open-telemetry-hub/types.ts
@@ -52,6 +52,7 @@ export interface LayoutProps {
   authorDetails: CoreContent<Authors | MDXContent>[]
   authors: string[]
   children: ReactNode
+  markdownContent?: string
   toc: TocItemProps[]
   navItems: HubNavItem[]
   currentHubPath: string


### PR DESCRIPTION
## Summary
- sync branch work with request to extend the docs copy markdown button usage to /guides, /blog, /comparisons, and /opentelemetry pages
- re-use existing docs component instead of adding a new one, per request

## Testing
- Not run (not requested)