### PR TITLE
docs: revamp the Cloud Quickstart guide and clarify Alertmanager configuration

### DIFF
--- a/components/Setup/CollectionAgentsListicle.tsx
+++ b/components/Setup/CollectionAgentsListicle.tsx
@@ -49,7 +49,7 @@ export default function SelfHostInstallationListicle({
           className={`inline-block rounded-full px-4 py-2 text-sm font-medium transition-colors
             ${
               activeSection === section.id
-                ? 'bg-signoz_orange-500 dark:bg-signoz_orange-400 text-white'
+                ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
             }`}
         >

--- a/components/Setup/SelfHostInstallationListicle.tsx
+++ b/components/Setup/SelfHostInstallationListicle.tsx
@@ -14,7 +14,6 @@ import {
   SiRedhatopenshift,
   SiRender,
 } from 'react-icons/si'
-import { HelpCircle, Store, Trash2, Calculator } from 'lucide-react'
 import IconCardGrid from '../Card/IconCardGrid'
 
 /**

--- a/components/Setup/SelfHostInstallationListicle.tsx
+++ b/components/Setup/SelfHostInstallationListicle.tsx
@@ -11,8 +11,10 @@ import {
   SiArgo,
   SiLinux,
   SiAmazonecs,
-  SiRedhatopenshift
+  SiRedhatopenshift,
+  SiRender,
 } from 'react-icons/si'
+import { HelpCircle, Store, Trash2, Calculator } from 'lucide-react'
 import IconCardGrid from '../Card/IconCardGrid'
 
 /**
@@ -34,23 +36,22 @@ export default function SelfHostInstallationListicle({
     { id: 'binary', label: 'Binary' },
     { id: 'kubernetes', label: 'Kubernetes' },
     { id: 'others', label: 'Others' },
-
   ] as const
 
-  const [activeSection, setActiveSection] = useState<
-    typeof sections[number]['id']
-  >(sections.map(s => s.id).includes(platform) ? platform : 'all')
+  const [activeSection, setActiveSection] = useState<(typeof sections)[number]['id']>(
+    sections.map((s) => s.id).includes(platform) ? platform : 'all'
+  )
 
   const NavigationPills = () => (
     <div className="mb-8 flex flex-wrap gap-2">
-      {sections.map(section => (
+      {sections.map((section) => (
         <button
           key={section.id}
           onClick={() => setActiveSection(section.id)}
           className={`inline-block rounded-full px-4 py-2 text-sm font-medium transition-colors
             ${
               activeSection === section.id
-                ? 'bg-signoz_orange-500 text-white dark:bg-signoz_orange-400'
+                ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
             }`}
         >
@@ -70,7 +71,16 @@ export default function SelfHostInstallationListicle({
   const helmIcon = <SiHelm className="h-7 w-7 text-indigo-500" />
   const argocdIcon = <SiArgo className="h-7 w-7 text-gray-500" />
   const awsEcsIcon = <SiAmazonecs className="h-7 w-7 text-amber-500" />
-  const redhatOpenshiftIcon = <SiRedhatopenshift className='h-7 w-7 text-red-800' />
+  const redhatOpenshiftIcon = <SiRedhatopenshift className="h-7 w-7 text-red-800" />
+  const railwayIcon = (
+    <img src="/img/icons/railway-icon.webp" alt="Railway" className="h-7 w-7 object-contain" />
+  )
+  const vultrIcon = (
+    <img src="/img/icons/vultr.svg" alt="Vultr" className="h-7 w-7 object-contain" />
+  )
+  const coolifyIcon = (
+    <img src="/img/icons/coolify-logo.png" alt="Coolify" className="h-7 w-7 object-contain" />
+  )
 
   // Docker: Standalone, Swarm, SELinux
   const renderDocker = () => (
@@ -80,9 +90,24 @@ export default function SelfHostInstallationListicle({
         sectionName="Docker"
         gridCols="grid-cols-2 sm:grid-cols-3 md:grid-cols-4"
         cards={[
-          { name: 'Standalone', href: '/docs/install/docker', icon: dockerIcon, clickName: 'Install Docker Standalone' },
-          { name: 'Swarm', href: '/docs/install/docker-swarm', icon: dockerIcon, clickName: 'Install Docker Swarm' },
-          { name: 'SELinux', href: '/docs/install/docker-selinux', icon: dockerIcon, clickName: 'Install Docker SELinux' },
+          {
+            name: 'Standalone',
+            href: '/docs/install/docker',
+            icon: dockerIcon,
+            clickName: 'Install Docker Standalone',
+          },
+          {
+            name: 'Swarm',
+            href: '/docs/install/docker-swarm',
+            icon: dockerIcon,
+            clickName: 'Install Docker Swarm',
+          },
+          {
+            name: 'SELinux',
+            href: '/docs/install/docker-selinux',
+            icon: dockerIcon,
+            clickName: 'Install Docker SELinux',
+          },
         ]}
       />
     </div>
@@ -96,7 +121,12 @@ export default function SelfHostInstallationListicle({
         sectionName="Binary"
         gridCols="grid-cols-2 sm:grid-cols-3 md:grid-cols-4"
         cards={[
-          { name: 'Linux', href: '/docs/install/linux', icon: linuxIcon, clickName: 'Install Binary Linux' },
+          {
+            name: 'Linux',
+            href: '/docs/install/linux',
+            icon: linuxIcon,
+            clickName: 'Install Binary Linux',
+          },
         ]}
       />
     </div>
@@ -110,15 +140,54 @@ export default function SelfHostInstallationListicle({
         sectionName="Kubernetes"
         gridCols="grid-cols-2 sm:grid-cols-3 md:grid-cols-4"
         cards={[
-          { name: 'AWS', href: '/docs/install/kubernetes/aws', icon: awsIcon, clickName: 'Deploy to AWS' },
-          { name: 'GCP', href: '/docs/install/kubernetes/gcp', icon: gcpIcon, clickName: 'Deploy to GCP' },
-          { name: 'AKS', href: '/docs/install/kubernetes/aks', icon: <img src="/img/icons/azure-icon.svg" width={20} height={20} alt="Azure" />, clickName: 'Deploy to AKS' },
-          { name: 'DigitalOcean', href: '/docs/install/digital-ocean', icon: doIcon, clickName: 'Deploy to DigitalOcean' },
-          { name: 'Other Platform', href: '/docs/install/kubernetes/others', icon: helmIcon, clickName: 'Deploy to Other Platform' },
-          { name: 'Local', href: '/docs/install/kubernetes/local', icon: k8sIcon, clickName: 'Deploy Locally' },
-          { name: 'ArgoCD', href: '/docs/install/argocd', icon: argocdIcon, clickName: 'Deploy with ArgoCD' },
-          { name: 'Openshift', href: '/docs/install/kubernetes/openshift', icon: redhatOpenshiftIcon, clickName: 'Deploy to Openshift' },
-
+          {
+            name: 'AWS',
+            href: '/docs/install/kubernetes/aws',
+            icon: awsIcon,
+            clickName: 'Deploy to AWS',
+          },
+          {
+            name: 'GCP',
+            href: '/docs/install/kubernetes/gcp',
+            icon: gcpIcon,
+            clickName: 'Deploy to GCP',
+          },
+          {
+            name: 'AKS',
+            href: '/docs/install/kubernetes/aks',
+            icon: <img src="/img/icons/azure-icon.svg" width={20} height={20} alt="Azure" />,
+            clickName: 'Deploy to AKS',
+          },
+          {
+            name: 'DigitalOcean',
+            href: '/docs/install/digital-ocean',
+            icon: doIcon,
+            clickName: 'Deploy to DigitalOcean',
+          },
+          {
+            name: 'Other Platform',
+            href: '/docs/install/kubernetes/others',
+            icon: helmIcon,
+            clickName: 'Deploy to Other Platform',
+          },
+          {
+            name: 'Local',
+            href: '/docs/install/kubernetes/local',
+            icon: k8sIcon,
+            clickName: 'Deploy Locally',
+          },
+          {
+            name: 'ArgoCD',
+            href: '/docs/install/argocd',
+            icon: argocdIcon,
+            clickName: 'Deploy with ArgoCD',
+          },
+          {
+            name: 'Openshift',
+            href: '/docs/install/kubernetes/openshift',
+            icon: redhatOpenshiftIcon,
+            clickName: 'Deploy to Openshift',
+          },
         ]}
       />
     </div>
@@ -132,6 +201,42 @@ export default function SelfHostInstallationListicle({
         gridCols="grid-cols-2 sm:grid-cols-3 md:grid-cols-4"
         cards={[
           { name: 'ECS', href: '/docs/install/ecs/', icon: awsEcsIcon, clickName: 'Deploy to ECS' },
+          {
+            name: 'Azure Container Apps',
+            href: '/docs/install/azure-container-apps',
+            icon: <img src="/img/icons/azure-icon.svg" width={20} height={20} alt="Azure" />,
+            clickName: 'Deploy to Azure Container Apps',
+          },
+          {
+            name: 'Render',
+            href: '/docs/setup/render',
+            icon: <SiRender className="h-7 w-7 text-black dark:text-white" />,
+            clickName: 'Deploy to Render',
+          },
+          {
+            name: 'Railway',
+            href: 'https://railway.com/deploy/signoz',
+            icon: railwayIcon,
+            clickName: 'Deploy to Railway',
+          },
+          {
+            name: 'DigitalOcean (Marketplace)',
+            href: 'https://marketplace.digitalocean.com/apps/signoz',
+            icon: doIcon,
+            clickName: 'Deploy to DigitalOcean Marketplace',
+          },
+          {
+            name: 'Vultr',
+            href: 'https://www.vultr.com/marketplace/apps/signoz/',
+            icon: vultrIcon,
+            clickName: 'Deploy to Vultr',
+          },
+          {
+            name: 'Coolify',
+            href: 'https://github.com/coollabsio/coolify/blob/v4.x/templates/compose/signoz.yaml',
+            icon: coolifyIcon,
+            clickName: 'Deploy to Coolify',
+          },
         ]}
       />
     </div>
@@ -143,7 +248,6 @@ export default function SelfHostInstallationListicle({
       {(activeSection === 'all' || activeSection === 'binary') && renderBinary()}
       {(activeSection === 'all' || activeSection === 'kubernetes') && renderKubernetes()}
       {(activeSection === 'all' || activeSection === 'others') && renderOthers()}
-
     </div>
   )
 }

--- a/data/docs/alerts-management/notification-channel/email.mdx
+++ b/data/docs/alerts-management/notification-channel/email.mdx
@@ -1,9 +1,10 @@
 ---
-date: 2025-12-15
+date: 2026-03-12
 id: email
 
 title: Configure Email Channel
 description: Configure Email as a notification channel in SigNoz to receive alerts directly in your inbox.
+doc_type: howto
 ---
 
 ## Prerequisites
@@ -30,7 +31,7 @@ To create a new Email notification channel in SigNoz, follow these steps:
 ![new-notification-channel](/img/docs/email-new-channel.png)
 
 
-## Configuring Alertmanager
+## Configuring Alertmanager (Self-Hosted only)
 
 The following environment variables need to be set for alertmanager to send emails:
 
@@ -41,7 +42,7 @@ The following environment variables need to be set for alertmanager to send emai
 
 <Admonition type="info">
 
-This section is only required for **Self-Hosted** users. Cloud users don't need to follow this step.
+If you are using Helm to deploy SigNoz, you need to configure these variables as uppercase keys under the `signoz.env` block in your `values.yaml` (for example, `SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__SMARTHOST`).
 
 </Admonition>
 

--- a/data/docs/alerts-management/user-guides/user-guides.mdx
+++ b/data/docs/alerts-management/user-guides/user-guides.mdx
@@ -1,10 +1,8 @@
 ---
-date: 2026-02-19
+date: 2026-03-12
 id: user-guides
-description: User Guides for alerts
 title: User Guides
 description: Comprehensive user guides for setting up and managing alerts in SigNoz.
-tags: ["SigNoz Cloud", "Self-Host"]
 ---
 
 <DocCardContainer>

--- a/data/docs/cloud/quickstart.mdx
+++ b/data/docs/cloud/quickstart.mdx
@@ -1,18 +1,19 @@
 ---
-title: Send Demo App Telemetry to SigNoz Cloud in minutes
+title: Send OTel Demo Telemetry to SigNoz Cloud in 5 Minutes
 id: quickstart
-tags : [SigNoz Cloud]
-date: 2026-02-03
-doc_type: howto
-description: Set up the OpenTelemetry Demo Application to send logs, metrics, and traces to SigNoz Cloud in minutes.
+tags: [SigNoz Cloud]
+date: 2026-03-12
+doc_type: tutorial
+description: Spin up the OpenTelemetry Demo App and start exploring traces, logs, metrics, and service maps in SigNoz Cloud in under 5 minutes.
 ---
 
-Want to explore SigNoz without setting up your own app? This quickstart guide walks you through how to spin up a [lightweight OpenTelemetry Demo](https://github.com/SigNoz/opentelemetry-demo-lite) and
-start sending logs, metrics, and traces to SigNoz Cloud in minutes. 
+import GetHelp from '@/components/shared/get-help.md'
+
+This quickstart spins up a multi-service <a href="https://github.com/SigNoz/opentelemetry-demo-lite" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry Demo</a> app and sends traces, logs, and metrics to your SigNoz Cloud account — no code changes needed.
 
 <video
   src="/img/docs/otel-demo-quickstart.mp4"
-  alt="OpenTelemetry Demo App"
+  alt="OpenTelemetry Demo App sending telemetry to SigNoz Cloud"
   muted
   autoPlay
   loop
@@ -21,123 +22,156 @@ start sending logs, metrics, and traces to SigNoz Cloud in minutes.
   Your browser does not support the video tag.
 </video>
 
-The OpenTelemetry Demo App is a distributed microservices application with built-in telemetry, making it an ideal environment for exploring observability workflows with SigNoz.
-
 ## Prerequisites
 
-- [A SigNoz Cloud account](/teams/)
-- Docker and Docker Compose installed
+- A SigNoz Cloud account ([sign up free](https://signoz.io/teams/))
+- <a href="https://docs.docker.com/get-docker/" target="_blank" rel="noopener noreferrer nofollow">Docker</a> and <a href="https://docs.docker.com/compose/install/" target="_blank" rel="noopener noreferrer nofollow">Docker Compose</a> installed
 
 ## Setup
 
-### Step 1: Clone the OpenTelemetry Demo App
+### Step 1: Clone the demo app
 
 ```bash
 git clone https://github.com/SigNoz/opentelemetry-demo-lite.git
 cd opentelemetry-demo-lite
 ```
 
-### Step 2: Start the Demo App
+### Step 2: Start the demo app
 
-From the root of the `opentelemetry-demo-lite` directory, run:
+Run the following command from the `opentelemetry-demo-lite` directory:
 
 ```bash
 OTLP_ENDPOINT=ingest.<region>.signoz.cloud:443 SIGNOZ_INGESTION_KEY=<your-ingestion-key> docker compose up -d
 ```
 
-- `<your-ingestion-key>`: Your SigNoz [ingestion key](/docs/ingestion/signoz-cloud/keys/)
-- `<region>`: Your SigNoz Cloud [region](/docs/ingestion/signoz-cloud/overview/#get-started)
+Replace the following:
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
 
-Alternatively, you can create a `.env` file in the project root with these values:
+<KeyPointCallout title="Alternative: use a .env file" defaultCollapsed={true}>
+Instead of passing environment variables inline, create a `.env` file in the project root:
 
-```bash
+```bash:.env
 OTLP_ENDPOINT=ingest.<region>.signoz.cloud:443
 SIGNOZ_INGESTION_KEY=<your-ingestion-key>
 ```
 
-Then run:
+Then start the app:
 
 ```bash
 docker compose up -d
 ```
+</KeyPointCallout>
 
-Verify the services are running:
+### Step 3: Verify containers are running
 
 ```bash
 docker compose ps -a
 ```
 
-<figure>
-  <img src="/img/docs/otel-demo-docker-containers.webp" />
-  <figcaption>Docker containers of OTel Demo App</figcaption>
-</figure>
+You should see all 12 services in the `running` state:
 
-The application is pre-configured to send telemetry data to SigNoz Cloud automatically.
+<Figure
+  src="/img/docs/otel-demo-docker-containers.webp"
+  alt="Docker containers of the OpenTelemetry demo app running"
+  caption="All demo app containers should show a running status"
+/>
 
-### Step 4: Verify Telemetry in SigNoz Cloud
+The app automatically generates traffic using a built-in browser simulator, so telemetry starts flowing to SigNoz immediately.
 
-1. Navigate to the **Services** tab — you should see a list of services from the demo app
-2. Use the **Service Map** to visualize the architecture and request flows
-3. Check the **Traces**, **Logs**, and **Metrics** tabs to explore telemetry data
+## Validate
 
-<figure>
-  <img src="/img/docs/otel-demo-services.webp" alt="SigNoz services tab" />
-  <figcaption>Services Listed down in SigNoz services tab</figcaption>
-</figure>
+After 2–3 minutes, open your SigNoz Cloud dashboard and verify each signal:
 
-You are now successfully sending data to SigNoz Cloud!
+1. **Services** — Navigate to **Services** tab. You should see services like `frontend`, `cartservice`, `checkoutservice`, and others listed with live RED metrics (Rate, Errors, Duration).
+
+<Figure
+  src="/img/docs/otel-demo-services.webp"
+  alt="SigNoz Services tab showing demo app services"
+  caption="Demo app services appear in the Services tab with live metrics"
+/>
+
+2. **Traces** — Go to **Traces** and search for traces from any service. Click a trace to see the full request journey across services.
+
+3. **Logs** — Go to **Logs** tab and filter by any service name to see structured log entries.
+
+4. **Metrics** — Go to **Metrics Explorer** and explore metrics.
+
+<Admonition type="info">
+The demo app's browser simulator generates continuous traffic at ~5 requests per second, so you'll see a steady stream of telemetry data.
+</Admonition>
 
 <details>
 <ToggleHeading>
 ## Troubleshooting
 </ToggleHeading>
 
-### Enable collector's debug logging
+### Services not appearing in SigNoz
 
-Edit `otel-collector-config.yaml` and change the log level from `info` to `debug`:
+- **Check your credentials** — Verify that `OTLP_ENDPOINT` and `SIGNOZ_INGESTION_KEY` are set correctly. Re-run with the correct values if needed.
+- **Wait for data** — OpenTelemetry batches data before sending. Wait 2–3 minutes after starting the demo app.
+- **Check network connectivity** — Ensure your machine can reach `ingest.<region>.signoz.cloud:443`. Test with:
+  ```bash
+  curl -v https://ingest.<region>.signoz.cloud:443
+  ```
 
-```yaml
+### Containers not starting
+
+Check logs for the failing service:
+
+```bash
+docker compose logs <service-name>
+```
+
+Common causes:
+- **Insufficient memory** — The demo app requires ~4 GB of available Docker memory. Check Docker Desktop settings.
+- **Port conflicts** — Ensure no other services are using ports required by the demo containers.
+
+### Enable Collector debug logging
+
+Edit `otel-collector-config.yaml` and change the log level:
+
+```yaml {4}
 service:
   telemetry:
     logs:
       level: debug
 ```
 
-Restart with rebuild to apply changes:
+Restart and rebuild to apply changes:
 
 ```bash
 docker compose up -d --build
 ```
 
-Check the OTel Collector logs for detailed export information:
+Then check the OTel Collector logs:
 
 ```bash
 docker compose logs otel-col
 ```
 
-Look for successful export messages or errors like connection failures and authentication issues.
-
-### Containers not starting
-
-If containers are failing to start, check the logs for the specific service:
-
-```bash
-docker compose logs <service-name>
-```
-
-Ensure Docker has adequate memory and no port conflicts exist.
-
-### Services not appearing in SigNoz
-
-- Verify your `OTLP_ENDPOINT` and `SIGNOZ_INGESTION_KEY` are set correctly
-- Check network connectivity to the SigNoz endpoint
-- Wait 2-3 minutes after starting the demo app (OpenTelemetry buffers data before sending)
+Look for export confirmation messages or errors like connection failures and authentication issues.
 
 </details>
 
+## Clean up
+
+When you're done exploring, stop and remove all containers:
+
+```bash
+docker compose down
+```
+
 ## Next Steps
 
-- Set up a [Redis dashboard](/docs/integrations/redis/#connect-redis) to monitor the database used by the demo app
-- Explore [Kafka monitoring](/docs/messaging-queues/kafka-overview/) to observe message queues in the demo app
-- Use [Infrastructure Monitoring](/docs/infrastructure-monitoring/overview/) to get a unified view of host and container performance
+Now that you have telemetry flowing, try these:
 
+- **Instrument your own app** — Set up [OpenTelemetry instrumentation](https://signoz.io/docs/instrumentation/) for your language and framework
+- **Send logs** — Collect and send [application logs](https://signoz.io/docs/logs-management/send-logs-to-signoz/) to SigNoz from your own services
+- **Send metrics** — Push [custom metrics](https://signoz.io/docs/metrics-management/send-metrics/) from your applications to SigNoz
+- **Set up alerts** — Create [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
+- **Monitor infrastructure** — Use [Infrastructure Monitoring](https://signoz.io/docs/infrastructure-monitoring/overview/) for a unified view of host and container performance
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/manage/administrator-guide/configuration/alertmanager.mdx
+++ b/data/docs/manage/administrator-guide/configuration/alertmanager.mdx
@@ -1,9 +1,10 @@
 ---
-date: 2025-04-15
+date: 2026-03-12
 id: alertmanager
-tags : [Self-Host]
+tags: [Self-Host]
 title: Alertmanager Configuration Guide
 description: Learn how to Configure SMTP server and External URL in Alertmanager in SigNoz as an administrator
+doc_type: howto
 ---
 SigNoz allows you to configure Alertmanager settings through environment variables. This guide covers how to configure SMTP server settings for email notifications and external URL settings for alert links.
 
@@ -56,6 +57,12 @@ The following environment variables can be set to configure SMTP settings:
 | `SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__TLS__MAX__VERSION` | Maximum TLS version (e.g., "TLS12", "TLS13") |
 
 Remember to consult your SMTP provider's documentation for specific requirements regarding ports, authentication, and TLS settings. When setting up email notifications, ensure these environment variables are properly configured in your deployment environment.
+
+<Admonition type="info">
+
+If you are using Helm to deploy SigNoz, you need to configure these variables as uppercase keys under the `signoz.env` block in your `values.yaml` (for example, `SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__SMARTHOST`).
+
+</Admonition>
 
 ## Common Alertmanager Configuration Scenarios
 

--- a/data/docs/manage/administrator-guide/configuration/smtp-email-invitations.mdx
+++ b/data/docs/manage/administrator-guide/configuration/smtp-email-invitations.mdx
@@ -1,9 +1,10 @@
 ---
-date: 2025-04-15
+date: 2026-03-12
 id: smpt-email-invitations
-tags : [Self-Host]
+tags: [Self-Host]
 title: Enable SMTP for Email Invitations
 description: Learn how to Configure SMTP for Email Invitations
+doc_type: howto
 ---
 
 SigNoz allows you to configure email settings for sending email Invitations. Depending on the version you're using, you can choose which variables to configure.
@@ -28,6 +29,14 @@ SigNoz allows you to configure email settings for sending email Invitations. Dep
 | **`SIGNOZ_EMAILING_SMTP_TLS_CA_FILE_PATH`**         | Path to CA file                                                                                                                            |
 | **`SIGNOZ_EMAILING_SMTP_TLS_KEY_FILE_PATH`**        | Path to Key file                                                                                                                           |
 | **`SIGNOZ_EMAILING_SMTP_TLS_CERT_FILE_PATH`**       | Path to the Certificate file                                                                                                               |
+
+<Admonition type="info">
+
+If you are using Helm to deploy SigNoz, you need to configure these variables as lowercase keys under the `signoz.env` block in your `values.yaml` (for example, `signoz_emailing_smtp_address`). 
+
+Also note that these variables **only** configure SMTP for **Email Invitations** and **Forgot Password** functionality. If you want to configure SMTP for alert notifications, you must separately configure Alertmanager. See [Alertmanager Configuration](https://signoz.io/docs/manage/administrator-guide/configuration/alertmanager/) and [Email Alert Channels](https://signoz.io/docs/alerts-management/notification-channel/email/).
+
+</Admonition>
 
 ## Versions less than or equal to 0.84.x
 


### PR DESCRIPTION
## Description

docs: revamp the Cloud Quickstart guide with the OTel Demo and clarify self-hosted Alertmanager email configuration

## Type of Change

- [x] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Other** – e.g. dependencies, scripts, CI

## Context & Screenshots

Various doc updates to address recent issues:
- Revamped the Cloud Quickstart guide
- Clarified self-hosted Alertmanager email configuration

## Checklist

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [x] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [x] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc
