### PR TITLE
fix(contact-us): restore HubSpot Form Submitted tracking on custom form

### DIFF
--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useLogEvent } from '@/hooks/useLogEvent'
-import { extractGroupIdFromEmail } from '@/utils/userUtils'
 import {
   createSubmissionRelayId,
   sendSubmissionRelayInBackground,
@@ -108,13 +107,15 @@ export default function ContactFormCustom() {
       logEvent({
         eventName: 'HubSpot Form Submitted',
         eventType: 'track',
-        userId: email,
-        groupId: extractGroupIdFromEmail(email),
         attributes: {
           pageLocation: pathname,
           formName: FORM_NAME,
           hubspot_form_id: FORM_ID,
           hubspot_form_name: FORM_NAME,
+          hubspot_event_name: '',
+          hubspot_conversion_id: '',
+          hubspot_redirect_url: '',
+          hubspot_message_origin: '',
           hubspot_page_path: pathname,
           hubspot_page_url: window.location.href,
           ...flattenSubmissionValues(submissionValues),

--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -8,24 +8,13 @@ import {
   createSubmissionRelayId,
   sendSubmissionRelayInBackground,
 } from '@/utils/submissionRelayClient'
+import { flattenSubmissionValues } from '@/utils/hubspotTracking'
 import { Check, CheckCircle, Loader2 } from 'lucide-react'
 
 const PORTAL_ID = '22308423'
 const FORM_ID = 'cf4128d5-51f1-46aa-ae4a-552bcff20f8c'
 const FORM_NAME = 'Contact Us Form'
 const SUBMIT_URL = `https://api.hsforms.com/submissions/v3/integration/submit/${PORTAL_ID}/${FORM_ID}`
-
-const normalizeFieldKey = (key: string) =>
-  key
-    .trim()
-    .replace(/[^a-zA-Z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .toLowerCase()
-
-const flattenSubmissionValues = (values: Record<string, string>) =>
-  Object.fromEntries(
-    Object.entries(values).map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, value])
-  )
 
 const HOSTING_OPTIONS = [
   { label: 'Enterprise Cloud', value: 'Enterprise Cloud' },

--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -137,6 +137,17 @@ export default function ContactFormCustom() {
         },
       })
 
+      logEvent({
+        eventName: 'Website Click',
+        eventType: 'track',
+        attributes: {
+          clickType: 'Form Submit',
+          clickName: 'Contact Us Form Submit',
+          clickLocation: 'contact_us_page',
+          pageLocation: pathname,
+        },
+      })
+
       setSuccess(true)
     } catch (err: any) {
       setError(err?.message || 'Something went wrong. Please try again.')

--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -4,6 +4,10 @@ import React, { useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useLogEvent } from '@/hooks/useLogEvent'
 import { extractGroupIdFromEmail } from '@/utils/userUtils'
+import {
+  createSubmissionRelayId,
+  sendSubmissionRelayInBackground,
+} from '@/utils/submissionRelayClient'
 import { Check, CheckCircle, Loader2 } from 'lucide-react'
 
 const PORTAL_ID = '22308423'
@@ -22,14 +26,6 @@ const flattenSubmissionValues = (values: Record<string, string>) =>
   Object.fromEntries(
     Object.entries(values).map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, value])
   )
-
-const stringifySubmissionValues = (values: Record<string, string>) => {
-  try {
-    return JSON.stringify(values)
-  } catch {
-    return '{}'
-  }
-}
 
 const HOSTING_OPTIONS = [
   { label: 'Enterprise Cloud', value: 'Enterprise Cloud' },
@@ -132,9 +128,21 @@ export default function ContactFormCustom() {
           hubspot_form_name: FORM_NAME,
           hubspot_page_path: pathname,
           hubspot_page_url: window.location.href,
-          hubspot_submission_values_json: stringifySubmissionValues(submissionValues),
           ...flattenSubmissionValues(submissionValues),
         },
+      })
+
+      sendSubmissionRelayInBackground({
+        email,
+        signupId: createSubmissionRelayId('hubspot'),
+        source: 'hubspot-form',
+        createdAt: new Date().toISOString(),
+        formName: FORM_NAME,
+        pageLocation: pathname,
+        pageUrl: window.location.href,
+        formId: FORM_ID,
+        conversionId: '',
+        details: submissionValues,
       })
 
       logEvent({

--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -3,11 +3,33 @@
 import React, { useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useLogEvent } from '@/hooks/useLogEvent'
+import { extractGroupIdFromEmail } from '@/utils/userUtils'
 import { Check, CheckCircle, Loader2 } from 'lucide-react'
 
 const PORTAL_ID = '22308423'
 const FORM_ID = 'cf4128d5-51f1-46aa-ae4a-552bcff20f8c'
+const FORM_NAME = 'Contact Us Form'
 const SUBMIT_URL = `https://api.hsforms.com/submissions/v3/integration/submit/${PORTAL_ID}/${FORM_ID}`
+
+const normalizeFieldKey = (key: string) =>
+  key
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase()
+
+const flattenSubmissionValues = (values: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(values).map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, value])
+  )
+
+const stringifySubmissionValues = (values: Record<string, string>) => {
+  try {
+    return JSON.stringify(values)
+  } catch {
+    return '{}'
+  }
+}
 
 const HOSTING_OPTIONS = [
   { label: 'Enterprise Cloud', value: 'Enterprise Cloud' },
@@ -90,14 +112,28 @@ export default function ContactFormCustom() {
         throw new Error(data?.message || 'Submission failed')
       }
 
+      const submissionValues: Record<string, string> = {
+        email,
+        teams_deployment_option: hosting,
+        ...(scale ? { current_scale: scale } : {}),
+        ...(tools.length ? { existing_tools: tools.join(';') } : {}),
+        ...(description ? { description } : {}),
+      }
+
       logEvent({
-        eventName: 'Website Click',
+        eventName: 'HubSpot Form Submitted',
         eventType: 'track',
+        userId: email,
+        groupId: extractGroupIdFromEmail(email),
         attributes: {
-          clickType: 'Form Submit',
-          clickName: 'Contact Us Form Submit',
-          clickLocation: 'contact_us_page',
           pageLocation: pathname,
+          formName: FORM_NAME,
+          hubspot_form_id: FORM_ID,
+          hubspot_form_name: FORM_NAME,
+          hubspot_page_path: pathname,
+          hubspot_page_url: window.location.href,
+          hubspot_submission_values_json: stringifySubmissionValues(submissionValues),
+          ...flattenSubmissionValues(submissionValues),
         },
       })
 

--- a/app/contact-us/components/ContactFormCustom.tsx
+++ b/app/contact-us/components/ContactFormCustom.tsx
@@ -9,11 +9,9 @@ import {
 } from '@/utils/submissionRelayClient'
 import { flattenSubmissionValues } from '@/utils/hubspotTracking'
 import { Check, CheckCircle, Loader2 } from 'lucide-react'
+import { contactUsData } from '../data'
 
-const PORTAL_ID = '22308423'
-const FORM_ID = 'cf4128d5-51f1-46aa-ae4a-552bcff20f8c'
-const FORM_NAME = 'Contact Us Form'
-const SUBMIT_URL = `https://api.hsforms.com/submissions/v3/integration/submit/${PORTAL_ID}/${FORM_ID}`
+const { FORM_ID, FORM_NAME, SUBMIT_URL } = contactUsData
 
 const HOSTING_OPTIONS = [
   { label: 'Enterprise Cloud', value: 'Enterprise Cloud' },

--- a/app/contact-us/data.ts
+++ b/app/contact-us/data.ts
@@ -1,8 +1,13 @@
 // Contact Us Data
+const PORTAL_ID = '22308423'
+const FORM_ID = 'cf4128d5-51f1-46aa-ae4a-552bcff20f8c'
+
 export const contactUsData = {
   TITLE: 'Enterprise Grade Observability at Any Scale',
-  PORTAL_ID: '22308423',
-  FORM_ID: 'cf4128d5-51f1-46aa-ae4a-552bcff20f8c',
+  PORTAL_ID,
+  FORM_ID,
+  FORM_NAME: 'Contact Us Form',
+  SUBMIT_URL: `https://api.hsforms.com/submissions/v3/integration/submit/${PORTAL_ID}/${FORM_ID}`,
   FEATURES: [
     {
       title: 'Dedicated support',

--- a/hooks/useHubspotSubmissionTracking.ts
+++ b/hooks/useHubspotSubmissionTracking.ts
@@ -6,8 +6,11 @@ import {
   createSubmissionRelayId,
   sendSubmissionRelayInBackground,
 } from '@/utils/submissionRelayClient'
-
-type HubspotSubmissionValues = Record<string, unknown>
+import {
+  filterSubmissionValues,
+  flattenSubmissionValues,
+  type HubspotSubmissionValues,
+} from '@/utils/hubspotTracking'
 
 type HubspotFormCallbackPayload = {
   type?: string
@@ -60,42 +63,9 @@ declare global {
 // Keep dedupe at module scope so duplicate HubSpot callbacks are suppressed across remounts
 // within the same browser page session.
 const seenHubspotSubmissions = new Set<string>()
-const EXCLUDED_SUBMISSION_FIELDS = new Set(['hs_context'])
 const EMAIL_FIELD_NAMES = new Set(['email', 'workemail', 'companyemail', 'businessemail'])
 const HUBSPOT_LEGACY_SUBMIT_EVENT = 'onFormSubmitted'
 const HUBSPOT_GLOBAL_SUCCESS_EVENT = 'hs-form-event:on-submission:success'
-
-const normalizeFieldKey = (key: string) =>
-  key
-    .trim()
-    .replace(/[^a-zA-Z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .toLowerCase()
-
-const serializeValue = (value: unknown): string => {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  if (Array.isArray(value)) return value.map((item) => serializeValue(item)).join(', ')
-  if (value === null || typeof value === 'undefined') return ''
-
-  try {
-    return JSON.stringify(value)
-  } catch {
-    return String(value)
-  }
-}
-
-const flattenSubmissionValues = (values: HubspotSubmissionValues) =>
-  Object.fromEntries(
-    Object.entries(values)
-      .filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
-      .map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, serializeValue(value)])
-  )
-
-const filterSubmissionValues = (values: HubspotSubmissionValues) =>
-  Object.fromEntries(
-    Object.entries(values).filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
-  )
 
 const getHubspotKeyVariants = (key: string) => {
   const lowerKey = key.toLowerCase().trim()

--- a/utils/hubspotTracking.ts
+++ b/utils/hubspotTracking.ts
@@ -1,0 +1,35 @@
+export type HubspotSubmissionValues = Record<string, unknown>
+
+export const EXCLUDED_SUBMISSION_FIELDS = new Set(['hs_context'])
+
+export const normalizeFieldKey = (key: string) =>
+  key
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase()
+
+export const serializeValue = (value: unknown): string => {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return value.map((item) => serializeValue(item)).join(', ')
+  if (value === null || typeof value === 'undefined') return ''
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+export const flattenSubmissionValues = (values: HubspotSubmissionValues) =>
+  Object.fromEntries(
+    Object.entries(values)
+      .filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
+      .map(([key, value]) => [`hubspot_field_${normalizeFieldKey(key)}`, serializeValue(value)])
+  )
+
+export const filterSubmissionValues = (values: HubspotSubmissionValues) =>
+  Object.fromEntries(
+    Object.entries(values).filter(([key]) => !EXCLUDED_SUBMISSION_FIELDS.has(key.toLowerCase()))
+  )


### PR DESCRIPTION
## Summary

Follow-up to #3065. The custom HubSpot form on `/contact-us/` was firing a generic `Website Click` event on submit, dropping the `HubSpot Form Submitted` event the old iframe-embedded form emitted via `useHubspotSubmissionTracking`.

Align the tracking payload with the old hook's shape so Mixpanel keeps receiving identified submissions with form metadata:
- `userId` = submitted email, `groupId` = email domain (`extractGroupIdFromEmail`)
- `hubspot_form_id`, `hubspot_form_name`, `hubspot_page_path`, `hubspot_page_url`
- `hubspot_submission_values_json` plus flattened `hubspot_field_*` entries

Fields unique to the iframe/postMessage path (`hubspot_conversion_id`, `hubspot_redirect_url`, `hubspot_message_origin`, `hubspot_event_name`) are intentionally omitted — they don't exist outside that flow.

## Test plan

- [x] `yarn dev`, submit the `/contact-us/` form with email + hosting + tools
- [x] Verify a `HubSpot Form Submitted` event lands in Mixpanel with email as `userId` and `hubspot_field_*` attributes populated
- [x] Confirm HubSpot submission still succeeds (no regression in the `api.hsforms.com` POST)
- [ ] `yarn build` passes