### PR TITLE
fix: update queries to reflect timestamp is not required

### DIFF
--- a/data/docs/userguide/writing-clickhouse-traces-query.mdx
+++ b/data/docs/userguide/writing-clickhouse-traces-query.mdx
@@ -371,7 +371,7 @@ Note: Older version of SigNoz required timestamp to be available in the query re
 
 #### Examples
 
-##### Average duration of spans in millisecond where `method = 'POST'` , `service.name = 'sample-service'`
+##### Average duration of spans in millisecond where `method = 'POST'` , `service.name = 'frontend'`
 
 ```sql
 WITH __resource_filter AS (
@@ -389,10 +389,7 @@ WHERE
     timestamp BETWEEN $start_datetime AND $end_datetime AND
     ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
     http_method = 'POST' AND 
-    resource_fingerprint GLOBAL IN __resource_filter
-GROUP BY ts 
-ORDER BY ts ASC
-
+    resource_fingerprint GLOBAL IN __resource_filter;
 ```
 
 ##### Average count of spans per minute with resource filtering for `service.name = 'frontend'` and `environment = 'production'`
@@ -416,8 +413,8 @@ SELECT avg(value) as avg_count FROM (
         timestamp BETWEEN $start_datetime AND $end_datetime AND
         ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
     GROUP BY ts 
-    ORDER BY ts ASC;
-)
+    ORDER BY ts ASC
+);
 ```
 
 ### Table
@@ -439,7 +436,8 @@ SELECT attributes_string['example_string_attribute'] AS attribute_name,
 FROM signoz_traces.distributed_signoz_index_v3  
 WHERE timestamp BETWEEN $start_datetime AND $end_datetime
     AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
-GROUP BY (attribute_name, ts) order by (attribute_name, ts) ASC;
+GROUP BY attribute_name 
+ORDER BY attribute_name ASC;
 ```
 
 ##### Count of spans by service name with resource filtering

--- a/data/docs/userguide/writing-clickhouse-traces-query.mdx
+++ b/data/docs/userguide/writing-clickhouse-traces-query.mdx
@@ -1,8 +1,9 @@
 ---
-date: 2024-06-06
+date: 2026-03-05
 
 title: Writing traces based ClickHouse queries for building dashboard panels
 id: writing-clickhouse-traces-query
+description: Writing traces based ClickHouse queries for building dashboard panels
 ---
 
 ## Traces Schema
@@ -275,7 +276,7 @@ SELECT count(*)
 FROM signoz_traces.distributed_signoz_index_v3 
 WHERE resource_fingerprint GLOBAL IN __resource_filter
     AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
-    AND timestamp >= {{.start_datetime}} AND timestamp <= {{.end_datetime}}
+    AND timestamp >= $start_datetime AND timestamp <= $end_datetime
 ```
 
 ### Using Resource Attributes in SELECT and GROUP BY
@@ -358,19 +359,19 @@ FROM (
  FROM signoz_traces.distributed_signoz_index_v3
  WHERE resource_string_service$$name='frontend' 
  AND duration_nano>=50*exp10(6) 
- AND timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}}
+ AND timestamp BETWEEN $start_datetime AND $end_datetime
  AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp)
  GROUP BY interval ORDER BY interval ASC;
 ```
 
 ### Value
 
-For the value type panel, the overall query will be similar to timeseries, just that you will have to get the absolute value at the end.
-You can reduce your end result to either average, latest, sum, min, or max.
+You can reduce your query result to either average, latest, sum, min, or max.
+Note: Older version of SigNoz required timestamp to be available in the query result, this is no longer the case.
 
 #### Examples
 
-##### Average duration of spans where `method = 'POST'` , `service.name = 'sample-service'`
+##### Average duration of spans in millisecond where `method = 'POST'` , `service.name = 'sample-service'`
 
 ```sql
 WITH __resource_filter AS (
@@ -379,25 +380,22 @@ WITH __resource_filter AS (
     WHERE (simpleJSONExtractString(labels, 'service.name') = 'frontend') 
     AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
+
 SELECT 
-    avg(value) as value, 
-    any(ts) as ts FROM (
-        SELECT 
-            toStartOfInterval((timestamp), INTERVAL 1 MINUTE) AS ts, 
-            toFloat64(count()) AS value 
-        FROM 
-            signoz_traces.distributed_signoz_index_v3
-        WHERE 
-            timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND
-            ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
-            http_method = 'POST' AND 
-            resource_fingerprint GLOBAL IN __resource_filter
-        GROUP BY ts 
-        ORDER BY ts ASC
-    )
+    avg(duration_nano) / 1000_000 as duration_ms
+FROM 
+    signoz_traces.distributed_signoz_index_v3
+WHERE 
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
+    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
+    http_method = 'POST' AND 
+    resource_fingerprint GLOBAL IN __resource_filter
+GROUP BY ts 
+ORDER BY ts ASC
+
 ```
 
