### PR TITLE
fix: added fix for codeblock background

### DIFF
--- a/components/Changelog/Renderer/styles.module.css
+++ b/components/Changelog/Renderer/styles.module.css
@@ -54,3 +54,9 @@
   padding: 0.15rem 0.5rem;
   border-radius: 0.25rem;
 }
+
+.changelog-container pre code {
+  padding: 0;
+  background: none;
+  border-radius: 0;
+}

--- a/components/Changelog/Renderer/styles.module.css
+++ b/components/Changelog/Renderer/styles.module.css
@@ -1,42 +1,56 @@
 .changelog-container h1 {
-    @apply text-2xl leading-9;
+  @apply text-2xl leading-9;
 }
 
 .changelog-container h2 {
-    @apply text-xl leading-7;
+  @apply text-xl leading-7;
 }
 
-.changelog-container h1, .changelog-container h2, .changelog-container h3, .changelog-container h4, .changelog-container h5, .changelog-container h6 {
-    font-family: 'Inter', sans-serif;
-    @apply font-semibold text-signoz_vanilla-100;
+.changelog-container h1,
+.changelog-container h2,
+.changelog-container h3,
+.changelog-container h4,
+.changelog-container h5,
+.changelog-container h6 {
+  font-family: 'Inter', sans-serif;
+  @apply font-semibold text-signoz_vanilla-100;
 }
 
-.changelog-container p, .changelog-container li {
-    font-family: 'Inter', sans-serif;
-    @apply text-signoz_vanilla-400 text-sm leading-5;
+.changelog-container p,
+.changelog-container li {
+  font-family: 'Inter', sans-serif;
+  @apply text-sm leading-5 text-signoz_vanilla-400;
 }
 
-.changelog-container ul, .changelog-container ol {
-    @apply flex flex-col gap-4;
+.changelog-container ul,
+.changelog-container ol {
+  @apply flex flex-col gap-4;
 }
 
 .changelog-container li {
-    @apply relative;
+  @apply relative;
 }
 
 .changelog-container li::before {
-    @apply absolute w-5 h-0.5 bg-signoz_robin-500;
-    content: '';
-    left: -10px;
-    top: 10px;
-    transform: translate(-100%, -50%);
+  @apply absolute h-0.5 w-5 bg-signoz_robin-500;
+  content: '';
+  left: -10px;
+  top: 10px;
+  transform: translate(-100%, -50%);
 }
 
 .changelog-container a {
-    @apply text-signoz_robin-500 font-semibold underline;
+  @apply font-semibold text-signoz_robin-500 underline;
 }
 
 .changelog-container :last-child,
 .changelog-container :only-child {
-    margin-bottom: unset;
+  margin-bottom: unset;
+}
+
+.changelog-container pre,
+.changelog-container code {
+  @apply bg-signoz_ink-100 text-signoz_vanilla-400;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
 }


### PR DESCRIPTION
## Summary
Fixes the missing background on inline `code` and `pre` blocks rendered inside the changelog by adding explicit styles in the changelog renderer's CSS module.

## Changes
- Added `pre` and `code` selectors under `.changelog-container` with `bg-signoz_ink-100` background, `text-signoz_vanilla-400` text color, padding, and rounded corners.
- Reformatted `components/Changelog/Renderer/styles.module.css` (4→2 space indentation, split grouped selectors onto separate lines, normalized Tailwind class order, added trailing newline). No behavioral change from these formatting tweaks.

## Type of Change
- [x] **Site Code** – Changes to `components/**`

## Impact
- [x] UI changes — affects only the changelog page rendering

## Before / After
_Before:_ inline code and code blocks in changelog entries rendered with no background, blending into surrounding copy.
_After:_ code/pre blocks have a distinct ink-100 background, vanilla-400 text, and rounded padding for clear visual separation.

(Screenshots recommended before merge.)

## Testing
- [x] Tested locally on the changelog page
- [x] Existing changelog typography (headings, lists, links) verified unchanged

Steps to test:
1. `yarn dev`
2. Open a changelog entry that contains inline `code` and a fenced code block.
3. Confirm both render with the dark ink-100 background and rounded padding; confirm headings/lists/links look unchanged.

## Additional Context
Scope is limited to `components/Changelog/Renderer/styles.module.css` (33 additions / 19 deletions, single file). No redirects, docs metadata, or sidebar changes involved.
