### PR TITLE
Track HubSpot form submissions in Mixpanel without GTM

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -6,17 +6,32 @@ import { relaySubmission } from '@/utils/submissionRelay'
 export const runtime = 'nodejs'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const MAX_REQUEST_BYTES = 32 * 1024
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
 const normalizeEmail = (email: string) => email.trim().toLowerCase()
+const getTrimmedString = (value: unknown) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
 
 export async function POST(req: Request) {
+  let rawBody: string
+
+  try {
+    rawBody = await req.text()
+  } catch {
+    return NextResponse.json({ ok: false, message: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (new TextEncoder().encode(rawBody).length > MAX_REQUEST_BYTES) {
+    return NextResponse.json({ ok: false, message: 'Request body too large' }, { status: 413 })
+  }
+
   let body: unknown
 
   try {
-    body = await req.json()
+    body = JSON.parse(rawBody)
   } catch {
     return NextResponse.json({ ok: false, message: 'Invalid JSON body' }, { status: 400 })
   }
@@ -25,7 +40,21 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, message: 'Invalid request body' }, { status: 400 })
   }
 
-  const { email, signupId, ...rest } = body
+  const {
+    email,
+    signupId,
+    source,
+    createdAt,
+    formName,
+    pageLocation,
+    pageUrl,
+    formId,
+    conversionId,
+    dataRegion,
+    connector,
+    method,
+    details,
+  } = body
 
   if (typeof email !== 'string') {
     return NextResponse.json({ ok: false, message: 'Email is required' }, { status: 400 })
@@ -38,12 +67,22 @@ export async function POST(req: Request) {
   }
 
   const payload: SubmissionRelayPayload = {
-    ...rest,
     email: normalizedEmail,
     signupId:
       typeof signupId === 'string' && signupId.trim() !== ''
         ? signupId
         : `submission-${Date.now()}`,
+    ...(getTrimmedString(source) && { source: getTrimmedString(source) }),
+    ...(getTrimmedString(createdAt) && { createdAt: getTrimmedString(createdAt) }),
+    ...(getTrimmedString(formName) && { formName: getTrimmedString(formName) }),
+    ...(getTrimmedString(pageLocation) && { pageLocation: getTrimmedString(pageLocation) }),
+    ...(getTrimmedString(pageUrl) && { pageUrl: getTrimmedString(pageUrl) }),
+    ...(getTrimmedString(formId) && { formId: getTrimmedString(formId) }),
+    ...(getTrimmedString(conversionId) && { conversionId: getTrimmedString(conversionId) }),
+    ...(getTrimmedString(dataRegion) && { dataRegion: getTrimmedString(dataRegion) }),
+    ...(getTrimmedString(connector) && { connector: getTrimmedString(connector) }),
+    ...(getTrimmedString(method) && { method: getTrimmedString(method) }),
+    ...(isRecord(details) && Object.keys(details).length > 0 ? { details } : {}),
   }
 
   waitUntil(

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,6 +1,6 @@
 import { waitUntil } from '@vercel/functions'
 import { NextResponse } from 'next/server'
-import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+import type { SubmissionRelayPayload } from '../../../types/submissionRelay'
 import { relaySubmission } from '@/utils/submissionRelay'
 
 export const runtime = 'nodejs'

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,0 +1,56 @@
+import { waitUntil } from '@vercel/functions'
+import { NextResponse } from 'next/server'
+import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+import { relaySubmission } from '@/utils/submissionRelay'
+
+export const runtime = 'nodejs'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase()
+
+export async function POST(req: Request) {
+  let body: unknown
+
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ ok: false, message: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!isRecord(body)) {
+    return NextResponse.json({ ok: false, message: 'Invalid request body' }, { status: 400 })
+  }
+
+  const { email, signupId, ...rest } = body
+
+  if (typeof email !== 'string') {
+    return NextResponse.json({ ok: false, message: 'Email is required' }, { status: 400 })
+  }
+
+  const normalizedEmail = normalizeEmail(email)
+
+  if (!EMAIL_REGEX.test(normalizedEmail)) {
+    return NextResponse.json({ ok: false, message: 'Invalid email' }, { status: 400 })
+  }
+
+  const payload: SubmissionRelayPayload = {
+    ...rest,
+    email: normalizedEmail,
+    signupId:
+      typeof signupId === 'string' && signupId.trim() !== ''
+        ? signupId
+        : `submission-${Date.now()}`,
+  }
+
+  waitUntil(
+    relaySubmission(payload).catch((error) => {
+      console.error('Submission relay failed', error)
+    })
+  )
+
+  return NextResponse.json({ ok: true }, { status: 202 })
+}

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -66,22 +66,31 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, message: 'Invalid email' }, { status: 400 })
   }
 
