### PR TITLE
perf(app): move content layer reads to server side

### DIFF
--- a/app/resource-center/ResourceCenterClient.tsx
+++ b/app/resource-center/ResourceCenterClient.tsx
@@ -6,9 +6,12 @@ import ComparisonsListing from './comparisons/Comparisons'
 import Guides from './guides/Guides'
 import OpenTelemetry from './opentelemetry/OpenTelemetry'
 import Button from '@/components/ui/Button'
-import type { MDXContent } from '@/utils/strapi'
-import type { Comparison } from 'types/transformedContent'
-import type { ResourceCenterBlog, ResourceCenterGuide } from './content'
+import type {
+  ResourceCenterBlog,
+  ResourceCenterComparison,
+  ResourceCenterGuide,
+  ResourceCenterOpenTelemetryArticle,
+} from './content'
 
 const tabs = [
   {
@@ -45,8 +48,8 @@ export default function ResourceCenterClient({
 }: {
   blogPosts: ResourceCenterBlog[]
   guidePosts: ResourceCenterGuide[]
-  openTelemetryArticles?: MDXContent[]
-  comparisonPosts?: Comparison[]
+  openTelemetryArticles?: ResourceCenterOpenTelemetryArticle[]
+  comparisonPosts?: ResourceCenterComparison[]
 }) {
   const [activeTab, setActiveTab] = useState('blog-tab')
 

--- a/app/resource-center/ResourceCenterClient.tsx
+++ b/app/resource-center/ResourceCenterClient.tsx
@@ -6,6 +6,9 @@ import ComparisonsListing from './comparisons/Comparisons'
 import Guides from './guides/Guides'
 import OpenTelemetry from './opentelemetry/OpenTelemetry'
 import Button from '@/components/ui/Button'
+import type { MDXContent } from '@/utils/strapi'
+import type { Comparison } from 'types/transformedContent'
+import type { ResourceCenterBlog, ResourceCenterGuide } from './content'
 
 const tabs = [
   {
@@ -13,33 +16,55 @@ const tabs = [
     label: 'Blog',
     target: '#blog',
     controls: 'blog',
-    component: Blogs,
   },
   {
     id: 'comparisons-tab',
     label: 'Comparisons',
     target: '#comparisons',
     controls: 'comparisons',
-    component: ComparisonsListing,
   },
   {
     id: 'guides-tab',
     label: 'Guides',
     target: '#guides',
     controls: 'guides',
-    component: Guides,
   },
   {
     id: 'openTelemetry-tab',
     label: 'OpenTelemetry',
     target: '#openTelemetry',
     controls: 'openTelemetry',
-    component: OpenTelemetry,
   },
 ]
 
-export default function ResourceCenterClient() {
+export default function ResourceCenterClient({
+  blogPosts,
+  guidePosts,
+  openTelemetryArticles = [],
+  comparisonPosts = [],
+}: {
+  blogPosts: ResourceCenterBlog[]
+  guidePosts: ResourceCenterGuide[]
+  openTelemetryArticles?: MDXContent[]
+  comparisonPosts?: Comparison[]
+}) {
   const [activeTab, setActiveTab] = useState('blog-tab')
+
+  let content = <Blogs posts={blogPosts} />
+
+  if (activeTab === 'comparisons-tab') {
+    content = <ComparisonsListing posts={comparisonPosts} />
+  } else if (activeTab === 'guides-tab') {
+    content = <Guides posts={guidePosts} />
+  } else if (activeTab === 'openTelemetry-tab') {
+    content = (
+      <OpenTelemetry
+        articles={openTelemetryArticles}
+        blogPosts={blogPosts}
+        guidePosts={guidePosts}
+      />
+    )
+  }
 
   return (
     <div className="container mx-auto py-4">
@@ -71,9 +96,7 @@ export default function ResourceCenterClient() {
         </ul>
       </div>
 
-      <div className="tab-content pt-6">
-        {tabs.map((tab) => activeTab === tab.id && <tab.component key={tab.id} />)}
-      </div>
+      <div className="tab-content pt-6">{content}</div>
     </div>
   )
 }

--- a/app/resource-center/Shared/BlogPostCard.tsx
+++ b/app/resource-center/Shared/BlogPostCard.tsx
@@ -1,18 +1,20 @@
 import siteMetadata from '@/data/siteMetadata'
-import { Blog, Guide } from 'contentlayer/generated'
 import Authors from '../../../constants/authors.json'
 import { Clock4 } from 'lucide-react'
 import Link from 'next/link'
-import { CoreContent } from 'pliny/utils/contentlayer'
 import { formatDate } from 'pliny/utils/formatDate'
-import { MDXContent } from '@/utils/strapi'
-import { type Comparison } from 'types/transformedContent'
 
-export default function BlogPostCard({
-  blog,
-}: {
-  blog: CoreContent<Blog | Guide | MDXContent | Comparison>
-}) {
+type BlogPostCardContent = {
+  path: string
+  date: string
+  title: string
+  authors?: unknown[]
+  readingTime: {
+    text: string
+  }
+}
+
+export default function BlogPostCard({ blog }: { blog: BlogPostCardContent }) {
   const { path, date, title, authors } = blog
 
   const getAuthorDetails = (authorID) => {

--- a/app/resource-center/blog/Blogs.tsx
+++ b/app/resource-center/blog/Blogs.tsx
@@ -2,11 +2,10 @@
 
 import React, { useState } from 'react'
 import { filterData } from 'app/utils/common'
-import { allBlogs } from 'contentlayer/generated'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import SearchInput from '../Shared/Search'
 import FeaturedBlogs from './FeaturedBlogs'
 import AllBlogs from './AllBlogs'
+import type { ResourceCenterBlog } from '../content'
 
 interface BlogPageHeaderProps {
   onSearch: (e) => void
@@ -31,8 +30,7 @@ const BlogsPageHeader: React.FC<BlogPageHeaderProps> = ({ onSearch }) => {
   )
 }
 
-export default function Blogs() {
-  const posts = allCoreContent(sortPosts(allBlogs))
+export default function Blogs({ posts }: { posts: ResourceCenterBlog[] }) {
   const [blogs, setBlogs] = useState(posts)
   const [searchValue, setSearchValue] = useState('')
 
@@ -45,7 +43,7 @@ export default function Blogs() {
   return (
     <div>
       <BlogsPageHeader onSearch={handleSearch} />
-      {searchValue.length === 0 && <FeaturedBlogs isDarkMode={true} />}
+      {searchValue.length === 0 && <FeaturedBlogs isDarkMode={true} posts={posts} />}
       <AllBlogs blogs={blogs} />
     </div>
   )

--- a/app/resource-center/blog/FeaturedBlogs.tsx
+++ b/app/resource-center/blog/FeaturedBlogs.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
 import BlogPostCard from '../Shared/BlogPostCard'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
-import { allBlogs } from 'contentlayer/generated'
+import type { ResourceCenterBlog } from '../content'
 
 interface FeaturedBlogsProps {
   isDarkMode: boolean
+  posts: ResourceCenterBlog[]
 }
 
-function FeaturedBlogs({ isDarkMode }: FeaturedBlogsProps) {
-  const posts = allCoreContent(sortPosts(allBlogs))
-
+function FeaturedBlogs({ isDarkMode, posts }: FeaturedBlogsProps) {
   const primaryFeaturedBlogs = posts.slice(0, 2)
   const secondaryFeaturedBlogs = posts.slice(2, 5)
 

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Blogs from './Blogs'
 import siteMetadata from '@/data/siteMetadata'
 import { Metadata } from 'next'
+import { getResourceCenterBlogs } from '../content'
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -28,10 +29,12 @@ export const metadata: Metadata = {
 }
 
 export default async function BlogHome() {
+  const posts = getResourceCenterBlogs()
+
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">
       <div className="tab-content pt-6">
-        <Blogs />
+        <Blogs posts={posts} />
       </div>
     </div>
   )

--- a/app/resource-center/blog/page.tsx
+++ b/app/resource-center/blog/page.tsx
@@ -28,13 +28,13 @@ export const metadata: Metadata = {
   },
 }
 
-export default async function BlogHome() {
-  const posts = getResourceCenterBlogs()
+const blogPosts = getResourceCenterBlogs()
 
+export default async function BlogHome() {
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">
       <div className="tab-content pt-6">
-        <Blogs posts={posts} />
+        <Blogs posts={blogPosts} />
       </div>
     </div>
   )

--- a/app/resource-center/comparisons/Comparisons.tsx
+++ b/app/resource-center/comparisons/Comparisons.tsx
@@ -5,6 +5,7 @@ import SearchInput from '../Shared/Search'
 import React from 'react'
 import { filterData } from 'app/utils/common'
 import { Frown } from 'lucide-react'
+import type { ResourceCenterComparison } from '../content'
 
 interface ComparisonsPageHeaderProps {
   onSearch: (e) => void
@@ -29,7 +30,7 @@ const ComparisonsPageHeader: React.FC<ComparisonsPageHeaderProps> = ({ onSearch 
   )
 }
 
-export default function ComparisonsListing({ posts = [] }: { posts?: any[] }) {
+export default function ComparisonsListing({ posts = [] }: { posts?: ResourceCenterComparison[] }) {
   const primaryFeaturedBlogs = posts.slice(0, 2)
   const secondaryFeaturedBlogs = posts.slice(0)
 

--- a/app/resource-center/comparisons/page.tsx
+++ b/app/resource-center/comparisons/page.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import Comparisons from './Comparisons'
 import { fetchAllComparisonsForPage } from '@/utils/cachedData'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
+import { sortPosts } from 'pliny/utils/contentlayer'
 import { CMS_REVALIDATE_INTERVAL } from '@/constants/cache'
+import { pickResourceCenterCardFields } from '../content'
 
 export const revalidate = CMS_REVALIDATE_INTERVAL
 export const dynamic = 'force-static'
 
 export default async function ComparisonsHome() {
   const comparisons = await fetchAllComparisonsForPage()
-  const posts = allCoreContent(sortPosts(comparisons))
+  const posts = sortPosts(comparisons).map(pickResourceCenterCardFields)
 
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">

--- a/app/resource-center/content.ts
+++ b/app/resource-center/content.ts
@@ -1,0 +1,15 @@
+import { allBlogs, allGuides } from 'contentlayer/generated'
+import type { Blog, Guide } from 'contentlayer/generated'
+import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
+import type { CoreContent } from 'pliny/utils/contentlayer'
+
+export type ResourceCenterBlog = CoreContent<Blog>
+export type ResourceCenterGuide = CoreContent<Guide>
+
+export function getResourceCenterBlogs(): ResourceCenterBlog[] {
+  return allCoreContent(sortPosts(allBlogs))
+}
+
+export function getResourceCenterGuides(): ResourceCenterGuide[] {
+  return allCoreContent(sortPosts(allGuides))
+}

--- a/app/resource-center/content.ts
+++ b/app/resource-center/content.ts
@@ -1,15 +1,95 @@
 import { allBlogs, allGuides } from 'contentlayer/generated'
-import type { Blog, Guide } from 'contentlayer/generated'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
-import type { CoreContent } from 'pliny/utils/contentlayer'
+import { sortPosts } from 'pliny/utils/contentlayer'
+import type { MDXContent } from '@/utils/strapi'
 
-export type ResourceCenterBlog = CoreContent<Blog>
-export type ResourceCenterGuide = CoreContent<Guide>
+type ResourceCenterCardSource = {
+  slug?: string | null
+  path: string
+  date?: string | null
+  publishedAt?: string | null
+  title: string
+  description?: string | null
+  summary?: string | null
+  tags?: string[] | null
+  authors?: unknown[] | null
+  readingTime?: {
+    text?: string | null
+  } | null
+}
+
+/**
+ * NEVER INCLUDE BODY, THIS WILL CAUSE MANY BUNDLE ISSUES
+ */
+export type ResourceCenterCard = {
+  slug: string
+  path: string
+  date: string
+  title: string
+  description?: string
+  summary?: string
+  tags?: string[]
+  authors?: unknown[]
+  readingTime: {
+    text: string
+  }
+}
+
+export type ResourceCenterBlog = ResourceCenterCard
+export type ResourceCenterGuide = ResourceCenterCard
+export type ResourceCenterComparison = ResourceCenterCard
+export type ResourceCenterOpenTelemetryArticle = ResourceCenterCard
+
+export function pickResourceCenterCardFields(source: ResourceCenterCardSource): ResourceCenterCard {
+  /**
+   * NEVER INCLUDE BODY, THIS WILL CAUSE MANY BUNDLE ISSUES
+   */
+  return {
+    slug: source.slug ?? source.path.split('/').filter(Boolean).pop() ?? '',
+    path: source.path,
+    date: source.date ?? source.publishedAt ?? '',
+    title: source.title,
+    description: source.description ?? undefined,
+    summary: source.summary ?? undefined,
+    tags: source.tags ?? undefined,
+    authors: source.authors ?? undefined,
+    readingTime: {
+      text: source.readingTime?.text ?? '5 min read',
+    },
+  }
+}
+
+export function pickOpenTelemetryArticleFields(
+  article: MDXContent
+): ResourceCenterOpenTelemetryArticle {
+  let path = article.path || ''
+  if (path.startsWith('/')) {
+    path = path.slice(1)
+  }
+  if (!path.startsWith('opentelemetry/')) {
+    path = `opentelemetry/${path}`
+  }
+
+  return pickResourceCenterCardFields({
+    slug: article.slug,
+    path,
+    publishedAt: article.publishedAt,
+    title: article.title,
+    description: article.description,
+    summary: article.summary || article.description,
+    authors:
+      article.authors?.map((author: any) => ({
+        ...author,
+        name: author.name,
+        image_url: author.image_url || author.avatar,
+      })) || [],
+    readingTime: { text: article.readingTime?.text || '5 min read' },
+  })
+}
 
 export function getResourceCenterBlogs(): ResourceCenterBlog[] {
-  return allCoreContent(sortPosts(allBlogs))
+  return sortPosts(allBlogs).map(pickResourceCenterCardFields)
 }
 
 export function getResourceCenterGuides(): ResourceCenterGuide[] {
-  return allCoreContent(sortPosts(allGuides))
+  return sortPosts(allGuides).map(pickResourceCenterCardFields)
 }

--- a/app/resource-center/guides/Guides.tsx
+++ b/app/resource-center/guides/Guides.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { allGuides } from 'contentlayer/generated'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import React, { useState, useEffect, useMemo } from 'react'
 import BlogPostCard from '../Shared/BlogPostCard'
 import { filterData } from 'app/utils/common'
 import SearchInput from '../Shared/Search'
 import { Frown } from 'lucide-react'
 import SideBar, { GUIDES_TOPICS } from '@/components/SideBar'
+import type { ResourceCenterGuide } from '../content'
 
 interface HeadingProps {
   tag: string
@@ -44,8 +43,7 @@ const GuidesHeader = ({ title, description, searchPlaceholder, onSearch }) => {
   )
 }
 
-export default function Guides() {
-  const posts = allCoreContent(sortPosts(allGuides))
+export default function Guides({ posts }: { posts: ResourceCenterGuide[] }) {
   const [activeItem, setActiveItem] = useState(GUIDES_TOPICS.ALL)
   const [searchQuery, setSearchQuery] = useState('')
   const POST_PER_PAGE = 20

--- a/app/resource-center/guides/page.tsx
+++ b/app/resource-center/guides/page.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import Guides from './Guides'
+import { getResourceCenterGuides } from '../content'
 
 export default function GuidesHome() {
+  const posts = getResourceCenterGuides()
+
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">
       <div className="tab-content pt-6">
-        <Guides />
+        <Guides posts={posts} />
       </div>
     </div>
   )

--- a/app/resource-center/guides/page.tsx
+++ b/app/resource-center/guides/page.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import Guides from './Guides'
 import { getResourceCenterGuides } from '../content'
 
-export default function GuidesHome() {
-  const posts = getResourceCenterGuides()
+const guidePosts = getResourceCenterGuides()
 
+export default function GuidesHome() {
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">
       <div className="tab-content pt-6">
-        <Guides posts={posts} />
+        <Guides posts={guidePosts} />
       </div>
     </div>
   )

--- a/app/resource-center/opentelemetry/OpenTelemetry.tsx
+++ b/app/resource-center/opentelemetry/OpenTelemetry.tsx
@@ -2,29 +2,18 @@
 
 import hubConfig from '@/constants/opentelemetry_hub.json'
 import { LEARN_CHAPTER_ORDER } from '@/constants/opentelemetryHub'
-import { coreContent, type CoreContent } from 'pliny/utils/contentlayer'
-import type { MDXContent } from '@/utils/strapi'
 import BlogPostCard from '../Shared/BlogPostCard'
 import SearchInput from '../Shared/Search'
 import React from 'react'
 import { filterData } from 'app/utils/common'
 import { Frown } from 'lucide-react'
-import { type Comparison } from 'types/transformedContent'
-import type { ResourceCenterBlog, ResourceCenterGuide } from '../content'
+import type {
+  ResourceCenterBlog,
+  ResourceCenterGuide,
+  ResourceCenterOpenTelemetryArticle,
+} from '../content'
 
-type TransformedStrapiArticle = CoreContent<MDXContent> & {
-  path: string
-  date: string
-  readingTime: {
-    text: string
-  }
-  authors: Record<string, unknown>[]
-  title: string
-  description?: string
-  summary?: string
-}
-
-type HubDoc = ResourceCenterBlog | Comparison | ResourceCenterGuide | TransformedStrapiArticle
+type HubDoc = ResourceCenterBlog | ResourceCenterGuide | ResourceCenterOpenTelemetryArticle
 
 type HubChapterGroup = {
   key: string
@@ -78,32 +67,6 @@ function formatLanguageLabel(label: string) {
   return label
 }
 
-function transformStrapiArticle(article: any): TransformedStrapiArticle {
-  let path = article.path || ''
-  if (path.startsWith('/')) {
-    path = path.slice(1)
-  }
-  if (!path.startsWith('opentelemetry/')) {
-    path = `opentelemetry/${path}`
-  }
-
-  return {
-    ...article,
-    path,
-    date: article.publishedAt,
-    readingTime: { text: article.readingTime?.text || '5 min read' },
-    authors:
-      article.authors?.map((author: any) => ({
-        ...author,
-        name: author.name,
-        image_url: author.image_url || author.avatar,
-      })) || [],
-    title: article.title,
-    description: article.description,
-    summary: article.summary || article.description,
-  }
-}
-
 interface OpenTelemetryPageHeaderProps {
   onSearch: (e) => void
 }
@@ -127,7 +90,7 @@ const OpenTelemetryPageHeader: React.FC<OpenTelemetryPageHeaderProps> = ({ onSea
 }
 
 interface OpenTelemetryProps {
-  articles?: MDXContent[]
+  articles?: ResourceCenterOpenTelemetryArticle[]
   blogPosts: ResourceCenterBlog[]
   guidePosts: ResourceCenterGuide[]
 }
@@ -149,17 +112,11 @@ export default function OpenTelemetry({
       const normalizedDocMap = new Map<string, HubDoc>()
 
       // Merge collections
-      const allDocs: HubDoc[] = [...blogPosts, ...guidePosts]
-
-      // Add Strapi opentelemetry articles
-      articles.forEach((article) => {
-        allDocs.push(transformStrapiArticle(article))
-      })
+      const allDocs: HubDoc[] = [...blogPosts, ...guidePosts, ...articles]
 
       allDocs.forEach((doc) => {
-        const content = ('path' in doc ? doc : coreContent(doc)) as HubDoc
-        const normalizedPath = normalizeRoute(`/${content.path}`)
-        normalizedDocMap.set(normalizedPath, content)
+        const normalizedPath = normalizeRoute(`/${doc.path}`)
+        normalizedDocMap.set(normalizedPath, doc)
       })
 
       function setDocLanguage(doc: HubDoc | null, language?: string) {
@@ -239,9 +196,8 @@ export default function OpenTelemetry({
       quickStartDocs.forEach((doc) => docRegistry.set(doc.path, doc))
 
       articles.forEach((article) => {
-        const transformed = transformStrapiArticle(article)
-        if (!docRegistry.has(transformed.path)) {
-          docRegistry.set(transformed.path, transformed)
+        if (!docRegistry.has(article.path)) {
+          docRegistry.set(article.path, article)
         }
       })
 

--- a/app/resource-center/opentelemetry/OpenTelemetry.tsx
+++ b/app/resource-center/opentelemetry/OpenTelemetry.tsx
@@ -2,7 +2,6 @@
 
 import hubConfig from '@/constants/opentelemetry_hub.json'
 import { LEARN_CHAPTER_ORDER } from '@/constants/opentelemetryHub'
-import { allBlogs, allGuides, type Blog, type Guide } from 'contentlayer/generated'
 import { coreContent, type CoreContent } from 'pliny/utils/contentlayer'
 import type { MDXContent } from '@/utils/strapi'
 import BlogPostCard from '../Shared/BlogPostCard'
@@ -11,8 +10,21 @@ import React from 'react'
 import { filterData } from 'app/utils/common'
 import { Frown } from 'lucide-react'
 import { type Comparison } from 'types/transformedContent'
+import type { ResourceCenterBlog, ResourceCenterGuide } from '../content'
 
-type HubDoc = CoreContent<Blog | Comparison | Guide | MDXContent>
+type TransformedStrapiArticle = CoreContent<MDXContent> & {
+  path: string
+  date: string
+  readingTime: {
+    text: string
+  }
+  authors: Record<string, unknown>[]
+  title: string
+  description?: string
+  summary?: string
+}
+
+type HubDoc = ResourceCenterBlog | Comparison | ResourceCenterGuide | TransformedStrapiArticle
 
 type HubChapterGroup = {
   key: string
@@ -66,7 +78,7 @@ function formatLanguageLabel(label: string) {
   return label
 }
 
-function transformStrapiArticle(article: any): HubDoc {
+function transformStrapiArticle(article: any): TransformedStrapiArticle {
   let path = article.path || ''
   if (path.startsWith('/')) {
     path = path.slice(1)
@@ -116,9 +128,15 @@ const OpenTelemetryPageHeader: React.FC<OpenTelemetryPageHeaderProps> = ({ onSea
 
 interface OpenTelemetryProps {
   articles?: MDXContent[]
+  blogPosts: ResourceCenterBlog[]
+  guidePosts: ResourceCenterGuide[]
 }
 
-export default function OpenTelemetry({ articles = [] }: OpenTelemetryProps) {
+export default function OpenTelemetry({
+  articles = [],
+  blogPosts,
+  guidePosts,
+}: OpenTelemetryProps) {
   const [searchValue, setSearchValue] = React.useState('')
   const [activeLanguageKey, setActiveLanguageKey] = React.useState('ALL')
   const trimmedSearch = searchValue.trim()
@@ -131,7 +149,7 @@ export default function OpenTelemetry({ articles = [] }: OpenTelemetryProps) {
       const normalizedDocMap = new Map<string, HubDoc>()
 
       // Merge collections
-      const allDocs: (Blog | Comparison | Guide | HubDoc)[] = [...allBlogs, ...allGuides]
+      const allDocs: HubDoc[] = [...blogPosts, ...guidePosts]
 
       // Add Strapi opentelemetry articles
       articles.forEach((article) => {
@@ -246,7 +264,7 @@ export default function OpenTelemetry({ articles = [] }: OpenTelemetryProps) {
         AVAILABLE_LANGUAGES: languages,
         getDocLanguage: (doc: HubDoc) => docLanguageMap.get(doc.path),
       }
-    }, [articles])
+    }, [articles, blogPosts, guidePosts])
 
   const handleSearch = (e) => {
     setSearchValue(e.target.value)

--- a/app/resource-center/opentelemetry/OpenTelemetryClient.tsx
+++ b/app/resource-center/opentelemetry/OpenTelemetryClient.tsx
@@ -5,28 +5,35 @@ import Blogs from '../blog/Blogs'
 import Comparisons from '../comparisons/Comparisons'
 import Guides from '../guides/Guides'
 import OpenTelemetry from './OpenTelemetry'
-import { MDXContent } from '@/utils/strapi'
-import { Comparison } from 'types/transformedContent'
+import type { MDXContent } from '@/utils/strapi'
+import type { Comparison } from 'types/transformedContent'
+import type { ResourceCenterBlog, ResourceCenterGuide } from '../content'
 
 export default function OpenTelemetryClient({
   initialArticles,
   comparisonPosts,
+  blogPosts,
+  guidePosts,
 }: {
   initialArticles?: MDXContent[]
   comparisonPosts?: Comparison[]
+  blogPosts: ResourceCenterBlog[]
+  guidePosts: ResourceCenterGuide[]
 }) {
   const [activeTab, setActiveTab] = useState('openTelemetry-tab')
 
   return (
     <div className="container mx-auto !mt-[48px] py-16 sm:py-8">
       <div className="tab-content pt-6">
-        {activeTab === 'blog-tab' && <Blogs />}
+        {activeTab === 'blog-tab' && <Blogs posts={blogPosts} />}
 
         {activeTab === 'comparisons-tab' && <Comparisons posts={comparisonPosts} />}
 
-        {activeTab === 'guides-tab' && <Guides />}
+        {activeTab === 'guides-tab' && <Guides posts={guidePosts} />}
 
-        {activeTab === 'openTelemetry-tab' && <OpenTelemetry articles={initialArticles} />}
+        {activeTab === 'openTelemetry-tab' && (
+          <OpenTelemetry articles={initialArticles} blogPosts={blogPosts} guidePosts={guidePosts} />
+        )}
       </div>
     </div>
   )

--- a/app/resource-center/opentelemetry/OpenTelemetryClient.tsx
+++ b/app/resource-center/opentelemetry/OpenTelemetryClient.tsx
@@ -5,9 +5,12 @@ import Blogs from '../blog/Blogs'
 import Comparisons from '../comparisons/Comparisons'
 import Guides from '../guides/Guides'
 import OpenTelemetry from './OpenTelemetry'
-import type { MDXContent } from '@/utils/strapi'
-import type { Comparison } from 'types/transformedContent'
-import type { ResourceCenterBlog, ResourceCenterGuide } from '../content'
+import type {
+  ResourceCenterBlog,
+  ResourceCenterComparison,
+  ResourceCenterGuide,
+  ResourceCenterOpenTelemetryArticle,
+} from '../content'
 
 export default function OpenTelemetryClient({
   initialArticles,
@@ -15,8 +18,8 @@ export default function OpenTelemetryClient({
   blogPosts,
   guidePosts,
 }: {
-  initialArticles?: MDXContent[]
-  comparisonPosts?: Comparison[]
+  initialArticles?: ResourceCenterOpenTelemetryArticle[]
+  comparisonPosts?: ResourceCenterComparison[]
   blogPosts: ResourceCenterBlog[]
   guidePosts: ResourceCenterGuide[]
 }) {

--- a/app/resource-center/opentelemetry/page.tsx
+++ b/app/resource-center/opentelemetry/page.tsx
@@ -2,10 +2,16 @@ import OpenTelemetryClient from './OpenTelemetryClient'
 import { Metadata } from 'next'
 import { fetchMDXContentByPath, MDXContent } from '@/utils/strapi'
 import { fetchAllComparisonsForPage } from '@/utils/cachedData'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
+import { sortPosts } from 'pliny/utils/contentlayer'
 import { CMS_REVALIDATE_INTERVAL } from '@/constants/cache'
-import { type Comparison } from 'types/transformedContent'
-import { getResourceCenterBlogs, getResourceCenterGuides } from '../content'
+import {
+  getResourceCenterBlogs,
+  getResourceCenterGuides,
+  pickOpenTelemetryArticleFields,
+  pickResourceCenterCardFields,
+  type ResourceCenterComparison,
+  type ResourceCenterOpenTelemetryArticle,
+} from '../content'
 
 export const revalidate = CMS_REVALIDATE_INTERVAL
 export const dynamic = 'force-static'
@@ -37,8 +43,8 @@ export const metadata: Metadata = {
 export default async function OpenTelemetryHome() {
   const isProduction = process.env.VERCEL_ENV === 'production'
   const deployment_status = isProduction ? 'live' : 'staging'
-  let articles: MDXContent[] = []
-  let comparisonPosts: Comparison[] = []
+  let articles: ResourceCenterOpenTelemetryArticle[] = []
+  let comparisonPosts: ResourceCenterComparison[] = []
 
   try {
     const [articlesResponse, comparisonsResult] = await Promise.all([
@@ -46,8 +52,8 @@ export default async function OpenTelemetryHome() {
       fetchAllComparisonsForPage(),
     ])
 
-    comparisonPosts = allCoreContent(sortPosts(comparisonsResult)) as Comparison[]
-    articles = (articlesResponse.data || []) as MDXContent[]
+    comparisonPosts = sortPosts(comparisonsResult).map(pickResourceCenterCardFields)
+    articles = ((articlesResponse.data || []) as MDXContent[]).map(pickOpenTelemetryArticleFields)
   } catch (error) {
     console.error('Error fetching OpenTelemetry articles:', error)
   }

--- a/app/resource-center/opentelemetry/page.tsx
+++ b/app/resource-center/opentelemetry/page.tsx
@@ -40,6 +40,9 @@ export const metadata: Metadata = {
   },
 }
 
+const blogPosts = getResourceCenterBlogs()
+const guidePosts = getResourceCenterGuides()
+
 export default async function OpenTelemetryHome() {
   const isProduction = process.env.VERCEL_ENV === 'production'
   const deployment_status = isProduction ? 'live' : 'staging'
@@ -62,8 +65,8 @@ export default async function OpenTelemetryHome() {
     <OpenTelemetryClient
       initialArticles={articles}
       comparisonPosts={comparisonPosts}
-      blogPosts={getResourceCenterBlogs()}
-      guidePosts={getResourceCenterGuides()}
+      blogPosts={blogPosts}
+      guidePosts={guidePosts}
     />
   )
 }

--- a/app/resource-center/opentelemetry/page.tsx
+++ b/app/resource-center/opentelemetry/page.tsx
@@ -5,6 +5,7 @@ import { fetchAllComparisonsForPage } from '@/utils/cachedData'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { CMS_REVALIDATE_INTERVAL } from '@/constants/cache'
 import { type Comparison } from 'types/transformedContent'
+import { getResourceCenterBlogs, getResourceCenterGuides } from '../content'
 
 export const revalidate = CMS_REVALIDATE_INTERVAL
 export const dynamic = 'force-static'
@@ -51,5 +52,12 @@ export default async function OpenTelemetryHome() {
     console.error('Error fetching OpenTelemetry articles:', error)
   }
 
-  return <OpenTelemetryClient initialArticles={articles} comparisonPosts={comparisonPosts} />
+  return (
+    <OpenTelemetryClient
+      initialArticles={articles}
+      comparisonPosts={comparisonPosts}
+      blogPosts={getResourceCenterBlogs()}
+      guidePosts={getResourceCenterGuides()}
+    />
+  )
 }

--- a/app/resource-center/page.tsx
+++ b/app/resource-center/page.tsx
@@ -2,11 +2,9 @@ import React from 'react'
 import ResourceCenterClient from './ResourceCenterClient'
 import { getResourceCenterBlogs, getResourceCenterGuides } from './content'
 
+const blogPosts = getResourceCenterBlogs()
+const guidePosts = getResourceCenterGuides()
+
 export default async function ResourceCenter() {
-  return (
-    <ResourceCenterClient
-      blogPosts={getResourceCenterBlogs()}
-      guidePosts={getResourceCenterGuides()}
-    />
-  )
+  return <ResourceCenterClient blogPosts={blogPosts} guidePosts={guidePosts} />
 }

--- a/app/resource-center/page.tsx
+++ b/app/resource-center/page.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import ResourceCenterClient from './ResourceCenterClient'
+import { getResourceCenterBlogs, getResourceCenterGuides } from './content'
 
 export default async function ResourceCenter() {
-  return <ResourceCenterClient />
+  return (
+    <ResourceCenterClient
+      blogPosts={getResourceCenterBlogs()}
+      guidePosts={getResourceCenterGuides()}
+    />
+  )
 }

--- a/app/upgrade-path/components/DocRender.tsx
+++ b/app/upgrade-path/components/DocRender.tsx
@@ -1,18 +1,20 @@
-import { allDocs, Doc } from 'contentlayer/generated'
 import { coreContent } from 'pliny/utils/contentlayer.js'
 import DocContent from '@/components/DocContent/DocContent'
 import { RegionProvider } from '@/components/Region/RegionContext'
+import type { Doc } from 'contentlayer/generated'
 
 const DocRenderer = ({
   docUrl,
+  docsBySlug,
   setHasError,
 }: {
   docUrl: string
+  docsBySlug: Record<string, Doc>
   setHasError: (hasError: boolean) => void
 }) => {
   const slug = decodeURI(`${docUrl.replace('https://signoz.io/docs/', '').replace(/^\/+/, '')}`)
 
-  const post = allDocs?.find((p) => p?.slug === slug) as Doc
+  const post = docsBySlug[slug]
 
   if (!post) {
     setHasError(true)

--- a/app/upgrade-path/components/DocumentationPanel.tsx
+++ b/app/upgrade-path/components/DocumentationPanel.tsx
@@ -4,15 +4,22 @@ import DocRenderer from './DocRender'
 import { Card } from '@/components/ui/Card'
 import Link from 'next/link'
 import { AlertTriangle } from 'lucide-react'
+import type { Doc } from 'contentlayer/generated'
 
 interface DocumentationPanelProps {
   currentStep: UpgradePath
   className?: string
   docUrl: string
   version: string
+  docsBySlug: Record<string, Doc>
 }
 
-const DocumentationPanel: React.FC<DocumentationPanelProps> = ({ version, className, docUrl }) => {
+const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
+  version,
+  className,
+  docUrl,
+  docsBySlug,
+}) => {
   const [hasError, setHasError] = useState(false)
 
   return (
@@ -59,7 +66,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({ version, classN
                 </div>
               </div>
             ) : (
-              <DocRenderer docUrl={docUrl} setHasError={setHasError} />
+              <DocRenderer docUrl={docUrl} docsBySlug={docsBySlug} setHasError={setHasError} />
             )}
           </div>
         </Card>

--- a/app/upgrade-path/components/UpgradePathTool.tsx
+++ b/app/upgrade-path/components/UpgradePathTool.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { UpgradePathState, UpgradeSchema, GitHubReleasesResponse } from '../types/upgrade'
+import type { Doc } from 'contentlayer/generated'
 import upgradeSchema from '@/constants/upgradeSchema.json'
 import {
   calculateUpgradePath,
@@ -22,7 +25,7 @@ import Link from 'next/link'
 
 const TYPED_UPGRADE_SCHEMA = upgradeSchema as unknown as UpgradeSchema
 
-const UpgradePathTool: React.FC = () => {
+const UpgradePathTool: React.FC<{ docsBySlug: Record<string, Doc> }> = ({ docsBySlug }) => {
   const [state, setState] = useState<UpgradePathState>({
     currentVersion: '',
     targetVersion: '',
@@ -280,6 +283,7 @@ const UpgradePathTool: React.FC = () => {
                   className="col-span-2 max-h-screen w-full"
                   currentStep={currentStepData}
                   docUrl={currentStepData?.releaseInfo?.guideUrl ?? ''}
+                  docsBySlug={docsBySlug}
                 />
               </div>
             )}

--- a/app/upgrade-path/page.tsx
+++ b/app/upgrade-path/page.tsx
@@ -1,18 +1,45 @@
-'use client'
-import UpgradePathTool from './components/UpgradePathTool';
+import { allDocs } from 'contentlayer/generated'
+import type { Doc } from 'contentlayer/generated'
+import UpgradePathTool from './components/UpgradePathTool'
+import upgradeSchema from '@/constants/upgradeSchema.json'
+
+function getUpgradeDocsBySlug(): Record<string, Doc> {
+  const guideUrls = Array.from(
+    new Set(
+      Object.values(upgradeSchema.releases)
+        .map((release) => release.guideUrl)
+        .filter(Boolean)
+    )
+  )
+
+  return Object.fromEntries(
+    guideUrls
+      .map((guideUrl) => {
+        const slug = decodeURI(
+          `${guideUrl.replace('https://signoz.io/docs/', '').replace(/^\/+/, '')}`
+        )
+        const doc = allDocs.find((candidate) => candidate.slug === slug)
+
+        return doc ? [slug, doc] : null
+      })
+      .filter(Boolean) as [string, Doc][]
+  )
+}
 
 function UpgradePathToolPage() {
+  const docsBySlug = getUpgradeDocsBySlug()
+
   return (
     <>
-    <header className="relative !mx-auto">
-      <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[0] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
-      <div className="bg-dot-pattern masked-dots absolute top-0 flex h-screen w-full items-center justify-center" />
-      <div className="relative !mx-auto flex flex-col items-center border !border-b-0 border-dashed border-signoz_slate-400 pb-4 pt-12 md:pt-[4rem] min-h-screen">
-        <UpgradePathTool />
-      </div>
-    </header>
+      <header className="relative !mx-auto">
+        <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[0] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
+        <div className="bg-dot-pattern masked-dots absolute top-0 flex h-screen w-full items-center justify-center" />
+        <div className="relative !mx-auto flex min-h-screen flex-col items-center border !border-b-0 border-dashed border-signoz_slate-400 pb-4 pt-12 md:pt-[4rem]">
+          <UpgradePathTool docsBySlug={docsBySlug} />
+        </div>
+      </header>
     </>
   )
 }
 
-export default UpgradePathToolPage;
+export default UpgradePathToolPage

--- a/components/Chatbase/ChatbaseServer.tsx
+++ b/components/Chatbase/ChatbaseServer.tsx
@@ -1,12 +1,19 @@
 import React from 'react'
 import { cookies } from 'next/headers'
-import { generateUserHash } from '@/utils/userUtils'
 import ChatbaseClient from './ChatbaseClient'
 import ChatbaseCookieSync from './ChatbaseCookieSync'
+import crypto from 'crypto'
 
 interface ChatbaseServerProps {
   className?: string
   disableFloatingMessages?: boolean
+}
+
+/**
+ * Generate user hash for identity verification (server-side only)
+ */
+export const generateUserHash = (userId: string, secret: string): string => {
+  return crypto.createHmac('sha256', secret).update(userId).digest('hex')
 }
 
 /**
@@ -25,10 +32,7 @@ export default async function ChatbaseServer({
     return (
       <>
         <ChatbaseCookieSync />
-        <ChatbaseClient
-          className={className}
-          disableFloatingMessages={disableFloatingMessages}
-        />
+        <ChatbaseClient className={className} disableFloatingMessages={disableFloatingMessages} />
       </>
     )
   }
@@ -44,10 +48,7 @@ export default async function ChatbaseServer({
     return (
       <>
         <ChatbaseCookieSync />
-        <ChatbaseClient
-          className={className}
-          disableFloatingMessages={disableFloatingMessages}
-        />
+        <ChatbaseClient className={className} disableFloatingMessages={disableFloatingMessages} />
       </>
     )
   }

--- a/utils/userUtils.ts
+++ b/utils/userUtils.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from 'uuid'
-import crypto from 'crypto'
 
 const ANONYMOUS_ID_KEY = 'app_anonymous_id'
 const USER_ID_KEY = 'app_user_id'
@@ -35,13 +34,6 @@ export const getUserId = (): string | undefined => {
   } catch (error) {
     return undefined
   }
-}
-
-/**
- * Generate user hash for identity verification (server-side only)
- */
-export const generateUserHash = (userId: string, secret: string): string => {
-  return crypto.createHmac('sha256', secret).update(userId).digest('hex')
 }
 
 /**


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Provide a concise overview of the change. -->

Move content layer reads to server-side, reducing from 130mb to 10mb of resource fetch on /guides page.

## Motivation / Problem
<!-- Why is this change needed? What problem does it solve? -->
<!-- Link issues if applicable (e.g. Fixes #123) -->

The current code was importing all blogs/guides/everything into client side.

/guides page loaded 90mb of JS file due do this.

**Important Notes**: Even on RSC, if we pass the whole allBlogs, it still ends up in the user bundle when the user makes a request via `?rsc`, likely on prefetch. To avoid the damages, I also added a map to exclude body and avoid at all costs having the entire blog post to be embedded.

## Changes

Move all content layer reads to server side only, and pass it as props to the components reading it.

## Description
<!-- Briefly describe what this PR does and why -->

To reduce bundle size.

## Type of Change
<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
<!-- Who or what is affected by this change? -->
- [ ] Documentation only
- [ ] UI changes
- [ ] Developer workflow
- [x] Performance impact
- [ ] Breaking change

## Context & Screenshots
<!-- Add screenshots for UI or docs changes when helpful -->

## Before / After (if applicable)

Before:

<img width="627" height="956" alt="image" src="https://github.com/user-attachments/assets/6de893bc-8761-44ef-ac87-c0a451a4d847" />

After:

<img width="617" height="953" alt="image" src="https://github.com/user-attachments/assets/11494789-8947-4592-b666-0a5fdd8a53ff" />

## Checklist

<!-- Complete the sections that apply to your changes -->

### General
- [x] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [x] Self-reviewed the code
- [x] Comments added for complex logic

### For all changes
- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Followed the docs author checklist in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc
- [ ] Any added docs images use WebP format and live under `public/img/docs/<topic>/`

### For blog changes
- [ ] Followed the blog workflow in [contributing/blog-workflow.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/blog-workflow.md)
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [ ] Followed the site code playbook in [contributing/site-code.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/site-code.md)
- [ ] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Followed the redirects and discovery section in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

## Testing
<!-- Describe how the change was tested -->
- [x] Tested locally
- [x] Edge cases considered
- [x] Existing functionality verified
- [x] New tests added (if applicable)

Steps to test:
1. Open Guides
2. Press F12
3. Refresh the page
4. See network tab
