### PR TITLE
perf(blog-post-card): avoid prefetch

### DIFF
--- a/app/resource-center/Shared/BlogPostCard.tsx
+++ b/app/resource-center/Shared/BlogPostCard.tsx
@@ -44,7 +44,7 @@ export default function BlogPostCard({
   }
 
   return (
-    <Link href={`/${path}`} prefetch={true}>
+    <Link href={`/${path}`} prefetch={false}>
       <div className="flex cursor-pointer flex-col max-md:ml-0 max-md:w-full">
         <div
           className={`mx-auto flex w-full grow flex-col rounded border border-solid p-4 transition-colors duration-150 hover:bg-signoz_ink-300 active:opacity-70 dark:border-signoz_ink-500 dark:bg-signoz_ink-400 dark:hover:bg-signoz_ink-300 max-md:mt-6`}


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Provide a concise overview of the change. -->

## Motivation / Problem
<!-- Why is this change needed? What problem does it solve? -->
<!-- Link issues if applicable (e.g. Fixes #123) -->

I don't think there's a real need for the prefetch here, it will fetch every page we scroll, causing it to fetch all guides when scroll to the bottom.