### PR TITLE
feat(homepage): add newsletter pill linking to Hail Mary post

### DIFF
--- a/components/index-header/HeroSectionPill.tsx
+++ b/components/index-header/HeroSectionPill.tsx
@@ -1,21 +1,23 @@
-'use client'
-
-import React from 'react'
 import TrackingLink from '@/components/TrackingLink'
 
-export function NewsletterPill() {
+interface HeroSectionPillProps {
+  href: string
+  text: string
+}
+
+export function HeroSectionPill({ href, text }: HeroSectionPillProps) {
   return (
     <TrackingLink
-      href="https://newsletter.signoz.io/p/our-project-hail-mary-the-observability"
+      href={href}
       clickType="Pill CTA"
-      clickName="Newsletter Pill"
-      clickText="From our Newsletter: How we observe 21B metric points daily"
+      clickName="Hero Section Pill"
+      clickText={text}
       clickLocation="Hero Section"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="nofollow"
     >
       <span className="flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-xs font-medium leading-5 text-white shadow-[0_0_14px_0_rgba(78,116,248,0.40)] sm:gap-2 sm:text-sm">
-        💌 From our Newsletter: How we observe 21B metric points daily →
+        {text}
       </span>
     </TrackingLink>
   )

--- a/components/index-header/NewsletterPill.tsx
+++ b/components/index-header/NewsletterPill.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import React from 'react'
+import TrackingLink from '@/components/TrackingLink'
+
+export function NewsletterPill() {
+  return (
+    <TrackingLink
+      href="https://newsletter.signoz.io/p/our-project-hail-mary-the-observability"
+      clickType="Pill CTA"
+      clickName="Newsletter Pill"
+      clickText="From our Newsletter: How we observe 21B metric points daily"
+      clickLocation="Hero Section"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span className="flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-xs font-medium leading-5 text-white shadow-[0_0_14px_0_rgba(78,116,248,0.40)] sm:gap-2 sm:text-sm">
+        💌 From our Newsletter: How we observe 21B metric points daily →
+      </span>
+    </TrackingLink>
+  )
+}

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -15,6 +15,19 @@ export function Header() {
       <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[-1] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
 
       <div className="relative mx-auto flex w-full flex-col items-center border  !border-b-0 !border-t-0  border-dashed border-signoz_slate-400 pt-12 text-center md:pt-16">
+        <TrackingLink
+          href="https://newsletter.signoz.io/p/our-project-hail-mary-the-observability"
+          clickType="Pill CTA"
+          clickName="Newsletter Pill"
+          clickText="From our Newsletter: How we observe 21B metric points daily"
+          clickLocation="Hero Section"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <button className="flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-xs font-medium leading-5 text-white shadow-[0_0_14px_0_rgba(78,116,248,0.40)] sm:gap-2 sm:text-sm">
+            💌 From our Newsletter: How we observe 21B metric points daily →
+          </button>
+        </TrackingLink>
         <Hero>
           <span className="md:hidden">Observability on Your Terms, Powered by Open Standards.</span>
           <span className="hidden md:inline">Observability on Your Terms,</span>

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -1,13 +1,13 @@
-'use client'
-
 import React from 'react'
 import Hero from '@/components/ui/Hero'
 import { ArrowRight, Calendar } from 'lucide-react'
 import Button from '@/components/Button/Button'
 import TrackingLink from '@/components/TrackingLink'
 import { VideoModalPlayer } from './VideoModalPlayer'
+import { NewsletterPill } from './NewsletterPill'
 import landingThumbnail from '@/public/img/landing/landing_thumbnail.webp'
 
+// Server component with single CTA
 export function Header() {
   const primaryCTA = 'Get Started - Free'
 
@@ -16,19 +16,9 @@ export function Header() {
       <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[-1] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
 
       <div className="relative mx-auto flex w-full flex-col items-center border  !border-b-0 !border-t-0  border-dashed border-signoz_slate-400 pt-12 text-center md:pt-16">
-        <TrackingLink
-          href="https://newsletter.signoz.io/p/our-project-hail-mary-the-observability"
-          clickType="Pill CTA"
-          clickName="Newsletter Pill"
-          clickText="From our Newsletter: How we observe 21B metric points daily"
-          clickLocation="Hero Section"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <button className="flex h-10 items-center justify-center gap-1.5 rounded-full border border-signoz_slate-200 bg-signoz_slate-400 px-4 py-2 text-xs font-medium leading-5 text-white shadow-[0_0_14px_0_rgba(78,116,248,0.40)] sm:gap-2 sm:text-sm">
-            💌 From our Newsletter: How we observe 21B metric points daily →
-          </button>
-        </TrackingLink>
+        {/* Comment this when the newsletter is notlive */}
+        <NewsletterPill />
+        {/* End of newsletter section */}
         <Hero>
           <span className="md:hidden">Observability on Your Terms, Powered by Open Standards.</span>
           <span className="hidden md:inline">Observability on Your Terms,</span>

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Calendar } from 'lucide-react'
 import Button from '@/components/Button/Button'
 import TrackingLink from '@/components/TrackingLink'
 import { VideoModalPlayer } from './VideoModalPlayer'
-import { NewsletterPill } from './NewsletterPill'
+import { HeroSectionPill } from './HeroSectionPill'
 import landingThumbnail from '@/public/img/landing/landing_thumbnail.webp'
 
 // Server component with single CTA
@@ -16,8 +16,12 @@ export function Header() {
       <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[-1] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
 
       <div className="relative mx-auto flex w-full flex-col items-center border  !border-b-0 !border-t-0  border-dashed border-signoz_slate-400 pt-12 text-center md:pt-16">
-        {/* Comment this when the newsletter is notlive */}
-        <NewsletterPill />
+        {/* Comment this when the newsletter is not live */}
+        
+        <HeroSectionPill
+          href="https://newsletter.signoz.io/p/our-project-hail-mary-the-observability"
+          text="💌 From our Newsletter: How we observe 21B metric points daily →"
+        />
         {/* End of newsletter section */}
         <Hero>
           <span className="md:hidden">Observability on Your Terms, Powered by Open Standards.</span>

--- a/components/index-header/index.tsx
+++ b/components/index-header/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import Hero from '@/components/ui/Hero'
 import { ArrowRight, Calendar } from 'lucide-react'
@@ -6,7 +8,6 @@ import TrackingLink from '@/components/TrackingLink'
 import { VideoModalPlayer } from './VideoModalPlayer'
 import landingThumbnail from '@/public/img/landing/landing_thumbnail.webp'
 
-// Server component with single CTA
 export function Header() {
   const primaryCTA = 'Get Started - Free'
 


### PR DESCRIPTION
Re-adds the homepage pill above the hero heading, linking to https://newsletter.signoz.io/p/our-project-hail-mary-the-observability. Uses TrackingLink so clicks emit the Website Click event (clickType: Pill CTA, clickName: Newsletter Pill, clickLocation: Hero Section). Marks the Header as 'use client' since the pill's TrackingLink uses hooks (usePathname, useLogEvent).