### PR TITLE
ci: Add GitHub Actions workflow to send daily Slack alerts for stale pull requests.

### DIFF
--- a/.github/workflows/stale-pr-slack-alert.yml
+++ b/.github/workflows/stale-pr-slack-alert.yml
@@ -1,0 +1,206 @@
+name: Daily Stale PR Slack Alert
+
+on:
+  schedule:
+    # Runs daily at 05:00 UTC.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build stale PR report
+        id: report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const STALE_DAYS = 7;
+            const MAX_MESSAGE_CHARS = 3000;
+            const MAX_TITLE_LENGTH = 160;
+            const DAY_MS = 24 * 60 * 60 * 1000;
+            const now = Date.now();
+
+            const escapeSlack = (value = '') =>
+              value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            const truncate = (value = '', max = MAX_TITLE_LENGTH) =>
+              value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const stalePulls = pulls
+              .filter((pr) => !pr.draft)
+              .map((pr) => ({
+                ...pr,
+                ageDays: Math.floor((now - new Date(pr.created_at).getTime()) / DAY_MS)
+              }))
+              .filter((pr) => pr.ageDays >= STALE_DAYS)
+              .sort((a, b) => b.ageDays - a.ageDays);
+
+            const repoName = `${context.repo.owner}/${context.repo.repo}`;
+            const prListUrl = `${context.serverUrl}/${repoName}/pulls`;
+            const payloads = [];
+
+            if (stalePulls.length === 0) {
+              payloads.push({
+                text: [
+                  ':white_check_mark: Daily stale PR check',
+                  `Repository: \`${repoName}\``,
+                  `No non-draft open PRs older than ${STALE_DAYS} days.`,
+                  `<${prListUrl}|View open PRs>`
+                ].join('\n')
+              });
+            } else {
+              const byCreator = stalePulls.reduce((acc, pr) => {
+                const login = pr.user.login;
+
+                if (!acc.has(login)) {
+                  acc.set(login, []);
+                }
+
+                acc.get(login).push(pr);
+                return acc;
+              }, new Map());
+
+              const creators = Array.from(byCreator.entries())
+                .map(([login, prs]) => ({
+                  login,
+                  prs: prs.sort((a, b) => b.ageDays - a.ageDays),
+                  count: prs.length,
+                  oldestAgeDays: prs.reduce((maxAge, pr) => Math.max(maxAge, pr.ageDays), 0)
+                }))
+                .sort(
+                  (a, b) =>
+                    b.count - a.count ||
+                    b.oldestAgeDays - a.oldestAgeDays ||
+                    a.login.localeCompare(b.login)
+                );
+
+              payloads.push({
+                text: [
+                  `:warning: Daily stale PR check: *${stalePulls.length}* non-draft open PR(s) older than ${STALE_DAYS} days`,
+                  `Repository: \`${repoName}\``,
+                  `Creators with stale PRs: *${creators.length}*`,
+                  `<${prListUrl}|View all open PRs>`
+                ].join('\n')
+              });
+
+              const buildHeading = (login, count, part) =>
+                part === 1
+                  ? `:bust_in_silhouette: *@${login}* (${count} stale PR${count > 1 ? 's' : ''})`
+                  : `:bust_in_silhouette: *@${login}* (${count} stale PR${count > 1 ? 's' : ''}, part ${part})`;
+
+              const sections = [];
+
+              for (const creator of creators) {
+                const authorSearchUrl = `${prListUrl}?q=is%3Apr+is%3Aopen+author%3A${encodeURIComponent(creator.login)}`;
+                const footer = `<${authorSearchUrl}|View open PRs by @${creator.login}>`;
+                const prLines = creator.prs.map(
+                  (pr) =>
+                    `• <${pr.html_url}|#${pr.number}> ${escapeSlack(truncate(pr.title))} (${pr.ageDays}d old)`
+                );
+
+                let part = 1;
+                let lines = [];
+
+                const flush = () => {
+                  if (lines.length === 0) {
+                    return;
+                  }
+
+                  sections.push([buildHeading(creator.login, creator.count, part), ...lines, footer].join('\n'));
+
+                  part += 1;
+                  lines = [];
+                };
+
+                for (const line of prLines) {
+                  const candidate = [
+                    buildHeading(creator.login, creator.count, part),
+                    ...lines,
+                    line,
+                    footer
+                  ].join('\n');
+
+                  if (candidate.length > MAX_MESSAGE_CHARS && lines.length > 0) {
+                    flush();
+                  }
+
+                  lines.push(line);
+                }
+
+                flush();
+              }
+
+              // Batch multiple creator sections into each Slack message.
+              let sectionBatch = [];
+
+              const flushBatch = () => {
+                if (sectionBatch.length === 0) {
+                  return;
+                }
+
+                payloads.push({
+                  text: sectionBatch.join('\n\n')
+                });
+
+                sectionBatch = [];
+              };
+
+              for (const section of sections) {
+                const candidate = [...sectionBatch, section].join('\n\n');
+
+                if (candidate.length > MAX_MESSAGE_CHARS && sectionBatch.length > 0) {
+                  flushBatch();
+                }
+
+                sectionBatch.push(section);
+              }
+
+              flushBatch();
+            }
+
+            core.setOutput('payloads', JSON.stringify(payloads));
+
+      - name: Send reports to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_PAYLOADS: ${{ steps.report.outputs.payloads }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "Missing required secret: SLACK_WEBHOOK_URL"
+            exit 1
+          fi
+
+          if [ -z "${SLACK_PAYLOADS}" ] || [ "${SLACK_PAYLOADS}" = "[]" ]; then
+            echo "No Slack payloads generated; skipping."
+            exit 0
+          fi
+
+          echo "${SLACK_PAYLOADS}" | jq -c '.[]' | while IFS= read -r payload; do
+            http_code="$(curl -sS -o /tmp/slack_response.txt -w "%{http_code}" \
+              -X POST \
+              -H "Content-type: application/json" \
+              --data "${payload}" \
+              "${SLACK_WEBHOOK_URL}")"
+
+            if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+              echo "Slack webhook request failed with HTTP ${http_code}"
+              cat /tmp/slack_response.txt
+              exit 1
+            fi
+
+            sleep 1
+          done


### PR DESCRIPTION


## Description

Add GitHub Actions workflow to send daily Slack alerts for stale pull requests grouped by author and message chunks of 3000 chars.

## Type of Change

<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [x] **Other** – e.g. dependencies, scripts, CI

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)
---
