### PR TITLE
chore: add .mamba to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ gha-creds-*.json
 # Agent files
 .agent/
 .test-transpile-*
+
+# Mamba's Resources
+.mamba


### PR DESCRIPTION
### Motivation
- Prevent Mamba environment/resource files from being tracked in the repo by ignoring the `.mamba` directory.

### Description
- Added `.mamba` entry to `.gitignore` in a new `# Mamba's Resources` section (updated file: `.gitignore`).

### Testing
- No automated tests required for this ignore-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb203ceb483239740d7c2447950bf)