### PR TITLE
fix: homepage sizing fixes

### DIFF
--- a/components/observability/index.tsx
+++ b/components/observability/index.tsx
@@ -9,7 +9,7 @@ const Observability = () => {
   return (
     <section>
       <div className="flex h-auto w-auto flex-col border !border-b-0 !border-r-0 border-dashed border-signoz_slate-400 px-8 py-10 md:pl-10">
-        <div className="flex flex-col justify-between gap-8 2xl:flex-row">
+        <div className="flex flex-col justify-between gap-8 md:flex-row md:items-center">
           <div className="flex shrink-[10] flex-col justify-between">
             <p className="mb-2 block text-2xl font-semibold text-signoz_vanilla-100">
               {' '}
@@ -51,7 +51,7 @@ const Observability = () => {
               </li>
             </ul>
           </div>
-          <div className="mx-auto aspect-[272/404] w-[272px] max-w-[min(272px,50%)]">
+          <div className="mx-auto aspect-[272/404] w-[272px] max-w-[min(272px,50%)] md:shrink-0">
             <Image
               src={featureGraphicEnterprise2}
               alt="Enterprise-grade Observability"

--- a/components/why-opentelemetry/index.tsx
+++ b/components/why-opentelemetry/index.tsx
@@ -96,7 +96,6 @@ export const WhyOpenTelemetry = ({ className }: { className?: string }) => {
       >
         <div className="mb-16 px-0">
           <div className="grid gap-9 p-9">
-            {/* <div className="grid grid-cols-1 items-start gap-8 xl:grid-cols-[minmax(0,1fr)_auto]"> */}
             <div className="flex flex-col items-center gap-8 md:flex-row">
               <div className="min-w-0">
                 <p className="text-2xl font-semibold text-signoz_vanilla-100">

--- a/components/why-opentelemetry/index.tsx
+++ b/components/why-opentelemetry/index.tsx
@@ -96,7 +96,8 @@ export const WhyOpenTelemetry = ({ className }: { className?: string }) => {
       >
         <div className="mb-16 px-0">
           <div className="grid gap-9 p-9">
-            <div className="grid grid-cols-1 items-start gap-8 xl:grid-cols-[minmax(0,1fr)_auto]">
+            {/* <div className="grid grid-cols-1 items-start gap-8 xl:grid-cols-[minmax(0,1fr)_auto]"> */}
+            <div className="flex flex-col items-center gap-8 md:flex-row">
               <div className="min-w-0">
                 <p className="text-2xl font-semibold text-signoz_vanilla-100">
                   {' '}
@@ -143,9 +144,9 @@ export const WhyOpenTelemetry = ({ className }: { className?: string }) => {
                   </li>
                 </ul>
               </div>
-              <div className="mx-auto mb-6 aspect-[449/352] h-[400px] shrink-0 sm:h-[300px] 2xl:block">
+              <div className="mx-auto mb-6 shrink-0 sm:h-[300px] 2xl:block">
                 <Image
-                  className="w-full"
+                  className="h-full w-full"
                   src={featureGraphicOtel}
                   alt="Illustration showing SigNoz built on top of OpenTelemetry"
                   width={449}

--- a/components/why-opentelemetry/index.tsx
+++ b/components/why-opentelemetry/index.tsx
@@ -96,7 +96,7 @@ export const WhyOpenTelemetry = ({ className }: { className?: string }) => {
       >
         <div className="mb-16 px-0">
           <div className="grid gap-9 p-9">
-            <div className="flex flex-col items-center gap-8 md:flex-row">
+            <div className="flex flex-col items-center gap-8 lg:flex-row">
               <div className="min-w-0">
                 <p className="text-2xl font-semibold text-signoz_vanilla-100">
                   {' '}

--- a/components/why-select-signoz/index.tsx
+++ b/components/why-select-signoz/index.tsx
@@ -34,8 +34,8 @@ const WhySelectSignoz = ({
           </p>
         </div>
         <div className="min-w-0">
-          <div className="ml-0 grid grid-cols-1 gap-8 border !border-b-0 !border-r-0 !border-t-0 border-dashed border-signoz_slate-400 md:py-10 md:pl-10 2xl:grid-cols-[minmax(0,1fr)_auto] 2xl:items-start">
-            <div className="grid min-w-0 grid-cols-1 gap-16 px-8 md:px-0">
+          <div className="ml-0 flex flex-col gap-8 border !border-b-0 !border-r-0 !border-t-0 border-dashed border-signoz_slate-400 md:flex-row md:items-center md:py-10 md:pl-10">
+            <div className="flex min-w-0 flex-1 flex-col gap-16 px-8 md:px-0">
               <div>
                 <p className="mb-2 block text-base font-medium text-signoz_vanilla-100">
                   Built for scale
@@ -64,7 +64,7 @@ const WhySelectSignoz = ({
                 </p>
               </div>
             </div>
-            <div className="mx-auto aspect-[272/352] w-[272px] max-w-[80vw]">
+            <div className="mx-auto aspect-[272/352] w-[272px] max-w-[80vw] md:shrink-0">
               <Image
                 className="w-full"
                 src={featureGraphicEnterprise}


### PR DESCRIPTION
the PR https://github.com/SigNoz/signoz.io/pull/3066 introduced a regression causing homepage to break on mobile, this is to fix it - the page was not made live so it did not make it to production but was caught on preview https://signoz-web-git-fix-home-page-signoz.vercel.app/ 

before
<img width="387" height="673" alt="Screenshot 2026-04-15 at 18 39 18" src="https://github.com/user-attachments/assets/056e3a1f-8bc2-4adc-8f2e-48ea88938bbf" />

after
<img width="398" height="690" alt="Screenshot 2026-04-15 at 18 38 30" src="https://github.com/user-attachments/assets/77b7c67b-50cb-49e2-8eaa-78e8a02fc7e3" />
