### PR TITLE
docs: add table for mapping bw datadog and signoz APM metrics

### DIFF
--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -160,27 +160,27 @@ SigNoz generates eight metrics from span data.
 **Core R.E.D Metrics (all spans)**
 
 - `signoz_calls_total` — Request and error counts (counter).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 - `signoz_latency.bucket` — Latency distribution as histogram buckets.
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 - `signoz_latency.sum` — Sum of all latency values (for avg = sum/count).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 - `signoz_latency.count` — Count of latency observations (for avg = sum/count).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 
 **DB Call Metrics**
 
 - `signoz_db_latency_sum` — Sum of DB call latency.
-  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 - `signoz_db_latency_count` — Count of DB call latency observations.
-  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 
 **External Call Metrics**
 
 - `signoz_external_call_latency_sum` — Sum of external call latency.
-  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 - `signoz_external_call_latency_count` — Count of external call latency observations.
-  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
+  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`
 
 ### Metric Mapping
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -160,27 +160,27 @@ SigNoz generates eight metrics from span data.
 **Core R.E.D Metrics (all spans)**
 
 - `signoz_calls_total` — Request and error counts (counter).
-  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 - `signoz_latency.bucket` — Latency distribution as histogram buckets.
-  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 - `signoz_latency.sum` — Sum of all latency values (for avg = sum/count).
-  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 - `signoz_latency.count` — Count of latency observations (for avg = sum/count).
-  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 
 **DB Call Metrics**
 
 - `signoz_db_latency_sum` — Sum of DB call latency.
-  - Relevant Dimensions: `service.name`, `status.code`, `db.system`, `db.name`
+  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 - `signoz_db_latency_count` — Count of DB call latency observations.
-  - Relevant Dimensions: `service.name`, `status.code`, `db.system`, `db.name`
+  - Dimensions: `service.name`, `status.code`, `db.system`, `db.name`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 
 **External Call Metrics**
 
 - `signoz_external_call_latency_sum` — Sum of external call latency.
-  - Relevant Dimensions: `service.name`, `status.code`, `http.status_code`
+  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 - `signoz_external_call_latency_count` — Count of external call latency observations.
-  - Relevant Dimensions: `service.name`, `status.code`, `http.status_code`
+  - Dimensions: `service.name`, `status.code`, `http.status_code`, `address`, `service.namespace`, `deployment.environment`, `signoz.collector.id`, `resource_deployment.environment`, `resource_signoz.collector.id`
 
 ### Metric Mapping
 
@@ -193,9 +193,9 @@ SigNoz uses **one metric with multiple dimensions**, and additionally breaks out
 | Datadog Metric | SigNoz Equivalent |
 | --- | --- |
 | `trace.<SPAN_NAME>.hits` | `signoz_calls_total{operation="<SPAN_NAME>"}` |
-| `trace.<SPAN_NAME>.hits.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", http.status_code="200"}` |
+| `trace.<SPAN_NAME>.hits.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>"}` |
 | `trace.<SPAN_NAME>.errors` | `signoz_calls_total{operation="<SPAN_NAME>", status.code="STATUS_CODE_ERROR"}` |
-| `trace.<SPAN_NAME>.errors.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", status.code="STATUS_CODE_ERROR", http.status_code="503"}` |
+| `trace.<SPAN_NAME>.errors.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", status.code="STATUS_CODE_ERROR"}` |
 
 **Latency**
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-18
+date: 2026-04-14
 id: metrics
 title: Migrate Metrics from Datadog
 description: Learn how to migrate your application and infrastructure metrics from Datadog to SigNoz using OpenTelemetry.
@@ -155,12 +155,65 @@ See [Using Datadog Receiver](https://signoz.io/docs/migration/migrate-from-datad
 
 APM metrics (like `trace.servlet.request.hits`, `trace.servlet.request.duration`) are generated from traces. When you migrate traces to SigNoz using OpenTelemetry (see [Migrate Traces](https://signoz.io/docs/migration/migrate-from-datadog/traces/)), SigNoz automatically generates equivalent APM metrics.
 
-SigNoz generates these metrics from traces:
+SigNoz generates eight metrics from span data.
 
-- Request rate (calls per second)
-- Error rate (errors per second)
-- P50, P90, P99 latency
-- Apdex score
+**Core R.E.D Metrics (all spans)**
+
+- `signoz_calls_total` — Request and error counts (counter).
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`
+- `signoz_latency.bucket` — Latency distribution as histogram buckets.
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+- `signoz_latency.sum` — Sum of all latency values (for avg = sum/count).
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+- `signoz_latency.count` — Count of latency observations (for avg = sum/count).
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+
+**DB Call Metrics**
+
+- `signoz_db_latency_sum` — Sum of DB call latency.
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `db.system`, `db.name`
+- `signoz_db_latency_count` — Count of DB call latency observations.
+  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `db.system`, `db.name`
+
+**External Call Metrics**
+
+- `signoz_external_call_latency_sum` — Sum of external call latency.
+  - Dimensions: `service.name`, `operation`, `status.code`, `http.status_code`
+- `signoz_external_call_latency_count` — Count of external call latency observations.
+  - Dimensions: `service.name`, `operation`, `status.code`, `http.status_code`
+
+### Metric Mapping
+
+Datadog creates a **separate metric per operation** — the span name (e.g. `rails.request`, `redis.command`, `mysql.query`) is embedded in the metric name itself. It also uses separate metric names for HTTP-status breakdowns (`.by_http_status`). DB calls and external calls are not broken out into separate metrics — they use different span names (e.g. `trace.mysql.query.hits` vs `trace.rails.request.hits`).
+
+SigNoz uses **one metric with multiple dimensions**, and additionally breaks out DB and external call latency into dedicated metrics. All SigNoz APM metrics carry labels, and you filter/group by them instead of querying different metric names.
+
+
+**Request and Error Counts**
+
+| Datadog Metric | SigNoz Equivalent |
+| --- | --- |
+| `trace.<SPAN_NAME>.hits` | `signoz_calls_total{operation="<SPAN_NAME>"}` |
+| `trace.<SPAN_NAME>.hits.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", http.status_code="200"}` |
+| `trace.<SPAN_NAME>.errors` | `signoz_calls_total{status.code="STATUS_CODE_ERROR"}` |
+| `trace.<SPAN_NAME>.errors.by_http_status` | `signoz_calls_total{status.code="STATUS_CODE_ERROR", http.status_code="503"}` |
+
+**Latency**
+
+| Datadog Metric | SigNoz Equivalent |
+| --- | --- |
+| `trace.<SPAN_NAME>` (DDSketch distribution) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` — supports p50/p75/p90/p95/p99 |
+| `trace.<SPAN_NAME>.duration` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` |
+| `trace.<SPAN_NAME>.duration.by_http_status` (legacy) | `signoz_latency.bucket{status.code="..."}` |
+| `trace.<SPAN_NAME>.duration.by_service` (legacy) | `signoz_latency.bucket{service.name="..."}` |
+| `trace.<SPAN_NAME>.apdex` | No separate metric — compute via ClickHouse query |
+
+**DB and External Call Latency**
+
+| Datadog Metric | SigNoz Equivalent |
+| --- | --- |
+| `trace.mysql.query`, `trace.postgres.query`, etc. | `signoz_db_latency_sum{db.system="..."}` / `signoz_db_latency_count{db.system="..."}` (average only) |
+| `trace.http.request`, `trace.okhttp.request`, etc. | `signoz_external_call_latency_sum` / `signoz_external_call_latency_count` (average only) |
 
 ### From Prometheus Exporters
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -188,15 +188,14 @@ Datadog creates a **separate metric per operation** — the span name (e.g. `rai
 
 SigNoz uses **one metric with multiple dimensions**, and additionally breaks out DB and external call latency into dedicated metrics. All SigNoz APM metrics carry labels, and you filter/group by them instead of querying different metric names.
 
-
 **Request and Error Counts**
 
 | Datadog Metric | SigNoz Equivalent |
 | --- | --- |
 | `trace.<SPAN_NAME>.hits` | `signoz_calls_total{operation="<SPAN_NAME>"}` |
 | `trace.<SPAN_NAME>.hits.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", http.status_code="200"}` |
-| `trace.<SPAN_NAME>.errors` | `signoz_calls_total{status.code="STATUS_CODE_ERROR"}` |
-| `trace.<SPAN_NAME>.errors.by_http_status` | `signoz_calls_total{status.code="STATUS_CODE_ERROR", http.status_code="503"}` |
+| `trace.<SPAN_NAME>.errors` | `signoz_calls_total{operation="<SPAN_NAME>", status.code="STATUS_CODE_ERROR"}` |
+| `trace.<SPAN_NAME>.errors.by_http_status` | `signoz_calls_total{operation="<SPAN_NAME>", status.code="STATUS_CODE_ERROR", http.status_code="503"}` |
 
 **Latency**
 
@@ -204,8 +203,8 @@ SigNoz uses **one metric with multiple dimensions**, and additionally breaks out
 | --- | --- |
 | `trace.<SPAN_NAME>` (DDSketch distribution) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` — supports p50/p75/p90/p95/p99 |
 | `trace.<SPAN_NAME>.duration` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` |
-| `trace.<SPAN_NAME>.duration.by_http_status` (legacy) | `signoz_latency.bucket{status.code="..."}` |
-| `trace.<SPAN_NAME>.duration.by_service` (legacy) | `signoz_latency.bucket{service.name="..."}` |
+| `trace.<SPAN_NAME>.duration.by_http_status` (legacy) | No equivalent metric |
+| `trace.<SPAN_NAME>.duration.by_service` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>", service.name="..."}` |
 | `trace.<SPAN_NAME>.apdex` | No separate metric — compute via ClickHouse query |
 
 **DB and External Call Latency**

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-15
+date: 2026-04-16
 id: metrics
 title: Migrate Metrics from Datadog
 description: Learn how to migrate your application and infrastructure metrics from Datadog to SigNoz using OpenTelemetry.
@@ -160,27 +160,27 @@ SigNoz generates eight metrics from span data.
 **Core R.E.D Metrics (all spans)**
 
 - `signoz_calls_total` — Request and error counts (counter).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`
+  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `http.status_code`
 - `signoz_latency.bucket` — Latency distribution as histogram buckets.
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
 - `signoz_latency.sum` — Sum of all latency values (for avg = sum/count).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
 - `signoz_latency.count` — Count of latency observations (for avg = sum/count).
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
+  - Relevant Dimensions: `service.name`, `operation`, `span.kind`, `status.code`
 
 **DB Call Metrics**
 
 - `signoz_db_latency_sum` — Sum of DB call latency.
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `db.system`, `db.name`
+  - Relevant Dimensions: `service.name`, `status.code`, `db.system`, `db.name`
 - `signoz_db_latency_count` — Count of DB call latency observations.
-  - Dimensions: `service.name`, `operation`, `span.kind`, `status.code`, `db.system`, `db.name`
+  - Relevant Dimensions: `service.name`, `status.code`, `db.system`, `db.name`
 
 **External Call Metrics**
 
 - `signoz_external_call_latency_sum` — Sum of external call latency.
-  - Dimensions: `service.name`, `operation`, `status.code`, `http.status_code`
+  - Relevant Dimensions: `service.name`, `status.code`, `http.status_code`
 - `signoz_external_call_latency_count` — Count of external call latency observations.
-  - Dimensions: `service.name`, `operation`, `status.code`, `http.status_code`
+  - Relevant Dimensions: `service.name`, `status.code`, `http.status_code`
 
 ### Metric Mapping
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-14
+date: 2026-04-15
 id: metrics
 title: Migrate Metrics from Datadog
 description: Learn how to migrate your application and infrastructure metrics from Datadog to SigNoz using OpenTelemetry.

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -205,7 +205,7 @@ SigNoz uses **one metric with multiple dimensions**, and additionally breaks out
 | `trace.<SPAN_NAME>.duration` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` |
 | `trace.<SPAN_NAME>.duration.by_http_status` (legacy) | No equivalent metric |
 | `trace.<SPAN_NAME>.duration.by_service` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>", service.name="..."}` |
-| `trace.<SPAN_NAME>.apdex` | No separate metric — compute via ClickHouse query |
+| `trace.<SPAN_NAME>.apdex` | No separate metric — use a SigNoz formula over `signoz_latency_count{operation="<SPAN_NAME>"}`: `(A + 0.5*(B - A)) / C` where A = `signoz_latency_count{le="T", operation="<SPAN_NAME>"}`, B = `signoz_latency_count{le="4T", operation="<SPAN_NAME>"}`, C = `signoz_latency_count{operation="<SPAN_NAME>"}` |
 
 **DB and External Call Latency**
 

--- a/data/docs/migration/migrate-from-datadog/metrics.mdx
+++ b/data/docs/migration/migrate-from-datadog/metrics.mdx
@@ -205,7 +205,7 @@ SigNoz uses **one metric with multiple dimensions**, and additionally breaks out
 | `trace.<SPAN_NAME>.duration` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>"}` |
 | `trace.<SPAN_NAME>.duration.by_http_status` (legacy) | No equivalent metric |
 | `trace.<SPAN_NAME>.duration.by_service` (legacy) | `signoz_latency.bucket{operation="<SPAN_NAME>", service.name="..."}` |
-| `trace.<SPAN_NAME>.apdex` | No separate metric — use a SigNoz formula over `signoz_latency_count{operation="<SPAN_NAME>"}`: `(A + 0.5*(B - A)) / C` where A = `signoz_latency_count{le="T", operation="<SPAN_NAME>"}`, B = `signoz_latency_count{le="4T", operation="<SPAN_NAME>"}`, C = `signoz_latency_count{operation="<SPAN_NAME>"}` |
+| `trace.<SPAN_NAME>.apdex` | No separate metric — compute via ClickHouse query |
 
 **DB and External Call Latency**
 


### PR DESCRIPTION
## Summary
It adds a proper table to tell the mapping of DataDog's APM Metrics to equivalent metrics in Signoz.

## Motivation / Problem
A user has asked for this mapping in order to migrate their use cases from DD to Signoz.

## Changes
- Listed down all the APM metrics in signoz and their key dimensions that are used to map to DD's APM metrics.
- Pointed out the structural differences between APM metrics in DD and Signoz
- Provided proper tables to know which metric + dimension in a Signoz metric matches a DD APM metric.

## Description

DD metrics don't map 1-1 to Signoz Metrics because Signoz's structure is different. For DD, each trace span gets its own metric, while in Signoz, this is done via the span name dimension. Only external calls and databases get their own metrics in signoz. This table would be helpful for users who may not be aware of this.

## Type of Change
<!-- Check all that apply -->

- [x] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
<!-- Who or what is affected by this change? -->
- [x] Documentation only
- [ ] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

If breaking change, describe migration steps:
_Not a breaking change_

## Context & Screenshots
## Before / After (if applicable)

Before
<img width="829" height="356" alt="Screenshot 2026-04-14 at 14 01 37" src="https://github.com/user-attachments/assets/cc01cf62-4b47-411e-aefe-f80972d55046" />

After

https://github.com/user-attachments/assets/04ce98d9-a193-4eed-b822-e057931b424d



## Checklist

<!-- Complete the sections that apply to your changes -->

### General
- [x] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [x] Self-reviewed the code
- [ ] Comments added for complex logic

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [ ] Ran `yarn lint` and fixed any issues
- [ ] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [ ] Followed the docs author checklist in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc
- [ ] Any added docs images use WebP format and live under `public/img/docs/<topic>/`

### For blog changes
- [ ] Followed the blog workflow in [contributing/blog-workflow.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/blog-workflow.md)
- [ ] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [ ] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

### For site code changes
- [ ] Followed the site code playbook in [contributing/site-code.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/site-code.md)
- [ ] New dependencies are justified in the PR description (if any)

### For renamed or moved docs
- [ ] Followed the redirects and discovery section in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [ ] Added permanent redirect in `next.config.js` under `async redirects()`
- [ ] Updated internal links and sidebar in `constants/docsSideNav.ts`
- [ ] Ran `yarn check:doc-redirects` to verify

## Testing
<!-- Describe how the change was tested -->
- [ ] Tested locally
- [ ] Edge cases considered
- [ ] Existing functionality verified
- [ ] New tests added (if applicable)

Steps to test:
1.
2.
3.

## Rollout / Deployment Notes
<!-- Any special steps required during deployment -->

## Additional Context
<!-- Anything reviewers should know -->

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
