### PR TITLE
Add homepage header copy experiment content

### DIFF
--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Hero from '@/components/ui/Hero'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, BookOpen } from 'lucide-react'
 import Button from '@/components/Button/Button'
 import TrackingLink from '@/components/TrackingLink'
 import { VideoModalPlayer } from './VideoModalPlayer'
@@ -15,7 +15,7 @@ export async function Header() {
   const variantId = useAlternativeCopy
     ? EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.VARIANT
     : EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.CONTROL
-  const primaryCTA = useAlternativeCopy ? 'Get Started — Free' : 'Get Started - Free'
+  const primaryCTA = useAlternativeCopy ? 'Get Started - Free' : 'Get Started - Free'
 
   return (
     <header className="relative !mx-auto mt-16 !w-[100vw] md:!w-[80vw]">
@@ -36,7 +36,12 @@ export async function Header() {
           </Hero>
           <p className="m-0 p-3 text-base font-medium sm:p-0">
             {useAlternativeCopy ? (
-              'Traces, metrics, and logs in a unified, OpenTelemetry-native platform. Simple usage-based pricing, no proprietary lock-in, and the freedom to run on our cloud or your infrastructure.'
+              <>
+                Traces, metrics, and logs in a unified, OpenTelemetry-native platform. Simple
+                usage-based pricing,
+                <br className="hidden lg:inline" /> no proprietary lock-in, and the freedom to run
+                on our cloud or your infrastructure.
+              </>
             ) : (
               <>
                 SigNoz is an open-source Datadog or New Relic alternative. Get APM, logs,{' '}
@@ -47,7 +52,45 @@ export async function Header() {
           </p>
         </div>
         <div className="!mx-auto mx-2 flex !w-[100vw] flex-col items-center justify-center gap-3 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw] md:flex-row">
-          <div className="flex flex-col items-center">
+          {useAlternativeCopy ? (
+            <div className="grid grid-cols-1 items-center gap-y-3 md:grid-cols-[auto_auto] md:items-start md:gap-x-3 md:gap-y-2">
+              <div className="flex flex-col items-center">
+                <TrackingLink
+                  href="/teams/"
+                  clickType="Primary CTA"
+                  clickName="Sign Up Button"
+                  clickText={primaryCTA}
+                  clickLocation="Hero Section"
+                  experimentId={experimentId}
+                  variantId={variantId}
+                  className="block w-[220px]"
+                >
+                  <Button className="flex-center !w-full" id="btn-get-started-homepage-hero">
+                    {primaryCTA}
+                    <ArrowRight size={14} />
+                  </Button>
+                </TrackingLink>
+                <p className="mt-2 hidden text-xs italic md:block">No credit card required</p>
+              </div>
+              <div className="flex justify-center">
+                <TrackingLink
+                  href="/docs/introduction/"
+                  clickType="Secondary CTA"
+                  clickName="Explore Docs Button"
+                  clickText="Explore the Docs"
+                  clickLocation="Hero Section"
+                  experimentId={experimentId}
+                  variantId={variantId}
+                  className="block w-[220px]"
+                >
+                  <Button className="flex-center !w-full" type={Button.TYPES.SECONDARY}>
+                    <BookOpen size={14} />
+                    Explore the Docs
+                  </Button>
+                </TrackingLink>
+              </div>
+            </div>
+          ) : (
             <TrackingLink
               href="/teams/"
               clickType="Primary CTA"
@@ -60,22 +103,6 @@ export async function Header() {
               <Button className="flex-center" id="btn-get-started-homepage-hero">
                 {primaryCTA}
                 <ArrowRight size={14} />
-              </Button>
-            </TrackingLink>
-            {useAlternativeCopy && <p className="mt-2 text-xs italic">No credit card required</p>}
-          </div>
-          {useAlternativeCopy && (
-            <TrackingLink
-              href="/docs/introduction/"
-              clickType="Secondary CTA"
-              clickName="Explore Docs Button"
-              clickText="Explore the Docs"
-              clickLocation="Hero Section"
-              experimentId={experimentId}
-              variantId={variantId}
-            >
-              <Button className="flex-center" type={Button.TYPES.SECONDARY}>
-                Explore the Docs
               </Button>
             </TrackingLink>
           )}

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -61,21 +61,26 @@ export async function Header() {
         <div className="!mx-auto mx-2 flex !w-[100vw] flex-col items-center justify-center gap-3 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw] md:flex-row">
           {useAlternativeCopy ? (
             <div className="flex flex-col items-center gap-3 md:flex-row">
-              <TrackingLink
-                href="/teams/"
-                clickType="Primary CTA"
-                clickName="Sign Up Button"
-                clickText={primaryCTA}
-                clickLocation="Hero Section"
-                experimentId={experimentId}
-                variantId={variantId}
-                className="block w-[220px]"
-              >
-                <Button className="flex-center !w-full" id="btn-get-started-homepage-hero">
-                  {primaryCTA}
-                  <ArrowRight size={14} />
-                </Button>
-              </TrackingLink>
+              <div className="group relative flex flex-col items-center">
+                <TrackingLink
+                  href="/teams/"
+                  clickType="Primary CTA"
+                  clickName="Sign Up Button"
+                  clickText={primaryCTA}
+                  clickLocation="Hero Section"
+                  experimentId={experimentId}
+                  variantId={variantId}
+                  className="block w-[220px]"
+                >
+                  <Button className="flex-center !w-full" id="btn-get-started-homepage-hero">
+                    {primaryCTA}
+                    <ArrowRight size={14} />
+                  </Button>
+                </TrackingLink>
+                <p className="pointer-events-none absolute left-1/2 top-full hidden -translate-x-1/2 whitespace-nowrap pt-2 text-xs italic opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100 md:block">
+                  No credit card required
+                </p>
+              </div>
               <TrackingLink
                 href="/docs/introduction/"
                 clickType="Secondary CTA"

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -77,7 +77,7 @@ export async function Header() {
                     <ArrowRight size={14} />
                   </Button>
                 </TrackingLink>
-                <p className="pointer-events-none absolute left-1/2 top-full hidden -translate-x-1/2 whitespace-nowrap pt-2 text-xs italic opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100 md:block">
+                <p className="pointer-events-none absolute left-1/2 top-full hidden -translate-x-1/2 whitespace-nowrap pt-2 text-xs opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100 md:block">
                   No credit card required
                 </p>
               </div>

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -15,7 +15,7 @@ export async function Header() {
   const variantId = useAlternativeCopy
     ? EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.VARIANT
     : EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.CONTROL
-  const primaryCTA = useAlternativeCopy ? 'Get Started - Free' : 'Get Started - Free'
+  const primaryCTA = 'Get Started - Free'
 
   return (
     <header className="relative !mx-auto mt-16 !w-[100vw] md:!w-[80vw]">

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -1,55 +1,86 @@
 import React from 'react'
 import Hero from '@/components/ui/Hero'
-import { ArrowRight, Handshake, LucideGamepad2, LucideRocket } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import Button from '@/components/Button/Button'
 import TrackingLink from '@/components/TrackingLink'
-import Link from 'next/link'
 import { VideoModalPlayer } from './VideoModalPlayer'
+import { ExperimentTracker } from '@/components/ExperimentTracker'
+import { EXPERIMENTS } from '@/constants/experiments'
+import { evaluateFeatureFlag } from '@/utils/growthbookServer'
 
 // Server component with single CTA
 export async function Header() {
+  const useAlternativeCopy = await evaluateFeatureFlag(EXPERIMENTS.HOMEPAGE_HEADER_COPY.flagName)
+  const experimentId = EXPERIMENTS.HOMEPAGE_HEADER_COPY.id
+  const variantId = useAlternativeCopy
+    ? EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.VARIANT
+    : EXPERIMENTS.HOMEPAGE_HEADER_COPY.variants.CONTROL
+  const primaryCTA = useAlternativeCopy ? 'Get Started — Free' : 'Get Started - Free'
+
   return (
     <header className="relative !mx-auto mt-16 !w-[100vw] md:!w-[80vw]">
-      <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[-1] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
-      <div className="relative !mx-auto flex !w-[100vw] flex-col items-center border  !border-b-0 !border-t-0  border-dashed border-signoz_slate-400 px-2 pb-4 pt-12 text-center md:!w-[80vw] md:px-5 md:pt-[4rem]">
-        {/* Uncomment the below link tag to create a pill on homepage */}
-
-        {/* <Link
-          href="https://newsletter.signoz.io/p/is-your-opentelemetry-auto-instrumented"
-          target="_blank"
-        >
-          <button className="flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-xs font-medium leading-5 text-white shadow-[0_0_14px_0_rgba(78,116,248,0.40)] sm:gap-2 sm:text-sm">
-            💌 From our Newsletter: How to reduce telemetry volume by 40%? →
-          </button>
-        </Link> */}
-        <div className="absolute left-0 top-[147px] z-[-1] h-10 !w-[100vw] border !border-l-0 !border-r-0 border-dashed border-signoz_slate-400 sm:h-14 md:top-[253px] md:!w-[80vw]" />
-        <Hero>
-          OpenTelemetry-Native Logs,&nbsp;
-          <br className="hidden lg:inline" />
-          Metrics and Traces in a single pane
-        </Hero>
-        <p className="m-0 p-3 text-base font-medium sm:p-0">
-          SigNoz is an open-source Datadog or New Relic alternative. Get APM, logs,{' '}
-          <br className="hidden lg:inline" /> traces, metrics, exceptions, & alerts in a single
-          tool.
-        </p>
-      </div>
-      {/* <div className='!w-[80vw] h-12 !mx-auto border border-signoz_slate-400 border-dashed !border-t-0 !border-b-0' /> */}
-      <div className="!mx-auto mx-2 flex !w-[100vw] flex-col items-center justify-center gap-3 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw] md:flex-row">
-        {/* Single CTA with control version */}
-        <TrackingLink
-          href="/teams/"
-          clickType="Primary CTA"
-          clickName="Sign Up Button"
-          clickText="Get Started - Free"
-          clickLocation="Hero Section"
-        >
-          <Button className="flex-center" id="btn-get-started-homepage-hero">
-            Get Started - Free
-            <ArrowRight size={14} />
-          </Button>
-        </TrackingLink>
-      </div>
+      <ExperimentTracker experimentId={experimentId} variantId={variantId}>
+        <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[-1] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
+        <div className="relative !mx-auto flex !w-[100vw] flex-col items-center border  !border-b-0 !border-t-0  border-dashed border-signoz_slate-400 px-2 pb-4 pt-12 text-center md:!w-[80vw] md:px-5 md:pt-[4rem]">
+          <div className="absolute left-0 top-[147px] z-[-1] h-10 !w-[100vw] border !border-l-0 !border-r-0 border-dashed border-signoz_slate-400 sm:h-14 md:top-[253px] md:!w-[80vw]" />
+          <Hero>
+            {useAlternativeCopy ? (
+              'Observability on your terms, powered by open standards.'
+            ) : (
+              <>
+                OpenTelemetry-Native Logs,&nbsp;
+                <br className="hidden lg:inline" />
+                Metrics and Traces in a single pane
+              </>
+            )}
+          </Hero>
+          <p className="m-0 p-3 text-base font-medium sm:p-0">
+            {useAlternativeCopy ? (
+              'Traces, metrics, and logs in a unified, OpenTelemetry-native platform. Simple usage-based pricing, no proprietary lock-in, and the freedom to run on our cloud or your infrastructure.'
+            ) : (
+              <>
+                SigNoz is an open-source Datadog or New Relic alternative. Get APM, logs,{' '}
+                <br className="hidden lg:inline" /> traces, metrics, exceptions, & alerts in a
+                single tool.
+              </>
+            )}
+          </p>
+        </div>
+        <div className="!mx-auto mx-2 flex !w-[100vw] flex-col items-center justify-center gap-3 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw] md:flex-row">
+          <div className="flex flex-col items-center">
+            <TrackingLink
+              href="/teams/"
+              clickType="Primary CTA"
+              clickName="Sign Up Button"
+              clickText={primaryCTA}
+              clickLocation="Hero Section"
+              experimentId={experimentId}
+              variantId={variantId}
+            >
+              <Button className="flex-center" id="btn-get-started-homepage-hero">
+                {primaryCTA}
+                <ArrowRight size={14} />
+              </Button>
+            </TrackingLink>
+            {useAlternativeCopy && <p className="mt-2 text-xs italic">No credit card required</p>}
+          </div>
+          {useAlternativeCopy && (
+            <TrackingLink
+              href="/docs/introduction/"
+              clickType="Secondary CTA"
+              clickName="Explore Docs Button"
+              clickText="Explore the Docs"
+              clickLocation="Hero Section"
+              experimentId={experimentId}
+              variantId={variantId}
+            >
+              <Button className="flex-center" type={Button.TYPES.SECONDARY}>
+                Explore the Docs
+              </Button>
+            </TrackingLink>
+          )}
+        </div>
+      </ExperimentTracker>
       <div className="section-container !mx-auto !mt-0 !w-[90vw] border !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw] md:border-dashed">
         <div className="w-100 mx-[-28px]">
           <VideoModalPlayer

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -25,7 +25,14 @@ export async function Header() {
           <div className="absolute left-0 top-[147px] z-[-1] h-10 !w-[100vw] border !border-l-0 !border-r-0 border-dashed border-signoz_slate-400 sm:h-14 md:top-[253px] md:!w-[80vw]" />
           <Hero>
             {useAlternativeCopy ? (
-              'Observability on your terms, powered by open standards.'
+              <>
+                <span className="md:hidden">
+                  Observability on Your Terms, Powered by Open Standards.
+                </span>
+                <span className="hidden md:inline">Observability on Your Terms,</span>
+                <br className="hidden md:inline" />
+                <span className="hidden md:inline">Powered by Open Standards.</span>
+              </>
             ) : (
               <>
                 OpenTelemetry-Native Logs,&nbsp;
@@ -53,42 +60,37 @@ export async function Header() {
         </div>
         <div className="!mx-auto mx-2 flex !w-[100vw] flex-col items-center justify-center gap-3 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw] md:flex-row">
           {useAlternativeCopy ? (
-            <div className="grid grid-cols-1 items-center gap-y-3 md:grid-cols-[auto_auto] md:items-start md:gap-x-3 md:gap-y-2">
-              <div className="flex flex-col items-center">
-                <TrackingLink
-                  href="/teams/"
-                  clickType="Primary CTA"
-                  clickName="Sign Up Button"
-                  clickText={primaryCTA}
-                  clickLocation="Hero Section"
-                  experimentId={experimentId}
-                  variantId={variantId}
-                  className="block w-[220px]"
-                >
-                  <Button className="flex-center !w-full" id="btn-get-started-homepage-hero">
-                    {primaryCTA}
-                    <ArrowRight size={14} />
-                  </Button>
-                </TrackingLink>
-                <p className="mt-2 hidden text-xs italic md:block">No credit card required</p>
-              </div>
-              <div className="flex justify-center">
-                <TrackingLink
-                  href="/docs/introduction/"
-                  clickType="Secondary CTA"
-                  clickName="Explore Docs Button"
-                  clickText="Explore the Docs"
-                  clickLocation="Hero Section"
-                  experimentId={experimentId}
-                  variantId={variantId}
-                  className="block w-[220px]"
-                >
-                  <Button className="flex-center !w-full" type={Button.TYPES.SECONDARY}>
-                    <BookOpen size={14} />
-                    Explore the Docs
-                  </Button>
-                </TrackingLink>
-              </div>
+            <div className="flex flex-col items-center gap-3 md:flex-row">
+              <TrackingLink
+                href="/teams/"
+                clickType="Primary CTA"
+                clickName="Sign Up Button"
+                clickText={primaryCTA}
+                clickLocation="Hero Section"
+                experimentId={experimentId}
+                variantId={variantId}
+                className="block w-[220px]"
+              >
+                <Button className="flex-center !w-full" id="btn-get-started-homepage-hero">
+                  {primaryCTA}
+                  <ArrowRight size={14} />
+                </Button>
+              </TrackingLink>
+              <TrackingLink
+                href="/docs/introduction/"
+                clickType="Secondary CTA"
+                clickName="Explore Docs Button"
+                clickText="Explore the Docs"
+                clickLocation="Hero Section"
+                experimentId={experimentId}
+                variantId={variantId}
+                className="block w-[220px]"
+              >
+                <Button className="flex-center !w-full" type={Button.TYPES.SECONDARY}>
+                  <BookOpen size={14} />
+                  Explore the Docs
+                </Button>
+              </TrackingLink>
             </div>
           ) : (
             <TrackingLink

--- a/constants/experiments.ts
+++ b/constants/experiments.ts
@@ -57,6 +57,14 @@ export const EXPERIMENTS = {
     concluded: true,
     defaultVariant: 'get-started-free-copy',
   },
+  HOMEPAGE_HEADER_COPY: {
+    id: 'homepage-header-copy-experiment',
+    variants: {
+      CONTROL: 'existing-homepage-header-copy',
+      VARIANT: 'observability-on-your-terms-copy',
+    },
+    flagName: 'homepage-header-copy-experiment',
+  },
   TEAMS_PAGE: {
     id: 'teams-page-focused-layout-experiment',
     variants: {


### PR DESCRIPTION
Summary
- outline the new A/B test for the homepage header copy running under `homepage-header-copy-experiment`
- describe the alternate headline, sub-headline, and CTA copy components (free start, docs)
- mention that the experiment balances messaging about feeling trapped and OpenTelemetry-native freedom

Testing
- Not run (not requested)