### PR TITLE
feat: add why OpenTelemetry is needed landing page

### DIFF
--- a/app/opentelemetry/why-is-opentelemetry-needed/WhyOpenTelemetryNeededPage.tsx
+++ b/app/opentelemetry/why-is-opentelemetry-needed/WhyOpenTelemetryNeededPage.tsx
@@ -1,0 +1,333 @@
+'use client'
+
+import React from 'react'
+import {
+  ArrowRight,
+  BookOpen,
+  Boxes,
+  Gauge,
+  LockOpen,
+  Network,
+  ShieldCheck,
+  Waypoints,
+  Workflow,
+} from 'lucide-react'
+import Button from '@/components/ui/Button'
+import TrackingLink from '@/components/TrackingLink'
+import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
+import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
+import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
+import IconTitleDescriptionCardGrid, {
+  type IconTitleDescriptionCardData,
+} from '@/shared/components/molecules/FeaturePages/IconTitleDescriptionCard'
+import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
+import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
+import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
+
+const heroButtons = [
+  {
+    text: 'Start free with SigNoz',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: 'flex-center',
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Why OpenTelemetry Hero Start Trial',
+      clickLocation: 'Why OpenTelemetry Hero',
+      clickText: 'Start free with SigNoz',
+    },
+  },
+  {
+    text: 'Read OTel docs',
+    href: '/docs/instrumentation/overview/',
+    variant: 'secondary' as const,
+    className: 'flex-center',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Why OpenTelemetry Hero Docs',
+      clickLocation: 'Why OpenTelemetry Hero',
+      clickText: 'Read OTel docs',
+    },
+  },
+]
+
+const benefitCards = [
+  {
+    icon: <Workflow className="h-5 w-5" />,
+    title: 'One instrumentation approach',
+    description:
+      'Use one open standard for traces, metrics, and logs instead of stitching together different agents and data models.',
+  },
+  {
+    icon: <LockOpen className="h-5 w-5" />,
+    title: 'Portable telemetry',
+    description:
+      'Instrument once and keep the freedom to change vendors, storage backends, or deployment models without rewriting code.',
+  },
+  {
+    icon: <Waypoints className="h-5 w-5" />,
+    title: 'Shared context across signals',
+    description:
+      'Correlate requests, spans, logs, and service metadata using the same conventions so incidents are easier to debug.',
+  },
+]
+
+const painCards: IconTitleDescriptionCardData[] = [
+  {
+    icon: <Boxes className="h-5 w-5" />,
+    iconText: 'Fragmented stack',
+    title: 'Different tools collect different parts of the story',
+    description:
+      'Teams often end up with one agent for APM, another for logs, and a separate pipeline for metrics. That creates duplicated effort and inconsistent telemetry.',
+  },
+  {
+    icon: <LockOpen className="h-5 w-5" />,
+    iconText: 'Vendor lock-in',
+    title: 'Proprietary agents tie instrumentation to a single backend',
+    description:
+      'If the pricing, roadmap, or deployment model stops fitting, migration becomes a code project instead of a configuration change.',
+  },
+  {
+    icon: <Network className="h-5 w-5" />,
+    iconText: 'Distributed systems',
+    title: 'Modern architectures need context propagation by default',
+    description:
+      'Microservices, queues, serverless functions, and external APIs all add hops. Without a shared standard, tracing those hops is brittle and incomplete.',
+  },
+  {
+    icon: <ShieldCheck className="h-5 w-5" />,
+    iconText: 'Platform governance',
+    title: 'Teams need guardrails without blocking developer velocity',
+    description:
+      'OpenTelemetry lets platform teams standardize resource attributes, semantic conventions, and collection paths while letting app teams move quickly.',
+  },
+]
+
+const outcomeCards: IconTitleDescriptionCardData[] = [
+  {
+    icon: <Gauge className="h-5 w-5" />,
+    iconText: 'Faster response',
+    title: 'Lower MTTR during incidents',
+    description:
+      'Consistent spans, service names, and attributes make it easier to move from a latency spike to the exact request path and related logs.',
+  },
+  {
+    icon: <Workflow className="h-5 w-5" />,
+    iconText: 'Cleaner operations',
+    title: 'A dedicated collection layer',
+    description:
+      'The OpenTelemetry Collector gives you a central place to batch, enrich, filter, and route telemetry without touching application code.',
+  },
+  {
+    icon: <Boxes className="h-5 w-5" />,
+    iconText: 'Future-proofing',
+    title: 'A better long-term observability foundation',
+    description:
+      'When your stack changes, the telemetry model does not have to. That makes experimentation, cost control, and backend changes much less disruptive.',
+  },
+  {
+    icon: <Waypoints className="h-5 w-5" />,
+    iconText: 'Team alignment',
+    title: 'A common language for developers and platform teams',
+    description:
+      'Standard resource attributes and semantic conventions reduce ambiguity, speed up onboarding, and improve cross-team debugging.',
+  },
+]
+
+const workflowSteps = [
+  'Developers instrument services once with OpenTelemetry SDKs or auto-instrumentation.',
+  'Telemetry flows into the OpenTelemetry Collector, where routing and processing are controlled centrally.',
+  'Traces, metrics, and logs stay correlated because they share the same context and conventions.',
+  'You can send that telemetry to SigNoz now and still keep the option to evolve your backend strategy later.',
+]
+
+export default function WhyOpenTelemetryNeededPage() {
+  return (
+    <FeaturePageLayout>
+      <FeaturePageHeader
+        title={
+          <>
+            Why OpenTelemetry Is Needed <br /> For Modern Observability
+          </>
+        }
+        description={
+          <>
+            OpenTelemetry gives teams a single, open way to generate, collect, and route telemetry.
+            <br />
+            It reduces vendor lock-in, standardizes instrumentation, and keeps traces, metrics, and
+            logs connected as systems grow.
+          </>
+        }
+        buttons={heroButtons}
+        heroImage="/img/graphics/homepage/feature-graphic-otel.webp"
+        heroImageAlt="OpenTelemetry overview graphic"
+      />
+
+      <HeroCards cards={benefitCards} cols={3} className="!border-b-0" />
+
+      <SectionLayout variant="bordered" className="!border-b-0">
+        <div className="px-4 py-12 md:px-8">
+          <div className="mb-8 max-w-3xl">
+            <p className="mb-3 text-sm font-medium uppercase tracking-[0.08em] text-signoz_sakura-400">
+              Why teams adopt OTel
+            </p>
+            <h2 className="mb-4 text-signoz_vanilla-100">
+              Proprietary observability breaks down as systems and teams scale
+            </h2>
+            <p className="mb-0 leading-8 text-signoz_vanilla-400">
+              The need for OpenTelemetry usually shows up when teams realize their telemetry is
+              expensive to maintain, hard to correlate, and tightly coupled to one vendor&apos;s
+              agent model. OTel solves that by separating instrumentation from backend choice.
+            </p>
+          </div>
+
+          <IconTitleDescriptionCardGrid cards={painCards} variant="xl" />
+        </div>
+      </SectionLayout>
+
+      <SectionLayout variant="bordered" className="!border-b-0 !px-0">
+        <div className="grid grid-cols-1 lg:grid-cols-2">
+          <div className="border-b border-dashed border-signoz_slate-400 p-8 lg:border-b-0 lg:border-r">
+            <p className="mb-3 text-sm font-medium uppercase tracking-[0.08em] text-signoz_sakura-400">
+              What changes with OTel
+            </p>
+            <h2 className="mb-4 text-signoz_vanilla-100">
+              OpenTelemetry turns observability into an open pipeline
+            </h2>
+            <p className="mb-0 leading-8 text-signoz_vanilla-400">
+              Instead of baking one vendor&apos;s collection model into every service, OTel gives
+              you open SDKs, standard context propagation, semantic conventions, and a flexible
+              collector layer.
+            </p>
+          </div>
+
+          <div className="space-y-4 p-8">
+            {workflowSteps.map((step) => (
+              <div
+                key={step}
+                className="rounded-lg border border-dashed border-signoz_slate-400 bg-signoz_ink-400 p-4"
+              >
+                <p className="mb-0 text-sm leading-7 text-signoz_vanilla-200">{step}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </SectionLayout>
+
+      <SectionLayout variant="bordered" className="!border-b-0">
+        <div className="px-4 py-12 md:px-8">
+          <div className="mb-8 max-w-3xl">
+            <p className="mb-3 text-sm font-medium uppercase tracking-[0.08em] text-signoz_sakura-400">
+              Why it matters
+            </p>
+            <h2 className="mb-4 text-signoz_vanilla-100">
+              The payoff is better debugging, cleaner architecture, and less migration risk
+            </h2>
+            <p className="mb-0 leading-8 text-signoz_vanilla-400">
+              OpenTelemetry is not just an instrumentation library. It becomes the control plane for
+              how telemetry is produced and moved through your stack, which is why it keeps gaining
+              traction across platform teams.
+            </p>
+          </div>
+
+          <IconTitleDescriptionCardGrid cards={outcomeCards} variant="xl" />
+        </div>
+      </SectionLayout>
+
+      <SectionLayout variant="bordered" className="!border-b-0 !px-0">
+        <div className="grid grid-cols-1 lg:grid-cols-[1.3fr_0.7fr]">
+          <div className="border-b border-dashed border-signoz_slate-400 p-8 lg:border-b-0 lg:border-r">
+            <p className="mb-3 text-sm font-medium uppercase tracking-[0.08em] text-signoz_sakura-400">
+              Why SigNoz fits
+            </p>
+            <h2 className="mb-4 text-signoz_vanilla-100">
+              Use an OpenTelemetry-native backend instead of translating your data back into a
+              proprietary model
+            </h2>
+            <p className="mb-6 leading-8 text-signoz_vanilla-400">
+              SigNoz is built around OpenTelemetry from ingestion through visualization, so teams
+              can keep OTel as the source of truth while getting correlation across traces, metrics,
+              logs, and exceptions in one place.
+            </p>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button
+                variant="default"
+                rounded="full"
+                className="flex w-fit items-center gap-2"
+                asChild
+              >
+                <TrackingLink
+                  href="/teams/"
+                  clickType="Primary CTA"
+                  clickName="Why OpenTelemetry Bottom Start Trial"
+                  clickLocation="Why OpenTelemetry Bottom CTA"
+                  clickText="Start free with SigNoz"
+                >
+                  Start free with SigNoz
+                  <ArrowRight size={14} />
+                </TrackingLink>
+              </Button>
+
+              <Button
+                variant="secondary"
+                rounded="full"
+                className="flex w-fit items-center gap-2"
+                asChild
+              >
+                <TrackingLink
+                  href="/docs/instrumentation/overview/"
+                  clickType="Secondary CTA"
+                  clickName="Why OpenTelemetry Bottom Docs"
+                  clickLocation="Why OpenTelemetry Bottom CTA"
+                  clickText="Read instrumentation docs"
+                >
+                  <BookOpen size={14} />
+                  Read instrumentation docs
+                </TrackingLink>
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-center gap-4 p-8">
+            <div className="rounded-lg border border-dashed border-signoz_slate-400 bg-signoz_ink-400 p-5">
+              <p className="mb-2 text-sm font-medium uppercase tracking-[0.08em] text-signoz_vanilla-400">
+                Recommended path
+              </p>
+              <p className="mb-0 text-sm leading-7 text-signoz_vanilla-200">
+                Adopt OpenTelemetry as the standard inside your applications, then choose a backend
+                that natively understands it.
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-dashed border-signoz_slate-400 bg-signoz_ink-400 p-5">
+              <p className="mb-2 text-sm font-medium uppercase tracking-[0.08em] text-signoz_vanilla-400">
+                Best fit
+              </p>
+              <p className="mb-0 text-sm leading-7 text-signoz_vanilla-200">
+                Teams that want lower migration risk, consistent instrumentation, and full
+                correlation across telemetry signals.
+              </p>
+            </div>
+          </div>
+        </div>
+      </SectionLayout>
+
+      <CustomerStoriesSection
+        tracking={{
+          clickName: 'Why OpenTelemetry Customer Stories',
+          clickLocation: 'Why OpenTelemetry Customer Stories',
+        }}
+      />
+
+      <UsageBasedPricing
+        show={['traces', 'metrics', 'logs']}
+        sectionTitle="Keep your OpenTelemetry setup flexible"
+        sectionDescription="Adopt OTel once, then control cost and deployment choice without rewriting your instrumentation."
+      />
+
+      <SigNozStats />
+    </FeaturePageLayout>
+  )
+}

--- a/app/opentelemetry/why-is-opentelemetry-needed/page.tsx
+++ b/app/opentelemetry/why-is-opentelemetry-needed/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+import WhyOpenTelemetryNeededPage from './WhyOpenTelemetryNeededPage'
+
+export const metadata: Metadata = {
+  title: {
+    absolute: 'Why OpenTelemetry Is Needed for Modern Observability | SigNoz',
+  },
+  description:
+    'Learn why OpenTelemetry is needed: open instrumentation, vendor-neutral telemetry, consistent context across traces, metrics, and logs, and a cleaner observability architecture.',
+  alternates: {
+    canonical: 'https://signoz.io/opentelemetry/why-is-opentelemetry-needed/',
+  },
+  openGraph: {
+    title: 'Why OpenTelemetry Is Needed for Modern Observability | SigNoz',
+    description:
+      'OpenTelemetry helps teams standardize instrumentation, avoid vendor lock-in, and keep telemetry portable as systems grow.',
+    images: '/img/graphics/homepage/feature-graphic-otel.webp',
+    url: 'https://signoz.io/opentelemetry/why-is-opentelemetry-needed/',
+    siteName: 'SigNoz',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Why OpenTelemetry Is Needed for Modern Observability | SigNoz',
+    description:
+      'OpenTelemetry helps teams standardize instrumentation, avoid vendor lock-in, and keep telemetry portable as systems grow.',
+    images: '/img/graphics/homepage/feature-graphic-otel.webp',
+  },
+}
+
+export default function WhyOpenTelemetryNeeded() {
+  return <WhyOpenTelemetryNeededPage />
+}

--- a/app/resource-center/opentelemetry/OpenTelemetry.tsx
+++ b/app/resource-center/opentelemetry/OpenTelemetry.tsx
@@ -9,7 +9,8 @@ import BlogPostCard from '../Shared/BlogPostCard'
 import SearchInput from '../Shared/Search'
 import React from 'react'
 import { filterData } from 'app/utils/common'
-import { Frown } from 'lucide-react'
+import Link from 'next/link'
+import { ArrowUpRight, Frown } from 'lucide-react'
 import { type Comparison } from 'types/transformedContent'
 
 type HubDoc = CoreContent<Blog | Comparison | Guide | MDXContent>
@@ -107,6 +108,14 @@ const OpenTelemetryPageHeader: React.FC<OpenTelemetryPageHeaderProps> = ({ onSea
       <p className="my-4 w-full text-lg leading-8 tracking-normal text-gray-700 dark:text-stone-300 max-md:max-w-full">
         Articles on OpenTelemetry concepts, implementation, and its use cases.
       </p>
+
+      <Link
+        href="/opentelemetry/why-is-opentelemetry-needed/"
+        className="mb-4 inline-flex w-fit items-center gap-2 rounded-full border border-signoz_slate-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:border-signoz_sakura-400 hover:text-signoz_sakura-500 dark:border-signoz_slate-400 dark:text-stone-200 dark:hover:text-signoz_sakura-400"
+      >
+        Start here: why OpenTelemetry is needed
+        <ArrowUpRight className="h-4 w-4" />
+      </Link>
 
       <SearchInput placeholder={'Search for a blog...'} onSearch={onSearch} />
     </section>

--- a/components/why-opentelemetry/index.tsx
+++ b/components/why-opentelemetry/index.tsx
@@ -49,15 +49,15 @@ export const WhyOpenTelemetry = () => {
               Kubernetes being more active.
             </p>
             <TrackingLink
-              href="/opentelemetry/#why-developers-choose-opentelemetry"
+              href="/opentelemetry/why-is-opentelemetry-needed/"
               clickType="Secondary CTA"
-              clickName="Why Developers choose OpenTelemetry Link"
-              clickText="Learn why Developers choose OpenTelemetry"
+              clickName="Why OpenTelemetry Needed Link"
+              clickText="Learn why teams need OpenTelemetry"
               clickLocation="Why OpenTelemetry Section"
               className="mb-3 mt-3 flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-[10px] font-medium leading-5 text-white shadow-[0_0_20px_0_rgba(242,71,105,0.20)] sm:text-sm"
             >
               <BookOpen className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-              Learn why Developers choose OpenTelemetry
+              Learn why teams need OpenTelemetry
               <ArrowRight className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
             </TrackingLink>
           </div>

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -906,6 +906,12 @@ const docsSideNav = [
             route:
               '/docs/opentelemetry-collection-agents/opentelemetry-collector/why-to-use-collector',
           },
+          {
+            type: 'doc',
+            label: 'Routing Connector',
+            route:
+              '/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector',
+          },
         ],
       },
     ],

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -19,6 +19,10 @@ The **Routing Connector** solves this by selectively routing telemetry based on 
 
 For connector basics, see the <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry connector documentation</a>.
 
+<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
+    Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
+</KeyPointCallout>
+
 ## Example: Route services to different exporters
 
 In this example, all services send telemetry to one OTLP receiver. The routing connector checks `service.name`, sends `payments` traffic to one exporter, sends `search` traffic to another exporter, and sends everything else to a default exporter.
@@ -30,24 +34,9 @@ In this example, all services send telemetry to one OTLP receiver. The routing c
 />
 
 Add the following snippets to your existing `otel-collector-config.yaml`.
+Make sure your Collector already has `receivers` and `processors` configured.
 
-### 1. Add the receiver and processors
-
-```yaml:otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-
-processors:
-  memory_limiter:
-    check_interval: 1s
-    limit_mib: 512
-  batch:
-```
-
-### 2. Add the routing connector
+### 1. Add the routing connector
 
 ```yaml:otel-collector-config.yaml
 connectors:
@@ -55,10 +44,10 @@ connectors:
     default_pipelines: [traces/default]
     table:
       - context: resource
-        condition: resource.attributes["service.name"] == "payments"
+        statement: resource.attributes["service.name"] == "payments"
         pipelines: [traces/payments]
       - context: resource
-        condition: resource.attributes["service.name"] == "search"
+        statement: resource.attributes["service.name"] == "search"
         pipelines: [traces/search]
 ```
 
@@ -72,11 +61,11 @@ Here is what the main routing fields mean:
 
 - `table`: the list of routing rules the connector checks.
 - `context`: where the connector should look for fields. Use `resource` when you want to match resource attributes such as `service.name`.
-- `condition`: the OTTL expression that decides whether a rule matches.
+- `statement`: the OTTL expression that decides whether a rule matches.
 - `pipelines`: the destination pipeline to use when the rule matches.
 - `default_pipelines`: the fallback pipeline to use when no rule matches.
 
-### 3. Add the exporters
+### 2. Add the exporters
 
 You can point each exporter to a different SigNoz account, ingestion key, or backend destination.
 
@@ -102,31 +91,30 @@ Verify these values:
 - `<default-ingestion-key>`, `<payments-ingestion-key>`, `<search-ingestion-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each destination
 
 
-### 4. Wire everything in `service.pipelines`
+### 3. Wire everything in `service.pipelines`
 
-```yaml:otel-collector-config.yaml
+```yaml:otel-collector-config.yaml {6,8,10,12}
 service:
   pipelines:
     traces/incoming:
       receivers: [otlp]
       processors: [memory_limiter, batch]
       exporters: [routing]
-
     traces/payments:
       receivers: [routing]
       exporters: [otlp/vendor-payments]
-
     traces/search:
       receivers: [routing]
       exporters: [otlp/vendor-search]
-
     traces/default:
       receivers: [routing]
       exporters: [otlp/signoz]
 ```
+<Admonition type="info">
+A connector appears as an **exporter** in the upstream pipeline and as a **receiver** in each downstream pipeline. This is how the Collector bridges pipelines together.
+</Admonition>
 
 The `traces/incoming` pipeline receives all OTLP traffic and sends it to the `routing` connector. Each downstream pipeline then receives only the telemetry that matches its rule and exports it with its own exporter.
-
 
 <details>
 <ToggleHeading>

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -17,11 +17,21 @@ The **Routing Connector** solves this by selectively routing telemetry based on 
 - Send telemetry from specific services to **different backends**.
 - Isolate traffic by environment or team.
 
-For connector basics, see the <a href="https://opentelemetry.io/docs/collector/components/connector/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry connector documentation</a>.
+For connector basics, see the <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry connector documentation</a>.
 
-## Simple Example: Segregating Services
+## Example: Route services to different exporters
 
-In this scenario, all services send to one OTLP receiver, but the `payments` and `search` services are routed to separate backends (or different SigNoz accounts) while everything else goes to a default SigNoz instance.
+In this example, all services send telemetry to one OTLP receiver. The routing connector checks `service.name`, sends `payments` traffic to one exporter, sends `search` traffic to another exporter, and sends everything else to a default exporter.
+
+<Figure
+  src="/img/docs/opentelemetry-collection-agents/routing-connector-flow.svg"
+  alt="Routing connector flow showing payments, search, and other services sending telemetry to one receiver and then being routed to different exporters"
+  caption="The routing connector reads service attributes and sends each service to the matching exporter pipeline"
+/>
+
+Add the following snippets to your existing `otel-collector-config.yaml`.
+
+### 1. Add the receiver and processors
 
 ```yaml:otel-collector-config.yaml
 receivers:
@@ -35,7 +45,11 @@ processors:
     check_interval: 1s
     limit_mib: 512
   batch:
+```
 
+### 2. Add the routing connector
+
+```yaml:otel-collector-config.yaml
 connectors:
   routing:
     default_pipelines: [traces/default]
@@ -46,23 +60,51 @@ connectors:
       - context: resource
         condition: resource.attributes["service.name"] == "search"
         pipelines: [traces/search]
+```
 
+This connector reads `resource.attributes["service.name"]` and maps matching telemetry to a pipeline:
+
+- `payments` goes to `traces/payments`
+- `search` goes to `traces/search`
+- anything else goes to `traces/default`
+
+Here is what the main routing fields mean:
+
+- `table`: the list of routing rules the connector checks.
+- `context`: where the connector should look for fields. Use `resource` when you want to match resource attributes such as `service.name`.
+- `condition`: the OTTL expression that decides whether a rule matches.
+- `pipelines`: the destination pipeline to use when the rule matches.
+- `default_pipelines`: the fallback pipeline to use when no rule matches.
+
+### 3. Add the exporters
+
+You can point each exporter to a different SigNoz account, ingestion key, or backend destination.
+
+```yaml:otel-collector-config.yaml
 exporters:
   otlp/signoz:
-    endpoint: 'ingest.<region>.signoz.cloud:443'
+    endpoint: "ingest.<region>.signoz.cloud:443"
     headers:
-      "signoz-ingestion-key": "${DEFAULT_KEY}"
+      signoz-ingestion-key: "<default-ingestion-key>"
 
   otlp/vendor-payments:
-    endpoint: 'ingest.<region>.signoz.cloud:443'
+    endpoint: "ingest.<region>.signoz.cloud:443"
     headers:
-      "signoz-ingestion-key": "${PAYMENTS_KEY}"
+      signoz-ingestion-key: "<payments-ingestion-key>"
 
   otlp/vendor-search:
-    endpoint: 'ingest.<region>.signoz.cloud:443'
+    endpoint: "ingest.<region>.signoz.cloud:443"
     headers:
-      "signoz-ingestion-key": "${SEARCH_KEY}"
+      signoz-ingestion-key: "<search-ingestion-key>"
+```
+Verify these values:
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<default-ingestion-key>`, `<payments-ingestion-key>`, `<search-ingestion-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each destination
 
+
+### 4. Wire everything in `service.pipelines`
+
+```yaml:otel-collector-config.yaml
 service:
   pipelines:
     traces/incoming:
@@ -83,46 +125,8 @@ service:
       exporters: [otlp/signoz]
 ```
 
-Verify these values:
-- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-- `<your-default-key>`, `<your-payments-key>`, `<your-search-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each account
+The `traces/incoming` pipeline receives all OTLP traffic and sends it to the `routing` connector. Each downstream pipeline then receives only the telemetry that matches its rule and exports it with its own exporter.
 
-## Best practice for Multiple-Service Ingestion
-
-Usually, all services should send to the same OTLP receiver, and each service must set a distinct `service.name`. Then the Collector can:
-1. **Fan-out:** Keep all services together and send them to multiple exporters.
-2. **Route:** Direct traffic based on `service.name`, `deployment.environment`, `tenant.id`, or other resource attributes.
-
-<Admonition type="tip">
-In practice, route using resource attributes such as:
-- `service.name`
-- `service.namespace`
-- `deployment.environment`
-- custom tenant attribute like `tenant.id`
-</Admonition>
-
-## Fan-Out vs Routing
-
-Start with fan-out when every service should go to every backend. Switch to the routing connector when some telemetry needs different destinations or different downstream processing.
-
-| Pattern | Use it when | Configuration |
-| :--- | :--- | :--- |
-| **Fan-out** | Every service goes to every backend | List multiple exporters in one pipeline |
-| **Routing connector** | Services or tenants need different destinations | Use `routing` connector to bridge pipelines |
-
-## Configuration Reference
-
-The settings below summarize the current <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/routingconnector/README.md" target="_blank" rel="noopener noreferrer nofollow">routing connector README</a>.
-
-| Setting | Description |
-| :--- | :--- |
-| `table` | **Required.** The routing table that contains the matching rules. |
-| `table.context` | The OTTL context (`resource`, `span`, `metric`, `log`, etc.). Default is `resource`. |
-| `table.condition` | The OTTL condition for the route (e.g., `resource.attributes["service.name"] == "payments"`). |
-| `table.action` | `move` (default) routes matched data out. `copy` sends a copy and keeps evaluating later rules. |
-| `table.pipelines` | **Required.** The pipelines to receive telemetry when the rule matches. |
-| `default_pipelines` | Pipelines used when none of the rules match. |
-| `error_mode` | Controls errors: `propagate` (default), `ignore`, or `silent`. |
 
 <details>
 <ToggleHeading>

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -82,6 +82,7 @@ service:
       receivers: [routing]
       exporters: [otlp/signoz]
 ```
+
 Verify these values:
 - `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
 - `<your-default-key>`, `<your-payments-key>`, `<your-search-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each account
@@ -123,13 +124,18 @@ The settings below summarize the current <a href="https://github.com/open-teleme
 | `default_pipelines` | Pipelines used when none of the rules match. |
 | `error_mode` | Controls errors: `propagate` (default), `ignore`, or `silent`. |
 
+<details>
+<ToggleHeading>
 ## Troubleshooting
+</ToggleHeading>
 
 ### Wrong OTTL context
 Use `context: resource` for resource attributes such as `service.name`. Use `context: span` for span fields like `status.code`.
 
 ### Missing `default_pipelines`
 If nothing matches and `default_pipelines` is missing, unmatched telemetry is dropped. Always include a default pipeline unless you intentionally want to drop data.
+
+</details>
 
 ## Next Steps
 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -23,7 +23,7 @@ For connector basics, see the <a href="https://opentelemetry.io/docs/collector/c
 
 In this scenario, all services send to one OTLP receiver, but the `payments` and `search` services are routed to separate backends (or different SigNoz accounts) while everything else goes to a default SigNoz instance.
 
-```yaml
+```yaml:otel-collector-config.yaml
 receivers:
   otlp:
     protocols:

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-03-17
 id: routing-connector
-title: Routing connector
+title: OpenTelemetry Collector Routing Connector
 description: Learn how to separate telemetry from multiple services using a single OpenTelemetry Collector and send it to different destinations or ingestion keys.
 doc_type: howto
 ---

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -49,17 +49,17 @@ connectors:
 
 exporters:
   otlp/signoz:
-    endpoint: ingest.<region>.signoz.cloud:443
+    endpoint: 'ingest.<region>.signoz.cloud:443'
     headers:
       "signoz-ingestion-key": "${DEFAULT_KEY}"
 
   otlp/vendor-payments:
-    endpoint: ingest.<region>.signoz.cloud:443
+    endpoint: 'ingest.<region>.signoz.cloud:443'
     headers:
       "signoz-ingestion-key": "${PAYMENTS_KEY}"
 
   otlp/vendor-search:
-    endpoint: ingest.<region>.signoz.cloud:443
+    endpoint: 'ingest.<region>.signoz.cloud:443'
     headers:
       "signoz-ingestion-key": "${SEARCH_KEY}"
 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-17
+date: 2026-03-25
 id: routing-connector
 title: OpenTelemetry Collector Routing Connector
 description: Learn how to separate telemetry from multiple services using a single OpenTelemetry Collector and send it to different destinations or ingestion keys.
@@ -23,9 +23,17 @@ For connector basics, see the <a href="https://github.com/open-telemetry/opentel
     Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
-## Example: Route services to different exporters
+## Set up routing by service
 
-In this example, all services send telemetry to one OTLP receiver. The routing connector checks `service.name`, sends `payments` traffic to one exporter, sends `search` traffic to another exporter, and sends everything else to a default exporter.
+Use this walkthrough to route telemetry from one OTLP receiver to different exporters based on `service.name`.
+
+In the example below, the routing connector sends `payments` traffic to one exporter, `search` traffic to another exporter, and everything else to a default exporter.
+
+We will do this in three steps:
+
+1. Add routing rules for each service.
+2. Add one exporter per destination.
+3. Connect the incoming and downstream pipelines.
 
 <Figure
   src="/img/docs/opentelemetry-collection-agents/routing-connector-flow.svg"
@@ -33,10 +41,9 @@ In this example, all services send telemetry to one OTLP receiver. The routing c
   caption="The routing connector reads service attributes and sends each service to the matching exporter pipeline"
 />
 
-Add the following snippets to your existing `otel-collector-config.yaml`.
-Make sure your Collector already has `receivers` and `processors` configured.
+Add the following snippets to your existing `otel-collector-config.yaml`. This walkthrough assumes your Collector already has `receivers` and `processors` configured.
 
-### 1. Add the routing connector
+### Step 1: Add the routing connector
 
 ```yaml:otel-collector-config.yaml
 connectors:
@@ -65,7 +72,7 @@ Here is what the main routing fields mean:
 - `pipelines`: the destination pipeline to use when the rule matches.
 - `default_pipelines`: the fallback pipeline to use when no rule matches.
 
-### 2. Add the exporters
+### Step 2: Add the exporters
 
 You can point each exporter to a different SigNoz account, ingestion key, or backend destination.
 
@@ -91,7 +98,7 @@ Verify these values:
 - `<default-ingestion-key>`, `<payments-ingestion-key>`, `<search-ingestion-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each destination
 
 
-### 3. Wire everything in `service.pipelines`
+### Step 3: Connect the pipelines
 
 ```yaml:otel-collector-config.yaml {6,8,10,12}
 service:
@@ -115,6 +122,63 @@ A connector appears as an **exporter** in the upstream pipeline and as a **recei
 </Admonition>
 
 The `traces/incoming` pipeline receives all OTLP traffic and sends it to the `routing` connector. Each downstream pipeline then receives only the telemetry that matches its rule and exports it with its own exporter.
+
+<details>
+<ToggleHeading>
+See the complete configuration
+</ToggleHeading>
+
+```yaml:otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+   
+connectors:
+  routing:
+    default_pipelines: [traces/default]
+    table:
+      - context: resource
+        statement: resource.attributes["service.name"] == "payments"
+        pipelines: [traces/payments]
+      - context: resource
+        statement: resource.attributes["service.name"] == "search"
+        pipelines: [traces/search]
+
+exporters:
+  otlp/signoz:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<default-ingestion-key>"
+
+  otlp/vendor-payments:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<payments-ingestion-key>"
+
+  otlp/vendor-search:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<search-ingestion-key>"
+
+service:
+  pipelines:
+    traces/incoming:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [routing]
+    traces/payments:
+      receivers: [routing]
+      exporters: [otlp/vendor-payments]
+    traces/search:
+      receivers: [routing]
+      exporters: [otlp/vendor-search]
+    traces/default:
+      receivers: [routing]
+      exporters: [otlp/signoz]
+```
+</details>
 
 <details>
 <ToggleHeading>

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -141,3 +141,7 @@ If nothing matches and `default_pipelines` is missing, unmatched telemetry is dr
 
 - [Collector configuration reference](https://signoz.io/docs/opentelemetry-collection-agents/opentelemetry-collector/configuration/) — Review receivers, processors, and exporters.
 - [Switch to Collector](https://signoz.io/docs/opentelemetry-collection-agents/opentelemetry-collector/switch-to-collector/) — Move apps to a central Collector before you add routing.
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -1,0 +1,132 @@
+---
+date: 2026-03-17
+id: routing-connector
+title: Routing connector
+description: Learn how to separate telemetry from multiple services using a single OpenTelemetry Collector and send it to different destinations or ingestion keys.
+doc_type: howto
+---
+
+## Overview
+
+A common challenge when using a single OpenTelemetry Collector is segregation. If multiple services send telemetry to one Collector, they often share the same ingestion key and backend destination. 
+
+The **Routing Connector** solves this by selectively routing telemetry based on resource attributes (like `service.name` or `tenant.id`). This allows you to:
+- Use **different ingestion keys** for different services.
+- Send telemetry from specific services to **different backends**.
+- Isolate traffic by environment or team.
+
+For connector basics, see the [OpenTelemetry connector documentation](https://opentelemetry.io/docs/collector/components/connector/).
+
+## Simple Example: Segregating Services
+
+In this scenario, all services send to one OTLP receiver, but the `payments` and `search` services are routed to separate backends (or different SigNoz accounts) while everything else goes to a default SigNoz instance.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+  batch:
+
+connectors:
+  routing:
+    default_pipelines: [traces/default]
+    table:
+      - context: resource
+        condition: resource.attributes["service.name"] == "payments"
+        pipelines: [traces/payments]
+      - context: resource
+        condition: resource.attributes["service.name"] == "search"
+        pipelines: [traces/search]
+
+exporters:
+  otlp/signoz:
+    endpoint: ingest.<region>.signoz.cloud:443
+    headers:
+      "signoz-ingestion-key": "${DEFAULT_KEY}"
+
+  otlp/vendor-payments:
+    endpoint: ingest.<region>.signoz.cloud:443
+    headers:
+      "signoz-ingestion-key": "${PAYMENTS_KEY}"
+
+  otlp/vendor-search:
+    endpoint: ingest.<region>.signoz.cloud:443
+    headers:
+      "signoz-ingestion-key": "${SEARCH_KEY}"
+
+service:
+  pipelines:
+    traces/incoming:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [routing]
+
+    traces/payments:
+      receivers: [routing]
+      exporters: [otlp/vendor-payments]
+
+    traces/search:
+      receivers: [routing]
+      exporters: [otlp/vendor-search]
+
+    traces/default:
+      receivers: [routing]
+      exporters: [otlp/signoz]
+```
+
+## Best practice for “multiple services in ingestion”
+
+Usually, all services should send to the same OTLP receiver, and each service must set a distinct `service.name`. Then the Collector can:
+1. **Fan-out:** Keep all services together and send them to multiple exporters.
+2. **Route:** Direct traffic based on `service.name`, `deployment.environment`, `tenant.id`, or other resource attributes.
+
+<Admonition type="tip">
+In practice, route using resource attributes such as:
+- `service.name`
+- `service.namespace`
+- `deployment.environment`
+- custom tenant attribute like `tenant.id`
+</Admonition>
+
+## Fan-Out vs Routing
+
+Start with fan-out when every service should go to every backend. Switch to the routing connector when some telemetry needs different destinations or different downstream processing.
+
+| Pattern | Use it when | Configuration |
+| :--- | :--- | :--- |
+| **Fan-out** | Every service goes to every backend | List multiple exporters in one pipeline |
+| **Routing connector** | Services or tenants need different destinations | Use `routing` connector to bridge pipelines |
+
+## Configuration Reference
+
+The settings below summarize the current <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/routingconnector/README.md" target="_blank" rel="noopener noreferrer nofollow">routing connector README</a>.
+
+| Setting | Description |
+| :--- | :--- |
+| `table` | **Required.** The routing table that contains the matching rules. |
+| `table.context` | The OTTL context (`resource`, `span`, `metric`, `log`, etc.). Default is `resource`. |
+| `table.condition` | The OTTL condition for the route (e.g., `resource.attributes["service.name"] == "payments"`). |
+| `table.action` | `move` (default) routes matched data out. `copy` sends a copy and keeps evaluating later rules. |
+| `table.pipelines` | **Required.** The pipelines to receive telemetry when the rule matches. |
+| `default_pipelines` | Pipelines used when none of the rules match. |
+| `error_mode` | Controls errors: `propagate` (default), `ignore`, or `silent`. |
+
+## Troubleshooting
+
+### Wrong OTTL context
+Use `context: resource` for resource attributes such as `service.name`. Use `context: span` for span fields like `status.code`.
+
+### Missing `default_pipelines`
+If nothing matches and `default_pipelines` is missing, unmatched telemetry is dropped. Always include a default pipeline unless you intentionally want to drop data.
+
+## Next Steps
+
+- [Collector configuration reference](https://signoz.io/docs/opentelemetry-collection-agents/opentelemetry-collector/configuration/) — Review receivers, processors, and exporters.
+- [Switch to Collector](https://signoz.io/docs/opentelemetry-collection-agents/opentelemetry-collector/switch-to-collector/) — Move apps to a central Collector before you add routing.

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -6,6 +6,8 @@ description: Learn how to separate telemetry from multiple services using a sing
 doc_type: howto
 ---
 
+import GetHelp from '@/components/shared/get-help.md'
+
 ## Overview
 
 A common challenge when using a single OpenTelemetry Collector is segregation. If multiple services send telemetry to one Collector, they often share the same ingestion key and backend destination. 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/routing-connector.mdx
@@ -17,7 +17,7 @@ The **Routing Connector** solves this by selectively routing telemetry based on 
 - Send telemetry from specific services to **different backends**.
 - Isolate traffic by environment or team.
 
-For connector basics, see the [OpenTelemetry connector documentation](https://opentelemetry.io/docs/collector/components/connector/).
+For connector basics, see the <a href="https://opentelemetry.io/docs/collector/components/connector/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry connector documentation</a>.
 
 ## Simple Example: Segregating Services
 
@@ -82,8 +82,11 @@ service:
       receivers: [routing]
       exporters: [otlp/signoz]
 ```
+Verify these values:
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<your-default-key>`, `<your-payments-key>`, `<your-search-key>`: SigNoz [ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/) for each account
 
-## Best practice for “multiple services in ingestion”
+## Best practice for Multiple-Service Ingestion
 
 Usually, all services should send to the same OTLP receiver, and each service must set a distinct `service.name`. Then the Collector can:
 1. **Fan-out:** Keep all services together and send them to multiple exporters.

--- a/public/img/docs/opentelemetry-collection-agents/routing-connector-flow.svg
+++ b/public/img/docs/opentelemetry-collection-agents/routing-connector-flow.svg
@@ -1,0 +1,257 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 620" font-family="'Inter', 'Segoe UI', Arial, sans-serif">
+  <defs>
+    <!-- Background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0f1a"/>
+      <stop offset="100%" stop-color="#1a1a2e"/>
+    </linearGradient>
+
+    <!-- Service card gradients -->
+    <linearGradient id="paymentsGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6c5ce7"/>
+      <stop offset="100%" stop-color="#4834d4"/>
+    </linearGradient>
+    <linearGradient id="searchGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00b894"/>
+      <stop offset="100%" stop-color="#00997b"/>
+    </linearGradient>
+    <linearGradient id="othersGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#636e72"/>
+      <stop offset="100%" stop-color="#4a5459"/>
+    </linearGradient>
+
+    <!-- Receiver gradient -->
+    <linearGradient id="receiverGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0984e3"/>
+      <stop offset="100%" stop-color="#0769b8"/>
+    </linearGradient>
+
+    <!-- Router gradient -->
+    <linearGradient id="routerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e17055"/>
+      <stop offset="100%" stop-color="#d63031"/>
+    </linearGradient>
+
+    <!-- Exporter gradients -->
+    <linearGradient id="expPayGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6c5ce7"/>
+      <stop offset="100%" stop-color="#5a4bd1"/>
+    </linearGradient>
+    <linearGradient id="expSearchGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00b894"/>
+      <stop offset="100%" stop-color="#009a7d"/>
+    </linearGradient>
+    <linearGradient id="expDefaultGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#636e72"/>
+      <stop offset="100%" stop-color="#525c60"/>
+    </linearGradient>
+
+    <!-- Glow filters -->
+    <filter id="glowPurple" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feFlood flood-color="#6c5ce7" flood-opacity="0.4" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="glow"/>
+      <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowGreen" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feFlood flood-color="#00b894" flood-opacity="0.4" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="glow"/>
+      <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowGray" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feFlood flood-color="#b2bec3" flood-opacity="0.4" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="glow"/>
+      <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowBlue" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feFlood flood-color="#0984e3" flood-opacity="0.5" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="glow"/>
+      <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowOrange" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feFlood flood-color="#e17055" flood-opacity="0.5" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="glow"/>
+      <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+
+    <!-- Animated dots -->
+    <circle id="dotPurple" r="5" fill="#a29bfe" filter="url(#glowPurple)"/>
+    <circle id="dotGreen"  r="5" fill="#55efc4" filter="url(#glowGreen)"/>
+    <circle id="dotGray"   r="5" fill="#dfe6e9" filter="url(#glowGray)"/>
+
+    <!-- Collector boundary pattern -->
+    <pattern id="collectorPattern" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle cx="10" cy="10" r="0.5" fill="rgba(255,255,255,0.03)"/>
+    </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1100" height="620" fill="url(#bgGrad)" rx="12"/>
+
+  <!-- Title -->
+  <text x="550" y="38" text-anchor="middle" fill="#f5f6fa" font-size="18" font-weight="700" letter-spacing="0.5">
+    Routing Connector — Service-Based Trace Segregation
+  </text>
+
+  <!-- ======================== COLLECTOR BOUNDARY ======================== -->
+  <rect x="250" y="55" width="600" height="545" rx="16" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="1.5" stroke-dasharray="8 4"/>
+  <rect x="250" y="55" width="600" height="545" rx="16" fill="url(#collectorPattern)"/>
+  <text x="550" y="80" text-anchor="middle" fill="rgba(255,255,255,0.35)" font-size="11" font-weight="600" letter-spacing="1.5">OPENTELEMETRY COLLECTOR</text>
+
+  <!-- ======================== LEFT: SERVICES ======================== -->
+  <!-- Payments Service -->
+  <g filter="url(#shadow)">
+    <rect x="30" y="120" width="160" height="70" rx="10" fill="url(#paymentsGrad)"/>
+    <text x="110" y="150" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">💳  payments</text>
+    <text x="110" y="170" text-anchor="middle" fill="rgba(255,255,255,0.65)" font-size="10">service.name</text>
+  </g>
+
+  <!-- Search Service -->
+  <g filter="url(#shadow)">
+    <rect x="30" y="280" width="160" height="70" rx="10" fill="url(#searchGrad)"/>
+    <text x="110" y="310" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">🔍  search</text>
+    <text x="110" y="330" text-anchor="middle" fill="rgba(255,255,255,0.65)" font-size="10">service.name</text>
+  </g>
+
+  <!-- Other Services -->
+  <g filter="url(#shadow)">
+    <rect x="30" y="440" width="160" height="70" rx="10" fill="url(#othersGrad)"/>
+    <text x="110" y="470" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">📦  other services</text>
+    <text x="110" y="490" text-anchor="middle" fill="rgba(255,255,255,0.65)" font-size="10">default route</text>
+  </g>
+
+  <!-- ======================== RECEIVER ======================== -->
+  <g filter="url(#shadow)">
+    <rect x="290" y="235" width="140" height="160" rx="12" fill="url(#receiverGrad)"/>
+    <text x="360" y="275" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">OTLP Receiver</text>
+    <line x1="310" y1="288" x2="410" y2="288" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+    <text x="360" y="310" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-size="10">gRPC + HTTP</text>
+    <text x="360" y="340" text-anchor="middle" fill="rgba(255,255,255,0.55)" font-size="9">memory_limiter</text>
+    <text x="360" y="358" text-anchor="middle" fill="rgba(255,255,255,0.55)" font-size="9">batch</text>
+    <text x="360" y="385" text-anchor="middle" fill="rgba(255,255,255,0.45)" font-size="9" font-style="italic">traces/incoming</text>
+  </g>
+
+  <!-- ======================== ROUTING CONNECTOR ======================== -->
+  <g filter="url(#shadow)">
+    <!-- Diamond / hexagonal shape for the router -->
+    <rect x="510" y="200" width="170" height="230" rx="14" fill="url(#routerGrad)"/>
+    <text x="595" y="230" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">Routing Connector</text>
+    <line x1="530" y1="242" x2="660" y2="242" stroke="rgba(255,255,255,0.2)" stroke-width="1"/>
+    <!-- Routing rules -->
+    <text x="595" y="268" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-size="10" font-weight="600">Routing Rules</text>
+
+    <!-- Rule 1 -->
+    <rect x="525" y="280" width="140" height="30" rx="6" fill="rgba(108,92,231,0.35)" stroke="rgba(108,92,231,0.6)" stroke-width="1"/>
+    <text x="595" y="300" text-anchor="middle" fill="#d6d0ff" font-size="9" font-weight="600">service.name == "payments"</text>
+
+    <!-- Rule 2 -->
+    <rect x="525" y="320" width="140" height="30" rx="6" fill="rgba(0,184,148,0.35)" stroke="rgba(0,184,148,0.6)" stroke-width="1"/>
+    <text x="595" y="340" text-anchor="middle" fill="#b8f5e5" font-size="9" font-weight="600">service.name == "search"</text>
+
+    <!-- Default -->
+    <rect x="525" y="360" width="140" height="30" rx="6" fill="rgba(99,110,114,0.4)" stroke="rgba(99,110,114,0.6)" stroke-width="1"/>
+    <text x="595" y="380" text-anchor="middle" fill="#dfe6e9" font-size="9" font-weight="600">default → traces/default</text>
+
+    <text x="595" y="418" text-anchor="middle" fill="rgba(255,255,255,0.4)" font-size="9" font-style="italic">connector bridge</text>
+  </g>
+
+  <!-- ======================== RIGHT: EXPORTERS / BACKENDS ======================== -->
+  <!-- Payments Backend -->
+  <g filter="url(#shadow)">
+    <rect x="890" y="120" width="180" height="70" rx="10" fill="url(#expPayGrad)"/>
+    <text x="980" y="147" text-anchor="middle" fill="#fff" font-size="11" font-weight="700">otlp/vendor-payments</text>
+    <text x="980" y="167" text-anchor="middle" fill="rgba(255,255,255,0.6)" font-size="9">PAYMENTS_KEY</text>
+    <text x="980" y="182" text-anchor="middle" fill="rgba(255,255,255,0.45)" font-size="8" font-style="italic">traces/payments</text>
+  </g>
+
+  <!-- Search Backend -->
+  <g filter="url(#shadow)">
+    <rect x="890" y="280" width="180" height="70" rx="10" fill="url(#expSearchGrad)"/>
+    <text x="980" y="307" text-anchor="middle" fill="#fff" font-size="11" font-weight="700">otlp/vendor-search</text>
+    <text x="980" y="327" text-anchor="middle" fill="rgba(255,255,255,0.6)" font-size="9">SEARCH_KEY</text>
+    <text x="980" y="342" text-anchor="middle" fill="rgba(255,255,255,0.45)" font-size="8" font-style="italic">traces/search</text>
+  </g>
+
+  <!-- Default Backend -->
+  <g filter="url(#shadow)">
+    <rect x="890" y="440" width="180" height="70" rx="10" fill="url(#expDefaultGrad)"/>
+    <text x="980" y="467" text-anchor="middle" fill="#fff" font-size="11" font-weight="700">otlp/signoz</text>
+    <text x="980" y="487" text-anchor="middle" fill="rgba(255,255,255,0.6)" font-size="9">DEFAULT_KEY</text>
+    <text x="980" y="502" text-anchor="middle" fill="rgba(255,255,255,0.45)" font-size="8" font-style="italic">traces/default</text>
+  </g>
+
+  <!-- ======================== CONNECTION PATHS ======================== -->
+  <!-- Services → Receiver (converging) -->
+  <path id="pathPayIn" d="M190,155 Q240,155 290,290" fill="none" stroke="rgba(108,92,231,0.25)" stroke-width="2"/>
+  <path id="pathSearchIn" d="M190,315 L290,315" fill="none" stroke="rgba(0,184,148,0.25)" stroke-width="2"/>
+  <path id="pathOtherIn" d="M190,475 Q240,475 290,340" fill="none" stroke="rgba(99,110,114,0.25)" stroke-width="2"/>
+
+  <!-- Receiver → Router -->
+  <path id="pathRecvToRoute" d="M430,315 L510,315" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="2"/>
+
+  <!-- Router → Exporters (diverging) -->
+  <path id="pathPayOut" d="M680,295 Q785,295 785,155 L890,155" fill="none" stroke="rgba(108,92,231,0.25)" stroke-width="2"/>
+  <path id="pathSearchOut" d="M680,335 L890,315" fill="none" stroke="rgba(0,184,148,0.25)" stroke-width="2"/>
+  <path id="pathDefaultOut" d="M680,375 Q785,375 785,475 L890,475" fill="none" stroke="rgba(99,110,114,0.25)" stroke-width="2"/>
+
+  <!-- ======================== ANIMATED DOTS ======================== -->
+
+  <!-- Payments trace: service → receiver (staggered) -->
+  <use href="#dotPurple"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite"/><animateMotion dur="4s" repeatCount="indefinite"><mpath href="#pathPayIn"/></animateMotion></use>
+  <use href="#dotPurple"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite" begin="0.6s"/><animateMotion dur="4s" repeatCount="indefinite" begin="0.6s"><mpath href="#pathPayIn"/></animateMotion></use>
+
+  <!-- Payments trace: receiver → router -->
+  <use href="#dotPurple"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3s" repeatCount="indefinite" begin="1s"/><animateMotion dur="3s" repeatCount="indefinite" begin="1s"><mpath href="#pathRecvToRoute"/></animateMotion></use>
+
+  <!-- Payments trace: router → exporter -->
+  <use href="#dotPurple"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite" begin="1.5s"/><animateMotion dur="4s" repeatCount="indefinite" begin="1.5s"><mpath href="#pathPayOut"/></animateMotion></use>
+  <use href="#dotPurple"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite" begin="2.1s"/><animateMotion dur="4s" repeatCount="indefinite" begin="2.1s"><mpath href="#pathPayOut"/></animateMotion></use>
+
+  <!-- Search trace: service → receiver -->
+  <use href="#dotGreen"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3s" repeatCount="indefinite" begin="0.3s"/><animateMotion dur="3s" repeatCount="indefinite" begin="0.3s"><mpath href="#pathSearchIn"/></animateMotion></use>
+  <use href="#dotGreen"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3s" repeatCount="indefinite" begin="1s"/><animateMotion dur="3s" repeatCount="indefinite" begin="1s"><mpath href="#pathSearchIn"/></animateMotion></use>
+
+  <!-- Search trace: receiver → router -->
+  <use href="#dotGreen"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3s" repeatCount="indefinite" begin="0.7s"/><animateMotion dur="3s" repeatCount="indefinite" begin="0.7s"><mpath href="#pathRecvToRoute"/></animateMotion></use>
+
+  <!-- Search trace: router → exporter -->
+  <use href="#dotGreen"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3.5s" repeatCount="indefinite" begin="1.2s"/><animateMotion dur="3.5s" repeatCount="indefinite" begin="1.2s"><mpath href="#pathSearchOut"/></animateMotion></use>
+  <use href="#dotGreen"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3.5s" repeatCount="indefinite" begin="1.9s"/><animateMotion dur="3.5s" repeatCount="indefinite" begin="1.9s"><mpath href="#pathSearchOut"/></animateMotion></use>
+
+  <!-- Other traces: service → receiver -->
+  <use href="#dotGray"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4.5s" repeatCount="indefinite" begin="0.5s"/><animateMotion dur="4.5s" repeatCount="indefinite" begin="0.5s"><mpath href="#pathOtherIn"/></animateMotion></use>
+  <use href="#dotGray"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4.5s" repeatCount="indefinite" begin="1.5s"/><animateMotion dur="4.5s" repeatCount="indefinite" begin="1.5s"><mpath href="#pathOtherIn"/></animateMotion></use>
+
+  <!-- Other traces: receiver → router -->
+  <use href="#dotGray"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="3s" repeatCount="indefinite" begin="1.8s"/><animateMotion dur="3s" repeatCount="indefinite" begin="1.8s"><mpath href="#pathRecvToRoute"/></animateMotion></use>
+
+  <!-- Other traces: router → default exporter -->
+  <use href="#dotGray"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite" begin="2s"/><animateMotion dur="4s" repeatCount="indefinite" begin="2s"><mpath href="#pathDefaultOut"/></animateMotion></use>
+  <use href="#dotGray"><animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.05;0.85;1" dur="4s" repeatCount="indefinite" begin="2.8s"/><animateMotion dur="4s" repeatCount="indefinite" begin="2.8s"><mpath href="#pathDefaultOut"/></animateMotion></use>
+
+  <!-- ======================== LEGEND ======================== -->
+  <rect x="30" y="565" width="330" height="40" rx="8" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+  <circle cx="55" cy="585" r="5" fill="#a29bfe"/>
+  <text x="68" y="589" fill="rgba(255,255,255,0.7)" font-size="10">payments trace</text>
+  <circle cx="165" cy="585" r="5" fill="#55efc4"/>
+  <text x="178" y="589" fill="rgba(255,255,255,0.7)" font-size="10">search trace</text>
+  <circle cx="262" cy="585" r="5" fill="#dfe6e9"/>
+  <text x="275" y="589" fill="rgba(255,255,255,0.7)" font-size="10">other traces</text>
+
+  <!-- Pulse animation on router (subtle) -->
+  <rect x="510" y="200" width="170" height="230" rx="14" fill="none" stroke="#e17055" stroke-width="1.5">
+    <animate attributeName="stroke-opacity" values="0.2;0.6;0.2" dur="3s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- Pulse on receiver -->
+  <rect x="290" y="235" width="140" height="160" rx="12" fill="none" stroke="#0984e3" stroke-width="1.5">
+    <animate attributeName="stroke-opacity" values="0.2;0.5;0.2" dur="3s" repeatCount="indefinite" begin="0.5s"/>
+  </rect>
+</svg>


### PR DESCRIPTION
## Summary
Add a dedicated site landing page explaining why OpenTelemetry is needed for modern observability.

## Motivation / Problem
The site already references why teams choose OpenTelemetry, but there was no dedicated destination for that message. This change creates a focused landing page and connects existing internal CTAs to it.

## Changes
- added a new `/opentelemetry/why-is-opentelemetry-needed/` route with page metadata and structured feature-page content
- updated the homepage "Why OpenTelemetry" section CTA to point to the new page
- added a "Start here" link from the OpenTelemetry resource center header

## Description
This PR adds a marketing/educational page that explains the need for OpenTelemetry in terms of standardization, portability, vendor neutrality, and signal correlation. It uses the repo's existing feature-page components and existing assets to keep the implementation minimal.

## Type of Change

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
- [ ] Documentation only
- [x] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

If breaking change, describe migration steps:

## Context & Screenshots
Screenshots not captured in this environment.

## Before / After (if applicable)
Before: existing CTAs referenced a missing or less direct destination for why OpenTelemetry matters.
After: users can navigate to a dedicated explainer page from existing OpenTelemetry entry points.

## Checklist

### General
- [ ] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [x] Self-reviewed the code
- [ ] Comments added for complex logic

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Completed the [Docs PR Checklist](CONTRIBUTING.md#docs-pr-checklist) in CONTRIBUTING.md
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc

### For blog changes
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [x] Follows [Site Code Guidelines](CONTRIBUTING.md#website-code-guidelines) in CONTRIBUTING.md
- [x] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

## Testing
- [x] Tested locally
- [x] Edge cases considered
- [x] Existing functionality verified
- [ ] New tests added (if applicable)

Steps to test:
1. Open `/opentelemetry/why-is-opentelemetry-needed/`.
2. Verify the new hero, content sections, and CTAs render correctly.
3. Verify links from the homepage Why OpenTelemetry section and resource center OpenTelemetry page navigate to the new route.

## Rollout / Deployment Notes
No special rollout steps.

## Additional Context
`yarn build` could not complete in this sandbox because Next.js attempted to fetch external Google Fonts and network access to `fonts.googleapis.com` was unavailable (`ENOTFOUND`).

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
