### PR TITLE
feat: serve docs markdown to AI agents

### DIFF
--- a/.agents/skills/signoz-docs-pr-review/SKILL.md
+++ b/.agents/skills/signoz-docs-pr-review/SKILL.md
@@ -169,5 +169,6 @@ curl -sI <URL>
 
 - Do not require a dedicated "Target Persona" section unless context truly needs it.
 - Keep advanced options out of the mandatory path unless essential for first success.
+- If a PR adds or changes docs MDX components or component-driven content patterns, verify both agent markdown handling (`utils/docs/agentMarkdownStubs.ts`) and rendered Copy Markdown behavior (`utils/docs/buildCopyMarkdownFromRendered.ts`) where relevant.
 - Keep review feedback decision-oriented and immediately actionable.
 - Do not mark a review complete if mandatory JTBD checks were skipped.

--- a/.agents/skills/signoz-website-frontend-pr-review/SKILL.md
+++ b/.agents/skills/signoz-website-frontend-pr-review/SKILL.md
@@ -125,6 +125,7 @@ If a PR includes docs too, use this skill for code review only.
 - Keep types/constants co-located and exported appropriately.
 - Avoid concurrent async invocations in handlers (loading/ref guards).
 - Be deliberate with DOM cleanup/transforms.
+- If a PR adds or changes MDX components used in `data/docs/**`, verify `utils/docs/agentMarkdownStubs.ts` still handles them, the agent-markdown tests/coverage remain valid, and rendered Copy Markdown behavior in `utils/docs/buildCopyMarkdownFromRendered.ts` still stays clean.
 - Justify dependency additions.
 
 ### 12) Error handling and edge cases

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ gha-creds-*.json
 # Agent directories and memory
 # Agent files
 .agent/
+.test-transpile-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ You are a focused contributor for `signoz.io`.
 - Prefer existing patterns/components before adding abstractions.
 - Use Next.js App Router conventions already present in the repo.
 - Keep types/constants organized per existing conventions.
+- If a change affects docs MDX components or docs rendering, verify both agent markdown (`utils/docs/agentMarkdownStubs.ts`) and Copy Markdown (`utils/docs/buildCopyMarkdownFromRendered.ts`) behavior.
 - Avoid new dependencies unless required; include justification in PR context.
 
 ### PR review output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,10 @@ These guidelines apply when your PR changes website code (for example: `app/**`,
   - For click handlers that do async work, prevent multiple concurrent runs (set loading state before `await` and/or guard with a ref).
 - Be deliberate about DOM cleanup/transforms
   - When cleaning up rendered DOM before transforming (for example, HTML → Markdown), avoid redundant selectors and ensure cleanup order matches the intended behavior.
+- Keep docs MDX components compatible with agent-markdown output
+  - If you add or change an MDX component used under `data/docs/**`, review its agent rendering in `utils/docs/agentMarkdownStubs.ts`.
+  - Add or update tests in `tests/agent-markdown-*.test.js`. The docs-wide component coverage test should stay green so new components are explicitly reviewed.
+  - If the component affects rendered article markup, also verify the `Copy Markdown` flow still produces clean output via `utils/docs/buildCopyMarkdownFromRendered.ts` and add/update targeted tests when practical.
 - Dependencies must be justified
   - Do not add new packages unless they are required and there is no existing dependency that fits.
   - If you add a dependency, include a short justification in the PR description and ensure it is used in code.

--- a/app/api/docs-markdown/[[...slug]]/route.ts
+++ b/app/api/docs-markdown/[[...slug]]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { allDocs } from 'contentlayer/generated'
+import type { Doc } from 'contentlayer/generated'
+import { renderDocMarkdownForAgents } from '@/utils/docs/renderDocMarkdownForAgents'
+import { resolveDocsMarkdownSlug } from '@/utils/docs/markdownRouting'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-static'
+
+const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+const notFoundResponse = () =>
+  new NextResponse('Not Found', {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  })
+
+export async function GET(_: Request, { params }: { params: { slug?: string[] } }) {
+  const slug = resolveDocsMarkdownSlug(params.slug)
+  const doc = allDocs.find((candidate) => candidate.slug === slug) as Doc | undefined
+
+  if (!doc) {
+    return notFoundResponse()
+  }
+
+  const markdown = await renderDocMarkdownForAgents(doc)
+
+  return new NextResponse(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': CACHE_CONTROL_HEADER,
+      Vary: 'Accept',
+    },
+  })
+}

--- a/app/api/docs-markdown/[[...slug]]/route.ts
+++ b/app/api/docs-markdown/[[...slug]]/route.ts
@@ -9,6 +9,16 @@ export const dynamic = 'force-static'
 
 const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
 
+export async function generateStaticParams() {
+  return [
+    { slug: [] },
+    ...allDocs
+      .filter((doc): doc is Doc & { slug: string } => typeof doc.slug === 'string')
+      .filter((doc) => doc.slug !== 'introduction')
+      .map((doc) => ({ slug: doc.slug.split('/') })),
+  ]
+}
+
 const notFoundResponse = () =>
   new NextResponse('Not Found', {
     status: 404,

--- a/app/docs/sitemap.md/route.ts
+++ b/app/docs/sitemap.md/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { getDocsRouteTree, type DocsRouteTreeItem } from '@/utils/docs/agentDiscovery'
+import siteMetadata from '@/data/siteMetadata'
+
+export const dynamic = 'force-static'
+
+const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+const formatSitemapRoute = (route: string): string => {
+  // Preserve fragment/query routes as-is (e.g. /docs/page#section).
+  if (route.includes('#') || route.includes('?')) {
+    return route
+  }
+
+  return route.endsWith('/') ? route : `${route}/`
+}
+
+const renderTree = (items: DocsRouteTreeItem[], indent = ''): string => {
+  return items
+    .map((item) => {
+      const linkLine = item.route
+        ? `${indent}- [${item.label}](${formatSitemapRoute(item.route)})`
+        : `${indent}- ${item.label}`
+      const children =
+        item.children.length > 0 ? `\n${renderTree(item.children, `${indent}  `)}` : ''
+      return `${linkLine}${children}`
+    })
+    .join('\n')
+}
+
+export async function GET() {
+  const tree = getDocsRouteTree()
+  const markdown = [
+    '# SigNoz Docs Sitemap',
+    '',
+    `Canonical docs base: ${siteMetadata.siteUrl}/docs/`,
+    '',
+    renderTree(tree),
+    '',
+  ].join('\n')
+
+  return new NextResponse(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': CACHE_CONTROL_HEADER,
+    },
+  })
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import siteMetadata from '@/data/siteMetadata'
+import { getLlmStarterLinks } from '@/utils/docs/agentDiscovery'
+
+export const dynamic = 'force-static'
+
+const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+export async function GET() {
+  const starters = getLlmStarterLinks()
+  const starterLines =
+    starters.length > 0
+      ? starters.map((item) => `- ${item.label}: ${siteMetadata.siteUrl}${item.route}/`).join('\n')
+      : `- Docs index: ${siteMetadata.siteUrl}/docs/introduction/`
+
+  const body = [
+    '# SigNoz Documentation for AI Agents',
+    '',
+    'SigNoz is an open-source observability platform for metrics, traces, and logs.',
+    '',
+    `Docs root: ${siteMetadata.siteUrl}/docs/introduction/`,
+    '',
+    '## Fetching docs pages',
+    `- Request ${siteMetadata.siteUrl}/docs/... with "Accept: text/markdown" to receive markdown page content.`,
+    '',
+    '## Starter docs',
+    starterLines,
+    '',
+    '## Discovery',
+    `- Markdown sitemap: ${siteMetadata.siteUrl}/docs/sitemap.md`,
+    '',
+  ].join('\n')
+
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': CACHE_CONTROL_HEADER,
+    },
+  })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -136,6 +136,12 @@ export function middleware(req: NextRequest) {
     })
   }
 
+  // Add custom headers for debugging (optional - remove in production if not needed)
+  if (isBot) {
+    res.headers.set('x-bot-detected', 'true')
+    res.headers.set('x-bot-type', botType || 'unknown')
+  }
+
   return res
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,12 @@ import { waitUntil, ipAddress } from '@vercel/functions'
 import { v4 as uuidv4 } from 'uuid'
 import { NOT_FOUND_PATHNAME_HEADER } from '@/components/not-found/constants'
 import { detectBotFromUserAgent, logEventServerSide } from './utils/logEvent'
