### PR TITLE
chore: fix duplicate title and meta description

### DIFF
--- a/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
@@ -1,8 +1,37 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allBlogs } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
 
 const POSTS_PER_PAGE = 5
+
+export async function generateMetadata({ params }: { params: { page: string } }) {
+  return {
+    title: `Blog - Page ${params.page}`,
+    description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+    openGraph: {
+      title: `Blog - Page ${params.page} | SigNoz`,
+      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      url: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: `Blog - Page ${params.page}`,
+      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      images: [siteMetadata.socialBanner],
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
+    },
+    robots: {
+      index: false,
+      follow: true,
+    },
+  }
+}
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(allBlogs.length / POSTS_PER_PAGE)

--- a/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: { page: string } })
     },
     twitter: {
       title: `Blog - Page ${params.page}`,
-      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
       images: [siteMetadata.socialBanner],
     },
     alternates: {

--- a/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/blog/page/[page]/page.tsx
@@ -8,10 +8,10 @@ const POSTS_PER_PAGE = 5
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {
     title: `Blog - Page ${params.page}`,
-    description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+    description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
     openGraph: {
       title: `Blog - Page ${params.page} | SigNoz`,
-      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
       url: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
       siteName: siteMetadata.title,
       locale: 'en_US',

--- a/app/(opentelemetry-hub-routes)/comparisons/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/comparisons/page/[page]/page.tsx
@@ -8,10 +8,10 @@ const POSTS_PER_PAGE = 5
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {
     title: `Comparisons - Page ${params.page}`,
-    description: `Comparisons - Page ${params.page} | SigNoz`,
+    description: `${siteMetadata.description} | Comparisons - Page ${params.page} | SigNoz`,
     openGraph: {
       title: `Comparisons - Page ${params.page} | SigNoz`,
-      description: `Comparisons - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Comparisons - Page ${params.page} | SigNoz`,
       url: `${siteMetadata.siteUrl}/comparisons/page/${params.page}`,
       siteName: siteMetadata.title,
       locale: 'en_US',
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: { page: string } })
     },
     twitter: {
       title: `Comparisons - Page ${params.page} | SigNoz`,
-      description: `Comparisons - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Comparisons - Page ${params.page} | SigNoz`,
       images: [siteMetadata.socialBanner],
     },
     alternates: {

--- a/app/(opentelemetry-hub-routes)/comparisons/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/comparisons/page/[page]/page.tsx
@@ -1,8 +1,37 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allBlogs } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
 
 const POSTS_PER_PAGE = 5
+
+export async function generateMetadata({ params }: { params: { page: string } }) {
+  return {
+    title: `Comparisons - Page ${params.page}`,
+    description: `Comparisons - Page ${params.page} | SigNoz`,
+    openGraph: {
+      title: `Comparisons - Page ${params.page} | SigNoz`,
+      description: `Comparisons - Page ${params.page} | SigNoz`,
+      url: `${siteMetadata.siteUrl}/comparisons/page/${params.page}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: `Comparisons - Page ${params.page} | SigNoz`,
+      description: `Comparisons - Page ${params.page} | SigNoz`,
+      images: [siteMetadata.socialBanner],
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/comparisons/page/${params.page}`,
+    },
+    robots: {
+      index: false,
+      follow: true,
+    },
+  }
+}
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(allBlogs.length / POSTS_PER_PAGE)

--- a/app/(opentelemetry-hub-routes)/guides/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/guides/page/[page]/page.tsx
@@ -8,10 +8,10 @@ const POSTS_PER_PAGE = 5
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {
     title: `Guides - Page ${params.page}`,
-    description: `Guides - Page ${params.page} | SigNoz`,
+    description: `${siteMetadata.description} | Guides - Page ${params.page} | SigNoz`,
     openGraph: {
       title: `Guides - Page ${params.page} | SigNoz`,
-      description: `Guides - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Guides - Page ${params.page} | SigNoz`,
       url: `${siteMetadata.siteUrl}/guides/page/${params.page}`,
       siteName: siteMetadata.title,
       locale: 'en_US',
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: { page: string } })
     },
     twitter: {
       title: `Guides - Page ${params.page} | SigNoz`,
-      description: `Guides - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Guides - Page ${params.page} | SigNoz`,
       images: [siteMetadata.socialBanner],
     },
     alternates: {

--- a/app/(opentelemetry-hub-routes)/guides/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/guides/page/[page]/page.tsx
@@ -1,8 +1,37 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allGuides } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
 
 const POSTS_PER_PAGE = 5
+
+export async function generateMetadata({ params }: { params: { page: string } }) {
+  return {
+    title: `Guides - Page ${params.page}`,
+    description: `Guides - Page ${params.page} | SigNoz`,
+    openGraph: {
+      title: `Guides - Page ${params.page} | SigNoz`,
+      description: `Guides - Page ${params.page} | SigNoz`,
+      url: `${siteMetadata.siteUrl}/guides/page/${params.page}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: `Guides - Page ${params.page} | SigNoz`,
+      description: `Guides - Page ${params.page} | SigNoz`,
+      images: [siteMetadata.socialBanner],
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/guides/page/${params.page}`,
+    },
+    robots: {
+      index: false,
+      follow: true,
+    },
+  }
+}
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(allGuides.length / POSTS_PER_PAGE)

--- a/app/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
@@ -1,8 +1,37 @@
 import ListLayout from '@/layouts/ListLayoutWithTags'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allBlogs } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
 
 const POSTS_PER_PAGE = 5
