### PR TITLE
feat: introduce signoz.io/foundry.sh installer URL

### DIFF
--- a/data/docs/setup/kubernetes/kustomize.mdx
+++ b/data/docs/setup/kubernetes/kustomize.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-26
+date: 2026-05-01
 title: Deploying to Kubernetes with Kustomize
 tags: [Self-Host]
 description: Learn how to deploy SigNoz on Kubernetes using Foundry and Kustomize. Foundry generates Kustomize manifests from your casting so you can deploy the full SigNoz stack without Helm.
@@ -29,35 +29,11 @@ Kustomize is built into `kubectl` and lets you customize Kubernetes manifests wi
 
 ## Step 1: Install foundryctl
 
-Download and extract the `foundryctl` binary from <a href="https://github.com/SigNoz/foundry/releases" target="_blank" rel="noopener noreferrer nofollow">GitHub Releases</a>.
-
-**Linux:**
-
 ```bash
-curl -L "https://github.com/SigNoz/foundry/releases/latest/download/foundry_linux_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g').tar.gz" -o foundry.tar.gz
-tar -xzf foundry.tar.gz
+curl -fsSL https://signoz.io/foundry.sh | bash
 ```
 
-**macOS:**
-
-```bash
-curl -L "https://github.com/SigNoz/foundry/releases/latest/download/foundry_darwin_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/arm64/arm64/g').tar.gz" -o foundry.tar.gz
-tar -xzf foundry.tar.gz
-```
-
-**Windows (PowerShell):**
-
-```powershell
-$ARCH = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
-Invoke-WebRequest -Uri "https://github.com/SigNoz/foundry/releases/latest/download/foundry_windows_${ARCH}.tar.gz" -OutFile foundry.tar.gz -UseBasicParsing
-tar -xzf foundry.tar.gz
-```
-
-After extracting, run `foundryctl` from the unpacked directory:
-
-```bash
-./foundry_*/bin/foundryctl <COMMAND> <OPTIONS>
-```
+For manual install (Windows PowerShell, air-gapped, etc.) or PATH setup, see the <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">foundry getting-started guide</a>.
 
 ## Step 2: Create casting.yaml
 

--- a/data/docs/setup/render.mdx
+++ b/data/docs/setup/render.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-26
+date: 2026-05-01
 title: Deploying to Render
 tags: [Self-Host]
 description: Learn how to install SigNoz on Render using Foundry. Foundry generates a Render Blueprint from your casting so you can deploy the full SigNoz stack.
@@ -20,35 +20,11 @@ This guide explains how to deploy SigNoz on <a href="https://render.com" target=
 
 ## Step 1: Install foundryctl
 
-Download and extract the `foundryctl` binary from <a href="https://github.com/SigNoz/foundry/releases" target="_blank" rel="noopener noreferrer nofollow">GitHub Releases</a>.
-
-**Linux:**
-
 ```bash
-curl -L "https://github.com/SigNoz/foundry/releases/latest/download/foundry_linux_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g').tar.gz" -o foundry.tar.gz
-tar -xzf foundry.tar.gz
+curl -fsSL https://signoz.io/foundry.sh | bash
 ```
 
-**macOS:**
-
-```bash
-curl -L "https://github.com/SigNoz/foundry/releases/latest/download/foundry_darwin_$(uname -m | sed 's/x86_64/amd64/g' | sed 's/arm64/arm64/g').tar.gz" -o foundry.tar.gz
-tar -xzf foundry.tar.gz
-```
-
-**Windows (PowerShell):**
-
-```powershell
-$ARCH = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
-Invoke-WebRequest -Uri "https://github.com/SigNoz/foundry/releases/latest/download/foundry_windows_${ARCH}.tar.gz" -OutFile foundry.tar.gz -UseBasicParsing
-tar -xzf foundry.tar.gz
-```
-
-After extracting, run `foundryctl` from the unpacked directory:
-
-```bash
-./foundry_*/bin/foundryctl <COMMAND> <OPTIONS>
-```
+For manual install (Windows PowerShell, air-gapped, etc.) or PATH setup, see the <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">foundry getting-started guide</a>.
 
 ## Step 2: Create casting.yaml
 

--- a/next.config.js
+++ b/next.config.js
@@ -93,7 +93,7 @@ module.exports = () => {
         {
           source: '/foundry.sh',
           destination: 'https://raw.githubusercontent.com/SigNoz/foundry/main/scripts/foundry.sh',
-          permanent: false,
+          permanent: true,
         },
         {
           source: '/enterprise-self-hosted/',

--- a/next.config.js
+++ b/next.config.js
@@ -91,6 +91,11 @@ module.exports = () => {
     async redirects() {
       return [
         {
+          source: '/foundry.sh',
+          destination: 'https://raw.githubusercontent.com/SigNoz/foundry/main/scripts/foundry.sh',
+          permanent: false,
+        },
+        {
           source: '/enterprise-self-hosted/',
           destination: '/contact-us/?source=redirect-enterprise-self-hosted',
           permanent: true,


### PR DESCRIPTION
## Summary

Introduces `signoz.io/foundry.sh` as the canonical install URL for `foundryctl`:

- Adds a redirect from `signoz.io/foundry.sh` → the foundry installer script in [SigNoz/foundry](https://github.com/SigNoz/foundry).
- Updates Render and Kubernetes-Kustomize setup docs to use the curl-pipe-bash one-liner instead of platform-specific manual download blocks. Manual install + PATH setup live in [foundry's getting-started guide](https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md) as the single source of truth.

```bash
curl -fsSL https://signoz.io/foundry.sh | bash
```

Pairs with [SigNoz/foundry#112](https://github.com/SigNoz/foundry/pull/112), which adds the installer script itself.

Related: SigNoz/platform-pod#2065.