### PR TITLE
bugfix: topnav hover competing with tabs

### DIFF
--- a/app/sre-skill-decay-index/animations.css
+++ b/app/sre-skill-decay-index/animations.css
@@ -1,5 +1,5 @@
 /* Hide site navbar and reset main margin on quiz page */
-body:has(.decay-page) .fixed.left-0.right-0.z-30 {
+body:has(.decay-page) .fixed.left-0.right-0.z-\[50\] {
   display: none !important;
 }
 body:has(.decay-page) main {
@@ -19,7 +19,13 @@ body:has(.decay-page) main {
   --amber: #ffb020;
   --terminal-green: #39ff14;
   font-family: var(--font-outfit), sans-serif;
-  background: radial-gradient(ellipse at 50% 0%, rgba(255, 61, 61, 0.25) 0%, rgba(255, 61, 61, 0.12) 35%, rgba(255, 61, 61, 0.04) 60%, transparent 85%),
+  background: radial-gradient(
+      ellipse at 50% 0%,
+      rgba(255, 61, 61, 0.25) 0%,
+      rgba(255, 61, 61, 0.12) 35%,
+      rgba(255, 61, 61, 0.04) 60%,
+      transparent 85%
+    ),
     var(--bg);
   color: var(--text);
   min-height: 100vh;

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -319,7 +319,7 @@ export default function TopNav() {
   }
 
   return (
-    <div className="fixed left-0 right-0 z-30">
+    <div className="fixed left-0 right-0 z-[100]">
       <header
         className={`header-bg mx-auto box-border flex h-[56px] w-full items-center border-b border-signoz_slate-500 px-4 text-signoz_vanilla-100 backdrop-blur-[20px] dark:text-signoz_vanilla-100 md:px-8 lg:px-8`}
       >

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -319,9 +319,9 @@ export default function TopNav() {
   }
 
   return (
-    <div className="fixed left-0 right-0 z-[100]">
+    <div className="fixed left-0 right-0 z-[50]">
       <header
-        className={`header-bg mx-auto box-border flex h-[56px] w-full items-center border-b border-signoz_slate-500 px-4 text-signoz_vanilla-100 backdrop-blur-[20px] dark:text-signoz_vanilla-100 md:px-8 lg:px-8`}
+        className={`header-bg relative z-10 mx-auto box-border flex h-[56px] w-full items-center border-b border-signoz_slate-500 px-4 text-signoz_vanilla-100 backdrop-blur-[20px] dark:text-signoz_vanilla-100 md:px-8 lg:px-8`}
       >
         <nav
           className="container flex w-full justify-between text-signoz_vanilla-100 dark:text-signoz_vanilla-100"


### PR DESCRIPTION
## Summary
Bugfix - When someone hovers on Product/Resources dropdown when Product nav is visible, the product nav takes a higher z-index and overlaps with content inside product/resources dropdown

## Motivation / Problem
<img width="1726" height="600" alt="Screenshot 2026-04-13 at 18 36 17" src="https://github.com/user-attachments/assets/3f813e94-bbb6-43fc-86a6-c020a8dea454" />

## Changes
Increase z-index for dropdown content

## Type of Change
<!-- Check all that apply -->


- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
<!-- Who or what is affected by this change? -->
- [ ] Documentation only
- [x] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

## Before / After (if applicable)
Before:
<img width="1726" height="600" alt="Screenshot 2026-04-13 at 18 36 17" src="https://github.com/user-attachments/assets/3f813e94-bbb6-43fc-86a6-c020a8dea454" />

After:
<img width="1728" height="635" alt="Screenshot 2026-04-13 at 19 03 09" src="https://github.com/user-attachments/assets/08471d36-c491-420e-8b94-9b3ab9bbf695" />


## Checklist

<!-- Complete the sections that apply to your changes -->

### General
- [x] Branch is up to date with `main`
- [ ] PR title follows conventional format (`type: description`)
- [ ] Self-reviewed the code
- [ ] Comments added for complex logic


---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
