### PR TITLE
docs: move Render metrics to integrations/outposts

### DIFF
--- a/constants/componentItems/metricsQuickStart.ts
+++ b/constants/componentItems/metricsQuickStart.ts
@@ -101,7 +101,7 @@ export const METRICS_QUICK_START_ITEMS = {
     },
     {
       name: 'Render',
-      href: '/docs/metrics-management/render-metrics',
+      href: '/docs/integrations/outposts/render',
       clickName: 'Render Metrics Link',
     },
   ] satisfies ComponentItem[],

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -1838,7 +1838,6 @@ const docsSideNav = [
                 route: '/docs/metrics-management/slurm-metrics',
                 label: 'SLURM',
               },
-              { type: 'doc', route: '/docs/metrics-management/render-metrics', label: 'Render' },
               {
                 type: 'doc',
                 route: '/docs/tutorial/traefik-observability',
@@ -3531,6 +3530,11 @@ const docsSideNav = [
         type: 'doc',
         route: '/docs/integrations/outposts/flyio',
         label: 'Fly.io',
+      },
+      {
+        type: 'doc',
+        route: '/docs/integrations/outposts/render',
+        label: 'Render',
       },
       {
         type: 'doc',

--- a/data/docs/dashboards/dashboard-templates/render-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/render-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-17
+date: 2026-05-08
 id: render-dashboard
 title: Render Dashboard
 description: Monitor Render service performance including CPU usage, memory consumption, and network throughput using Render Metrics Streams.
@@ -9,7 +9,7 @@ doc_type: explanation
 This dashboard provides monitoring of Render service performance using <a href="https://docs.render.com/metrics-streams" target="_blank" rel="noopener noreferrer nofollow">Render Metrics Streams</a>, giving you visibility into CPU usage, memory consumption, and network throughput for your Render services.
 
 <Admonition type="info">
-To use this dashboard, you need to configure Render to send metrics to SigNoz. Follow the [Render Metrics](https://signoz.io/docs/metrics-management/render-metrics/) guide to get started.
+To use this dashboard, you need to configure Render to send metrics to SigNoz. Follow the [Render Metrics](https://signoz.io/docs/integrations/outposts/render/) guide to get started.
 </Admonition>
 
 ## Dashboard Preview
@@ -54,5 +54,5 @@ This dashboard provides comprehensive monitoring of Render service performance, 
 
 ## Related Docs
 
-- [Render Metrics](https://signoz.io/docs/metrics-management/render-metrics/)
+- [Render Metrics](https://signoz.io/docs/integrations/outposts/render/)
 - [Host Metrics](https://signoz.io/docs/dashboards/dashboard-templates/hostmetrics-dashboards/)

--- a/data/docs/integrations/outposts/render.mdx
+++ b/data/docs/integrations/outposts/render.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2026-03-17  
+date: 2026-05-08
 title: Monitor Render with SigNoz
-id: render-metrics
+id: render
+slug: /docs/integrations/outposts/render
 tags: [SigNoz Cloud]
 doc_type: howto
 description: Stream Render service metrics to SigNoz using Render Metrics Streams and OpenTelemetry.

--- a/next.config.js
+++ b/next.config.js
@@ -1666,6 +1666,11 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/docs/metrics-management/render-metrics/',
+          destination: '/docs/integrations/outposts/render/',
+          permanent: true,
+        },
+        {
           source: '/docs/operate/docker-standalone/',
           destination: '/docs/install/docker/',
           permanent: true,


### PR DESCRIPTION
## Summary
- Moves Render metrics docs from `/docs/metrics-management/render-metrics/` to `/docs/integrations/outposts/render` (upstream: platform-pod#1097)
- Adds permanent redirect from old path
- Updates sidebar nav: removed from metrics-management, added under integrations/outposts

## Test plan
- [ ] Verify redirect from old URL works
- [ ] Verify new page renders at `/docs/integrations/outposts/render`
- [ ] Confirm sidebar shows Render under integrations/outposts

🤖 Generated with [Claude Code](https://claude.com/claude-code)