-##### Count of spans per minute with resource filtering for `service.name = 'frontend'` and `environment = 'production'`
+##### Average count of spans per minute with resource filtering for `service.name = 'frontend'` and `environment = 'production'`
 
 ```sql
 WITH __resource_filter AS (
@@ -407,51 +405,24 @@ WITH __resource_filter AS (
     AND (simpleJSONExtractString(labels, 'environment') = 'production')
     AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
-SELECT 
-    toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts,
-    toFloat64(count()) AS value 
-FROM 
-    signoz_traces.distributed_signoz_index_v3
-WHERE 
-    resource_fingerprint GLOBAL IN __resource_filter AND
-    timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND
-    ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
-GROUP BY ts 
-ORDER BY ts ASC;
-```
-
-##### Average duration of spans where `http.method = 'GET'` and `service.name = 'api-service'` using resource filtering
-
-```sql
-WITH __resource_filter AS (
-    SELECT fingerprint 
-    FROM signoz_traces.distributed_traces_v3_resource 
-    WHERE (simpleJSONExtractString(labels, 'service.name') = 'api-service') 
-    AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+SELECT avg(value) as avg_count FROM (
+    SELECT 
+        toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts,
+        toFloat64(count()) AS value 
+    FROM 
+        signoz_traces.distributed_signoz_index_v3
+    WHERE 
+        resource_fingerprint GLOBAL IN __resource_filter AND
+        timestamp BETWEEN $start_datetime AND $end_datetime AND
+        ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
+    GROUP BY ts 
+    ORDER BY ts ASC;
 )
-SELECT 
-    avg(value) as value, 
-    any(ts) as ts FROM (
-        SELECT 
-            toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts, 
-            toFloat64(avg(duration_nano)) AS value 
-        FROM 
-            signoz_traces.distributed_signoz_index_v3
-        WHERE 
-            resource_fingerprint GLOBAL IN __resource_filter AND
-            timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND
-            ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
-            http_method = 'GET'
-        GROUP BY ts 
-        ORDER BY ts ASC
-    )
 ```
 
 ### Table
 
-This is used when you want to view the timeseries data in a tabular format.
-
-The query is similar to timeseries query but instead of using time interval we use just use `now() as ts` in select.
+This is used when you want to view the timeseries data in a tabular format and queries are similar to timeseries query.
 
 #### Examples
 
@@ -463,11 +434,10 @@ WITH __resource_filter AS (
     FROM signoz_traces.distributed_traces_v3_resource 
     WHERE seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
-SELECT now() as ts, 
-    attributes_string['example_string_attribute'] AS attribute_name, 
+SELECT attributes_string['example_string_attribute'] AS attribute_name, 
     toFloat64(avg(duration_nano)) AS value 
 FROM signoz_traces.distributed_signoz_index_v3  
-WHERE timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}}
+WHERE timestamp BETWEEN $start_datetime AND $end_datetime
     AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 GROUP BY (attribute_name, ts) order by (attribute_name, ts) ASC;
 ```
@@ -481,17 +451,16 @@ WITH __resource_filter AS (
     WHERE seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
 SELECT 
-    now() as ts,
     resource.service.name::String as `service.name`,
     toFloat64(count()) AS value 
 FROM 
     signoz_traces.distributed_signoz_index_v3
 WHERE 
     resource_fingerprint GLOBAL IN __resource_filter AND
-    timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
     ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
     `service.name` IS NOT NULL
-GROUP BY `service.name`, ts 
+GROUP BY `service.name`
 ORDER BY value DESC;
 ```
 
@@ -505,23 +474,22 @@ WITH __resource_filter AS (
     AND seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
 SELECT 
-    now() as ts,
     http_method,
     toFloat64(avg(duration_nano)) AS avg_duration_nano 
 FROM 
     signoz_traces.distributed_signoz_index_v3
 WHERE 
     resource_fingerprint GLOBAL IN __resource_filter AND
-    timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND
+    timestamp BETWEEN $start_datetime AND $end_datetime AND
     ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp AND
     http_method IS NOT NULL AND http_method != ''
-GROUP BY http_method, ts 
+GROUP BY http_method
 ORDER BY avg_duration_nano DESC;
 ```
 
 ## Real Life Use Cases Examples
 
-### Number of spans generated by each service
+### Number of spans generated by each service in a minute
 
 ```sql
 WITH __resource_filter AS (
@@ -537,7 +505,7 @@ FROM
     signoz_traces.distributed_signoz_index_v3  
 WHERE 
     resource_fingerprint GLOBAL IN __resource_filter AND
-    timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND 
+    timestamp BETWEEN $start_datetime AND $end_datetime AND 
     `service.name` IS NOT NULL AND
     ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 GROUP BY `service.name`, ts
@@ -553,45 +521,44 @@ WITH __resource_filter AS (
     WHERE seen_at_ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
 )
 SELECT 
-    toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS ts,
     resource.service.name::String as `service.name`,
     toFloat64(count()) AS value 
 FROM 
     signoz_traces.distributed_signoz_index_v3  
 WHERE 
     resource_fingerprint GLOBAL IN __resource_filter AND
-    timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}} AND 
+    timestamp BETWEEN $start_datetime AND $end_datetime AND 
     has_error = true AND
     `service.name` IS NOT NULL AND
     ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
