### PR TITLE
[codex] Update SigNoz MCP Server docs

### DIFF
--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -758,11 +758,12 @@ Environment variables for the self-hosted MCP server. SigNoz Cloud users do not 
 | `TRANSPORT_MODE` | Transport protocol: `stdio` or `http` | `stdio` |
 | `MCP_SERVER_PORT` | Port for HTTP server (when `TRANSPORT_MODE=http`) | `8000` |
 | `LOG_LEVEL` | Logging verbosity: `debug`, `info`, `warn`, `error` | `info` |
+| `SIGNOZ_CUSTOM_HEADERS` | Extra HTTP headers added to every SigNoz API request, such as reverse-proxy auth headers. Format: `Key1:Value1,Key2:Value2` | _(optional)_ |
 | `OAUTH_ENABLED` | Enable OAuth 2.1 authentication (`true`/`false`) | `false` |
 | `OAUTH_TOKEN_SECRET` | Encryption key for OAuth tokens (min 32 bytes) | _(required when `OAUTH_ENABLED=true`)_ |
 | `OAUTH_ISSUER_URL` | Public URL of this MCP server | _(required when `OAUTH_ENABLED=true`)_ |
 | `OAUTH_ACCESS_TOKEN_TTL_MINUTES` | Access token lifetime in minutes | `60` |
-| `OAUTH_REFRESH_TOKEN_TTL_MINUTES` | Refresh token lifetime in minutes | `1440` (24h) |
+| `OAUTH_REFRESH_TOKEN_TTL_MINUTES` | Refresh token lifetime in minutes | `43200` (30d) |
 | `OAUTH_AUTH_CODE_TTL_SECONDS` | Authorization code lifetime in seconds | `600` (10min) |
 
 
@@ -784,16 +785,23 @@ After connecting, verify the server is working:
 
 The MCP server exposes the following tools to your AI assistant:
 
+<Admonition type="note">
+Alert-rule and notification-channel tools use newer SigNoz rules and channels APIs. Use SigNoz v0.120.0 or later for full compatibility with the latest MCP server. Older SigNoz deployments may return HTTP 404 for those tools.
+</Admonition>
+
 | Tool | Description |
 |------|-------------|
 | `signoz_list_metrics` | Search and list available metrics |
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
-| `signoz_list_alerts` | List alerts with filtering and pagination |
-| `signoz_get_alert` | Get details of a specific alert rule |
+| `signoz_list_alerts` | List firing, silenced, or inhibited Alertmanager alert instances |
+| `signoz_list_alert_rules` | List configured alert rules, including inactive or disabled rules |
+| `signoz_get_alert` | Get an alert rule definition by ID |
 | `signoz_get_alert_history` | Get alert history timeline for a rule |
 | `signoz_create_alert` | Create an alert rule using v2 schema validation |
+| `signoz_update_alert` | Update an existing alert rule |
+| `signoz_delete_alert` | Delete an alert rule |
 | `signoz_list_dashboards` | List all dashboards with summaries |
 | `signoz_get_dashboard` | Get full dashboard configuration |
 | `signoz_create_dashboard` | Create a new dashboard |
@@ -801,8 +809,11 @@ The MCP server exposes the following tools to your AI assistant:
 | `signoz_delete_dashboard` | Delete a dashboard by UUID |
 | `signoz_list_services` | List services within a time range |
 | `signoz_get_service_top_operations` | Get top operations for a service |
-| `signoz_list_log_views` | List all saved log views |
-| `signoz_get_log_view` | Get details of a saved log view |
+| `signoz_list_views` | List saved Explorer views for traces, logs, or metrics |
+| `signoz_get_view` | Get a saved Explorer view by UUID |
+| `signoz_create_view` | Create a saved Explorer view |
+| `signoz_update_view` | Replace an existing saved Explorer view |
+| `signoz_delete_view` | Delete a saved Explorer view |
 | `signoz_aggregate_logs` | Aggregate logs (count, avg, p99, etc.) with grouping |
 | `signoz_search_logs` | Search logs with flexible filtering |
 | `signoz_aggregate_traces` | Aggregate trace statistics with grouping |
@@ -810,8 +821,10 @@ The MCP server exposes the following tools to your AI assistant:
 | `signoz_get_trace_details` | Get full trace with all spans |
 | `signoz_execute_builder_query` | Execute a raw Query Builder v5 query |
 | `signoz_list_notification_channels` | List notification channels |
+| `signoz_get_notification_channel` | Get a single notification channel by ID |
 | `signoz_create_notification_channel` | Create a notification channel and send a test notification |
 | `signoz_update_notification_channel` | Update a notification channel and send a test notification |
+| `signoz_delete_notification_channel` | Delete a notification channel by ID |
 
 For detailed parameter reference, see the <a href="https://github.com/SigNoz/signoz-mcp-server?tab=readme-ov-file#available-tools" target="_blank" rel="noopener noreferrer nofollow">GitHub repository README</a>.
 
