### PR TITLE
chore: add @revmag to docs codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,8 +23,8 @@ scripts @SigNoz/frontend
 utils @SigNoz/frontend
 
 # Docs owners
-docs @makeavish @therealpandey @pranay01
+docs @makeavish @therealpandey @pranay01 @revmag
 docs/collection-agents/ @Nageshbansal @therealpandey
 docs/install/ @Nageshbansal @therealpandey
-constants/docsSideNav.ts @makeavish @therealpandey @pranay01
-next.config.js @SigNoz/frontend @makeavish @therealpandey @pranay01 @ankit01-oss
+constants/docsSideNav.ts @makeavish @therealpandey @pranay01 @revmag
+next.config.js @SigNoz/frontend @makeavish @therealpandey @pranay01 @ankit01-oss @revmag


### PR DESCRIPTION
## Summary

- Adds `@revmag` as a docs codeowner so they are auto-requested on docs PRs
- Applies to `docs`, `constants/docsSideNav.ts`, and `next.config.js` (which controls docs redirects)

## Test plan

- [x] Verify GitHub auto-requests `@revmag` on a future docs-only PR
- [x] Verify `next.config.js` and `constants/docsSideNav.ts` changes still also request existing owners