### PR TITLE
bugfix(upgrade-path): documentation panel standard upgrade guide

### DIFF
--- a/app/upgrade-path/page.tsx
+++ b/app/upgrade-path/page.tsx
@@ -2,14 +2,16 @@ import { allDocs } from 'contentlayer/generated'
 import type { Doc } from 'contentlayer/generated'
 import UpgradePathTool from './components/UpgradePathTool'
 import upgradeSchema from '@/constants/upgradeSchema.json'
+import { STANDARD_GUIDE_URL } from './utils/upgradeUtils'
 
 function getUpgradeDocsBySlug(): Record<string, Doc> {
   const guideUrls = Array.from(
-    new Set(
-      Object.values(upgradeSchema.releases)
+    new Set([
+      ...Object.values(upgradeSchema.releases)
         .map((release) => release.guideUrl)
-        .filter(Boolean)
-    )
+        .filter(Boolean),
+      STANDARD_GUIDE_URL,
+    ])
   )
 
   return Object.fromEntries(

--- a/app/upgrade-path/utils/upgradeUtils.ts
+++ b/app/upgrade-path/utils/upgradeUtils.ts
@@ -7,7 +7,7 @@ import {
 } from '../types/upgrade'
 import { compareSemverTags } from '@/utils/semverTags'
 
-/** Used for GitHub releases not listed in upgradeSchema.json; must stay in sync with getUpgradeDocsBySlug(). */
+/** Fallback guide for GitHub releases not listed in upgradeSchema.json. */
 export const STANDARD_GUIDE_URL = 'https://signoz.io/docs/operate/migration/upgrade-standard'
 
 export function mergeReleasesWithSchema(

--- a/app/upgrade-path/utils/upgradeUtils.ts
+++ b/app/upgrade-path/utils/upgradeUtils.ts
@@ -7,7 +7,8 @@ import {
 } from '../types/upgrade'
 import { compareSemverTags } from '@/utils/semverTags'
 
-const STANDARD_GUIDE_URL = 'https://signoz.io/docs/operate/migration/upgrade-standard'
+/** Used for GitHub releases not listed in upgradeSchema.json; must stay in sync with getUpgradeDocsBySlug(). */
+export const STANDARD_GUIDE_URL = 'https://signoz.io/docs/operate/migration/upgrade-standard'
 
 export function mergeReleasesWithSchema(
   githubData: GitHubReleasesResponse,


### PR DESCRIPTION
## Summary

Fixes the upgrade path tool documentation panel showing **“Unable to load documentation”** for releases whose guide URL is the generic standard upgrade doc (`operate/migration/upgrade-standard`), including newer GitHub-only versions (for example v0.116.0).

## Root cause

In [#3056](https://github.com/SigNoz/signoz.io/pull/3056), doc loading was moved to the server and the client received a `docsBySlug` map built **only** from `guideUrl` values in `constants/upgradeSchema.json`.

That list includes many version-specific migration guides but **does not** include `https://signoz.io/docs/operate/migration/upgrade-standard`.

Separately, [#2926](https://github.com/SigNoz/signoz.io/pull/2926) (`mergeReleasesWithSchema`) assigns `STANDARD_GUIDE_URL` (that same standard guide) to any non-patch GitHub release that has **no** entry in `upgradeSchema.json`.

For those steps, `DocRender` looks up slug `operate/migration/upgrade-standard` in `docsBySlug`, finds nothing, and shows the error state.

Before #3056, `DocRender` used `allDocs.find(...)`, so the standard guide was always available.

## What changed

- Export `STANDARD_GUIDE_URL` from `app/upgrade-path/utils/upgradeUtils.ts` so it stays the single source of truth with `mergeReleasesWithSchema`.
- In `getUpgradeDocsBySlug()` in `app/upgrade-path/page.tsx`, include that URL when building the map (union with schema `guideUrl`s).

## Risk / scope

Adds one extra doc to the props passed to the upgrade path client—minimal compared to loading all docs—and preserves the intent of #3056.

## How to verify

1. Open `/upgrade-path/`.
2. Use a path that includes a version only from GitHub (not in `upgradeSchema.json`) whose step uses the standard guide.
3. Confirm the **Full Documentation** panel renders instead of **Unable to load documentation**; “Open in new tab” should behave as before.