### PR TITLE
docs: standardize on Admonition for callouts

### DIFF
--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -120,8 +120,7 @@ When documenting OpenTelemetry Collector changes:
 
 ## Patterns And Components
 
-- Use `Admonition` for notes, warnings, and tips.
-- Use `KeyPointCallout` for supplementary or optional material.
+- Use `Admonition` for notes, warnings, tips, and supplementary or optional material.
 - Use `Tabs` and `TabItem` only when flows materially differ by platform or environment.
 - Prefer numbered steps for procedures and bullets for reference content.
 - Keep headings short and meaningful.

--- a/contributing/docs-review.md
+++ b/contributing/docs-review.md
@@ -198,7 +198,7 @@ cat contributing/docs-authoring.md
 cat contributing/docs-review.md
 
 # likely docs quality issues
-rg -n "## Next steps|## Troubleshooting|KeyPointCallout|ToggleHeading|https?://|<[^>]+>" data/docs
+rg -n "## Next steps|## Troubleshooting|Admonition|ToggleHeading|https?://|<[^>]+>" data/docs
 
 # link health
 curl -sI <URL>

--- a/contributing/docs-review.md
+++ b/contributing/docs-review.md
@@ -198,7 +198,7 @@ cat contributing/docs-authoring.md
 cat contributing/docs-review.md
 
 # likely docs quality issues
-rg -n "## Next steps|## Troubleshooting|Admonition|ToggleHeading|https?://|<[^>]+>" data/docs
+rg -n "## Next steps|## Troubleshooting|KeyPointCallout|ToggleHeading|https?://|<[^>]+>" data/docs
 
 # link health
 curl -sI <URL>

--- a/contributing/templates/send-data-doc.md
+++ b/contributing/templates/send-data-doc.md
@@ -8,11 +8,11 @@
 <!-- Mention OpenTelemetry in the title, slug, and overview. -->
 <!-- Use direct export to SigNoz Cloud as the primary path. -->
 
