### PR TITLE
docs(mcp): add header-based auth for cloud MCP clients

### DIFF
--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -226,6 +226,32 @@ If you run into authentication issues, open the command palette and run **Authen
 </TabItem>
 </Tabs>
 
+### Header-Based Authentication (for Cloud MCP Clients)
+
+Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot perform interactive OAuth authentication. For these clients, use header-based authentication by passing your API key and instance URL directly in the request headers.
+
+<Admonition type="info">
+**When to use this:** If your MCP client doesn't support OAuth flows or stdio transport — for example, Cursor Automations — use this header-based configuration instead.
+</Admonition>
+
+```json title="mcp.json"
+{
+  "mcpServers": {
+    "signoz": {
+      "url": "https://mcp.<region>.signoz.cloud/mcp",
+      "headers": {
+        "SIGNOZ-API-KEY": "<your-api-key>",
+        "X-SigNoz-URL": "https://<tenant>.signoz.cloud"
+      }
+    }
+  }
+}
+```
+
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<your-api-key>`: The API key from [Get your API Key](#get-your-api-key)
+- `<tenant>`: Your SigNoz Cloud tenant name (the subdomain of your instance URL)
+
 ### Get your API Key
 
 When you add the hosted MCP URL to your client, the MCP client will initiate an authentication flow. You will be prompted to enter:

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -252,6 +252,10 @@ Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot 
 - `<your-api-key>`: The API key from [Get your API Key](#get-your-api-key)
 - `<tenant>`: Your SigNoz Cloud tenant name (the subdomain of your instance URL)
 
+<Admonition type="warning">
+Keep your API key secure — never commit `mcp.json` to version control when it contains secrets.
+</Admonition>
+
 ### Get your API Key
 
 When you add the hosted MCP URL to your client, the MCP client will initiate an authentication flow. You will be prompted to enter:

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -226,7 +226,17 @@ If you run into authentication issues, open the command palette and run **Authen
 </TabItem>
 </Tabs>
 
-### Header-Based Authentication (for Cloud MCP Clients)
+### Authenticate from your client
+
+When you add the hosted MCP URL to your client, the MCP client will initiate an authentication flow. You will be prompted to enter:
+1. Your **SigNoz instance URL** (e.g., `https://your-instance.signoz.cloud`)
+2. Your **API key** — go to **Settings → Service Accounts** in SigNoz, create a service account, and generate an API key (requires **Admin** role). See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
+
+<Admonition type="warning">
+Only **Admin** users can create API keys. If you don't see the option, contact your workspace administrator.
+</Admonition>
+
+### Header-Based Authentication
 
 Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot perform interactive OAuth authentication. For these clients, use header-based authentication by passing your API key and instance URL directly in the request headers.
 
@@ -241,7 +251,7 @@ Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot 
       "url": "https://mcp.<region>.signoz.cloud/mcp",
       "headers": {
         "SIGNOZ-API-KEY": "<your-api-key>",
-        "X-SigNoz-URL": "https://<tenant>.signoz.cloud"
+        "X-SigNoz-URL": "<your-signoz-instance-url>"
       }
     }
   }
@@ -249,21 +259,11 @@ Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot 
 ```
 
 - `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
-- `<your-api-key>`: The API key from [Get your API Key](#get-your-api-key)
-- `<tenant>`: Your SigNoz Cloud tenant name (the subdomain of your instance URL)
+- `<your-api-key>`: API key from [SigNoz Service accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/)
+- `<your-signoz-instance-url>`: Your SigNoz Cloud instance URL
 
 <Admonition type="warning">
 Keep your API key secure — never commit `mcp.json` to version control when it contains secrets.
-</Admonition>
-
-### Get your API Key
-
-When you add the hosted MCP URL to your client, the MCP client will initiate an authentication flow. You will be prompted to enter:
-1. Your **SigNoz instance URL** (e.g., `https://your-instance.signoz.cloud`)
-2. Your **API key** — go to **Settings → Service Accounts** in SigNoz, create a service account, and generate an API key (requires **Admin** role). See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
-
-<Admonition type="warning">
-Only **Admin** users can create API keys. If you don't see the option, contact your workspace administrator.
 </Admonition>
 
 </TabItem>


### PR DESCRIPTION
## Summary

- Adds documentation for header-based authentication configuration for SigNoz Cloud MCP server
- This configuration is required for cloud-only MCP clients (like Cursor Automations) that cannot perform interactive OAuth flows
- Documents the `SIGNOZ-API-KEY` and `X-SigNoz-URL` headers

## Context

Slack thread: https://signoz-team.slack.com/archives/C02C7P6KE06/p1777551896696279?thread_ts=1777549854.289999&cid=C02C7P6KE06

Some MCP clients run entirely in the cloud and don't support stdio transport or interactive OAuth authentication. This adds the header-based configuration as an alternative for those use cases.

## Test plan

- [x] Verify the MDX renders correctly on the docs site
- [x] Confirm internal links resolve properly
- [x] Test the configuration with Cursor Automations

https://claude.ai/code/session_01NSdVEAU2ezkk4kzzsgE99G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSdVEAU2ezkk4kzzsgE99G)_