### PR TITLE
fix: remove negative x margin from feature pages

### DIFF
--- a/app/datadog-migration-tool/DatadogMigrationTool.tsx
+++ b/app/datadog-migration-tool/DatadogMigrationTool.tsx
@@ -93,15 +93,13 @@ const Header: React.FC = () => {
 
       {/* Hero image */}
       <SectionLayout variant="bordered" className="!mt-0 max-md:-mb-[3rem]">
-        <div className="mx-[-28px]">
-          <Image
-            src="/img/platform/DatadogMigrationToolHero.webp"
-            alt="Datadog migration tool hero"
-            className="w-full rounded-xl"
-            width={10000}
-            height={10000}
-          />
-        </div>
+        <Image
+          src="/img/platform/DatadogMigrationToolHero.webp"
+          alt="Datadog migration tool hero"
+          className="w-full rounded-xl"
+          width={10000}
+          height={10000}
+        />
       </SectionLayout>
     </header>
   )

--- a/app/llm-observability/LlmObservabilityPage.tsx
+++ b/app/llm-observability/LlmObservabilityPage.tsx
@@ -65,7 +65,7 @@ const Header: React.FC = () => {
         </>
       }
       buttons={headerButtons}
-      sectionLayoutVariant="no-border"
+      sectionLayoutVariant="bordered"
       sectionLayoutClassName="!mt-0 max-md:-mb-[3rem]"
       heroImageAlt="Llm observability hero"
       heroImage="/img/platform/LlmObservabilityMeta.webp"

--- a/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
@@ -10,7 +10,7 @@ const FeaturePageHeader: React.FC<FeaturePageHeaderProps> = ({
   heroImage,
   heroImageAlt = '',
   children,
-  sectionLayoutVariant = 'no-border',
+  sectionLayoutVariant = 'bordered',
   sectionLayoutClassName = '!mt-0 max-md:-mb-[3rem]',
   className = '',
 }) => {

--- a/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
@@ -16,7 +16,7 @@ const FeaturePageHeader: React.FC<FeaturePageHeaderProps> = ({
 }) => {
   const heroContent =
     typeof heroImage === 'string' ? (
-      <div className="relative z-[1] mx-[-28px] w-full">
+      <div className="relative z-[1] w-full">
         <Image
           src={heroImage}
           alt={heroImageAlt}

--- a/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
@@ -11,13 +11,13 @@ const SectionLayout: React.FC<SectionLayoutProps> = ({
       case 'full-width':
         return '!mx-auto !w-[100vw] md:!w-[80vw]'
       case 'bordered':
-        return '!mx-auto !w-[100vw] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
       case 'no-border':
-        return '!mx-auto !w-[90vw] border !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw] border border-dashed !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw]'
       case 'border-x':
-        return '!mx-auto !w-[90vw] border border-b-1 border-t-1 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-dashed border-signoz_slate-400 md:!w-[80vw]'
       default:
-        return '!mx-auto !w-[100vw] border !border-b-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
     }
   }
 

--- a/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
@@ -11,13 +11,13 @@ const SectionLayout: React.FC<SectionLayoutProps> = ({
       case 'full-width':
         return '!mx-auto !w-[100vw] md:!w-[80vw]'
       case 'bordered':
-        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 !border-t-0 border-signoz_slate-400 md:!w-[80vw]'
       case 'no-border':
-        return '!mx-auto !w-[90vw] border border-dashed !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw] border !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw]'
       case 'border-x':
-        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-signoz_slate-400 md:!w-[80vw]'
       default:
-        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 border-dashed border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[100vw] border border-dashed !border-b-0 border-signoz_slate-400 md:!w-[80vw]'
     }
   }
 


### PR DESCRIPTION
## Description

negative margin was added to images to make up for spacing issues in hero sections in multiple pages, but since tailwind generated classnames have been removed from css file, the negative margin is no longer needed and is causing misalignment for images on feature pages, the PR fixes this

Also fixed breaking border styles for images in hero 

before:
<img width="1318" height="908" alt="Screenshot 2026-03-06 at 14 27 07" src="https://github.com/user-attachments/assets/bef757d6-c2db-49cb-8d67-16aa07cce444" />

after
<img width="1430" height="913" alt="Screenshot 2026-03-06 at 14 27 31" src="https://github.com/user-attachments/assets/120a95ce-6ad1-4517-9100-606d694374c0" />


## Type of Change

<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots

<!-- Add screenshots for UI or docs changes when helpful -->

## Checklist

<!-- Complete the sections that apply to your changes -->

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [ ] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [x] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [x] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
