### PR TITLE
fix: replace missing Loki image on log aggregation tools page

### DIFF
--- a/data/comparisons/log-aggregation-tools.mdx
+++ b/data/comparisons/log-aggregation-tools.mdx
@@ -344,7 +344,7 @@ New Relic is a cloud-based network monitoring and observability platform for fu
 Grafana Loki is a log aggregation system inspired by Prometheus. It is designed to be very cost-effective and easy to operate. It does not index the contents of the logs, but rather a set of labels for each log stream. This makes it an attractive option for developers who want "grep-like" searching without the high storage costs of full-text indexing.
 
 <figure data-zoomable align='center'>
-    <img className="box-shadowed-image" src="/img/blog/2024/03/loki_dashboard.webp" alt="Grafana Loki Dashboard"/>
+    <img className="box-shadowed-image" src="/img/comparisons/2025/01/graylog-vs-loki-image%201.webp" alt="Grafana Loki Dashboard"/>
     <figcaption><i>Grafana Loki within Grafana</i></figcaption>
 </figure>
 


### PR DESCRIPTION
### Motivation
- The Grafana Loki section on `/comparisons/log-aggregation-tools/` referenced a missing image which caused a broken image in preview and production, so the page needs a valid in-repo asset.

### Description
- Replaced the missing image reference in `data/comparisons/log-aggregation-tools.mdx` from `/img/blog/2024/03/loki_dashboard.webp` to the existing asset `/img/comparisons/2025/01/graylog-vs-loki-image%201.webp`.

### Testing
- Ran `yarn test:docs-metadata` which passed. 
- Ran `yarn test:doc-redirects` which passed. 
- `yarn check:docs-metadata` and `yarn check:doc-redirects` failed in this environment due to `git merge-base` error (no `origin/main` available), not due to content issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984d802ca8832382574e9730f63d25)