-GROUP BY `service.name`, ts 
-ORDER BY ts ASC;
+GROUP BY `service.name`;
 ```
 
 
-### GroupBy a tag/attribute in distributed tracing data
+### GroupBy a tag/attribute per minute timeseries in distributed tracing data
 
 ```sql
 SELECT toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS interval, 
-attributes_string['http.method'] AS method,
-toFloat64(avg(durationNano)) AS value 
+    attributes_string['http.route'] AS route,
+    toFloat64(avg(durationNano)) AS value 
 FROM signoz_traces.distributed_signoz_index_v3
 WHERE attributes_string['http.method']!=''
-AND timestamp > now() - INTERVAL 30 MINUTE
-AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(30))) - 1800
-GROUP BY (method, interval) order by (method, interval) ASC;
+    AND timestamp > now() - INTERVAL 30 MINUTE
+    AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(30))) - 1800
+GROUP BY (route, interval) order by (route, interval) ASC;
 ```
 
 ### Show count of each `customer_id` which is present as attribute of a span event
 
 ```sql
 WITH arrayFilter(x -> JSONExtractString(x, 'name')='Getting customer', events) AS filteredEvents
-SELECT toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS interval, toFloat64(count()) AS count, 
-arrayJoin(arrayMap(x -> JSONExtractString(JSONExtractString(x, 'attributeMap'), 'customer_id'), filteredEvents)) AS resultArray 
+SELECT toFloat64(count()) AS count, 
+    arrayJoin(arrayMap(x -> JSONExtractString(JSONExtractString(x, 'attributeMap'), 'customer_id'), filteredEvents)) AS resultArray 
 FROM signoz_traces.distributed_signoz_index_v3
 WHERE not empty(filteredEvents) 
-AND timestamp > toUnixTimestamp(now() - INTERVAL 30 MINUTE) 
-GROUP BY (resultArray, interval) order by (resultArray, interval) ASC;
+    AND timestamp > toUnixTimestamp(now() - INTERVAL 30 MINUTE) 
+GROUP BY resultArray 
+ORDER BY resultArray ASC;
 ```
 
 ### Avg latency between 2 spans of interest (part of the trace tree)
@@ -614,7 +581,7 @@ FROM
             minIf(timestamp, if(resource_string_service$$name='driver', if(name = '/driver.DriverService/FindNearest', if((resources_string['component']) = 'gRPC', true, false), false), false)) AS startTime1,
             minIf(timestamp, if(resource_string_service$$name='route', if(name = 'HTTP GET /route', true, false), false)) AS startTime2
         FROM signoz_traces.distributed_signoz_index_v3
-        WHERE (timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}}) AND (ts_bucket_start BETWEEN {{.start_timestamp}} - 1800 AND {{.end_timestamp}}) AND (resource_string_service$$name IN ('driver', 'route'))
+        WHERE (timestamp BETWEEN $start_datetime AND $end_datetime) AND (ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp) AND (resource_string_service$$name IN ('driver', 'route'))
         GROUP BY (interval, traceID)
         ORDER BY (interval, traceID) ASC
     )
@@ -644,25 +611,26 @@ Plot a chart of 1 minute showing count of spans in `100ms` interval of service `
 
 ```sql
 SELECT fromUnixTimestamp64Milli(intDiv( toUnixTimestamp64Milli ( timestamp ), 100) * 100) AS interval, 
-toFloat64(count()) AS count 
+    toFloat64(count()) AS count 
 FROM (
- SELECT timestamp 
- FROM signoz_traces.distributed_signoz_index_v3
- WHERE resource_string_service$$name='frontend' 
- AND durationNano>=50*exp10(6) 
- AND timestamp > now() - INTERVAL 1 MINUTE AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(1))) - 1800)
- GROUP BY interval 
- ORDER BY interval ASC;
+    SELECT timestamp 
+    FROM signoz_traces.distributed_signoz_index_v3
+    WHERE resource_string_service$$name='frontend' 
+        AND durationNano>=50*exp10(6) 
+        AND timestamp > now() - INTERVAL 1 MINUTE AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(1))) - 1800)
+    GROUP BY interval 
+    ORDER BY interval ASC
+);
 ```
 
 ### Show count of loglines per minute
 
 ```sql
 SELECT toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 1 MINUTE) AS interval, 
-toFloat64(count()) AS value 
+    toFloat64(count()) AS value 
 FROM signoz_logs.distributed_logs_v2
 WHERE timestamp > toUnixTimestamp64Nano(now64() - INTERVAL 30 MINUTE) 
-AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(30))) - 1800
+    AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(30))) - 1800
 GROUP BY interval 
 ORDER BY interval ASC;
 ```


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->

In older version of SigNoz queries, ts field was required even in values panel. This is no longer the case but doc was not updated. This needs to be updated since LLM agents can pickup the query format from these docs.

## Type of Change

<!-- Check all that apply -->

- [x] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots

<!-- Add screenshots for UI or docs changes when helpful -->

## Checklist

<!-- Complete the sections that apply to your changes -->

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [x] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [ ] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [ ] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
