### PR TITLE
chore: handle sync to staging instance for staging label

### DIFF
--- a/.github/workflows/sync-content-cms.yml
+++ b/.github/workflows/sync-content-cms.yml
@@ -25,9 +25,13 @@ env:
   # Configurable: Array of folders to sync to CMS
   SYNC_FOLDERS: '["faqs", "case-study", "opentelemetry", "comparisons"]'
   
-  # Strapi Configuration
+  # Strapi Configuration (production)
   CMS_API_URL: ${{ secrets.CMS_API_URL }}
   CMS_API_TOKEN: ${{ secrets.CMS_API_TOKEN }}
+  
+  # Strapi Configuration (staging)
+  CMS_STAGING_API_URL: ${{ secrets.CMS_STAGING_API_URL }}
+  CMS_STAGING_API_TOKEN: ${{ secrets.CMS_STAGING_API_TOKEN }}
   
   # Revalidation Configuration
   NEXT_PUBLIC_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}

--- a/scripts/sync-content-to-strapi.js
+++ b/scripts/sync-content-to-strapi.js
@@ -5,18 +5,17 @@ const axios = require('axios')
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const mime = require('mime-types')
 
-const DEPLOYMENT_TARGET = process.env.DEPLOYMENT_STATUS || 'staging'
-
 const CMS_API_URL =
-  DEPLOYMENT_TARGET === 'staging'
+  DEPLOYMENT_STATUS === 'staging'
     ? process.env.CMS_STAGING_API_URL || process.env.CMS_API_URL
     : process.env.CMS_API_URL
 const CMS_API_TOKEN =
-  DEPLOYMENT_TARGET === 'staging'
+  DEPLOYMENT_STATUS === 'staging'
     ? process.env.CMS_STAGING_API_TOKEN || process.env.CMS_API_TOKEN
     : process.env.CMS_API_TOKEN
 
 const SYNC_FOLDERS = JSON.parse(process.env.SYNC_FOLDERS)