+
+export async function generateMetadata({ params }: { params: { page: string } }) {
+  return {
+    title: `OpenTelemetry - Page ${params.page}`,
+    description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+    openGraph: {
+      title: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      url: `${siteMetadata.siteUrl}/opentelemetry/page/${params.page}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      images: [siteMetadata.socialBanner],
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/opentelemetry/page/${params.page}`,
+    },
+    robots: {
+      index: false,
+      follow: true,
+    },
+  }
+}
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(allBlogs.length / POSTS_PER_PAGE)

--- a/app/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
+++ b/app/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
@@ -8,10 +8,10 @@ const POSTS_PER_PAGE = 5
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {
     title: `OpenTelemetry - Page ${params.page}`,
-    description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+    description: `${siteMetadata.description} | OpenTelemetry - Page ${params.page} | SigNoz`,
     openGraph: {
       title: `OpenTelemetry - Page ${params.page} | SigNoz`,
-      description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | OpenTelemetry - Page ${params.page} | SigNoz`,
       url: `${siteMetadata.siteUrl}/opentelemetry/page/${params.page}`,
       siteName: siteMetadata.title,
       locale: 'en_US',
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: { page: string } })
     },
     twitter: {
       title: `OpenTelemetry - Page ${params.page} | SigNoz`,
-      description: `OpenTelemetry - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | OpenTelemetry - Page ${params.page} | SigNoz`,
       images: [siteMetadata.socialBanner],
     },
     alternates: {

--- a/app/api-reference/layout.tsx
+++ b/app/api-reference/layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react'
+import { Metadata } from 'next'
+
+import siteMetadata from '@/data/siteMetadata'
+
+export const metadata: Metadata = {
+  title: 'SigNoz API Reference',
+  description: 'SigNoz API Reference | SigNoz',
+  openGraph: {
+    title: 'SigNoz API Reference | SigNoz',
+    description: 'SigNoz API Reference | SigNoz',
+    url: `${siteMetadata.siteUrl}/api-reference`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'SigNoz API Reference | SigNoz',
+    description: 'SigNoz API Reference | SigNoz',
+    images: [siteMetadata.socialBanner],
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/api-reference`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+export default function APIReferenceLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -2,6 +2,34 @@
 
 import React from 'react'
 import OpenAPISpec from '../../components/OpenAPISpec'
+import siteMetadata from '@/data/siteMetadata'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'SigNoz API Reference',
+  description: 'SigNoz API Reference | SigNoz',
+  openGraph: {
+    title: 'SigNoz API Reference | SigNoz',
+    description: 'SigNoz API Reference | SigNoz',
+    url: `${siteMetadata.siteUrl}/api-reference`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'SigNoz API Reference | SigNoz',
+    description: 'SigNoz API Reference | SigNoz',
+    images: [siteMetadata.socialBanner],
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/api-reference`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
 
 export default function APIReference() {
   if (typeof window === 'undefined') return null

--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -2,34 +2,6 @@
 
 import React from 'react'
 import OpenAPISpec from '../../components/OpenAPISpec'
-import siteMetadata from '@/data/siteMetadata'
-import { Metadata } from 'next'
-
-export const metadata: Metadata = {
-  title: 'SigNoz API Reference',
-  description: 'SigNoz API Reference | SigNoz',
-  openGraph: {
-    title: 'SigNoz API Reference | SigNoz',
-    description: 'SigNoz API Reference | SigNoz',
-    url: `${siteMetadata.siteUrl}/api-reference`,
-    siteName: siteMetadata.title,
-    locale: 'en_US',
-    type: 'website',
-    images: [siteMetadata.socialBanner],
-  },
-  twitter: {
-    title: 'SigNoz API Reference | SigNoz',
-    description: 'SigNoz API Reference | SigNoz',
-    images: [siteMetadata.socialBanner],
-  },
-  alternates: {
-    canonical: `${siteMetadata.siteUrl}/api-reference`,
-  },
-  robots: {
-    index: true,
-    follow: true,
-  },
-}
 
 export default function APIReference() {
   if (typeof window === 'undefined') return null

--- a/app/changelog/[slug]/page.tsx
+++ b/app/changelog/[slug]/page.tsx
@@ -18,12 +18,16 @@ export async function generateMetadata({ params }: { params: { slug: string } })
     notFound()
   }
 
+  if (!changelogResponse?.data?.release_date || !changelogResponse?.data?.version) {
+    notFound()
+  }
+
   return {
-    title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+    title: changelogResponse.data.release_date + ' - ' + changelogResponse.data.version,
     description:
-      changelogResponse?.data?.release_date +
+      changelogResponse.data.release_date +
       ' - ' +
-      changelogResponse?.data?.version +
+      changelogResponse.data.version +
       ' - SigNoz Changelog',
     robots: {
       index: true,
@@ -33,11 +37,11 @@ export async function generateMetadata({ params }: { params: { slug: string } })
       canonical: `${siteMetadata.siteUrl}/changelog/${params.slug}`,
     },
     openGraph: {
-      title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+      title: changelogResponse.data.release_date + ' - ' + changelogResponse.data.version,
       description:
-        changelogResponse?.data?.release_date +
+        changelogResponse.data.release_date +
         ' - ' +
-        changelogResponse?.data?.version +
+        changelogResponse.data.version +
         ' - SigNoz Changelog',
       url: `${siteMetadata.siteUrl}/changelog/${params.slug}`,
       siteName: siteMetadata.title,
@@ -46,11 +50,11 @@ export async function generateMetadata({ params }: { params: { slug: string } })
       images: [siteMetadata.socialBanner],
     },
     twitter: {
-      title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+      title: changelogResponse.data.release_date + ' - ' + changelogResponse.data.version,
       description:
-        changelogResponse?.data?.release_date +
+        changelogResponse.data.release_date +
         ' - ' +
-        changelogResponse?.data?.version +
+        changelogResponse.data.version +
         ' - SigNoz Changelog',
       images: [siteMetadata.socialBanner],
       site: siteMetadata.twitter,

--- a/app/changelog/[slug]/page.tsx
+++ b/app/changelog/[slug]/page.tsx
@@ -5,8 +5,58 @@ import { ArrowLeft } from 'lucide-react'
 import { fetchChangelogById } from 'utils/strapi'
 import { notFound } from 'next/navigation'
 import { ChangelogByIdApiResponse } from 'utils/strapi'
+import siteMetadata from '@/data/siteMetadata'
 
 export const dynamicParams = false
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const changelogId = params.slug.split('-').pop()
+  let changelogResponse: ChangelogByIdApiResponse | null = null
+  try {
+    changelogResponse = await fetchChangelogById(changelogId as string)
+  } catch (error) {
+    notFound()
+  }
+
+  return {
+    title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+    description:
+      changelogResponse?.data?.release_date +
+      ' - ' +
+      changelogResponse?.data?.version +
+      ' - SigNoz Changelog',
+    robots: {
+      index: true,
+      follow: true,
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/changelog/${params.slug}`,
+    },
+    openGraph: {
+      title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+      description:
+        changelogResponse?.data?.release_date +
+        ' - ' +
+        changelogResponse?.data?.version +
+        ' - SigNoz Changelog',
+      url: `${siteMetadata.siteUrl}/changelog/${params.slug}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: changelogResponse?.data?.release_date + ' - ' + changelogResponse?.data?.version,
+      description:
+        changelogResponse?.data?.release_date +
+        ' - ' +
+        changelogResponse?.data?.version +
+        ' - SigNoz Changelog',
+      images: [siteMetadata.socialBanner],
+      site: siteMetadata.twitter,
+    },
+  }
+}
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const changelogId = params.slug.split('-').pop()

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -2,12 +2,41 @@ import ChangelogRenderer from '@/components/Changelog/Renderer/ChangelogRenderer
 import ChangelogFooter from '@/components/Changelog/Footer/ChangelogFooter'
 import ChangelogHeader from '@/components/Changelog/Header/ChangelogHeader'
 import { DeploymentType, fetchChangelogEntries } from '../../utils/strapi'
+import siteMetadata from '@/data/siteMetadata'
+import { Metadata } from 'next'
 
 interface ChangelogProps {
   searchParams: {
     page?: string
     deploymentType?: string
   }
+}
+
+export const metadata: Metadata = {
+  title: 'SigNoz Changelog',
+  description: 'SigNoz Changelog | SigNoz',
+  openGraph: {
+    title: 'SigNoz Changelog | SigNoz',
+    description: 'SigNoz Changelog | SigNoz',
+    url: `${siteMetadata.siteUrl}/changelog`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'SigNoz Changelog | SigNoz',
+    description: 'SigNoz Changelog | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/changelog`,
+  },
 }
 
 const Changelog = async ({ searchParams }: ChangelogProps) => {

--- a/app/product-comparison/datadog-savings/page.tsx
+++ b/app/product-comparison/datadog-savings/page.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/datadog-savings`,
+  },
 }
 
 export default function DatadogSavingsPage() {

--- a/app/product-comparison/datadog-savings/page.tsx
+++ b/app/product-comparison/datadog-savings/page.tsx
@@ -1,9 +1,30 @@
+import siteMetadata from '@/data/siteMetadata'
 import DatadogSaving from './DatadogSavings'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'SigNoz vs Datadog Cost Savings',
+  description: 'SigNoz vs Datadog Cost Savings | SigNoz',
+  openGraph: {
+    title: 'SigNoz vs Datadog Cost Savings | SigNoz',
+    description: 'SigNoz vs Datadog Cost Savings | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/datadog-savings`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'SigNoz vs Datadog Cost Savings | SigNoz',
+    description: 'SigNoz vs Datadog Cost Savings | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function DatadogSavingsPage() {

--- a/app/product-comparison/migrate-from-datadog/page.tsx
+++ b/app/product-comparison/migrate-from-datadog/page.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/migrate-from-datadog`,
+  },
 }
 
 export default function MigrateFromDataDogPage() {

--- a/app/product-comparison/migrate-from-datadog/page.tsx
+++ b/app/product-comparison/migrate-from-datadog/page.tsx
@@ -1,9 +1,30 @@
+import siteMetadata from '@/data/siteMetadata'
 import MigrateFromDataDog from './MigrateFromDataDog'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Migrate from Datadog',
+  description: 'Migrate from Datadog | SigNoz',
+  openGraph: {
+    title: 'Migrate from Datadog | SigNoz',
+    description: 'Migrate from Datadog | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/migrate-from-datadog`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Migrate from Datadog | SigNoz',
+    description: 'Migrate from Datadog | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function MigrateFromDataDogPage() {

--- a/app/product-comparison/migrate-from-dynatrace/page.tsx
+++ b/app/product-comparison/migrate-from-dynatrace/page.tsx
@@ -1,9 +1,30 @@
+import siteMetadata from '@/data/siteMetadata'
 import MigrateFromDynatrace from './MigrateFromDynatrace'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Migrate from Dynatrace',
+  description: 'Migrate from Dynatrace | SigNoz',
+  openGraph: {
+    title: 'Migrate from Dynatrace | SigNoz',
+    description: 'Migrate from Dynatrace | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/migrate-from-dynatrace`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Migrate from Dynatrace | SigNoz',
+    description: 'Migrate from Dynatrace | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function MigrateFromDynatracePage() {

--- a/app/product-comparison/migrate-from-dynatrace/page.tsx
+++ b/app/product-comparison/migrate-from-dynatrace/page.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/migrate-from-dynatrace`,
+  },
 }
 
 export default function MigrateFromDynatracePage() {

--- a/app/product-comparison/migrate-from-newrelic/page.tsx
+++ b/app/product-comparison/migrate-from-newrelic/page.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/migrate-from-newrelic`,
+  },
 }
 
 export default function MigrateFromNewRelicPage() {

--- a/app/product-comparison/migrate-from-newrelic/page.tsx
+++ b/app/product-comparison/migrate-from-newrelic/page.tsx
@@ -1,9 +1,30 @@
+import siteMetadata from '@/data/siteMetadata'
 import MigrateFromNewRelic from './MigrateFromNewRelic'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Migrate from NewRelic',
+  description: 'Migrate from NewRelic | SigNoz',
+  openGraph: {
+    title: 'Migrate from NewRelic | SigNoz',
+    description: 'Migrate from NewRelic | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/migrate-from-newrelic`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Migrate from NewRelic | SigNoz',
+    description: 'Migrate from NewRelic | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function MigrateFromNewRelicPage() {

--- a/app/product-comparison/newrelic-savings/page.tsx
+++ b/app/product-comparison/newrelic-savings/page.tsx
@@ -1,9 +1,33 @@
+import siteMetadata from '@/data/siteMetadata'
 import NewRelicSaving from './NewRelicSavings'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'New Relic Savings',
+  description: 'New Relic Savings | SigNoz',
+  openGraph: {
+    title: 'New Relic Savings | SigNoz',
+    description: 'New Relic Savings | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/newrelic-savings`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'New Relic Savings | SigNoz',
+    description: 'New Relic Savings | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/newrelic-savings`,
+  },
 }
 
 export default function MigrateFromDataDogPage() {

--- a/app/product-comparison/page.tsx
+++ b/app/product-comparison/page.tsx
@@ -24,6 +24,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison`,
+  },
 }
 
 const comparisons = [

--- a/app/product-comparison/page.tsx
+++ b/app/product-comparison/page.tsx
@@ -1,6 +1,30 @@
-import Hero from '@/components/ui/Hero'
+import siteMetadata from '@/data/siteMetadata'
+import { Metadata } from 'next'
 import Link from 'next/link'
-import { Children } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Product Comparisons',
+  description: 'Product Comparisons | SigNoz',
+  openGraph: {
+    title: 'Product Comparisons | SigNoz',
+    description: 'Product Comparisons | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Product Comparisons | SigNoz',
+    description: 'Product Comparisons | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
 
 const comparisons = [
   {

--- a/app/product-comparison/signoz-vs-dynatrace/page.tsx
+++ b/app/product-comparison/signoz-vs-dynatrace/page.tsx
@@ -1,9 +1,30 @@
+import siteMetadata from '@/data/siteMetadata'
 import SigNozVSDynatrace from './SigNozVsDynaTrace'
 
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'SigNoz VS DynaTrace',
+  description: 'SigNoz VS DynaTrace | SigNoz',
+  openGraph: {
+    title: 'SigNoz VS DynaTrace | SigNoz',
+    description: 'SigNoz VS DynaTrace | SigNoz',
+    url: `${siteMetadata.siteUrl}/product-comparison/signoz-vs-dynatrace`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'SigNoz VS DynaTrace | SigNoz',
+    description: 'SigNoz VS DynaTrace | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function SigNozVSDynatracePage() {

--- a/app/product-comparison/signoz-vs-dynatrace/page.tsx
+++ b/app/product-comparison/signoz-vs-dynatrace/page.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/product-comparison/signoz-vs-dynatrace`,
+  },
 }
 
 export default function SigNozVSDynatracePage() {

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import Blogs from './Blogs'
-import siteMetadata, { description } from '@/data/siteMetadata'
+import siteMetadata from '@/data/siteMetadata'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Blog | SigNoz',
-  description: description,
+  description: siteMetadata.description,
   openGraph: {
     title: 'Blog | SigNoz',
-    description: description,
-    url: `${siteMetadata.siteUrl}/blog`,
+    description: siteMetadata.description,
+    url: `${siteMetadata.siteUrl}/resource-center/blog`,
     siteName: siteMetadata.title,
     locale: 'en_US',
     type: 'website',
@@ -17,12 +17,12 @@ export const metadata: Metadata = {
   },
   twitter: {
     title: 'Blog | SigNoz',
-    description: description,
+    description: siteMetadata.description,
     images: [siteMetadata.socialBanner],
     site: siteMetadata.twitter,
   },
   robots: {
-    index: false,
+    index: true,
     follow: true,
   },
 }

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -4,11 +4,11 @@ import siteMetadata from '@/data/siteMetadata'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Blog | SigNoz',
-  description: siteMetadata.description,
+  title: 'Blog',
+  description: `${siteMetadata.description} | Blog | SigNoz`,
   openGraph: {
     title: 'Blog | SigNoz',
-    description: siteMetadata.description,
+    description: `${siteMetadata.description} | Blog | SigNoz`,
     url: `${siteMetadata.siteUrl}/resource-center/blog`,
     siteName: siteMetadata.title,
     locale: 'en_US',
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     title: 'Blog | SigNoz',
-    description: siteMetadata.description,
+    description: `${siteMetadata.description} | Blog | SigNoz`,
     images: [siteMetadata.socialBanner],
     site: siteMetadata.twitter,
   },

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -21,6 +21,10 @@ export const metadata: Metadata = {
     images: [siteMetadata.socialBanner],
     site: siteMetadata.twitter,
   },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default async function BlogHome() {

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -1,8 +1,27 @@
 import React from 'react'
 import Blogs from './Blogs'
-import { genPageMetadata } from 'app/seo'
+import siteMetadata, { description } from '@/data/siteMetadata'
+import { Metadata } from 'next'
 
-export const metadata = genPageMetadata({ title: 'Blog' })
+export const metadata: Metadata = {
+  title: 'Blog | SigNoz',
+  description: description,
+  openGraph: {
+    title: 'Blog | SigNoz',
+    description: description,
+    url: `${siteMetadata.siteUrl}/blog`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Blog | SigNoz',
+    description: description,
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+}
 
 export default async function BlogHome() {
   return (

--- a/app/resource-center/blog/page/[page]/page.tsx
+++ b/app/resource-center/blog/page/[page]/page.tsx
@@ -2,9 +2,7 @@ import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import GridLayout from '@/layouts/GridLayout'
 import { allBlogs } from 'contentlayer/generated'
 import React from 'react'
-import { genPageMetadata } from 'app/seo'
 import siteMetadata from '@/data/siteMetadata'
-import { Metadata } from 'next'
 
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {

--- a/app/resource-center/blog/page/[page]/page.tsx
+++ b/app/resource-center/blog/page/[page]/page.tsx
@@ -2,6 +2,37 @@ import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import GridLayout from '@/layouts/GridLayout'
 import { allBlogs } from 'contentlayer/generated'
 import React from 'react'
+import { genPageMetadata } from 'app/seo'
+import siteMetadata from '@/data/siteMetadata'
+import { Metadata } from 'next'
+
+export async function generateMetadata({ params }: { params: { page: string } }) {
+  return {
+    title: `Blog - Page ${params.page}`,
+    description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+    openGraph: {
+      title: `Blog - Page ${params.page} | SigNoz`,
+      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      url: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'website',
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      title: `Blog - Page ${params.page}`,
+      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      images: [siteMetadata.socialBanner],
+    },
+    alternates: {
+      canonical: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
+    },
+    robots: {
+      index: false,
+      follow: true,
+    },
+  }
+}
 
 const POSTS_PER_PAGE = 10
 
@@ -31,7 +62,7 @@ export default function Page({ params }: { params: { page: string } }) {
       initialDisplayPosts={initialDisplayPosts}
       pagination={pagination}
       title="All Posts"
-      isDarkMode = {true}
+      isDarkMode={true}
     />
   )
 }

--- a/app/resource-center/blog/page/[page]/page.tsx
+++ b/app/resource-center/blog/page/[page]/page.tsx
@@ -7,10 +7,10 @@ import siteMetadata from '@/data/siteMetadata'
 export async function generateMetadata({ params }: { params: { page: string } }) {
   return {
     title: `Blog - Page ${params.page}`,
-    description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+    description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
     openGraph: {
       title: `Blog - Page ${params.page} | SigNoz`,
-      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
       url: `${siteMetadata.siteUrl}/resource-center/blog/page/${params.page}`,
       siteName: siteMetadata.title,
       locale: 'en_US',
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: { params: { page: string } })
     },
     twitter: {
       title: `Blog - Page ${params.page}`,
-      description: `SigNoz is an open-source observability tool powered by OpenTelemetry. Get APM, logs, traces, metrics, exceptions, & alerts in a single tool. | Blog - Page ${params.page} | SigNoz`,
+      description: `${siteMetadata.description} | Blog - Page ${params.page} | SigNoz`,
       images: [siteMetadata.socialBanner],
     },
     alternates: {

--- a/app/terms-of-reference/page.tsx
+++ b/app/terms-of-reference/page.tsx
@@ -2,9 +2,33 @@ import MarkdownRenderer from '@/components/ReactMarkdown'
 import React from 'react'
 
 import { Metadata } from 'next'
+import siteMetadata from '@/data/siteMetadata'
 
 export const metadata: Metadata = {
   title: 'Terms of Reference',
+  description: 'Terms of Reference | SigNoz',
+  openGraph: {
+    title: 'Terms of Reference | SigNoz',
+    description: 'Terms of Reference | SigNoz',
+    url: `${siteMetadata.siteUrl}/terms-of-reference`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Terms of Reference | SigNoz',
+    description: 'Terms of Reference | SigNoz',
+    images: [siteMetadata.socialBanner],
+    site: siteMetadata.twitter,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/terms-of-reference`,
+  },
 }
 
 const markdownContent = `**TERMS OF REFERENCE**

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -2,9 +2,32 @@ import MarkdownRenderer from '@/components/ReactMarkdown'
 import React from 'react'
 
 import { Metadata } from 'next'
+import siteMetadata from '@/data/siteMetadata'
 
 export const metadata: Metadata = {
   title: 'Terms of Service',
+  description: 'Terms of Service | SigNoz',
+  openGraph: {
+    title: 'Terms of Service | SigNoz',
+    description: 'Terms of Service | SigNoz',
+    url: `${siteMetadata.siteUrl}/terms-of-service`,
+    siteName: siteMetadata.title,
+    locale: 'en_US',
+    type: 'website',
+    images: [siteMetadata.socialBanner],
+  },
+  twitter: {
+    title: 'Terms of Service | SigNoz',
+    description: 'Terms of Service | SigNoz',
+    images: [siteMetadata.socialBanner],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: `${siteMetadata.siteUrl}/terms-of-service`,
+  },
 }
 
 const markdownContent = `**TERMS AND CONDITIONS**


### PR DESCRIPTION
## Summary

Adds explicit Next.js `metadata` / `generateMetadata` across listing, marketing, legal, changelog, and API reference routes so each URL has distinct titles and meta descriptions (plus Open Graph, Twitter, canonical URLs, and robots where appropriate). Replaces generic `genPageMetadata` usage on the resource center blog index with page-specific metadata aligned to the site default description.

## Motivation / Problem

Several routes inherited duplicate or overly generic titles and meta descriptions (and in some cases only a title), which hurts SEO clarity and social previews. Paginated hub routes (`/blog/page/[page]`, `/guides/page/[page]`, etc.) and standalone pages needed per-URL metadata instead of falling back to the root layout defaults.

## Changes

- Add `app/api-reference/layout.tsx` with metadata for the API Reference section.
- Changelog: export metadata on `/changelog` and dynamic `generateMetadata` on `/changelog/[slug]` using Strapi data (release date, version).
- Product comparison: add descriptions, Open Graph, Twitter, robots, and canonicals on the index and migrate/savings/vs pages; remove unused imports (`Hero`, `Children`) from the product comparison index.
- Resource center blog: replace `genPageMetadata({ title: 'Blog' })` with explicit metadata; add `generateMetadata` for paginated blog pages under `resource-center/blog/page/[page]`.
- OpenTelemetry hub routes: add `generateMetadata` for paginated blog, comparisons, guides, and OpenTelemetry listing pages (`page/[page]`).
- Terms: add full metadata blocks for Terms of Service and Terms of Reference.

## Description

This PR standardizes SEO metadata across multiple App Router pages: unique `title` and `description` strings, consistent `openGraph` and `twitter` fields using `siteMetadata`, `alternates.canonical` where applicable, and explicit `robots` (paginated listing-style routes use `index: false, follow: true` where implemented). Changelog detail pages derive titles and descriptions from the fetched changelog entry.

## Type of Change

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact

- [ ] Documentation only
- [x] UI changes (meta tags / SEO only; no visual layout changes intended)
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change


## Before / After (if applicable)
Before /resource-center/page/1/
<img width="1728" height="956" alt="Screenshot 2026-04-06 at 12 50 33" src="https://github.com/user-attachments/assets/0896aca1-4e3c-4f54-84ca-919b4bffbd69" />


After /resource-center/page/1/ 
<img width="1728" height="963" alt="Screenshot 2026-04-06 at 12 50 49" src="https://github.com/user-attachments/assets/65489daa-463d-4a26-96eb-3472f6737075" />

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
