### PR TITLE
chore: change docs meta title to Docs

### DIFF
--- a/app/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/docs/(main-docs)/[...slug]/page.tsx
@@ -25,11 +25,13 @@ export async function generateMetadata({
     notFound()
   }
 
+  const fullTitle = post?.title ? `${post.title} | SigNoz Docs` : 'SigNoz Docs'
+
   return {
     title: post?.title,
     description: post?.description,
     openGraph: {
-      title: post?.title,
+      title: fullTitle,
       description: post?.description,
       siteName: siteMetadata.title,
       locale: 'en_US',
@@ -38,7 +40,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: 'summary_large_image',
-      title: post?.title,
+      title: fullTitle,
     },
   }
 }

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,6 +1,12 @@
-'use client'
-
 import React, { ReactNode } from 'react'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: {
+    template: '%s | SigNoz Docs',
+    default: 'SigNoz Docs',
+  },
+}
 
 interface LayoutProps {
   children: ReactNode


### PR DESCRIPTION
## Summary

Adds Next.js `metadata` for the docs route segment (with a title template and default), removes `'use client'` from the docs root layout so metadata can be exported, and aligns Open Graph / Twitter titles with the full docs title pattern (`<page title> | SigNoz Docs`).

Closes https://github.com/SigNoz/engineering-pod/issues/4812

## Motivation / Problem

Docs pages need consistent browser tab titles via the segment layout template, and social previews (Open Graph, Twitter) should show the same branded suffix as the visible docs title instead of only the bare page title.

## Changes

- `app/docs/layout.tsx`: Drop client directive; export `metadata` with `title.template` (`%s | SigNoz Docs`) and `title.default` (`SigNoz Docs`).
- `app/docs/(main-docs)/[...slug]/page.tsx`: Compute `fullTitle` for Open Graph and Twitter `title` so shared links match the full docs title pattern.

## Type of Change

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact

- [ ] Documentation only
- [x] UI changes *(browser tab title / social preview metadata for docs)*
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

## Context & Screenshots
<img width="1728" height="957" alt="Screenshot 2026-04-29 at 14 23 56" src="https://github.com/user-attachments/assets/d5c371cf-970c-4f1b-82d4-07017cd98cc8" />

<img width="511" height="461" alt="Screenshot 2026-04-29 at 14 24 23" src="https://github.com/user-attachments/assets/ec9a444d-dd19-4a53-82ed-6bfe67c333c4" />


## Before / After (if applicable)

- **Before:** Docs root layout was a client component without exported `metadata`; OG/Twitter titles used only `post.title`.
- **After:** Docs segment has `metadata` title template/default; OG/Twitter use `fullTitle` (`<post.title> | SigNoz Docs` when a title exists).

## Checklist

### General

- [ ] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [ ] Self-reviewed the code
- [ ] Comments added for complex logic

### For all changes

- [x] Built locally (`yarn build`) with no errors
- [x] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)


---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.