+import {
+  buildDocsMarkdownRewritePath,
+  shouldRewriteDocsToMarkdown,
+} from '@/utils/docs/markdownRouting'
+
+const INCLUDE_MARKDOWN_REWRITE_DEBUG_HEADER = process.env.NODE_ENV !== 'production'
 
 // Extract OS from user agent (server-side version)
 const getOSFromUserAgent = (userAgent: string): string => {
@@ -37,9 +43,7 @@ export function middleware(req: NextRequest) {
   const acceptHeader = req.headers.get('accept') || ''
   const contentTypeHeader = req.headers.get('content-type') || ''
 
-  const prefersMarkdown =
-    acceptHeader.toLowerCase().includes('text/markdown') ||
-    contentTypeHeader.toLowerCase().includes('text/markdown')
+  const prefersMarkdown = acceptHeader.toLowerCase().includes('text/markdown')
 
   // Get request details
   const pathname = req.nextUrl.pathname
@@ -77,7 +81,17 @@ export function middleware(req: NextRequest) {
   }
 
   // Prepare response
-  const res = NextResponse.next()
+  let res = NextResponse.next()
+  const shouldRewrite = shouldRewriteDocsToMarkdown(pathname, prefersMarkdown)
+
+  if (shouldRewrite) {
+    const rewriteUrl = req.nextUrl.clone()
+    rewriteUrl.pathname = buildDocsMarkdownRewritePath(pathname)
+    res = NextResponse.rewrite(rewriteUrl)
+    if (INCLUDE_MARKDOWN_REWRITE_DEBUG_HEADER) {
+      res.headers.set('x-markdown-rewrite', 'true')
+    }
+  }
 
   // Preserve request path for server-rendered global not-found suggestions.
   res.headers.set(NOT_FOUND_PATHNAME_HEADER, pathname)
@@ -120,12 +134,6 @@ export function middleware(req: NextRequest) {
       maxAge: 60 * 60 * 24 * 365, // one year
       sameSite: 'lax',
     })
-  }
-
-  // Add custom headers for debugging (optional - remove in production if not needed)
-  if (isBot) {
-    res.headers.set('x-bot-detected', 'true')
-    res.headers.set('x-bot-type', botType || 'unknown')
   }
 
   return res

--- a/tests/agent-discovery.test.js
+++ b/tests/agent-discovery.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { getLlmStarterLinks } = loadTsModule('utils/docs/agentDiscovery.ts')
+
+test('getLlmStarterLinks includes LLM, AWS, and GCP landing routes', async () => {
+  const starters = getLlmStarterLinks()
+  const routes = starters.map((item) => item.route)
+
+  assert.equal(routes.includes('/docs/llm-observability'), true)
+  assert.equal(routes.includes('/docs/aws-monitoring/overview'), true)
+  assert.equal(routes.includes('/docs/gcp-monitoring'), true)
+})
+
+test('getLlmStarterLinks includes migration landing pages', async () => {
+  const starters = getLlmStarterLinks()
+  const routes = starters.map((item) => item.route)
+
+  assert.equal(routes.includes('/docs/migration/migrate-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-datadog-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-grafana-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-elk-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-newrelic-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-honeycomb-to-signoz'), true)
+  assert.equal(routes.includes('/docs/migration/migrate-from-opentelemetry-to-signoz'), true)
+  assert.equal(
+    routes.includes('/docs/migration/migrate-from-signoz-self-host-to-signoz-cloud'),
+    true
+  )
+})
+
+test('getLlmStarterLinks orders setup before LLM/AWS/GCP and migration routes', async () => {
+  const starters = getLlmStarterLinks()
+  const routes = starters.map((item) => item.route)
+
+  const setupIndex = routes.indexOf('/docs/opentelemetry-collection-agents/get-started')
+  const llmIndex = routes.indexOf('/docs/llm-observability')
+  const awsIndex = routes.indexOf('/docs/aws-monitoring/overview')
+  const gcpIndex = routes.indexOf('/docs/gcp-monitoring')
+  const migrationIndex = routes.indexOf('/docs/migration/migrate-to-signoz')
+
+  assert.notEqual(setupIndex, -1)
+  assert.notEqual(llmIndex, -1)
+  assert.notEqual(awsIndex, -1)
+  assert.notEqual(gcpIndex, -1)
+  assert.notEqual(migrationIndex, -1)
+  assert.equal(setupIndex < llmIndex, true)
+  assert.equal(setupIndex < awsIndex, true)
+  assert.equal(setupIndex < gcpIndex, true)
+  assert.equal(llmIndex < migrationIndex, true)
+  assert.equal(awsIndex < migrationIndex, true)
+  assert.equal(gcpIndex < migrationIndex, true)
+})
+
+test('getLlmStarterLinks is unique and respects default max size', async () => {
+  const starters = getLlmStarterLinks()
+  const routes = starters.map((item) => item.route)
+  const uniqueRoutes = new Set(routes)
+
+  assert.equal(uniqueRoutes.size, routes.length)
+  assert.equal(starters.length <= 24, true)
+})

--- a/tests/agent-markdown-component-coverage.test.js
+++ b/tests/agent-markdown-component-coverage.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { extractMdxComponentNames, AGENT_MDX_COMPONENT_POLICIES } = loadTsModule(
+  'utils/docs/agentMarkdownStubs.ts'
+)
+
+const repoRoot = path.resolve(__dirname, '..')
+const docsRoot = path.join(repoRoot, 'data/docs')
+
+const getDocFiles = (dir) => {
+  const files = []
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...getDocFiles(fullPath))
+      continue
+    }
+
+    if (entry.name.endsWith('.mdx')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+test('all custom docs MDX components are explicitly reviewed for agent markdown rendering', async () => {
+  const missingCoverage = []
+
+  for (const filePath of getDocFiles(docsRoot)) {
+    const raw = fs.readFileSync(filePath, 'utf8')
+    const unreviewedComponents = extractMdxComponentNames(raw).filter(
+      (componentName) =>
+        !Object.prototype.hasOwnProperty.call(AGENT_MDX_COMPONENT_POLICIES, componentName)
+    )
+
+    if (unreviewedComponents.length > 0) {
+      missingCoverage.push(
+        `${path.relative(repoRoot, filePath)}: ${unreviewedComponents.sort().join(', ')}`
+      )
+    }
+  }
+
+  assert.deepEqual(
+    missingCoverage,
+    [],
+    [
+      'Found docs MDX components without an explicit agent-markdown policy.',
+      'Update utils/docs/agentMarkdownStubs.ts and decide whether each component needs a custom stub or a reviewed fallback.',
+      ...missingCoverage,
+    ].join('\n')
+  )
+})

--- a/tests/agent-markdown-stubs.test.js
+++ b/tests/agent-markdown-stubs.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const React = require('react')
+const { renderToStaticMarkup } = require('react-dom/server')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { buildAgentMdxComponentsForDoc } = loadTsModule('utils/docs/agentMarkdownStubs.ts')
+
+const createDoc = (raw) => ({
+  slug: 'monitor-http-endpoints',
+  title: 'Monitor HTTP Endpoints',
+  body: {
+    raw,
+  },
+})
+
+test('unknown component stubs preserve titles when children are rendered', async () => {
+  const doc = createDoc(
+    '<KeyPointCallout title="Using self-hosted SigNoz?">Most steps are identical.</KeyPointCallout>'
+  )
+  const components = buildAgentMdxComponentsForDoc(doc, [])
+  const html = renderToStaticMarkup(
+    React.createElement(
+      components.KeyPointCallout,
+      { title: 'Using self-hosted SigNoz?' },
+      React.createElement('p', null, 'Most steps are identical.')
+    )
+  )
+
+  assert.match(html, /Using self-hosted SigNoz\?/)
+  assert.match(html, /Most steps are identical\./)
+})
+
+test('Admonition stubs preserve the admonition type label', async () => {
+  const doc = createDoc('<Admonition type="warning">Keep existing receivers.</Admonition>')
+  const components = buildAgentMdxComponentsForDoc(doc, [])
+  const html = renderToStaticMarkup(
+    React.createElement(
+      components.Admonition,
+      { type: 'warning' },
+      React.createElement('p', null, 'Keep existing receivers.')
+    )
+  )
+
+  assert.match(html, /Warning/)
+  assert.match(html, /Keep existing receivers\./)
+})

--- a/tests/bot-patterns.test.js
+++ b/tests/bot-patterns.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { detectBotFromUserAgent } = loadTsModule('utils/botPatterns.ts')
+
+test('detectBotFromUserAgent identifies known AI assistant user agents as bots', async () => {
+  assert.equal(detectBotFromUserAgent('claude-user/1.0').isBot, true)
+  assert.equal(detectBotFromUserAgent('Mozilla/5.0 chatgpt-user/1.0').isBot, true)
+  assert.equal(detectBotFromUserAgent('OpenAI-SearchBot/1.0').isBot, true)
+  assert.equal(detectBotFromUserAgent('OpenAI-Codex').isBot, true)
+})
+
+test('detectBotFromUserAgent does not flag regular browser or empty user agents', async () => {
+  assert.equal(
+    detectBotFromUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+    ).isBot,
+    false
+  )
+  assert.equal(detectBotFromUserAgent('MyCursorTool/1.0').isBot, false)
+  assert.equal(detectBotFromUserAgent('CodexHelper/2.0').isBot, false)
+  assert.equal(detectBotFromUserAgent('').isBot, false)
+})

