### PR TITLE
chore: replace .mamba with .private in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ gha-creds-*.json
 .test-transpile-*
 
 # Mamba's Resources
-.mamba
+.private

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ gha-creds-*.json
 .agent/
 .test-transpile-*
 
-# Mamba's Resources
+# Local private workspace files
 .private


### PR DESCRIPTION
### Motivation
- Standardize the ignored private agent resources by replacing the `.mamba` ignore entry with `.private` so the intended private folder is excluded from VCS.

### Description
- Updated ` .gitignore` by removing the `.mamba` entry and adding `.private` in its place.

### Testing
- Verified the change with `rg -n "\.mamba|\.private" .gitignore`, inspected `git status --short`, and reviewed the relevant lines of `.gitignore` with `nl -ba .gitignore | sed -n '30,42p'`, all of which confirmed the update succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb42cca0c832388566c7e1be19730)