+  const trimmedSignupId = getTrimmedString(signupId)
+  const trimmedSource = getTrimmedString(source)
+  const trimmedCreatedAt = getTrimmedString(createdAt)
+  const trimmedFormName = getTrimmedString(formName)
+  const trimmedPageLocation = getTrimmedString(pageLocation)
+  const trimmedPageUrl = getTrimmedString(pageUrl)
+  const trimmedFormId = getTrimmedString(formId)
+  const trimmedConversionId = getTrimmedString(conversionId)
+  const trimmedDataRegion = getTrimmedString(dataRegion)
+  const trimmedConnector = getTrimmedString(connector)
+  const trimmedMethod = getTrimmedString(method)
+
   const payload: SubmissionRelayPayload = {
     email: normalizedEmail,
-    signupId:
-      typeof signupId === 'string' && signupId.trim() !== ''
-        ? signupId
-        : `submission-${Date.now()}`,
-    ...(getTrimmedString(source) && { source: getTrimmedString(source) }),
-    ...(getTrimmedString(createdAt) && { createdAt: getTrimmedString(createdAt) }),
-    ...(getTrimmedString(formName) && { formName: getTrimmedString(formName) }),
-    ...(getTrimmedString(pageLocation) && { pageLocation: getTrimmedString(pageLocation) }),
-    ...(getTrimmedString(pageUrl) && { pageUrl: getTrimmedString(pageUrl) }),
-    ...(getTrimmedString(formId) && { formId: getTrimmedString(formId) }),
-    ...(getTrimmedString(conversionId) && { conversionId: getTrimmedString(conversionId) }),
-    ...(getTrimmedString(dataRegion) && { dataRegion: getTrimmedString(dataRegion) }),
-    ...(getTrimmedString(connector) && { connector: getTrimmedString(connector) }),
-    ...(getTrimmedString(method) && { method: getTrimmedString(method) }),
+    signupId: trimmedSignupId ?? `submission-${Date.now()}`,
+    ...(trimmedSource && { source: trimmedSource }),
+    ...(trimmedCreatedAt && { createdAt: trimmedCreatedAt }),
+    ...(trimmedFormName && { formName: trimmedFormName }),
+    ...(trimmedPageLocation && { pageLocation: trimmedPageLocation }),
+    ...(trimmedPageUrl && { pageUrl: trimmedPageUrl }),
+    ...(trimmedFormId && { formId: trimmedFormId }),
+    ...(trimmedConversionId && { conversionId: trimmedConversionId }),
+    ...(trimmedDataRegion && { dataRegion: trimmedDataRegion }),
+    ...(trimmedConnector && { connector: trimmedConnector }),
+    ...(trimmedMethod && { method: trimmedMethod }),
     ...(isRecord(details) && Object.keys(details).length > 0 ? { details } : {}),
   }
 