--- a/tests/docs-markdown-routing.test.js
+++ b/tests/docs-markdown-routing.test.js
@@ -26,6 +26,12 @@ test('shouldRewriteDocsToMarkdown excludes sitemap and internal markdown routes'
   assert.equal(shouldRewriteDocsToMarkdown('/api/docs-markdown/introduction', true), false)
 })
 
+test('shouldRewriteDocsToMarkdown does not rewrite non-docs paths', async () => {
+  assert.equal(shouldRewriteDocsToMarkdown('/blog/post-slug', true), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/pricing', true), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/', true), false)
+})
+
 test('normalizeDocsSlugFromPathname normalizes docs paths', async () => {
   assert.equal(normalizeDocsSlugFromPathname('/docs'), '')
   assert.equal(normalizeDocsSlugFromPathname('/docs/'), '')

--- a/tests/docs-markdown-routing.test.js
+++ b/tests/docs-markdown-routing.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const {
+  shouldRewriteDocsToMarkdown,
+  normalizeDocsSlugFromPathname,
+  buildDocsMarkdownRewritePath,
+  resolveDocsMarkdownSlug,
+} = loadTsModule('utils/docs/markdownRouting.ts')
+
+test('shouldRewriteDocsToMarkdown rewrites docs paths when markdown is preferred', async () => {
+  assert.equal(shouldRewriteDocsToMarkdown('/docs', true), true)
+  assert.equal(shouldRewriteDocsToMarkdown('/docs/metrics-management/overview', true), true)
+})
+
+test('shouldRewriteDocsToMarkdown does not rewrite when markdown is not preferred', async () => {
+  assert.equal(shouldRewriteDocsToMarkdown('/docs', false), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/docs/logs-management/send-logs', false), false)
+})
+
+test('shouldRewriteDocsToMarkdown excludes sitemap and internal markdown routes', async () => {
+  assert.equal(shouldRewriteDocsToMarkdown('/docs/sitemap.md', true), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/docs/sitemap.md/', true), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/api/docs-markdown', true), false)
+  assert.equal(shouldRewriteDocsToMarkdown('/api/docs-markdown/introduction', true), false)
+})
+
+test('normalizeDocsSlugFromPathname normalizes docs paths', async () => {
+  assert.equal(normalizeDocsSlugFromPathname('/docs'), '')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/'), '')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/foo/bar'), 'foo/bar')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/foo/bar/'), 'foo/bar')
+})
+
+test('buildDocsMarkdownRewritePath builds expected internal route', async () => {
+  assert.equal(buildDocsMarkdownRewritePath('/docs'), '/api/docs-markdown')
+  assert.equal(buildDocsMarkdownRewritePath('/docs/'), '/api/docs-markdown')
+  assert.equal(buildDocsMarkdownRewritePath('/docs/foo/bar/'), '/api/docs-markdown/foo/bar')
+})
+
+test('resolveDocsMarkdownSlug resolves slug from route segments', async () => {
+  assert.equal(resolveDocsMarkdownSlug(), 'introduction')
+  assert.equal(resolveDocsMarkdownSlug([]), 'introduction')
+  assert.equal(resolveDocsMarkdownSlug(['', '  ']), 'introduction')
+  assert.equal(resolveDocsMarkdownSlug(['%20introduction%20']), 'introduction')
+  assert.equal(
+    resolveDocsMarkdownSlug(['metrics-management', 'overview']),
+    'metrics-management/overview'
+  )
+  assert.equal(resolveDocsMarkdownSlug(['logs%2Fmanagement']), 'logs/management')
+})