@@ -831,7 +844,7 @@ For detailed parameter reference, see the <a href="https://github.com/SigNoz/sig
 
 - For SigNoz Cloud: ensure you are using the correct [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint) in the MCP URL.
 - Confirm your API key is valid and has not expired.
-- For self-hosted HTTP mode, ensure the `Authorization` header format is `Bearer <your-api-key>`.
+- For self-hosted HTTP mode where the client sends the key, use the `SIGNOZ-API-KEY: <your-api-key>` header.
 
 ### SigNoz Cloud connection issues
 

--- a/data/docs/ai/use-cases/alert-correlation-analysis.mdx
+++ b/data/docs/ai/use-cases/alert-correlation-analysis.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-09
+date: 2026-04-28
 id: alert-correlation-analysis
 title: Alert Correlation Analysis
 description: When multiple services alert simultaneously, identify whether it's a cascade from one failure or separate incidents.
@@ -186,7 +186,7 @@ During this investigation, the MCP server called these tools:
 
 | Step | MCP Tool | What It Did |
 |------|----------|-------------|
-| 1 | `signoz_list_alerts` | Retrieved all currently firing alerts with their severity, start times, and conditions to identify which services are affected |
+| 1 | `signoz_list_alerts` | Retrieved currently firing Alertmanager alert instances with their severity, start times, and conditions to identify which services are affected |
 | 2 | `signoz_search_traces` | Found error traces from Checkout and Payment services to identify the relationship and common error patterns (gold-tier token failures) |
 | 3 | `signoz_get_trace_details` | Retrieved the full span tree for trace ID `b0263667e66d3a3fd1fbb0d8be54d792` showing how Payment failures cascade through Checkout to Frontend |
 | 4 | `signoz_search_traces` | Queried error spans from Checkout service filtered by error message patterns to calculate what percentage were caused by Payment failures |

--- a/data/docs/ai/use-cases/alert-fatigue-audit.mdx
+++ b/data/docs/ai/use-cases/alert-fatigue-audit.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-17
+date: 2026-04-28
 id: alert-fatigue-audit
 title: Alert Fatigue Audit
 description: Identify noisy, flapping, and stale alerts by analyzing which alerts correlate with actual service degradation and which don't.
@@ -233,7 +233,7 @@ During this investigation, the MCP server called these tools:
 
 | Step | MCP Tool | What It Did |
 |------|----------|-------------|
-| 1 | `signoz_list_alerts` | Enumerated every configured alert rule and its current state |
+| 1 | `signoz_list_alert_rules` | Enumerated every configured alert rule, including inactive and disabled rules |
 | 1 | `signoz_get_alert_history` | Fetched state-transition history per rule for the 24-hour window, including rules with zero transitions |
 | 2 | `signoz_get_alert_history` | Derived fire counts, mean auto-resolve duration, and peak fires per rolling 30-minute window |
 | 2 | `signoz_get_alert` | Retrieved each rule's threshold expression and referenced metric to support the STALE check |

--- a/data/docs/ai/use-cases/oncall-handoff-brief.mdx
+++ b/data/docs/ai/use-cases/oncall-handoff-brief.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-16
+date: 2026-04-28
 id: oncall-handoff-brief
 title: On-Call Handoff Brief
 description: Generate a handoff summary of recent incidents and ongoing issues for the next on-call engineer.
@@ -60,7 +60,7 @@ During this investigation, the MCP server called these tools:
 
 | Step | MCP Tool | What It Did |
 |------|----------|-------------|
-| 1 | `signoz_list_alerts` | Retrieved all currently firing alerts |
+| 1 | `signoz_list_alerts` | Retrieved currently firing Alertmanager alert instances |
 | 1 | `signoz_get_alert_history` | Fetched the complete alert state transition history for the 48-hour window to calculate flap counts and identify patterns |
 | 1 | `signoz_get_alert` | Retrieved detailed information for each alert including severity, conditions, and current status |
 


### PR DESCRIPTION
## Summary

- Sync the SigNoz MCP Server docs with the current upstream tool surface.
- Replace stale saved log view tool names with saved Explorer view tools.
- Add the new alert-rule and notification-channel tools to the reference list.
- Document `SIGNOZ_CUSTOM_HEADERS`, correct the OAuth refresh token default, and clarify self-hosted HTTP API-key header usage.
- Mention SigNoz v0.120.0+ as the minimum version for full compatibility with the latest MCP server alert-rule tooling.
- Align related AI use-case pages with the updated alert tool semantics: `signoz_list_alerts` for firing Alertmanager alert instances, `signoz_list_alert_rules` for configured rule inventory.

## Why

The upstream `signoz-mcp-server` README and manifest changed in v0.3.0, but the public docs still had older tool names and a few stale configuration/auth details. The latest alert-rule MCP tools use SigNoz `/api/v2/rules` endpoints that first appear in the SigNoz v0.120.0 release, so older deployments can return HTTP 404 for those tools.

## Testing

- `yarn check:docs-metadata`
- `yarn test:docs-metadata`
- `yarn check:doc-redirects`
- `yarn test:doc-redirects`
- `git diff --check`