-<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
+<Admonition type="info" title="Using self-hosted SigNoz?" defaultCollapsed={true}>
   Most steps are identical. Update the endpoint and remove the ingestion key
   header as shown in [Cloud ->
   Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
-</KeyPointCallout>
+</Admonition>
 
 ## Prerequisites
 

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -246,7 +246,7 @@ Only **Admin** users can create API keys. If you don't see the option, contact y
 
 Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot perform interactive OAuth authentication. For these clients, use header-based authentication by passing your API key and instance URL directly in the request headers.
 
-<Admonition type="info" title="When to use header-based authentication?" defaultCollapsed={true}>
+<Admonition type="info" title="When to use header-based authentication?">
 If your MCP client doesn't support OAuth flows or stdio transport — for example, Cursor Automations: use this header-based configuration instead.
 </Admonition>
 

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-28
+date: 2026-05-05
 id: signoz-mcp-server
 title: SigNoz MCP Server
 description: Connect AI assistants like Claude Desktop, Cursor, GitHub Copilot, Claude Code, OpenAI Codex, Windsurf, Gemini CLI, VS Code, and Zed to your SigNoz observability data using the MCP (Model Context Protocol) server.
@@ -232,6 +232,12 @@ When you add the hosted MCP URL to your client, the MCP client will initiate an 
 1. Your **SigNoz instance URL** (e.g., `https://your-instance.signoz.cloud`)
 2. Your **API key** — go to **Settings → Service Accounts** in SigNoz, create a service account, and generate an API key (requires **Admin** role). See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
 
+<Admonition type="info" title="How authentication works?" defaultCollapsed={true}>
+SigNoz Cloud's hosted MCP server uses OAuth 2.1 for client-to-MCP authentication. MCP clients discover the auth endpoints from the server metadata, dynamically register as an OAuth client using Dynamic Client Registration (DCR, RFC 7591) when supported, then use Authorization Code + PKCE. During the browser step, SigNoz asks for your SigNoz instance URL and service account API key; the MCP server validates those credentials and issues bearer/refresh tokens for future MCP requests.
+
+SigNoz Cloud's MCP server also supports header-based authentication for clients that can't do OAuth, but the recommended approach is to use OAuth when possible for better security and token management.
+</Admonition>
+
 <Admonition type="warning">
 Only **Admin** users can create API keys. If you don't see the option, contact your workspace administrator.
 </Admonition>
@@ -240,8 +246,8 @@ Only **Admin** users can create API keys. If you don't see the option, contact y
 
 Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot perform interactive OAuth authentication. For these clients, use header-based authentication by passing your API key and instance URL directly in the request headers.
 
-<Admonition type="info">
-**When to use this:** If your MCP client doesn't support OAuth flows or stdio transport — for example, Cursor Automations — use this header-based configuration instead.
+<Admonition type="info" title="When to use header-based authentication?" defaultCollapsed={true}>
+If your MCP client doesn't support OAuth flows or stdio transport — for example, Cursor Automations: use this header-based configuration instead.
 </Admonition>
 
 ```json title="mcp.json"


### PR DESCRIPTION
## Summary
Update contributing guidance and the MCP server doc to recommend `Admonition` for all callouts — both standard notes/warnings/tips and supplementary/optional material — including the collapsible variant via `defaultCollapsed`.

## Motivation / Problem
Contributing docs previously suggested two different components for callouts (`Admonition` for notes/warnings/tips and `KeyPointCallout` for supplementary material). `Admonition` already supports `title` and `defaultCollapsed`, so a single component covers both cases and gives readers a consistent UI.

## Changes
- `contributing/docs-authoring.md`: collapse the Patterns And Components guidance to a single line — `Admonition` covers notes, warnings, tips, and supplementary or optional material.
- `contributing/templates/send-data-doc.md`: switch the self-hosted callout template snippet to `<Admonition type="info" title="..." defaultCollapsed={true}>`.
- `contributing/docs-review.md`: update the review-time `rg` pattern to look for `Admonition` instead of `KeyPointCallout`.
- `data/docs/ai/signoz-mcp-server.mdx`: add a collapsible "How authentication works?" Admonition near the API key step, convert the existing header-based-auth note to a titled, collapsible Admonition, and bump the `date` frontmatter.

## Description
This standardizes the callout pattern in docs and brings the SigNoz MCP server page in line with that guidance. No URL or sidebar changes; no new images.

## Type of Change
- [x] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [x] **Other** – Contributing-docs guidance updates under `contributing/**`

## Impact
- [x] Documentation only
- [ ] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

If breaking change, describe migration steps:
N/A.

## Context & Screenshots
Component verified to support the props in use: `components/Admonition/Admonition.tsx` exposes `title`, `type`, `defaultCollapsed`, and `variant` on `AdmonitionProps`.

## Before / After (if applicable)
Template snippet (Before):
\`\`\`mdx
<KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed={true}>
  ...
</KeyPointCallout>
\`\`\`
Template snippet (After):
\`\`\`mdx
<Admonition type="info" title="Using self-hosted SigNoz?" defaultCollapsed={true}>
  ...
</Admonition>
\`\`\`

## Checklist

### General
- [x] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [x] Self-reviewed the code
- [x] Comments added for complex logic

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [ ] Ran `yarn lint` and fixed any issues
- [x] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [x] Followed the docs author checklist in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [x] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc — N/A, no URL change
- [x] Any added docs images use WebP format and live under `public/img/docs/<topic>/` — N/A, no images added

### For blog changes
- [ ] N/A

### For site code changes
- [ ] N/A

### For renamed or moved docs
- [ ] N/A

## Testing
- [x] Tested locally — ran `yarn check:docs-metadata` and `yarn check:doc-redirects`; both pass. Pre-commit hooks also re-ran these.
- [x] Edge cases considered — verified `Admonition` supports `title` and `defaultCollapsed` props in `components/Admonition/Admonition.tsx`.
- [x] Existing functionality verified
- [ ] New tests added (if applicable) — not applicable for docs-only change.

Steps to test:
1. Open the MCP server page locally (`yarn dev`) and confirm the two new collapsible callouts render with their titles and expand/collapse correctly.
2. In `contributing/templates/send-data-doc.md`, confirm the self-hosted snippet uses `<Admonition>` with `defaultCollapsed`.
3. Search docs for any remaining `KeyPointCallout` usage — out of scope for this PR but a candidate follow-up.

## Rollout / Deployment Notes
None — docs-only change.

## Additional Context
Existing `KeyPointCallout` usages elsewhere in `data/docs/**` are not touched here; they can be migrated incrementally.