### PR TITLE
fix: wrap doc renderer in region provider

### DIFF
--- a/app/upgrade-path/components/DocRender.tsx
+++ b/app/upgrade-path/components/DocRender.tsx
@@ -1,34 +1,36 @@
-import { allDocs, Doc } from "contentlayer/generated";
-import { coreContent } from "pliny/utils/contentlayer.js";
-import DocContent from "@/components/DocContent/DocContent"
+import { allDocs, Doc } from 'contentlayer/generated'
+import { coreContent } from 'pliny/utils/contentlayer.js'
+import DocContent from '@/components/DocContent/DocContent'
+import { RegionProvider } from '@/components/Region/RegionContext'
 
-const DocRenderer = ({docUrl, setHasError}: {docUrl: string, setHasError: (hasError: boolean) => void}) => {
-    const slug = decodeURI(
-        `${docUrl
-          .replace('https://signoz.io/docs/', '')
-          .replace(/^\/+/, '')}`
-      )
-    
-      const post = allDocs?.find((p) => p?.slug === slug) as Doc
-    
-      if (!post) {
-        setHasError(true);
-      }
-    
-      const mainContent = coreContent(post)
-      const toc = post?.toc || []
-      const { title } = mainContent
-    
-    return (
-        <>
-        {post && <DocContent
-            title={title}
-            post={post}
-            toc={toc}
-            hideTableOfContents={true}
-        />}
-        </>
-    );
+const DocRenderer = ({
+  docUrl,
+  setHasError,
+}: {
+  docUrl: string
+  setHasError: (hasError: boolean) => void
+}) => {
+  const slug = decodeURI(`${docUrl.replace('https://signoz.io/docs/', '').replace(/^\/+/, '')}`)
+
+  const post = allDocs?.find((p) => p?.slug === slug) as Doc
+
+  if (!post) {
+    setHasError(true)
+  }
+
+  const mainContent = coreContent(post)
+  const toc = post?.toc || []
+  const { title } = mainContent
+
+  return (
+    <>
+      {post && (
+        <RegionProvider>
+          <DocContent title={title} post={post} toc={toc} hideTableOfContents={true} />
+        </RegionProvider>
+      )}
+    </>
+  )
 }
 
-export default DocRenderer;
+export default DocRenderer

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -15,7 +15,6 @@ import OpenInAI from '@/components/OpenInAI'
 import TagsWithTooltips from '@/components/TagsWithTooltips/TagsWithTooltips'
 import { usePathname } from 'next/navigation'
 import { buildCopyMarkdownFromRendered } from '@/utils/docs/buildCopyMarkdownFromRendered'
-import { RegionProvider } from '../Region/RegionContext'
 
 const DocContent: React.FC<{
   title: string
@@ -86,9 +85,7 @@ const DocContent: React.FC<{
           )}
         </div>
         <article ref={articleRef} className="prose prose-slate max-w-none pb-6 dark:prose-invert">
-          <RegionProvider>
-            <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
-          </RegionProvider>
+          <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
         </article>
         <div className="mt-8 flex items-center justify-between text-sm">
           {formattedDate && (


### PR DESCRIPTION
## Description
upgrade path tool throws unhandled exception "useRegion must be used within region provider" since MDXLayout was wrapped in provider but docs toc uses RegionDropdown which must also be wrapped in the provider

## Type of Change

<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots

<!-- Add screenshots for UI or docs changes when helpful -->

## Checklist

<!-- Complete the sections that apply to your changes -->

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [ ] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [ ] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