+const DEPLOYMENT_STATUS = process.env.DEPLOYMENT_STATUS
 
 function getAssetsListFromEnv(envName, pathEnvName) {
   if (process.env[pathEnvName] && fs.existsSync(process.env[pathEnvName])) {
@@ -57,7 +56,7 @@ const COLLECTION_SCHEMAS = {
   faqs: {
     apiPath: 'api::faq.faq',
     endpoint: 'faqs',
-    fields: ['title', 'description', 'date', 'path', 'content'],
+    fields: ['title', 'description', 'date', 'path', 'content', 'deployment_status'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -81,7 +80,7 @@ const COLLECTION_SCHEMAS = {
   'case-study': {
     apiPath: 'api::case-study.case-study',
     endpoint: 'case-studies',
-    fields: ['title', 'description', 'image', 'path', 'content'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -93,7 +92,7 @@ const COLLECTION_SCHEMAS = {
   comparisons: {
     apiPath: 'api::comparison.comparison',
     endpoint: 'comparisons',
-    fields: ['title', 'description', 'image', 'path', 'content'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -129,7 +128,7 @@ const COLLECTION_SCHEMAS = {
   guides: {
     apiPath: 'api::guide.guide',
     endpoint: 'guides',
-    fields: ['title', 'description', 'image', 'path', 'content', 'date'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status', 'date'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -170,7 +169,7 @@ const COLLECTION_SCHEMAS = {
   opentelemetry: {
     apiPath: 'api::opentelemetry.opentelemetry',
     endpoint: 'opentelemetries',
-    fields: ['title', 'description', 'image', 'path', 'content', 'date'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status', 'date'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -456,6 +455,36 @@ async function fetchAllEntities(endpoint) {
   }
 }
 
+// Helper: Filter entities by deployment_status when available
+function filterEntitiesByDeploymentStatus(entities) {
+  console.log(
+    `  🔍 [DEBUG] Filtering entities by deployment_status: ${DEPLOYMENT_STATUS} ${entities.length} entities`
+  )
+  if (!Array.isArray(entities) || entities.length === 0) {
+    return entities
+  }
+
+  const filteredEntities = entities.filter((entity) => {
+    if (!Object.prototype.hasOwnProperty.call(entity, 'deployment_status')) {
+      return true
+    }
+
+    if (entity.deployment_status === null || entity.deployment_status === undefined) {
+      return true
+    }
+
+    return entity.deployment_status === DEPLOYMENT_STATUS
+  })
+
+  if (filteredEntities.length !== entities.length) {
+    console.log(
+      `  🔒 Filtered ${entities.length - filteredEntities.length} relation candidate(s) by deployment_status=${DEPLOYMENT_STATUS}`
+    )
+  }
+
+  return filteredEntities
+}
+
 // Helper: Create a tag or keyword entry
 async function createTagOrKeyword(endpoint, value, folderName) {
   try {
@@ -518,6 +547,7 @@ async function resolveRelations(folderName, frontmatter) {
 
     // Fetch all entities from the relation endpoint
     let entities = await fetchAllEntities(relationConfig.endpoint)
+    entities = filterEntitiesByDeploymentStatus(entities)
 
     if (entities.length === 0 && !isTagsOrKeywords) {
       console.warn(`  ⚠️ No entities found in ${relationConfig.endpoint}`)
@@ -554,7 +584,9 @@ async function resolveRelations(folderName, frontmatter) {
       // Check if matched and has documentId
       if (matched && matched?.documentId) {
         matchedIds.push(matched.documentId)
-        console.log(`    ✅ Matched "${value}" → ID: ${matched.documentId}`)
+        console.log(
+          `    ✅ Matched "${value}" → ID: ${matched.documentId} with deployment_status: ${matched.deployment_status}`
+        )
       } else if (matched && !matched?.documentId) {
         // Matched entity but no documentId
         unmatchedValues.push(value)
@@ -626,6 +658,7 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
   const data = {
     path: pathField,
     content: content,
+    deployment_status: DEPLOYMENT_STATUS,
     ...frontmatter,
   }
 
@@ -658,7 +691,9 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
   }
 
   // Check for missing required fields
-  const missingFields = schema.fields.filter((field) => !(field in data))
+  const missingFields = schema.fields.filter(
+    (field) => field !== 'deployment_status' && !(field in data)
+  )
 
   if (missingFields.length > 0) {
     console.warn(`  ⚠️ Missing fields: ${missingFields.join(', ')}`)
@@ -671,11 +706,13 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
 async function findEntryByPath(folderName, pathField) {
   const schema = COLLECTION_SCHEMAS[folderName]
   try {
-    console.log(`  🔍 [DEBUG] Searching for entry: endpoint=${schema.endpoint}, path=${pathField}`)
+    console.log(
+      `  🔍 [DEBUG] Searching for entry: endpoint=${schema.endpoint}, path=${pathField}, deployment_status=${DEPLOYMENT_STATUS}`
+    )
 
     const response = await axios.get(`${CMS_API_URL}/api/${schema.endpoint}`, {
       params: {
-        filters: { path: { $eq: pathField } },
+        filters: { path: { $eq: pathField }, deployment_status: { $eq: DEPLOYMENT_STATUS } },
         pagination: { limit: 1 },
       },
       headers: {
@@ -833,7 +870,7 @@ function detectOperationType(filePath, isDeletedFile = false) {
 // Main sync logic
 async function syncToStrapi() {
   console.log('🚀 Starting sync to Strapi CMS...\n')
-  console.log(`📦 Deployment Target: ${DEPLOYMENT_TARGET}`)
+  console.log(`📦 Deployment Status: ${DEPLOYMENT_STATUS}`)
   console.log(`🔗 CMS API URL: ${CMS_API_URL}`)
   console.log(`📁 Sync Folders: ${SYNC_FOLDERS.join(', ')}`)
   console.log(`\n📄 Changed Files (${CHANGED_FILES.length}):`)
@@ -984,7 +1021,7 @@ async function syncToStrapi() {
       })
 
       results.relationTypes = Array.from(allRelationNames)
-      results.deploymentTarget = DEPLOYMENT_TARGET
+      results.deploymentStatus = DEPLOYMENT_STATUS
 
       fs.writeFileSync('sync-results.json', JSON.stringify(results, null, 2))
     } catch (e) {
@@ -1104,7 +1141,7 @@ async function syncToStrapi() {
       })
 
       results.relationTypes = Array.from(allRelationNames)
-      results.deploymentTarget = DEPLOYMENT_TARGET
+      results.deploymentStatus = DEPLOYMENT_STATUS
 
       fs.writeFileSync('sync-results.json', JSON.stringify(results, null, 2))
     } catch (e) {
@@ -1133,7 +1170,7 @@ async function syncToStrapi() {
 
   // Add relation info to results
   results.relationTypes = Array.from(allRelationNames)
-  results.deploymentTarget = DEPLOYMENT_TARGET
+  results.deploymentStatus = DEPLOYMENT_STATUS
 
   // Save results to file for PR comment script
   try {

--- a/scripts/sync-content-to-strapi.js
+++ b/scripts/sync-content-to-strapi.js
@@ -5,11 +5,18 @@ const axios = require('axios')
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const mime = require('mime-types')
 
-// Configuration
-const CMS_API_URL = process.env.CMS_API_URL
-const CMS_API_TOKEN = process.env.CMS_API_TOKEN
+const DEPLOYMENT_TARGET = process.env.DEPLOYMENT_STATUS || 'staging'
+
+const CMS_API_URL =
+  DEPLOYMENT_TARGET === 'staging'
+    ? process.env.CMS_STAGING_API_URL || process.env.CMS_API_URL
+    : process.env.CMS_API_URL
+const CMS_API_TOKEN =
+  DEPLOYMENT_TARGET === 'staging'
+    ? process.env.CMS_STAGING_API_TOKEN || process.env.CMS_API_TOKEN
+    : process.env.CMS_API_TOKEN
+
 const SYNC_FOLDERS = JSON.parse(process.env.SYNC_FOLDERS)
-const DEPLOYMENT_STATUS = process.env.DEPLOYMENT_STATUS
 
 function getAssetsListFromEnv(envName, pathEnvName) {
   if (process.env[pathEnvName] && fs.existsSync(process.env[pathEnvName])) {
@@ -50,7 +57,7 @@ const COLLECTION_SCHEMAS = {
   faqs: {
     apiPath: 'api::faq.faq',
     endpoint: 'faqs',
-    fields: ['title', 'description', 'date', 'path', 'content', 'deployment_status'],
+    fields: ['title', 'description', 'date', 'path', 'content'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -74,7 +81,7 @@ const COLLECTION_SCHEMAS = {
   'case-study': {
     apiPath: 'api::case-study.case-study',
     endpoint: 'case-studies',
-    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status'],
+    fields: ['title', 'description', 'image', 'path', 'content'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -86,7 +93,7 @@ const COLLECTION_SCHEMAS = {
   comparisons: {
     apiPath: 'api::comparison.comparison',
     endpoint: 'comparisons',
-    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status'],
+    fields: ['title', 'description', 'image', 'path', 'content'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -122,7 +129,7 @@ const COLLECTION_SCHEMAS = {
   guides: {
     apiPath: 'api::guide.guide',
     endpoint: 'guides',
-    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status', 'date'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'date'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -163,7 +170,7 @@ const COLLECTION_SCHEMAS = {
   opentelemetry: {
     apiPath: 'api::opentelemetry.opentelemetry',
     endpoint: 'opentelemetries',
-    fields: ['title', 'description', 'image', 'path', 'content', 'deployment_status', 'date'],
+    fields: ['title', 'description', 'image', 'path', 'content', 'date'],
     relations: {
       authors: {
         endpoint: 'authors',
@@ -449,36 +456,6 @@ async function fetchAllEntities(endpoint) {
   }
 }
 
-// Helper: Filter entities by deployment_status when available
-function filterEntitiesByDeploymentStatus(entities) {
-  console.log(
-    `  🔍 [DEBUG] Filtering entities by deployment_status: ${DEPLOYMENT_STATUS} ${entities.length} entities`
-  )
-  if (!Array.isArray(entities) || entities.length === 0) {
-    return entities
-  }
-
-  const filteredEntities = entities.filter((entity) => {
-    if (!Object.prototype.hasOwnProperty.call(entity, 'deployment_status')) {
-      return true
-    }
-
-    if (entity.deployment_status === null || entity.deployment_status === undefined) {
-      return true
-    }
-
-    return entity.deployment_status === DEPLOYMENT_STATUS
-  })
-
-  if (filteredEntities.length !== entities.length) {
-    console.log(
-      `  🔒 Filtered ${entities.length - filteredEntities.length} relation candidate(s) by deployment_status=${DEPLOYMENT_STATUS}`
-    )
-  }
-
-  return filteredEntities
-}
-
 // Helper: Create a tag or keyword entry
 async function createTagOrKeyword(endpoint, value, folderName) {
   try {
@@ -541,7 +518,6 @@ async function resolveRelations(folderName, frontmatter) {
 
     // Fetch all entities from the relation endpoint
     let entities = await fetchAllEntities(relationConfig.endpoint)
-    entities = filterEntitiesByDeploymentStatus(entities)
 
     if (entities.length === 0 && !isTagsOrKeywords) {
       console.warn(`  ⚠️ No entities found in ${relationConfig.endpoint}`)
@@ -578,9 +554,7 @@ async function resolveRelations(folderName, frontmatter) {
       // Check if matched and has documentId
       if (matched && matched?.documentId) {
         matchedIds.push(matched.documentId)
-        console.log(
-          `    ✅ Matched "${value}" → ID: ${matched.documentId} with deployment_status: ${matched.deployment_status}`
-        )
+        console.log(`    ✅ Matched "${value}" → ID: ${matched.documentId}`)
       } else if (matched && !matched?.documentId) {
         // Matched entity but no documentId
         unmatchedValues.push(value)
@@ -652,7 +626,6 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
   const data = {
     path: pathField,
     content: content,
-    deployment_status: DEPLOYMENT_STATUS,
     ...frontmatter,
   }
 
@@ -685,9 +658,7 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
   }
 
   // Check for missing required fields
-  const missingFields = schema.fields.filter(
-    (field) => field !== 'deployment_status' && !(field in data)
-  )
+  const missingFields = schema.fields.filter((field) => !(field in data))
 
   if (missingFields.length > 0) {
     console.warn(`  ⚠️ Missing fields: ${missingFields.join(', ')}`)
@@ -700,13 +671,11 @@ async function mapToStrapiSchema(folderName, frontmatter, content, pathField) {
 async function findEntryByPath(folderName, pathField) {
   const schema = COLLECTION_SCHEMAS[folderName]
   try {
-    console.log(
-      `  🔍 [DEBUG] Searching for entry: endpoint=${schema.endpoint}, path=${pathField}, deployment_status=${DEPLOYMENT_STATUS}`
-    )
+    console.log(`  🔍 [DEBUG] Searching for entry: endpoint=${schema.endpoint}, path=${pathField}`)
 
     const response = await axios.get(`${CMS_API_URL}/api/${schema.endpoint}`, {
       params: {
-        filters: { path: { $eq: pathField }, deployment_status: { $eq: DEPLOYMENT_STATUS } },
+        filters: { path: { $eq: pathField } },
         pagination: { limit: 1 },
       },
       headers: {
@@ -864,7 +833,7 @@ function detectOperationType(filePath, isDeletedFile = false) {
 // Main sync logic
 async function syncToStrapi() {
   console.log('🚀 Starting sync to Strapi CMS...\n')
-  console.log(`📦 Deployment Status: ${DEPLOYMENT_STATUS}`)
+  console.log(`📦 Deployment Target: ${DEPLOYMENT_TARGET}`)
   console.log(`🔗 CMS API URL: ${CMS_API_URL}`)
   console.log(`📁 Sync Folders: ${SYNC_FOLDERS.join(', ')}`)
   console.log(`\n📄 Changed Files (${CHANGED_FILES.length}):`)
@@ -1015,7 +984,7 @@ async function syncToStrapi() {
       })
 
       results.relationTypes = Array.from(allRelationNames)
-      results.deploymentStatus = DEPLOYMENT_STATUS
+      results.deploymentTarget = DEPLOYMENT_TARGET
 
       fs.writeFileSync('sync-results.json', JSON.stringify(results, null, 2))
     } catch (e) {
@@ -1135,7 +1104,7 @@ async function syncToStrapi() {
       })
 
       results.relationTypes = Array.from(allRelationNames)
-      results.deploymentStatus = DEPLOYMENT_STATUS
+      results.deploymentTarget = DEPLOYMENT_TARGET
 
       fs.writeFileSync('sync-results.json', JSON.stringify(results, null, 2))
     } catch (e) {
@@ -1164,7 +1133,7 @@ async function syncToStrapi() {
 
   // Add relation info to results
   results.relationTypes = Array.from(allRelationNames)
-  results.deploymentStatus = DEPLOYMENT_STATUS
+  results.deploymentTarget = DEPLOYMENT_TARGET
 
   // Save results to file for PR comment script
   try {

--- a/scripts/sync-content-to-strapi.js
+++ b/scripts/sync-content-to-strapi.js
@@ -5,6 +5,8 @@ const axios = require('axios')
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 const mime = require('mime-types')
 
+const DEPLOYMENT_STATUS = process.env.DEPLOYMENT_STATUS
+
 const CMS_API_URL =
   DEPLOYMENT_STATUS === 'staging'
     ? process.env.CMS_STAGING_API_URL || process.env.CMS_API_URL
@@ -15,7 +17,6 @@ const CMS_API_TOKEN =
     : process.env.CMS_API_TOKEN
 
 const SYNC_FOLDERS = JSON.parse(process.env.SYNC_FOLDERS)
-const DEPLOYMENT_STATUS = process.env.DEPLOYMENT_STATUS
 
 function getAssetsListFromEnv(envName, pathEnvName) {
   if (process.env[pathEnvName] && fs.existsSync(process.env[pathEnvName])) {

--- a/scripts/sync-content-to-strapi.js
+++ b/scripts/sync-content-to-strapi.js
@@ -8,13 +8,9 @@ const mime = require('mime-types')
 const DEPLOYMENT_STATUS = process.env.DEPLOYMENT_STATUS
 
 const CMS_API_URL =
-  DEPLOYMENT_STATUS === 'staging'
-    ? process.env.CMS_STAGING_API_URL || process.env.CMS_API_URL
-    : process.env.CMS_API_URL
+  DEPLOYMENT_STATUS === 'staging' ? process.env.CMS_STAGING_API_URL : process.env.CMS_API_URL
 const CMS_API_TOKEN =
-  DEPLOYMENT_STATUS === 'staging'
-    ? process.env.CMS_STAGING_API_TOKEN || process.env.CMS_API_TOKEN
-    : process.env.CMS_API_TOKEN
+  DEPLOYMENT_STATUS === 'staging' ? process.env.CMS_STAGING_API_TOKEN : process.env.CMS_API_TOKEN
 
 const SYNC_FOLDERS = JSON.parse(process.env.SYNC_FOLDERS)
 

--- a/scripts/update-pr-comment.js
+++ b/scripts/update-pr-comment.js
@@ -3,7 +3,6 @@ const path = require('path')
 
 module.exports = async ({ github, context, core }) => {
   const status = process.env.JOB_STATUS
-  const deploymentTarget = process.env.DEPLOYMENT_TARGET
   const deploymentStatus = process.env.DEPLOYMENT_STATUS
 
   let body = ''
@@ -22,7 +21,7 @@ module.exports = async ({ github, context, core }) => {
     if (syncResults) {
       // Build comprehensive summary
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance with deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to CMS with deployment status: \`${deploymentStatus}\`\n\n`
 
       // Summary counts
       body += `### 📊 Summary\n\n`
@@ -84,7 +83,7 @@ module.exports = async ({ github, context, core }) => {
     } else {
       // Fallback if results file not found
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to Strapi CMS with deployment target: \`${deploymentTarget}\` and deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to CMS with deployment status: \`${deploymentStatus}\`\n\n`
       body += `Relations have been automatically resolved.`
     }
   } else {

--- a/scripts/update-pr-comment.js
+++ b/scripts/update-pr-comment.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 module.exports = async ({ github, context, core }) => {
   const status = process.env.JOB_STATUS
-  const deploymentStatus = process.env.DEPLOYMENT_STATUS
+  const deploymentTarget = process.env.DEPLOYMENT_STATUS || 'staging'
 
   let body = ''
 
@@ -21,7 +21,7 @@ module.exports = async ({ github, context, core }) => {
     if (syncResults) {
       // Build comprehensive summary
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to Strapi CMS with deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance\n\n`
 
       // Summary counts
       body += `### 📊 Summary\n\n`
@@ -83,7 +83,7 @@ module.exports = async ({ github, context, core }) => {
     } else {
       // Fallback if results file not found
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to Strapi CMS with deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance\n\n`
       body += `Relations have been automatically resolved.`
     }
   } else {

--- a/scripts/update-pr-comment.js
+++ b/scripts/update-pr-comment.js
@@ -3,7 +3,8 @@ const path = require('path')
 
 module.exports = async ({ github, context, core }) => {
   const status = process.env.JOB_STATUS
-  const deploymentTarget = process.env.DEPLOYMENT_STATUS || 'staging'
+  const deploymentTarget = process.env.DEPLOYMENT_TARGET
+  const deploymentStatus = process.env.DEPLOYMENT_STATUS
 
   let body = ''
 
@@ -21,7 +22,7 @@ module.exports = async ({ github, context, core }) => {
     if (syncResults) {
       // Build comprehensive summary
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance\n\n`
+      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance with deployment status: \`${deploymentStatus}\`\n\n`
 
       // Summary counts
       body += `### 📊 Summary\n\n`
@@ -83,7 +84,7 @@ module.exports = async ({ github, context, core }) => {
     } else {
       // Fallback if results file not found
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to the \`${deploymentTarget}\` Strapi CMS instance\n\n`
+      body += `Content has been synced to Strapi CMS with deployment target: \`${deploymentTarget}\` and deployment status: \`${deploymentStatus}\`\n\n`
       body += `Relations have been automatically resolved.`
     }
   } else {

--- a/scripts/update-pr-comment.js
+++ b/scripts/update-pr-comment.js
@@ -21,7 +21,7 @@ module.exports = async ({ github, context, core }) => {
     if (syncResults) {
       // Build comprehensive summary
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to CMS with deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to Strapi CMS with deployment status: \`${deploymentStatus}\`\n\n`
 
       // Summary counts
       body += `### 📊 Summary\n\n`
@@ -83,7 +83,7 @@ module.exports = async ({ github, context, core }) => {
     } else {
       // Fallback if results file not found
       body = `✅ **CMS Sync Successful**\n\n`
-      body += `Content has been synced to CMS with deployment status: \`${deploymentStatus}\`\n\n`
+      body += `Content has been synced to Strapi CMS with deployment status: \`${deploymentStatus}\`\n\n`
       body += `Relations have been automatically resolved.`
     }
   } else {


### PR DESCRIPTION
## Description

The sync currently handles only syncing to production cms instance, but staging documents should be synced to staging instance to reduce load on prod instance

⚠️ Future scope - remove the deployment status flag from schema definitions

## Type of Change

<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [x] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots
NA

## Checklist

<!-- Complete the sections that apply to your changes -->

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [ ] Ran `yarn lint` and fixed any issues
- [ ] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [ ] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [ ] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
