### PR TITLE
docs(logs-explorer): update frontmatter date and editorial fixes

### DIFF
--- a/data/docs/product-features/logs-explorer.mdx
+++ b/data/docs/product-features/logs-explorer.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2024-06-06
+date: 2026-03-16
 id: logs-explorer
 
 title: Logs Explorer in SigNoz
@@ -185,19 +185,9 @@ This shows the complete body of the log in `JSON` format by default. Once you to
 
 **Attributes**
 
-This the attributes of the logs in a tabular format showing the attribute name and its value.
+This shows the attributes of the logs in a tabular format with the attribute name and its value.
 
 The following features are available in this section:
-
-**Pin an attribute**
-
-You can pin an attribute using the pin icon shown on the left side of the attribute name. The pinned attribute will be shown at the top when you open a new log line.
-
-<figure data-zoomable align='center'>
-    <img src="/img/docs/product-features/logs-explorer/logs-explorer-log-details-overview-2.gif" alt="Pin an attribute"/>
-    <figcaption><i> Pin an attribute </i></figcaption>
-</figure>
-
 
 **Search Attribute**
 
@@ -205,7 +195,7 @@ You can search for an attribute available in your log using the search bar.
 
 <figure data-zoomable align='center'>
     <img src="/img/docs/product-features/logs-explorer/logs-explorer-log-details-overview-3.gif" alt="Search an attribute"/>
-    <figcaption><i> Pin an attribute </i></figcaption>
+    <figcaption><i> Search an attribute </i></figcaption>
 </figure>
 
 
@@ -213,7 +203,7 @@ You can search for an attribute available in your log using the search bar.
 
 Using this, you can instantly filter the logs based on a particular attribute and its value using the IN operator.
 
-For example, if the attribute is `container_id` and it's value is `debian` then using Filter for Value will create a filter `container_id IN debian`. This will list the logs where the `container_id` attribute is `debian`.
+For example, if the attribute is `container_id` and its value is `debian` then using Filter for Value will create a filter `container_id IN debian`. This will list the logs where the `container_id` attribute is `debian`.
 
 <figure data-zoomable align='center'>
     <img src="/img/docs/product-features/logs-explorer/logs-explorer-log-details-overview-4.gif" alt="Filter for Value"/>
@@ -226,7 +216,7 @@ For example, if the attribute is `container_id` and it's value is `debian` then 
 
 Using this, you can instantly filter the logs based on a particular attribute and its value using the NOT_IN operator.
 
-For example, if the attribute is `container_id` and it's value is `debian` then using Filter out Value will create a filter `container_id NOT_IN debian`. This will list the logs where the `container_id` attribute is not `debian`.
+For example, if the attribute is `container_id` and its value is `debian` then using Filter out Value will create a filter `container_id NOT_IN debian`. This will list the logs where the `container_id` attribute is not `debian`.
 
 <figure data-zoomable align='center'>
     <img src="/img/docs/product-features/logs-explorer/logs-explorer-log-details-overview-5.gif" alt="Filter out Value"/>
@@ -320,6 +310,5 @@ The Live Logs can be paused to stop the real-time feed. This allows users to scr
     <img src="/img/docs/product-features/logs-explorer/logs-explorer-live-view-3.gif" alt="Pause and Resume in Live view in Logs Explorer"/>
     <figcaption><i>Pause and Resume Live view in Logs Explorer</i></figcaption>
 </figure>
-
 
 


### PR DESCRIPTION
### Motivation

- Bring the Logs Explorer documentation up to date by updating the frontmatter `date` and fixing small copy issues for clarity and correctness.
- Remove stale or redundant content (a pinned-attribute demo block) to match the current UI behavior shown elsewhere in the docs.
- Correct captions and possessive usage to improve consistency across the page.

### Description

- Updated the frontmatter `date` in `data/docs/product-features/logs-explorer.mdx` from `2024-06-06` to `2026-03-16`.
- Replaced the sentence `This the attributes of the logs...` with `This shows the attributes of the logs...` to fix grammar.
- Replaced instances of `it's value` with the correct possessive `its value` for attribute examples.
- Removed the `Pin an attribute` subsection and updated the figcaption from `Pin an attribute` to `Search an attribute` to reflect the current content arrangement.

### Testing

- No automated tests were run as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82c63c30c8326948c1dbf824911ec)