--- a/tests/helpers/loadTsModule.js
+++ b/tests/helpers/loadTsModule.js
@@ -1,0 +1,53 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const ts = require('typescript')
+
+const resolveModulePath = (modulePath) => {
+  if (path.extname(modulePath)) return modulePath
+
+  const extensionCandidates = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
+  for (const extension of extensionCandidates) {
+    const candidate = `${modulePath}${extension}`
+    if (fs.existsSync(candidate)) return candidate
+  }
+
+  const indexCandidates = extensionCandidates.map((extension) =>
+    path.join(modulePath, `index${extension}`)
+  )
+  for (const candidate of indexCandidates) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+
+  return modulePath
+}
+
+const loadTsModule = (relativePath) => {
+  const repoRoot = path.resolve(__dirname, '..', '..')
+  const sourcePath = path.resolve(__dirname, '..', '..', relativePath)
+  const source = fs.readFileSync(sourcePath, 'utf8')
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      allowSyntheticDefaultImports: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+  })
+  const transpiledWithAliases = transpiled.outputText.replace(
+    /require\((['"])@\/([^'"]+)\1\)/g,
+    (_match, _quote, subPath) =>
+      `require(${JSON.stringify(resolveModulePath(path.join(repoRoot, subPath)))})`
+  )
+  const tmpFile = path.join(
+    repoRoot,
+    `.codex-test-${path.basename(relativePath)}-${process.pid}-${Date.now()}.cjs`
+  )
+  fs.writeFileSync(tmpFile, transpiledWithAliases, 'utf8')
+  try {
+    return require(tmpFile)
+  } finally {
+    fs.rmSync(tmpFile, { force: true })
+  }
+}
+
+module.exports = { loadTsModule }

--- a/tests/helpers/loadTsModule.js
+++ b/tests/helpers/loadTsModule.js
@@ -38,9 +38,10 @@ const loadTsModule = (relativePath) => {
     (_match, _quote, subPath) =>
       `require(${JSON.stringify(resolveModulePath(path.join(repoRoot, subPath)))})`
   )
+  // Keep the temp file in the repo root so transpiled relative imports resolve like source imports.
   const tmpFile = path.join(
     repoRoot,
-    `.codex-test-${path.basename(relativePath)}-${process.pid}-${Date.now()}.cjs`
+    `.test-transpile-${path.basename(relativePath)}-${process.pid}-${Date.now()}.cjs`
   )
   fs.writeFileSync(tmpFile, transpiledWithAliases, 'utf8')
   try {

--- a/tests/markdown-core.test.js
+++ b/tests/markdown-core.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { htmlToMarkdown, hastToMarkdown } = loadTsModule('utils/docs/markdownCore.ts')
+
+const HEADING_WITH_AUTOLINK_CHROME =
+  '<h2 class="content-header" id="overview"><a href="#overview" aria-hidden="true" tabindex="-1"><span class="content-header-link"><svg class="h-5 linkicon w-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536"></path></svg></span></a>Overview</h2>'
+
+test('htmlToMarkdown removes docs heading autolink chrome', async () => {
+  const markdown = await htmlToMarkdown(HEADING_WITH_AUTOLINK_CHROME, { cleanForDocsUi: true })
+
+  assert.match(markdown, /^## Overview$/m)
+  assert.doesNotMatch(markdown, /\[\]\(#overview\)/)
+})
+
+test('hastToMarkdown removes docs heading autolink chrome from parsed HAST', async () => {
+  const { unified } = await import('unified')
+  const { default: rehypeParse } = await import('rehype-parse')
+
+  const hast = unified().use(rehypeParse, { fragment: true }).parse(HEADING_WITH_AUTOLINK_CHROME)
+  const markdown = await hastToMarkdown(hast, { cleanForDocsUi: true })
+
+  assert.match(markdown, /^## Overview$/m)
+  assert.doesNotMatch(markdown, /\[\]\(#overview\)/)
+})
+
+test('cleanup removes empty anchors and preserves meaningful links', async () => {
+  const html =
+    '<p><a href="#overview" aria-hidden="true" tabindex="-1"></a><a href="/docs/foo">Guide</a></p>'
+  const markdown = await htmlToMarkdown(html, { cleanForDocsUi: true })
+
+  assert.match(markdown, /\[Guide\]\(\/docs\/foo\)/)
+  assert.doesNotMatch(markdown, /\[\]\(#overview\)/)
+})
+
+test('cleanup removes presentation-only nodes from markdown output', async () => {
+  const html =
+    '<p>Hello <button>Copy</button> world<span class="sr-only">screen reader only</span>.</p><p><svg><text>Icon</text></svg>Done.</p>'
+  const markdown = await htmlToMarkdown(html, { cleanForDocsUi: true })
+
+  assert.match(markdown, /Hello world\./)
+  assert.match(markdown, /Done\./)
+  assert.doesNotMatch(markdown, /Copy/)
+  assert.doesNotMatch(markdown, /screen reader only/)
+  assert.doesNotMatch(markdown, /Icon/)
+})

--- a/utils/docs/agentDiscovery.ts
+++ b/utils/docs/agentDiscovery.ts
@@ -1,0 +1,196 @@
+import docsSideNav from '@/constants/docsSideNav'
+
+type NavItem =
+  | {
+      type?: 'doc' | 'category'
+      label?: string
+      route?: string
+      items?: Array<NavItem | string>
+    }
+  | string
+
+export type DocsRouteListItem = {
+  label: string
+  route: string
+  depth: number
+}
+
+export type DocsRouteTreeItem = {
+  label: string
+  route?: string
+  children: DocsRouteTreeItem[]
+}
+
+const DOCS_ROOT = '/docs/introduction'
+
+const LLM_STARTER_ROUTE_MATCHERS: Array<(route: string) => boolean> = [
+  (route) => route === DOCS_ROOT,
+  (route) => /^\/docs\/install(?:\/|$)/.test(route),
+  (route) => /^\/docs\/cloud(?:\/|$)/.test(route),
+  (route) => /^\/docs\/opentelemetry-collection-agents\/get-started(?:\/|$)/.test(route),
+  (route) => route === '/docs/llm-observability',
+  (route) => route === '/docs/aws-monitoring/overview',
+  (route) => route === '/docs/gcp-monitoring',
+  (route) => route === '/docs/migration/migrate-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-datadog-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-grafana-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-elk-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-newrelic-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-honeycomb-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-opentelemetry-to-signoz',
+  (route) => route === '/docs/migration/migrate-from-signoz-self-host-to-signoz-cloud',
+  (route) => /^\/docs\/instrumentation(?:\/|$)/.test(route),
+  (route) => /^\/docs\/traces-management(?:\/|$)/.test(route),
+  (route) => /^\/docs\/metrics-management(?:\/|$)/.test(route),
+  (route) => /^\/docs\/logs-management(?:\/|$)/.test(route),
+  (route) => /^\/docs\/alerts-management(?:\/|$)/.test(route),
+  (route) => /^\/docs\/dashboards(?:\/|$)/.test(route),
+  (route) => /^\/docs\/manage\/administrator-guide(?:\/|$)/.test(route),
+  (route) => /^\/docs\/migration(?:\/|$)/.test(route),
+]
+
+const normalizeDocsRoute = (route?: string): string | null => {
+  if (!route) return null
+
+  const trimmed = route.trim()
+  if (!trimmed.startsWith('/docs')) return null
+
+  if (trimmed === '/docs' || trimmed === '/docs/') {
+    return DOCS_ROOT
+  }
+
+  if (trimmed.length > 1 && trimmed.endsWith('/')) {
+    return trimmed.slice(0, -1)
+  }
+
+  return trimmed
+}
+
+const fallbackLabelFromRoute = (route: string): string => {
+  const clean = route
+    .replace(/^\/docs\/?/, '')
+    .split('/')
+    .filter(Boolean)
+    .pop()
+
+  if (!clean) return 'Documentation'
+
+  return clean
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+const buildRouteLabelLookup = (items: NavItem[], lookup: Map<string, string>) => {
+  items.forEach((item) => {
+    if (typeof item === 'string') return
+
+    const route = normalizeDocsRoute(item.route)
+    if (route && item.label && !lookup.has(route)) {
+      lookup.set(route, item.label)
+    }
+
+    if (Array.isArray(item.items) && item.items.length > 0) {
+      buildRouteLabelLookup(item.items, lookup)
+    }
+  })
+}
+
+const routeLabelLookup = (() => {
+  const lookup = new Map<string, string>()
+  buildRouteLabelLookup(docsSideNav as NavItem[], lookup)
+  lookup.set(DOCS_ROOT, 'Get Started')
+  return lookup
+})()
+
+const toTree = (items: NavItem[]): DocsRouteTreeItem[] => {
+  return items
+    .map((item): DocsRouteTreeItem | null => {
+      if (typeof item === 'string') {
+        const route = normalizeDocsRoute(item)
+        if (!route) return null
+
+        return {
+          label: routeLabelLookup.get(route) || fallbackLabelFromRoute(route),
+          route,
+          children: [],
+        }
+      }
+
+      const label =
+        item.label || (item.route ? fallbackLabelFromRoute(item.route) : 'Documentation')
+      const route = normalizeDocsRoute(item.route)
+      const children = Array.isArray(item.items) ? toTree(item.items as NavItem[]) : []
+
+      if (!route && children.length === 0) {
+        return null
+      }
+
+      return {
+        label,
+        route: route || undefined,
+        children,
+      }
+    })
+    .filter(Boolean) as DocsRouteTreeItem[]
+}
+
+const flattenTree = (nodes: DocsRouteTreeItem[], depth: number, output: DocsRouteListItem[]) => {
+  nodes.forEach((node) => {
+    if (node.route) {
+      output.push({
+        label: node.label,
+        route: node.route,
+        depth,
+      })
+    }
+
+    if (node.children.length > 0) {
+      flattenTree(node.children, depth + 1, output)
+    }
+  })
+}
+
+export function getDocsRouteTree(): DocsRouteTreeItem[] {
+  return toTree(docsSideNav as NavItem[])
+}
+
+export function getDocsRouteList(): DocsRouteListItem[] {
+  const all: DocsRouteListItem[] = []
+  flattenTree(getDocsRouteTree(), 0, all)
+
+  const seen = new Set<string>()
+  return all.filter((item) => {
+    if (seen.has(item.route)) return false
+    seen.add(item.route)
+    return true
+  })
+}
+
+export function getLlmStarterLinks(limit = 24): Array<Pick<DocsRouteListItem, 'label' | 'route'>> {
+  const routes = getDocsRouteList()
+  const starters: Array<Pick<DocsRouteListItem, 'label' | 'route'>> = []
+  const seen = new Set<string>()
+  const sortedRoutes = [...routes].sort(
+    (a, b) => a.depth - b.depth || a.route.length - b.route.length
+  )
+
+  const addStarter = (item: Pick<DocsRouteListItem, 'label' | 'route'> | undefined) => {
+    if (!item || starters.length >= limit || seen.has(item.route)) return
+    seen.add(item.route)
+    starters.push({ label: item.label, route: item.route })
+  }
+
+  LLM_STARTER_ROUTE_MATCHERS.forEach((matcher) => {
+    const match = sortedRoutes.find((item) => matcher(item.route))
+    addStarter(match)
+  })
+
+  sortedRoutes
+    .filter((item) => item.depth <= 1)
+    .forEach((item) => {
+      addStarter(item)
+    })
+
+  return starters
+}

--- a/utils/docs/agentMarkdownStubs.ts
+++ b/utils/docs/agentMarkdownStubs.ts
@@ -1,0 +1,432 @@
+import React from 'react'
+import type { ComponentType, ReactNode } from 'react'
+import type { Doc } from 'contentlayer/generated'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+
+type StubProps = {
+  children?: ReactNode
+  [key: string]: unknown
+}
+
+type DocsComponentMap = Record<string, ComponentType<StubProps>>
+type MdxTreeNode = {
+  type?: string
+  name?: string | null
+  children?: MdxTreeNode[]
+}
+type AgentMdxComponentPolicy = 'custom-stub' | 'reviewed-fallback'
+
+const LLM_MONITORING_SLUGS = [
+  'codex-monitoring',
+  'anthropic-monitoring',
+  'groq-observability',
+  'openrouter-observability',
+  'vercel-ai-sdk-observability',
+  'langtrace',
+  'openlit',
+]
+export const KNOWN_AGENT_MDX_COMPONENT_NAMES = [
+  'Admonition',
+  'APMInstrumentationListicle',
+  'DocCard',
+  'DocCardContainer',
+  'Figure',
+  'HostingDecision',
+  'IntegrationsListicle',
+  'K8sInstallationListicle',
+  'KeyPointCallout',
+  'LLMMonitoringListicle',
+  'LogsInstrumentationListicle',
+  'MarketplaceInstallationListicle',
+  'SelfHostInstallationListicle',
+  'TabItem',
+  'Tabs',
+  'ToggleHeading',
+] as const
+export const REVIEWED_FALLBACK_AGENT_MDX_COMPONENT_NAMES = [
+  'APMDashboardsListicle',
+  'APMQuickStartOverview',
+  'AWSMonitoringListicle',
+  'AWSOneClickListicle',
+  'CHClientWithOutput',
+  'CICDMonitoringListicle',
+  'CloneRepo',
+  'CollectionAgentsListicle',
+  'CommonPrerequisites',
+  'DashboardActions',
+  'DashboardTemplatesListicle',
+  'DSConfigIntro',
+  'DSConfigOss',
+  'DSSendDataEc2',
+  'DSSendDataEnd',
+  'DSSendDataExternal',
+  'DSSendDataIntro',
+  'DSSetUpVerify',
+  'DSTemplateEC2',
+  'DSTemplateExternal',
+  'DSTemplateIntro',
+  'GetHelp',
+  'GetStartedInfrastructureMonitoring',
+  'HostMetricsDashboardsListicle',
+  'JavaInstrumentationListicle',
+  'JavascriptInstrumentationListicle',
+  'K8sInstall',
+  'K8sNextSteps',
+  'K8sOtelDemo',
+  'KubernetesDashboardsListicle',
+  'LibraryTab',
+  'LibraryTabs',
+  'LiteLLMDashboardsListicle',
+  'LogsQuickStartOverview',
+  'MDXButton',
+  'MetricsDefinition',
+  'MetricsQuickStartOverview',
+  'MigrateToSigNoz',
+  'MultiNodePart1',
+  'MultiNodePart2',
+  'PrereqsInstrument',
+  'RegionTable',
+  'RetentionInfo',
+  'SigNozCloud',
+  'TraefikMetrics',
+  'UpgradeInfo',
+  'UseHotRod',
+  'WebVitalsGrid',
+  'YouTube',
+] as const
+type KnownAgentMdxComponentName = (typeof KNOWN_AGENT_MDX_COMPONENT_NAMES)[number]
+
+const buildPolicyEntries = (names: readonly string[], policy: AgentMdxComponentPolicy) =>
+  names.reduce<Record<string, AgentMdxComponentPolicy>>((accumulator, name) => {
+    accumulator[name] = policy
+    return accumulator
+  }, {})
+
+export const AGENT_MDX_COMPONENT_POLICIES = {
+  ...buildPolicyEntries(KNOWN_AGENT_MDX_COMPONENT_NAMES, 'custom-stub'),
+  ...buildPolicyEntries(REVIEWED_FALLBACK_AGENT_MDX_COMPONENT_NAMES, 'reviewed-fallback'),
+} as const
+
+const toDocsPath = (slug: string): string => `/docs/${slug.replace(/^\/+|\/+$/g, '')}/`
+
+const getStringProp = (props: StubProps, key: string): string | null => {
+  const value = props[key]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const getFirstStringProp = (props: StubProps, keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = getStringProp(props, key)
+    if (value) {
+      return value
+    }
+  }
+
+  return null
+}
+
+const formatLabel = (value: string): string =>
+  value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+
+const hasRenderableChildren = (children: ReactNode): boolean => {
+  const nodes = React.Children.toArray(children)
+  return nodes.length > 0
+}
+
+const buildLabeledContent = (label: string | null, children?: ReactNode): ReactNode[] => {
+  const nodes: ReactNode[] = []
+
+  if (label) {
+    nodes.push(
+      React.createElement('p', { key: 'label' }, React.createElement('strong', null, label))
+    )
+  }
+
+  if (hasRenderableChildren(children)) {
+    nodes.push(React.createElement(React.Fragment, { key: 'children' }, children))
+  }
+
+  return nodes
+}
+
+const toDocListItems = (docs: Doc[]): Array<{ slug: string; title: string; href: string }> => {
+  const seen = new Set<string>()
+  const items: Array<{ slug: string; title: string; href: string }> = []
+
+  for (const doc of docs) {
+    const slug = typeof doc.slug === 'string' ? doc.slug.trim() : ''
+    if (!slug || seen.has(slug)) {
+      continue
+    }
+
+    seen.add(slug)
+    const title =
+      typeof doc.title === 'string' && doc.title.trim().length > 0 ? doc.title.trim() : slug
+
+    items.push({
+      slug,
+      title,
+      href: toDocsPath(slug),
+    })
+  }
+
+  items.sort((left, right) => left.title.localeCompare(right.title))
+  return items
+}
+
+const selectDocsByRules = (
+  docs: Doc[],
+  options: {
+    prefixes?: string[]
+    exactSlugs?: string[]
+  }
+): Doc[] => {
+  const prefixes = options.prefixes || []
+  const exactSlugs = new Set(options.exactSlugs || [])
+
+  return docs.filter((doc) => {
+    const slug = doc.slug || ''
+    if (!slug) return false
+    if (exactSlugs.has(slug)) return true
+
+    return prefixes.some((prefix) => {
+      if (!prefix) return false
+      const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`
+      return slug === prefix || slug.startsWith(prefix) || slug.startsWith(normalizedPrefix)
+    })
+  })
+}
+
+const createDocListComponent = (
+  allDocs: Doc[],
+  title: string,
+  options: {
+    prefixes?: string[]
+    exactSlugs?: string[]
+  }
+): ComponentType<StubProps> => {
+  const DocListComponent = () => {
+    const docs = toDocListItems(selectDocsByRules(allDocs, options))
+
+    if (docs.length === 0) {
+      return React.createElement('p', null, `${title}: No guides found.`)
+    }
+
+    return React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, title),
+      React.createElement(
+        'ul',
+        null,
+        ...docs.map((doc) =>
+          React.createElement(
+            'li',
+            { key: doc.slug },
+            React.createElement('a', { href: doc.href }, doc.title)
+          )
+        )
+      )
+    )
+  }
+
+  DocListComponent.displayName = `${title.replace(/[^a-zA-Z0-9]+/g, '') || 'DocList'}Stub`
+
+  return DocListComponent
+}
+
+const createUnknownComponentStub = (name: string): ComponentType<StubProps> => {
+  const UnknownComponentStub = (props: StubProps) => {
+    const text = getFirstStringProp(props, ['title', 'label', 'name'])
+
+    if (hasRenderableChildren(props.children)) {
+      return React.createElement('div', null, ...buildLabeledContent(text, props.children))
+    }
+
+    const href = getStringProp(props, 'href')
+
+    if (href) {
+      return React.createElement('p', null, React.createElement('a', { href }, text || href))
+    }
+
+    return React.createElement('p', null, text || `Component: ${name}`)
+  }
+
+  UnknownComponentStub.displayName = `${name}Stub`
+
+  return UnknownComponentStub
+}
+
+const createKnownComponentStubs = (
+  allDocs: Doc[]
+): Record<KnownAgentMdxComponentName, ComponentType<StubProps>> => ({
+  Figure: (props) => {
+    const src = getStringProp(props, 'src')
+    const alt = getStringProp(props, 'alt') || ''
+    const caption = getStringProp(props, 'caption')
+
+    if (!src) {
+      const UnknownFigure = createUnknownComponentStub('Figure')
+      return React.createElement(UnknownFigure, props)
+    }
+
+    return React.createElement(
+      'figure',
+      null,
+      React.createElement('img', { src, alt }),
+      caption ? React.createElement('figcaption', null, caption) : null
+    )
+  },
+  DocCard: (props) => {
+    const href = getStringProp(props, 'href')
+    const title = getStringProp(props, 'title') || getStringProp(props, 'name')
+
+    if (!href) {
+      const UnknownDocCard = createUnknownComponentStub('DocCard')
+      return React.createElement(UnknownDocCard, props)
+    }
+
+    return React.createElement('p', null, React.createElement('a', { href }, title || href))
+  },
+  DocCardContainer: (props) => React.createElement('div', null, props.children),
+  Admonition: (props) => {
+    const title = getStringProp(props, 'title')
+    const type = getStringProp(props, 'type')
+    const labelParts = [type ? formatLabel(type) : null, title].filter(Boolean) as string[]
+    const label = labelParts.join(': ')
+
+    return React.createElement('blockquote', null, ...buildLabeledContent(label, props.children))
+  },
+  KeyPointCallout: (props) => {
+    const title = getFirstStringProp(props, ['title', 'label', 'name'])
+
+    return React.createElement('section', null, ...buildLabeledContent(title, props.children))
+  },
+  Tabs: (props) => React.createElement('div', null, props.children),
+  TabItem: (props) => {
+    const label = getStringProp(props, 'label')
+    return React.createElement(
+      'section',
+      null,
+      label ? React.createElement('h3', null, label) : null,
+      props.children
+    )
+  },
+  ToggleHeading: (props) => React.createElement('div', null, props.children),
+  HostingDecision: () =>
+    React.createElement(
+      'ul',
+      null,
+      React.createElement(
+        'li',
+        null,
+        React.createElement(
+          'a',
+          { href: '/blog/cloud-vs-self-hosted-deployment-guide/' },
+          'Compare Self Host vs Cloud'
+        )
+      ),
+      React.createElement(
+        'li',
+        null,
+        React.createElement('a', { href: '/teams/' }, 'Get Started - Free')
+      )
+    ),
+  APMInstrumentationListicle: createDocListComponent(allDocs, 'APM Instrumentation Guides', {
+    prefixes: ['instrumentation/'],
+    exactSlugs: ['frontend-monitoring'],
+  }),
+  LogsInstrumentationListicle: createDocListComponent(allDocs, 'Logs Collection Guides', {
+    prefixes: [
+      'logs-management/send-logs/',
+      'userguide/collect_',
+      'userguide/fluent',
+      'userguide/send-logs-http',
+      'userguide/heroku_logs_to_signoz',
+      'userguide/vercel_logs_to_signoz',
+    ],
+  }),
+  SelfHostInstallationListicle: createDocListComponent(allDocs, 'Self-Host Installation Guides', {
+    exactSlugs: [
+      'install/docker',
+      'install/docker-swarm',
+      'install/docker-selinux',
+      'install/linux',
+      'install/digital-ocean',
+      'install/argocd',
+      'install/ecs',
+      'install/azure-container-apps',
+      'install/marketplaces',
+    ],
+    prefixes: ['install/kubernetes/'],
+  }),
+  K8sInstallationListicle: createDocListComponent(allDocs, 'Kubernetes Installation Guides', {
+    prefixes: ['install/kubernetes/'],
+  }),
+  MarketplaceInstallationListicle: createDocListComponent(
+    allDocs,
+    'Marketplace Installation Guides',
+    {
+      exactSlugs: ['install/marketplaces'],
+    }
+  ),
+  IntegrationsListicle: createDocListComponent(allDocs, 'Integrations Guides', {
+    prefixes: ['integrations/'],
+  }),
+  LLMMonitoringListicle: createDocListComponent(allDocs, 'LLM Monitoring Guides', {
+    exactSlugs: LLM_MONITORING_SLUGS,
+  }),
+})
+
+export const extractMdxComponentNames = (rawMdx: string): string[] => {
+  const tree = unified().use(remarkParse).use(remarkMdx).parse(rawMdx) as MdxTreeNode
+  const names = new Set<string>()
+
+  const visit = (node: MdxTreeNode) => {
+    if (
+      (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') &&
+      typeof node.name === 'string' &&
+      /^[A-Z]/.test(node.name)
+    ) {
+      names.add(node.name)
+    }
+
+    if (Array.isArray(node.children)) {
+      node.children.forEach((child) => visit(child))
+    }
+  }
+
+  visit(tree)
+
+  return Array.from(names)
+}
+
+export const buildAgentMdxComponentsForDoc = (doc: Doc, allDocs: Doc[]): DocsComponentMap => {
+  const componentNames = extractMdxComponentNames(doc.body.raw)
+  const knownStubs = createKnownComponentStubs(allDocs)
+  const unreviewedComponentNames = componentNames.filter(
+    (componentName) =>
+      !Object.prototype.hasOwnProperty.call(AGENT_MDX_COMPONENT_POLICIES, componentName)
+  )
+
+  if (unreviewedComponentNames.length > 0) {
+    console.warn(
+      `Review agent markdown handling for MDX components in "${doc.slug}": ${unreviewedComponentNames.join(', ')}`
+    )
+  }
+
+  return componentNames.reduce<DocsComponentMap>((accumulator, componentName) => {
+    accumulator[componentName] = Object.prototype.hasOwnProperty.call(knownStubs, componentName)
+      ? knownStubs[componentName as KnownAgentMdxComponentName]
+      : createUnknownComponentStub(componentName)
+    return accumulator
+  }, {})
+}

--- a/utils/docs/buildCopyMarkdownFromRendered.ts
+++ b/utils/docs/buildCopyMarkdownFromRendered.ts
@@ -1,14 +1,11 @@
 import { tagDefinitions } from '@/constants/tagDefinitions'
+import { hastToMarkdown, normalizeWhitespace } from './markdownCore'
 
 export type BuildCopyMarkdownOptions = {
   title: string
   tags: string[]
   includeTagDefinitions: boolean
 }
-
-const CLEANUP_SELECTORS = ['button', 'svg', '.sr-only', '.content-header-link']
-
-const normalizeWhitespace = (content: string) => content.replace(/\n{3,}/g, '\n\n').trim()
 
 const buildTagHeader = (tags: string[], includeTagDefinitions: boolean): string => {
   if (!tags || tags.length === 0) {
@@ -66,15 +63,6 @@ const expandTabsInClone = (clone: HTMLElement) => {
 const cloneAndCleanArticle = (articleEl: HTMLElement): HTMLElement => {
   const clone = articleEl.cloneNode(true) as HTMLElement
   expandTabsInClone(clone)
-  CLEANUP_SELECTORS.forEach((selector) => {
-    clone.querySelectorAll(selector).forEach((node) => node.remove())
-  })
-
-  clone.querySelectorAll('a').forEach((node) => {
-    if (node.textContent?.trim()) return
-    if (node.querySelector('img, svg')) return
-    node.remove()
-  })
   return clone
 }
 
@@ -82,23 +70,11 @@ export async function buildCopyMarkdownFromRendered(
   articleEl: HTMLElement,
   options: BuildCopyMarkdownOptions
 ): Promise<string> {
-  const { unified } = await import('unified')
-  const { default: rehypeRemark } = await import('rehype-remark')
-  const { default: remarkStringify } = await import('remark-stringify')
-  const { default: remarkGfm } = await import('remark-gfm')
   const { fromDom } = await import('hast-util-from-dom')
 
   const cleanedArticle = cloneAndCleanArticle(articleEl)
   const hast = fromDom(cleanedArticle)
-
-  const processor = unified().use(rehypeRemark).use(remarkGfm).use(remarkStringify, {
-    bullet: '-',
-    fences: true,
-    resourceLink: true,
-  })
-
-  const mdast = await processor.run(hast as any)
-  const bodyMarkdown = normalizeWhitespace(processor.stringify(mdast as any))
+  const bodyMarkdown = await hastToMarkdown(hast as any, { cleanForDocsUi: true })
 
   const headerLines = [`# ${options.title}`]
   const tagsHeader = buildTagHeader(options.tags, options.includeTagDefinitions)

--- a/utils/docs/markdownCore.ts
+++ b/utils/docs/markdownCore.ts
@@ -1,0 +1,134 @@
+import type {
+  Element as HastElement,
+  Root as HastRoot,
+  RootContent as HastContent,
+  Text as HastText,
+} from 'hast'
+
+export const MARKDOWN_STRINGIFY_OPTIONS = {
+  bullet: '-',
+  fences: true,
+  resourceLink: true,
+} as const
+
+const MARKDOWN_CLEANUP_TAG_NAMES = new Set(['button', 'svg'])
+const MARKDOWN_CLEANUP_CLASS_NAMES = new Set(['sr-only', 'content-header-link'])
+
+type HastParentNode = {
+  children: HastContent[]
+}
+
+export type MarkdownCleanupOptions = {
+  cleanForDocsUi?: boolean
+}
+
+export const normalizeWhitespace = (content: string) => content.replace(/\n{3,}/g, '\n\n').trim()
+
+const isHastElement = (node: HastContent): node is HastElement => node.type === 'element'
+
+const isHastText = (node: HastContent): node is HastText => node.type === 'text'
+
+const getClassNames = (node: HastElement): string[] => {
+  const className = node.properties?.className
+
+  if (Array.isArray(className)) {
+    return className.map((value) => String(value))
+  }
+
+  if (typeof className === 'string') {
+    return className.split(/\s+/).filter(Boolean)
+  }
+
+  return []
+}
+
+const shouldRemoveMarkdownElement = (node: HastElement): boolean => {
+  if (MARKDOWN_CLEANUP_TAG_NAMES.has(node.tagName)) {
+    return true
+  }
+
+  return getClassNames(node).some((className) => MARKDOWN_CLEANUP_CLASS_NAMES.has(className))
+}
+
+const hasMeaningfulMarkdownContent = (node: HastContent): boolean => {
+  if (isHastText(node)) {
+    return node.value.trim().length > 0
+  }
+
+  if (!isHastElement(node)) {
+    return false
+  }
+
+  if (node.tagName === 'img') {
+    return true
+  }
+
+  return ((node.children || []) as HastContent[]).some((child) =>
+    hasMeaningfulMarkdownContent(child)
+  )
+}
+
+const cleanMarkdownNode = (node: HastContent): HastContent[] => {
+  if (!isHastElement(node)) {
+    return [node]
+  }
+
+  if (shouldRemoveMarkdownElement(node)) {
+    return []
+  }
+
+  if (Array.isArray(node.children) && node.children.length > 0) {
+    cleanHastForMarkdown(node as unknown as HastParentNode)
+  }
+
+  if (
+    node.tagName === 'a' &&
+    !((node.children || []) as HastContent[]).some((child) => hasMeaningfulMarkdownContent(child))
+  ) {
+    return []
+  }
+
+  return [node]
+}
+
+export function cleanHastForMarkdown<T extends HastParentNode>(tree: T): T {
+  tree.children = ((tree.children || []) as HastContent[]).flatMap((child) =>
+    cleanMarkdownNode(child)
+  )
+  return tree
+}
+
+export async function hastToMarkdown(
+  hast: HastRoot,
+  options: MarkdownCleanupOptions = {}
+): Promise<string> {
+  const { unified } = await import('unified')
+  const { default: rehypeRemark } = await import('rehype-remark')
+  const { default: remarkStringify } = await import('remark-stringify')
+  const { default: remarkGfm } = await import('remark-gfm')
+
+  if (options.cleanForDocsUi) {
+    cleanHastForMarkdown(hast as unknown as HastParentNode)
+  }
+
+  const processor = unified()
+    .use(rehypeRemark)
+    .use(remarkGfm)
+    .use(remarkStringify, {
+      ...MARKDOWN_STRINGIFY_OPTIONS,
+    })
+
+  const mdast = await processor.run(hast as any)
+  return normalizeWhitespace(processor.stringify(mdast as any))
+}
+
+export async function htmlToMarkdown(
+  html: string,
+  options: MarkdownCleanupOptions = {}
+): Promise<string> {
+  const { unified } = await import('unified')
+  const { default: rehypeParse } = await import('rehype-parse')
+
+  const hast = unified().use(rehypeParse, { fragment: true }).parse(html) as HastRoot
+  return hastToMarkdown(hast, options)
+}

--- a/utils/docs/markdownRouting.ts
+++ b/utils/docs/markdownRouting.ts
@@ -1,0 +1,34 @@
+export const normalizeDocsSlugFromPathname = (pathname: string): string => {
+  const withoutPrefix = pathname.replace(/^\/docs\/?/, '')
+  return withoutPrefix.replace(/\/+$/, '')
+}
+
+export const shouldRewriteDocsToMarkdown = (
+  pathname: string,
+  prefersMarkdown: boolean
+): boolean => {
+  const isDocsPath = pathname === '/docs' || pathname.startsWith('/docs/')
+  const isDocsSitemapPath = pathname === '/docs/sitemap.md' || pathname === '/docs/sitemap.md/'
+  const isInternalMarkdownPath =
+    pathname === '/api/docs-markdown' || pathname.startsWith('/api/docs-markdown/')
+
+  return isDocsPath && !isDocsSitemapPath && !isInternalMarkdownPath && prefersMarkdown
+}
+
+export const buildDocsMarkdownRewritePath = (pathname: string): string => {
+  const docsSlug = normalizeDocsSlugFromPathname(pathname)
+  return docsSlug ? `/api/docs-markdown/${docsSlug}` : '/api/docs-markdown'
+}
+
+export const resolveDocsMarkdownSlug = (segments?: string[]): string => {
+  if (!segments || segments.length === 0) {
+    return 'introduction'
+  }
+
+  const joined = segments
+    .map((segment) => decodeURIComponent(segment).trim())
+    .filter(Boolean)
+    .join('/')
+
+  return joined || 'introduction'
+}

--- a/utils/docs/renderDocMarkdownForAgents.ts
+++ b/utils/docs/renderDocMarkdownForAgents.ts
@@ -1,0 +1,233 @@
+import { allDocs } from 'contentlayer/generated'
+import type { Doc } from 'contentlayer/generated'
+import { buildAgentMdxComponentsForDoc } from './agentMarkdownStubs'
+import { htmlToMarkdown, normalizeWhitespace } from './markdownCore'
+
+const markdownCache = new Map<string, string>()
+const MAX_MARKDOWN_CACHE_ENTRIES = 2000
+const MORE_DOCS_POINTER = 'More docs: /docs/sitemap.md'
+
+type GenericNode = {
+  type?: string
+  name?: string
+  value?: string
+  children?: GenericNode[]
+}
+
+const getDocTags = (doc: Doc): string[] => {
+  if (!Array.isArray(doc.docTags)) return []
+  return doc.docTags.filter(
+    (tag): tag is string => typeof tag === 'string' && tag.trim().length > 0
+  )
+}
+
+const normalizeHeadingText = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const getLeadingH1Text = (markdown: string): string | null => {
+  const lines = markdown.split(/\r?\n/)
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    const headingMatch = line.match(/^#\s+(.+?)\s*#*\s*$/)
+    return headingMatch ? headingMatch[1].trim() : null
+  }
+
+  return null
+}
+
+const hasMatchingLeadingH1 = (markdown: string, title: string): boolean => {
+  const leadingH1 = getLeadingH1Text(markdown)
+  if (!leadingH1) return false
+  return normalizeHeadingText(leadingH1) === normalizeHeadingText(title)
+}
+
+const buildHeader = (doc: Doc, options?: { includeTitle?: boolean }): string => {
+  const tags = getDocTags(doc)
+  const sections: string[] = []
+
+  if (options?.includeTitle !== false) {
+    sections.push(`# ${doc.title}`)
+  }
+
+  if (doc.description) {
+    sections.push(doc.description)
+  }
+
+  if (tags.length > 0) {
+    sections.push(`Tags: ${tags.join(', ')}`)
+  }
+
+  return normalizeWhitespace(sections.join('\n\n'))
+}
+
+const buildFallbackMarkdown = (doc: Doc): string => {
+  const includeTitle = !hasMatchingLeadingH1(doc.body.raw, doc.title)
+  const sections = [buildHeader(doc, { includeTitle }), doc.body.raw, MORE_DOCS_POINTER]
+  return normalizeWhitespace(sections.filter(Boolean).join('\n\n'))
+}
+
+const sanitizeMdxForAgentRendering = () => {
+  const toComponentPlaceholder = (name?: string): GenericNode => ({
+    type: 'paragraph',
+    children: [
+      {
+        type: 'text',
+        value: `[${name && name.trim().length > 0 ? name : 'Component'}]`,
+      },
+    ],
+  })
+
+  const transformNode = (node: GenericNode): GenericNode[] => {
+    if (!node || !node.type) {
+      return []
+    }
+
+    if (
+      node.type === 'mdxjsEsm' ||
+      node.type === 'mdxFlowExpression' ||
+      node.type === 'mdxTextExpression'
+    ) {
+      return []
+    }
+
+    if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+      const childNodes = Array.isArray(node.children)
+        ? node.children.flatMap((child) => transformNode(child))
+        : []
+
+      if (childNodes.length > 0) {
+        return childNodes
+      }
+
+      return [toComponentPlaceholder(node.name)]
+    }
+
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      node.children = node.children.flatMap((child) => transformNode(child))
+    }
+
+    return [node]
+  }
+
+  return (tree: GenericNode) => {
+    if (!tree || !Array.isArray(tree.children)) {
+      return
+    }
+
+    tree.children = tree.children.flatMap((child) => transformNode(child))
+  }
+}
+
+const convertRawMdxToMarkdown = async (rawMdx: string): Promise<string> => {
+  const { unified } = await import('unified')
+  const { default: remarkParse } = await import('remark-parse')
+  const { default: remarkMdx } = await import('remark-mdx')
+  const { default: remarkGfm } = await import('remark-gfm')
+  const { default: remarkRehype } = await import('remark-rehype')
+  const { default: rehypeStringify } = await import('rehype-stringify')
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkMdx)
+    .use(remarkGfm)
+    .use(sanitizeMdxForAgentRendering)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeStringify)
+
+  const html = String(await processor.process(rawMdx))
+  return htmlToMarkdown(html, { cleanForDocsUi: true })
+}
+
+const getMdxComponentFromCode = async (code: string) => {
+  const React = await import('react')
+  const ReactDOM = await import('react-dom')
+  const jsxRuntime = await import('react/jsx-runtime')
+
+  const scope = {
+    React,
+    ReactDOM,
+    _jsx_runtime: jsxRuntime,
+  }
+
+  const fn = new Function(...Object.keys(scope), code)
+  const moduleExports = fn(...Object.values(scope)) as { default?: unknown }
+
+  if (!moduleExports?.default) {
+    throw new Error('Compiled MDX module did not return a default component')
+  }
+
+  return moduleExports.default as unknown
+}
+
+const convertCompiledMdxToMarkdown = async (doc: Doc): Promise<string> => {
+  const React = await import('react')
+  const { renderToStaticMarkup } = await import('react-dom/server')
+  const mdxComponents = buildAgentMdxComponentsForDoc(doc, allDocs as Doc[])
+  const MdxComponent = await getMdxComponentFromCode(doc.body.code)
+  const element = React.createElement(MdxComponent as any, {
+    components: mdxComponents,
+    toc: doc.toc || [],
+  })
+  const html = renderToStaticMarkup(element as any)
+
+  return htmlToMarkdown(html, { cleanForDocsUi: true })
+}
+
+const setMarkdownCache = (key: string, value: string): void => {
+  if (!markdownCache.has(key) && markdownCache.size >= MAX_MARKDOWN_CACHE_ENTRIES) {
+    const oldestKey = markdownCache.keys().next().value
+    if (oldestKey) {
+      markdownCache.delete(oldestKey)
+    }
+  }
+
+  markdownCache.set(key, value)
+}
+
+export async function renderDocMarkdownForAgents(doc: Doc): Promise<string> {
+  const cacheKey = doc.slug || doc._id
+  const cached = markdownCache.get(cacheKey)
+
+  if (cached) {
+    return cached
+  }
+
+  try {
+    let bodyMarkdown = ''
+
+    try {
+      bodyMarkdown = await convertCompiledMdxToMarkdown(doc)
+    } catch (compiledRenderError) {
+      console.error(
+        `Failed compiled MDX render for doc slug "${doc.slug}". Falling back to raw MDX conversion.`,
+        compiledRenderError
+      )
+      bodyMarkdown = await convertRawMdxToMarkdown(doc.body.raw)
+    }
+
+    if (!bodyMarkdown) {
+      throw new Error('Empty markdown generated from MDX source')
+    }
+
+    const includeTitle = !hasMatchingLeadingH1(bodyMarkdown, doc.title)
+    const renderedMarkdown = normalizeWhitespace(
+      [buildHeader(doc, { includeTitle }), bodyMarkdown, MORE_DOCS_POINTER]
+        .filter(Boolean)
+        .join('\n\n')
+    )
+    setMarkdownCache(cacheKey, renderedMarkdown)
+    return renderedMarkdown
+  } catch (error) {
+    console.error(`Failed to render markdown for doc slug "${doc.slug}"`, error)
+    const fallbackMarkdown = buildFallbackMarkdown(doc)
+    setMarkdownCache(cacheKey, fallbackMarkdown)
+    return fallbackMarkdown
+  }
+}

--- a/utils/docs/renderDocMarkdownForAgents.ts
+++ b/utils/docs/renderDocMarkdownForAgents.ts
@@ -3,6 +3,9 @@ import type { Doc } from 'contentlayer/generated'
 import { buildAgentMdxComponentsForDoc } from './agentMarkdownStubs'
 import { htmlToMarkdown, normalizeWhitespace } from './markdownCore'
 
+// Next.js static generation is the primary cache for this route. This Map is only a
+// best-effort warm-process optimization, and eviction is intentionally FIFO rather than LRU
+// because each docs slug is normally rendered once under force-static.
 const markdownCache = new Map<string, string>()
 const MAX_MARKDOWN_CACHE_ENTRIES = 2000
 const MORE_DOCS_POINTER = 'More docs: /docs/sitemap.md'
@@ -156,6 +159,8 @@ const getMdxComponentFromCode = async (code: string) => {
     _jsx_runtime: jsxRuntime,
   }
 
+  // This is effectively eval(), but the input is Contentlayer-compiled MDX from trusted
+  // repository content at build/render time. Do not use this with untrusted input.
   const fn = new Function(...Object.keys(scope), code)
   const moduleExports = fn(...Object.values(scope)) as { default?: unknown }
 


### PR DESCRIPTION
## Description

Adds an agent-friendly markdown surface for SigNoz docs by:
- serving docs pages as markdown through a dedicated route and `Accept: text/markdown` rewrite path
- publishing `llms.txt` and docs/sitemap.md for discovery
- adding shared markdown cleanup so agent-rendered docs strip heading autolink chrome and other presentation-only UI markup
- adding regression tests for discovery, routing, MDX component coverage, bot detection, and markdown cleanup

No new dependencies were added.

## Type of Change

<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [x] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots

No UI screenshots; this change is route, middleware, utility, and test focused.

## Checklist

<!-- Complete the sections that apply to your changes -->

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

Build was intentionally not run for this PR.

### For docs changes (`data/docs/**`)
- [ ] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [x] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [x] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

## Verification

- `node --test tests/agent-discovery.test.js`
- `node --test tests/agent-markdown-component-coverage.test.js`
- `node --test tests/agent-markdown-stubs.test.js`
- `node --test tests/bot-patterns.test.js`
- `node --test tests/docs-markdown-routing.test.js`
- `node --test tests/markdown-core.test.js`
- `yarn lint`