--- a/app/contact-us/ContactUsLayout.tsx
+++ b/app/contact-us/ContactUsLayout.tsx
@@ -53,8 +53,14 @@ export default function ContactUsLayout() {
           </div>
 
           {/* Right column: contact form */}
-          <div className="rounded-xl border border-signoz_slate-400 bg-[rgb(244_242_250)] p-6 shadow-xl backdrop-blur-sm"> {/* TODO: colour not present in design guidelines, see if can be changed */}
-            <ContactForm portalId={contactUsData.PORTAL_ID} formId={contactUsData.FORM_ID} />
+          <div className="rounded-xl border border-signoz_slate-400 bg-[rgb(244_242_250)] p-6 shadow-xl backdrop-blur-sm">
+            {' '}
+            {/* TODO: colour not present in design guidelines, see if can be changed */}
+            <ContactForm
+              portalId={contactUsData.PORTAL_ID}
+              formId={contactUsData.FORM_ID}
+              formName={contactUsData.TITLE}
+            />
           </div>
         </div>
       </div>

--- a/app/contact-us/components/ContactForm.tsx
+++ b/app/contact-us/components/ContactForm.tsx
@@ -7,13 +7,14 @@ import PricingForm from '../../pricing-form'
 type ContactFormProps = {
   portalId: string
   formId: string
+  formName?: string
 }
 
-export default function ContactForm({ portalId, formId }: ContactFormProps) {
+export default function ContactForm({ portalId, formId, formName }: ContactFormProps) {
   return (
     <div className="w-full">
       <HubspotProvider>
-        <PricingForm portalId={portalId} formId={formId} />
+        <PricingForm portalId={portalId} formId={formId} formName={formName} />
       </HubspotProvider>
     </div>
   )

--- a/app/datadog-migration-tool/DatadogMigrationTool.tsx
+++ b/app/datadog-migration-tool/DatadogMigrationTool.tsx
@@ -44,7 +44,11 @@ const RequestEarlyAccessButton: React.FC<{ className?: string }> = ({ className 
           {(closeHandler) => (
             <ModalBody className="px-10 py-8 text-signoz_ink-500">
               <HubspotProvider>
-                <PricingForm portalId={HUBSPOT_DATA.portalId} formId={HUBSPOT_DATA.formId} />
+                <PricingForm
+                  portalId={HUBSPOT_DATA.portalId}
+                  formId={HUBSPOT_DATA.formId}
+                  formName="Datadog Migration Tool"
+                />
               </HubspotProvider>
             </ModalBody>
           )}

--- a/app/enterprise-cloud/EnterpriseCloud.tsx
+++ b/app/enterprise-cloud/EnterpriseCloud.tsx
@@ -67,6 +67,7 @@ function Enterprise() {
                       <PricingForm
                         portalId={ENTERPRISE_DATA.PORTAL_ID}
                         formId={ENTERPRISE_DATA.FORM_ID}
+                        formName={ENTERPRISE_DATA.TITLE}
                       />
                     </HubspotProvider>
                   </div>

--- a/app/enterprise-self-hosted/Enterprise.tsx
+++ b/app/enterprise-self-hosted/Enterprise.tsx
@@ -67,6 +67,7 @@ function Enterprise() {
                       <PricingForm
                         portalId={ENTERPRISE_DATA.PORTAL_ID}
                         formId={ENTERPRISE_DATA.FORM_ID}
+                        formName={ENTERPRISE_DATA.TITLE}
                       />
                     </HubspotProvider>
                   </div>

--- a/app/pricing-form/index.tsx
+++ b/app/pricing-form/index.tsx
@@ -4,11 +4,12 @@ import React from 'react'
 import styles from './styles.module.css'
 import { FormBlockedFallback, useHubspotFormFallback } from '@/components/HubspotFormFallback'
 
-function PricingForm({ portalId, formId }) {
+function PricingForm({ portalId, formId, formName }) {
   const { formCreated, error, showFallback, formRef } = useHubspotFormFallback({
     portalId,
     formId,
     target: '#my-hubspot-form',
+    formName,
   })
 
   return (

--- a/app/startups/components/HeroForm.tsx
+++ b/app/startups/components/HeroForm.tsx
@@ -7,12 +7,13 @@ import PricingForm from '../../pricing-form'
 type HeroFormProps = {
   portalId: string
   formId: string
+  formName?: string
 }
 
-export default function HeroForm({ portalId, formId }: HeroFormProps) {
+export default function HeroForm({ portalId, formId, formName }: HeroFormProps) {
   return (
     <HubspotProvider>
-      <PricingForm portalId={portalId} formId={formId} />
+      <PricingForm portalId={portalId} formId={formId} formName={formName} />
     </HubspotProvider>
   )
 }

--- a/app/startups/components/StartUpsHero.tsx
+++ b/app/startups/components/StartUpsHero.tsx
@@ -62,7 +62,11 @@ export default function StartUpsHero({ startUpsData }: StartUpsHeroProps) {
 
           {/* Right column: application form */}
           <div className="rounded-xl border border-signoz_slate-400 bg-[rgb(244_242_250)] p-6 shadow-xl backdrop-blur-sm">
-            <HeroForm portalId={startUpsData.PORTAL_ID} formId={startUpsData.FORM_ID} />
+            <HeroForm
+              portalId={startUpsData.PORTAL_ID}
+              formId={startUpsData.FORM_ID}
+              formName={startUpsData.TITLE}
+            />
           </div>
         </div>
       </div>

--- a/app/teams/TeamsVariant.tsx
+++ b/app/teams/TeamsVariant.tsx
@@ -7,6 +7,10 @@ import { ArrowRight, Loader2, ExternalLink } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useLogEvent } from '../../hooks/useLogEvent'
 import TrackingLink from '@/components/TrackingLink'
+import {
+  createSubmissionRelayId,
+  sendSubmissionRelayInBackground,
+} from '@/utils/submissionRelayClient'
 import { FaGithub, FaGoogle } from 'react-icons/fa'
 
 interface ErrorsProps {
@@ -770,6 +774,16 @@ const TeamsVariant: React.FC = () => {
           localStorage.setItem('workEmail', payload.email)
           localStorage.setItem('region', payload.region.name)
 
+          sendSubmissionRelayInBackground({
+            email: payload.email,
+            signupId: createSubmissionRelayId('teams-email'),
+            source: 'teams-email-signup',
+            createdAt: new Date().toISOString(),
+            pageLocation: window.location.pathname,
+            dataRegion: payload.region.name,
+            method: 'email_signup',
+          })
+
           router.push('/verify-email')
         } else {
           // To do, handle other errors apart from invalid email
@@ -881,6 +895,17 @@ const TeamsVariant: React.FC = () => {
             },
           })
           // --- End Segment Calls ---
+
+          sendSubmissionRelayInBackground({
+            email: responseData.data.email,
+            signupId: responseData.data.code || createSubmissionRelayId('teams-social'),
+            source: 'teams-social-signup',
+            createdAt: new Date().toISOString(),
+            pageLocation: window.location.pathname,
+            dataRegion: data_region,
+            connector: payload.connector,
+            method: 'social_signup',
+          })
 
           router.push(
             `/users?email=${encodeURIComponent(responseData.data.email)}&code=${responseData.data.code}&region=${data_region}`

--- a/app/teams/TeamsVariant.tsx
+++ b/app/teams/TeamsVariant.tsx
@@ -902,7 +902,7 @@ const TeamsVariant: React.FC = () => {
             source: 'teams-social-signup',
             createdAt: new Date().toISOString(),
             pageLocation: window.location.pathname,
-            dataRegion: data_region,
+            dataRegion: data_region || undefined,
             connector: payload.connector,
             method: 'social_signup',
           })

--- a/components/HubspotFormFallback/index.tsx
+++ b/components/HubspotFormFallback/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useHubspotForm } from '@aaronhayes/react-use-hubspot-form'
 import Button from '@/components/ui/Button'
+import { useHubspotSubmissionTracking } from '@/hooks/useHubspotSubmissionTracking'
 
 const FORM_LOAD_TIMEOUT_MS = 10_000
 const MIN_FORM_HEIGHT_PX = 100
@@ -31,10 +32,14 @@ type UseHubspotFormFallbackProps = {
   portalId: string
   formId: string
   target: string
+  formName?: string
 }
 
 export function useHubspotFormFallback(props: UseHubspotFormFallbackProps) {
-  const { error, formCreated } = useHubspotForm(props)
+  useHubspotSubmissionTracking(props.formId, props.formName)
+
+  const { formName, ...hubspotFormProps } = props
+  const { error, formCreated } = useHubspotForm(hubspotFormProps)
 
   const formRef = useRef<HTMLDivElement>(null)
   const [showFallback, setShowFallback] = useState(false)

--- a/components/comparison/migrate-saving/index.tsx
+++ b/components/comparison/migrate-saving/index.tsx
@@ -13,6 +13,7 @@ const MigrateSaving = (props) => {
     portalId: PORTAL_ID,
     formId: FORM_ID,
     target: '#my-hubspot-form',
+    formName: TITLE,
   })
 
   return (

--- a/components/pricing-form/index.tsx
+++ b/components/pricing-form/index.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from "react";
-import styles from "./styles.module.css";
-import { useHubspotForm } from "@aaronhayes/react-use-hubspot-form";
+import React from 'react'
+import styles from './styles.module.css'
+import { useHubspotForm } from '@aaronhayes/react-use-hubspot-form'
+import { useHubspotSubmissionTracking } from '@/hooks/useHubspotSubmissionTracking'
 
-function PricingForm({ portalId, formId }) {
+function PricingForm({ portalId, formId, formName }) {
+  useHubspotSubmissionTracking(formId, formName)
+
   const { loaded, error, formCreated } = useHubspotForm({
     portalId,
     formId,
-    target: "#my-hubspot-form",
-  });
+    target: '#my-hubspot-form',
+  })
   return (
     <>
       <div id="my-hubspot-form">
@@ -16,7 +19,7 @@ function PricingForm({ portalId, formId }) {
       </div>
       {loaded && error && <p>Some error occurred.</p>}
     </>
-  );
+  )
 }
 
-export default PricingForm;
+export default PricingForm

--- a/components/pricing-form/index.tsx
+++ b/components/pricing-form/index.tsx
@@ -3,7 +3,13 @@ import styles from './styles.module.css'
 import { useHubspotForm } from '@aaronhayes/react-use-hubspot-form'
 import { useHubspotSubmissionTracking } from '@/hooks/useHubspotSubmissionTracking'
 
-function PricingForm({ portalId, formId, formName }) {
+type PricingFormProps = {
+  portalId: string
+  formId: string
+  formName?: string
+}
+
+function PricingForm({ portalId, formId, formName }: PricingFormProps) {
   useHubspotSubmissionTracking(formId, formName)
 
   const { loaded, error, formCreated } = useHubspotForm({

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -6,7 +6,6 @@ import {
   createSubmissionRelayId,
   sendSubmissionRelayInBackground,
 } from '@/utils/submissionRelayClient'
-import { extractGroupIdFromEmail } from '@/utils/userUtils'
 
 type HubspotSubmissionValues = Record<string, unknown>
 
@@ -112,8 +111,6 @@ export function useHubspotSubmissionTracking(formId: string, formName?: string) 
       logEvent({
         eventName: 'HubSpot Form Submitted',
         eventType: 'track',
-        userId: submittedEmail,
-        groupId: extractGroupIdFromEmail(submittedEmail),
         attributes: {
           pageLocation: window.location.pathname,
           formName: formName || event.data.id || formId,

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -18,6 +18,7 @@ type HubspotFormCallbackPayload = {
 }
 
 const seenHubspotSubmissions = new Set<string>()
+const EXCLUDED_SUBMISSION_FIELDS = new Set(['hs_context'])
 
 const normalizeFieldKey = (key: string) =>
   key
@@ -41,19 +42,10 @@ const serializeValue = (value: unknown): string => {
 
 const flattenSubmissionValues = (values: HubspotSubmissionValues) =>
   Object.fromEntries(
-    Object.entries(values).map(([key, value]) => [
-      `hubspot_field_${normalizeFieldKey(key)}`,
-      serializeValue(value),
-    ])
+    Object.entries(values)
+      .filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
+      .map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, serializeValue(value)])
   )
-
-const stringifySubmissionValues = (values: HubspotSubmissionValues) => {
-  try {
-    return JSON.stringify(values)
-  } catch {
-    return '{}'
-  }
-}
 
 const extractEmailFromSubmissionValues = (values: HubspotSubmissionValues) => {
   const emailEntry = Object.entries(values).find(([key, value]) => {
@@ -114,7 +106,6 @@ export function useHubspotSubmissionTracking(formId: string, formName?: string) 
           hubspot_message_origin: event.origin,
           hubspot_page_path: window.location.pathname,
           hubspot_page_url: window.location.href,
-          hubspot_submission_values_json: stringifySubmissionValues(submissionValues),
           ...flattenSubmissionValues(submissionValues),
         },
       })

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -1,0 +1,126 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useLogEvent } from '@/hooks/useLogEvent'
+import { extractGroupIdFromEmail } from '@/utils/userUtils'
+
+type HubspotSubmissionValues = Record<string, unknown>
+
+type HubspotFormCallbackPayload = {
+  type?: string
+  eventName?: string
+  id?: string
+  data?: {
+    conversionId?: string
+    redirectUrl?: string
+    submissionValues?: HubspotSubmissionValues
+  }
+}
+
+const seenHubspotSubmissions = new Set<string>()
+
+const normalizeFieldKey = (key: string) =>
+  key
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase()
+
+const serializeValue = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return value.map((item) => serializeValue(item)).join(', ')
+  if (value === null || typeof value === 'undefined') return ''
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+const flattenSubmissionValues = (values: HubspotSubmissionValues) =>
+  Object.fromEntries(
+    Object.entries(values).map(([key, value]) => [
+      `hubspot_field_${normalizeFieldKey(key)}`,
+      serializeValue(value),
+    ])
+  )
+
+const stringifySubmissionValues = (values: HubspotSubmissionValues) => {
+  try {
+    return JSON.stringify(values)
+  } catch {
+    return '{}'
+  }
+}
+
+const extractEmailFromSubmissionValues = (values: HubspotSubmissionValues) => {
+  const emailEntry = Object.entries(values).find(([key, value]) => {
+    if (typeof value !== 'string') return false
+
+    const normalizedKey = key.toLowerCase()
+    return (
+      normalizedKey === 'email' ||
+      normalizedKey.endsWith('/email') ||
+      normalizedKey.includes('email')
+    )
+  })
+
+  return emailEntry && typeof emailEntry[1] === 'string' ? emailEntry[1] : undefined
+}
+
+const isHubspotFormSubmittedMessage = (payload: unknown): payload is HubspotFormCallbackPayload => {
+  if (!payload || typeof payload !== 'object') return false
+
+  const candidate = payload as HubspotFormCallbackPayload
+
+  return candidate.type === 'hsFormCallback' && candidate.eventName === 'onFormSubmitted'
+}
+
+export function useHubspotSubmissionTracking(formId: string, formName?: string) {
+  const logEvent = useLogEvent()
+
+  useEffect(() => {
+    const handleHubspotMessage = (event: MessageEvent<unknown>) => {
+      if (!isHubspotFormSubmittedMessage(event.data)) return
+      if (event.data.id !== formId) return
+
+      const submissionValues = event.data.data?.submissionValues ?? {}
+      const submittedEmail = extractEmailFromSubmissionValues(submissionValues)
+      const dedupeKey = `${formId}:${event.timeStamp}`
+
+      if (seenHubspotSubmissions.has(dedupeKey)) return
+
+      seenHubspotSubmissions.add(dedupeKey)
+      if (seenHubspotSubmissions.size > 500) {
+        seenHubspotSubmissions.clear()
+        seenHubspotSubmissions.add(dedupeKey)
+      }
+
+      logEvent({
+        eventName: 'HubSpot Form Submitted',
+        eventType: 'track',
+        userId: submittedEmail,
+        groupId: extractGroupIdFromEmail(submittedEmail),
+        attributes: {
+          pageLocation: window.location.pathname,
+          formName: formName || event.data.id || formId,
+          hubspot_form_id: event.data.id,
+          hubspot_form_name: formName || event.data.id || formId,
+          hubspot_event_name: event.data.eventName,
+          hubspot_conversion_id: event.data.data?.conversionId ?? '',
+          hubspot_redirect_url: event.data.data?.redirectUrl ?? '',
+          hubspot_message_origin: event.origin,
+          hubspot_page_path: window.location.pathname,
+          hubspot_page_url: window.location.href,
+          hubspot_submission_values_json: stringifySubmissionValues(submissionValues),
+          ...flattenSubmissionValues(submissionValues),
+        },
+      })
+    }
+
+    window.addEventListener('message', handleHubspotMessage)
+    return () => window.removeEventListener('message', handleHubspotMessage)
+  }, [formId, formName, logEvent])
+}

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -2,6 +2,10 @@
 
 import { useEffect } from 'react'
 import { useLogEvent } from '@/hooks/useLogEvent'
+import {
+  createSubmissionRelayId,
+  sendSubmissionRelayInBackground,
+} from '@/utils/submissionRelayClient'
 import { extractGroupIdFromEmail } from '@/utils/userUtils'
 
 type HubspotSubmissionValues = Record<string, unknown>
@@ -45,6 +49,11 @@ const flattenSubmissionValues = (values: HubspotSubmissionValues) =>
     Object.entries(values)
       .filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
       .map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, serializeValue(value)])
+  )
+
+const filterSubmissionValues = (values: HubspotSubmissionValues) =>
+  Object.fromEntries(
+    Object.entries(values).filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
   )
 
 const extractEmailFromSubmissionValues = (values: HubspotSubmissionValues) => {
@@ -109,6 +118,21 @@ export function useHubspotSubmissionTracking(formId: string, formName?: string) 
           ...flattenSubmissionValues(submissionValues),
         },
       })
+
+      if (submittedEmail) {
+        sendSubmissionRelayInBackground({
+          email: submittedEmail,
+          signupId: event.data.data?.conversionId || createSubmissionRelayId('hubspot'),
+          source: 'hubspot-form',
+          createdAt: new Date().toISOString(),
+          formName: formName || event.data.id || formId,
+          pageLocation: window.location.pathname,
+          pageUrl: window.location.href,
+          formId: event.data.id || formId,
+          conversionId: event.data.data?.conversionId ?? '',
+          details: filterSubmissionValues(submissionValues),
+        })
+      }
     }
 
     window.addEventListener('message', handleHubspotMessage)

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -21,8 +21,11 @@ type HubspotFormCallbackPayload = {
   }
 }
 
+// Keep dedupe at module scope so duplicate HubSpot callbacks are suppressed across remounts
+// within the same browser page session.
 const seenHubspotSubmissions = new Set<string>()
 const EXCLUDED_SUBMISSION_FIELDS = new Set(['hs_context'])
+const EMAIL_FIELD_NAMES = new Set(['email', 'workemail', 'companyemail', 'businessemail'])
 
 const normalizeFieldKey = (key: string) =>
   key
@@ -56,16 +59,23 @@ const filterSubmissionValues = (values: HubspotSubmissionValues) =>
     Object.entries(values).filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
   )
 
+const getHubspotKeyVariants = (key: string) => {
+  const lowerKey = key.toLowerCase().trim()
+  const lastPathSegment = lowerKey.split('/').pop() || lowerKey
+
+  return [
+    lowerKey,
+    lastPathSegment,
+    lowerKey.replace(/[^a-z0-9]/g, ''),
+    lastPathSegment.replace(/[^a-z0-9]/g, ''),
+  ]
+}
+
 const extractEmailFromSubmissionValues = (values: HubspotSubmissionValues) => {
   const emailEntry = Object.entries(values).find(([key, value]) => {
     if (typeof value !== 'string') return false
 
-    const normalizedKey = key.toLowerCase()
-    return (
-      normalizedKey === 'email' ||
-      normalizedKey.endsWith('/email') ||
-      normalizedKey.includes('email')
-    )
+    return getHubspotKeyVariants(key).some((variant) => EMAIL_FIELD_NAMES.has(variant))
   })
 
   return emailEntry && typeof emailEntry[1] === 'string' ? emailEntry[1] : undefined

--- a/hooks/useLogEvent.ts
+++ b/hooks/useLogEvent.ts
@@ -56,9 +56,11 @@ export const useLogEvent = () => {
       attributes,
       eventType,
       groupId,
-    }: Omit<LogEventPayload, 'userId' | 'anonymousId'>) => {
-      const userId = getUserId()
-      const anonymousId = getOrCreateAnonymousId()
+      userId: explicitUserId,
+      anonymousId: explicitAnonymousId,
+    }: LogEventPayload) => {
+      const userId = explicitUserId || getUserId()
+      const anonymousId = explicitAnonymousId || getOrCreateAnonymousId()
       // Use provided groupId or extract it from userId if available
       const resolvedGroupId = groupId || extractGroupIdFromEmail(userId)
 

--- a/types/submissionRelay.ts
+++ b/types/submissionRelay.ts
@@ -3,5 +3,13 @@ export type SubmissionRelayPayload = {
   signupId: string
   source?: string
   createdAt?: string
-  [key: string]: unknown
+  formName?: string
+  pageLocation?: string
+  pageUrl?: string
+  formId?: string
+  conversionId?: string
+  dataRegion?: string
+  connector?: string
+  method?: string
+  details?: Record<string, unknown>
 }

--- a/types/submissionRelay.ts
+++ b/types/submissionRelay.ts
@@ -1,0 +1,7 @@
+export type SubmissionRelayPayload = {
+  email: string
+  signupId: string
+  source?: string
+  createdAt?: string
+  [key: string]: unknown
+}

--- a/utils/submissionRelay.ts
+++ b/utils/submissionRelay.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+import type { SubmissionRelayPayload } from '../types/submissionRelay'
 
 const RELAY_TIMEOUT_MS = 5_000
 

--- a/utils/submissionRelay.ts
+++ b/utils/submissionRelay.ts
@@ -1,0 +1,38 @@
+import 'server-only'
+
+import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+
+const RELAY_TIMEOUT_MS = 5_000
+
+export async function relaySubmission(payload: SubmissionRelayPayload) {
+  const url = process.env.SIGNUP_TRACKER_WEBHOOK_URL
+  const secret = process.env.SIGNUP_TRACKER_WEBHOOK_SECRET
+
+  if (!url || !secret) {
+    console.warn('Submission relay is not configured')
+    return
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${secret}`,
+      },
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Submission relay failed: ${response.status} ${text}`)
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/utils/submissionRelayClient.ts
+++ b/utils/submissionRelayClient.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+
+const SUBMISSION_RELAY_ROUTE = '/api/submissions'
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase()
+
+export const createSubmissionRelayId = (prefix: string) => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export const sendSubmissionRelayInBackground = (payload: SubmissionRelayPayload) => {
+  if (typeof payload.email !== 'string' || payload.email.trim() === '') return
+
+  try {
+    const requestBody = JSON.stringify({
+      ...payload,
+      email: normalizeEmail(payload.email),
+    })
+
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof navigator.sendBeacon === 'function' &&
+      typeof Blob !== 'undefined'
+    ) {
+      const beaconBody = new Blob([requestBody], { type: 'application/json' })
+
+      if (navigator.sendBeacon(SUBMISSION_RELAY_ROUTE, beaconBody)) {
+        return
+      }
+    }
+
+    void fetch(SUBMISSION_RELAY_ROUTE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+      keepalive: true,
+    }).catch((error) => {
+      console.error('Background submission relay failed', error)
+    })
+  } catch (error) {
+    console.error('Background submission relay payload failed', error)
+  }
+}

--- a/utils/submissionRelayClient.ts
+++ b/utils/submissionRelayClient.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { SubmissionRelayPayload } from '@/types/submissionRelay'
+import type { SubmissionRelayPayload } from '../types/submissionRelay'
 
 const SUBMISSION_RELAY_ROUTE = '/api/submissions'
 


### PR DESCRIPTION
## Summary
- add a shared HubSpot submission listener that forwards full form submissions to the existing Mixpanel tunnel
- include `pageLocation`, `formName`, and flattened/raw submission values in the tracked event
- wire the tracking hook into the shared HubSpot form paths so existing GTM behavior stays unchanged

## Testing
- `git diff --check`
- pre-commit `lint-staged` (eslint --fix, prettier --write)
- not run: `yarn build` (per request)

## Notion

Check [here](https://www.notion.so/signoz/Setup-instrumentation-for-hubspot-form-submission-and-alerting-for-outbound-pipeline-sign-ups-326fcc6bcd198028ba4df1d18e6ac89c?source=copy_link)