### PR TITLE
docs: add new MCP server tools to signoz-mcp-server docs

### DIFF
--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-15
+date: 2026-04-22
 id: signoz-mcp-server
 
 title: SigNoz MCP Server
@@ -790,13 +790,15 @@ The MCP server exposes the following tools to your AI assistant:
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
-| `signoz_list_alerts` | List all active alerts |
+| `signoz_list_alerts` | List alerts with filtering and pagination |
 | `signoz_get_alert` | Get details of a specific alert rule |
 | `signoz_get_alert_history` | Get alert history timeline for a rule |
+| `signoz_create_alert` | Create an alert rule using v2 schema validation |
 | `signoz_list_dashboards` | List all dashboards with summaries |
 | `signoz_get_dashboard` | Get full dashboard configuration |
 | `signoz_create_dashboard` | Create a new dashboard |
 | `signoz_update_dashboard` | Update an existing dashboard |
+| `signoz_delete_dashboard` | Delete a dashboard by UUID |
 | `signoz_list_services` | List services within a time range |
 | `signoz_get_service_top_operations` | Get top operations for a service |
 | `signoz_list_log_views` | List all saved log views |
@@ -807,6 +809,9 @@ The MCP server exposes the following tools to your AI assistant:
 | `signoz_search_traces` | Search traces with flexible filtering |
 | `signoz_get_trace_details` | Get full trace with all spans |
 | `signoz_execute_builder_query` | Execute a raw Query Builder v5 query |
+| `signoz_list_notification_channels` | List notification channels |
+| `signoz_create_notification_channel` | Create a notification channel and send a test notification |
+| `signoz_update_notification_channel` | Update a notification channel and send a test notification |
 
 For detailed parameter reference, see the <a href="https://github.com/SigNoz/signoz-mcp-server?tab=readme-ov-file#available-tools" target="_blank" rel="noopener noreferrer nofollow">GitHub repository README</a>.
 


### PR DESCRIPTION
## Summary
- Updated the Available Tools table in `data/docs/ai/signoz-mcp-server.mdx` to match the upstream [signoz-mcp-server README](https://github.com/SigNoz/signoz-mcp-server#available-tools).
- Added 5 new tools: `signoz_create_alert`, `signoz_delete_dashboard`, `signoz_list_notification_channels`, `signoz_create_notification_channel`, `signoz_update_notification_channel`.
- Refreshed `signoz_list_alerts` description to "List alerts with filtering and pagination".
- Bumped `date` frontmatter to today's date.

## Test plan
- [x] `yarn check:docs-metadata` passes
- [x] `yarn check:doc-redirects` passes (pre-commit hook)
- [x] Verify the rendered table under `## Available Tools` on the MCP server docs page in a local preview.