### PR TITLE
fix: shuffle quiz options, show scores as X/3

### DIFF
--- a/app/sre-skill-decay-index/components/QuizSection.tsx
+++ b/app/sre-skill-decay-index/components/QuizSection.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from 'react'
 import Image from 'next/image'
-import { Category, QuizQuestion } from '../types'
+import { Category, QuizOption, QuizQuestion } from '../types'
 import { OLLY_IMAGES } from '../data/constants'
 
 interface QuizSectionProps {
@@ -11,6 +12,17 @@ interface QuizSectionProps {
 
 const OPTION_KEYS = ['A', 'B', 'C', 'D']
 
+function shuffleOptions(options: QuizOption[], seed: number): QuizOption[] {
+  const shuffled = [...options]
+  let s = seed
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    const j = s % (i + 1)
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled
+}
+
 export default function QuizSection({
   currentQuestion,
   totalQuestions,
@@ -19,6 +31,10 @@ export default function QuizSection({
 }: QuizSectionProps) {
   const progress = (currentQuestion / totalQuestions) * 100
   const ollyData = OLLY_IMAGES[question.olly]
+  const shuffledOptions = useMemo(
+    () => shuffleOptions(question.options, currentQuestion + 1),
+    [question.options, currentQuestion]
+  )
 
   return (
     <section className="pb-[120px] pt-20">
@@ -89,7 +105,7 @@ export default function QuizSection({
 
           {/* Options */}
           <div className="flex flex-col gap-3">
-            {question.options.map((option, i) => (
+            {shuffledOptions.map((option, i) => (
               <button
                 key={i}
                 onClick={() => onAnswer(option.score, option.category)}

--- a/app/sre-skill-decay-index/components/SkillBreakdownChart.tsx
+++ b/app/sre-skill-decay-index/components/SkillBreakdownChart.tsx
@@ -25,7 +25,7 @@ export default function SkillBreakdownChart({ breakdown }: SkillBreakdownChartPr
           <div className="mb-2 flex items-center justify-between">
             <span className="text-[13px] font-medium">{item.label}</span>
             <span className="font-[family-name:var(--font-jetbrains)] text-[13px] font-semibold">
-              {item.average.toFixed(1)}/10
+              {(item.score / item.count).toFixed(1)}/3
             </span>
           </div>
           <div className="h-[6px] overflow-hidden rounded-[3px] bg-[var(--surface-2)]">


### PR DESCRIPTION
## Summary
- Shuffle answer options per question so the best answer isn't always option A (uses a deterministic seeded shuffle)
- Display skill breakdown scores as X/3 instead of X/10 for clarity

## Test plan
- [ ] Complete the quiz and verify options appear in different order per question
- [ ] Verify the same question always shows the same shuffled order (deterministic)
- [ ] Check results page skill breakdown shows scores as X/3 format
- [ ] Verify scoring still works correctly regardless of option position

🤖 Generated with [Claude Code](https://claude.com/claude-code)