### PR TITLE
chore: Move to HTTP exporter in Python docs

### DIFF
--- a/data/docs/instrumentation/opentelemetry-python.mdx
+++ b/data/docs/instrumentation/opentelemetry-python.mdx
@@ -1,7 +1,6 @@
 ---
-date: 2026-03-05
+date: 2026-05-08
 id: python
-
 title: Python OpenTelemetry Instrumentation
 description: Send traces to SigNoz using OpenTelemetry instrumentation for Python frameworks like Django, Flask, FastAPI, and Celery.
 doc_type: howto
@@ -10,13 +9,13 @@ doc_type: howto
 This guide shows you how to instrument your Python application with OpenTelemetry and send traces to SigNoz. The auto-instrumentation approach works with Django, Flask, FastAPI, Falcon, Celery, and most Python libraries out of the box.
 
 <KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
-Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
+  Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
 ## Prerequisites
 
 - <a href="https://pypi.org/project/opentelemetry-distro/" target="_blank" rel="noopener noreferrer nofollow">Python 3.9+</a>
-- A SigNoz Cloud account or self-hosted SigNoz instance
+- An instance of SigNoz (either [Cloud](https://signoz.io/teams/) or [Self-Hosted](https://signoz.io/docs/install/self-host/))
 
 Tested with <a href="https://docs.python.org/3.11/" target="_blank" rel="noopener noreferrer nofollow">Python 3.11</a> and OpenTelemetry Python SDK <a href="https://pypi.org/project/opentelemetry-sdk/1.27.0/" target="_blank" rel="noopener noreferrer nofollow">v1.27.0</a>.
 
@@ -40,7 +39,7 @@ Use this section if you're deploying your Python application directly on a serve
 export OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>"
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
-export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_METRICS_EXPORTER="none"
 ```
 
@@ -106,7 +105,7 @@ env:
 - name: OTEL_EXPORTER_OTLP_HEADERS
   value: 'signoz-ingestion-key=<your-ingestion-key>'
 - name: OTEL_EXPORTER_OTLP_PROTOCOL
-  value: 'grpc'
+  value: 'http/protobuf'
 - name: OTEL_METRICS_EXPORTER
   value: 'none'
 ```
@@ -212,7 +211,7 @@ instrumentation.opentelemetry.io/otel-python-platform: "glibc"  # or "musl" for 
 $env:OTEL_RESOURCE_ATTRIBUTES = "service.name=<service-name>"
 $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://ingest.<region>.signoz.cloud:443"
 $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
-$env:OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
+$env:OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
 $env:OTEL_METRICS_EXPORTER = "none"
 ```
 
@@ -264,7 +263,7 @@ See [Framework instrumentation](#framework-instrumentation) below for framework-
 ENV OTEL_RESOURCE_ATTRIBUTES=service.name=<service-name>
 ENV OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.<region>.signoz.cloud:443
 ENV OTEL_EXPORTER_OTLP_HEADERS=signoz-ingestion-key=<your-ingestion-key>
-ENV OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ENV OTEL_METRICS_EXPORTER=none
 ```
 
@@ -274,7 +273,7 @@ Or pass them at runtime using `docker run`:
 docker run -e OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>" \
     -e OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443" \
     -e OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>" \
-    -e OTEL_EXPORTER_OTLP_PROTOCOL="grpc" \
+    -e OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf" \
     -e OTEL_METRICS_EXPORTER="none" \
     your-image:latest
 ```
@@ -463,7 +462,7 @@ Choose your framework below to see the specific run command. The setup steps abo
         from celery.signals import worker_process_init
         from opentelemetry.instrumentation.celery import CeleryInstrumentor
         from opentelemetry import trace
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -588,16 +587,6 @@ Application servers that spawn multiple worker processes require special handlin
 ### Hot reload breaks instrumentation
 
 Don't run your app in reloader/hot-reload mode. For Flask, avoid `FLASK_ENV=development`. For Django, use `--noreload`. For Uvicorn/FastAPI, don't use `--reload`.
-
-### gRPC installation issues
-
-If `grpcio` installation fails, use the HTTP exporter instead:
-
-```bash
-pip install opentelemetry-exporter-otlp-proto-http
-```
-
-Then set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
 
 ### Database calls not showing in traces
 

--- a/data/docs/logs-management/send-logs/python-logs.mdx
+++ b/data/docs/logs-management/send-logs/python-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-05-08
 title: Send logs from Python to SigNoz using OpenTelemetry
 id: opentelemetry-python-logs
 doc_type: howto
@@ -9,9 +9,7 @@ description: Learn how to send logs from Python to SigNoz using the OpenTelemetr
 import GetHelp from '@/components/shared/get-help.md'
 
 <KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
-  Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key
-  header as shown in [Cloud →
-  Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
+  Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
 
 ## Prerequisites
@@ -56,7 +54,7 @@ Use this section if you're deploying your application directly on a server or VM
 </KeyPointCallout>
 
 ```bash
-export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 export OTEL_SERVICE_NAME="python-app"
@@ -70,8 +68,8 @@ Verify these values:
 If using a local OTel Collector, use:
 
 ```bash
-export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
 export OTEL_SERVICE_NAME="python-app"
 ```
 
@@ -83,8 +81,8 @@ Add these environment variables to your deployment manifest:
 
 ```yaml
 env:
-  - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-    value: 'true'
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: 'http/protobuf'
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: 'https://ingest.<region>.signoz.cloud:443'
   - name: OTEL_EXPORTER_OTLP_HEADERS
@@ -125,7 +123,7 @@ RUN opentelemetry-bootstrap -a install
 COPY . .
 
 # Set OpenTelemetry environment variables
-ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ENV OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 ENV OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 ENV OTEL_SERVICE_NAME="python-app"
@@ -155,7 +153,7 @@ Replace the placeholders in the Dockerfile:
 Set environment variables in PowerShell:
 
 ```powershell
-$env:OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED="true"
+$env:OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
 $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://ingest.<region>.signoz.cloud:443"
 $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
 $env:OTEL_SERVICE_NAME = "python-app"
@@ -206,7 +204,7 @@ Use code-level instrumentation when you need fine-grained control over how logs 
 ### Step 1: Install dependencies
 
 ```bash
-pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc
+pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 ```
 
 ### Step 2: Set environment variables
@@ -272,7 +270,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 # Install OpenTelemetry dependencies
-RUN pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc
+RUN pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 
 # Copy application code
 COPY . .
@@ -326,8 +324,8 @@ Create a file to configure the OpenTelemetry logger with trace correlation:
 import logging
 from opentelemetry import trace
 from opentelemetry._logs import set_logger_provider
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
@@ -392,22 +390,17 @@ python main.py
 
 Captured logs can be viewed in the [Logs Explorer](https://signoz.io/docs/logs-management/overview/) section.
 
-<figure data-zoomable align="center">
-  <img src="/img/docs/logs-management/send-logs/python-logs.webp" alt="Python Logs" />
-  <figcaption>
-    <i>Python Application Logs</i>
-  </figcaption>
-</figure>
+<Figure 
+  src="/img/docs/logs-management/send-logs/python-logs.webp"
+  alt="Python Application Logs"
+  caption="Python Application Logs"
+/>
 
-<figure data-zoomable align="center">
-  <img
-    src="/img/docs/logs-management/send-logs/python-logs-detailed-view.webp"
-    alt="Python Logs Detailed View"
-  />
-  <figcaption>
-    <i>Python Application Logs Detailed View</i>
-  </figcaption>
-</figure>
+<Figure 
+  src="/img/docs/logs-management/send-logs/python-logs-detailed-view.webp"
+  alt="Python Application Logs Detailed View"
+  caption="Python Application Logs Detailed View"
+/>
 
 <details>
 <ToggleHeading>
@@ -445,13 +438,13 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 This usually happens if the endpoint URL is incorrect.
 
 - Cloud: `https://ingest.<region>.signoz.cloud:443`
-- Self-Hosted: `http://localhost:4317`
+- Self-Hosted (HTTP): `http://localhost:4318`
 
 #### Why are my logs not appearing in SigNoz?
 
 - Check if the application started successfully and is actually generating logs.
 - Verify your `<region>` and `<your-ingestion-key>` are correct.
-- Ensure `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` is set to `true` (if using auto-instrumentation).
+- Ensure `opentelemetry-bootstrap -a install` was run to install instrumentation packages including `opentelemetry-instrumentation-logging`.
 
 </details>
 

--- a/data/docs/logs-management/send-logs/python-logs.mdx
+++ b/data/docs/logs-management/send-logs/python-logs.mdx
@@ -17,6 +17,8 @@ import GetHelp from '@/components/shared/get-help.md'
 - Python 3.8 or higher
 - An instance of SigNoz (either [Cloud](https://signoz.io/teams/) or [Self-Hosted](https://signoz.io/docs/install/self-host/))
 
+Tested with <a href="https://docs.python.org/3.11/" target="_blank" rel="noopener noreferrer nofollow">Python 3.11</a> and OpenTelemetry Python SDK <a href="https://pypi.org/project/opentelemetry-sdk/1.41.1/" target="_blank" rel="noopener noreferrer nofollow">v1.41.1</a>.
+
 ## Send logs to SigNoz
 
 <Tabs>
@@ -166,6 +168,10 @@ Replace the placeholders:
 
 </TabItem>
 </Tabs>
+
+<Admonition type="info">
+  Automatic log capture requires OpenTelemetry Python SDK **1.40.0 or higher**, where `opentelemetry-instrumentation-logging` enables log collection by default. On older SDK versions, set `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true` explicitly to enable it.
+</Admonition>
 
 ### Step 3: Run your application
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
@@ -502,7 +502,7 @@ See the OpenTelemetry semantic conventions for the complete list:
     - Endpoint: `https://ingest.<region>.signoz.cloud:443`
     - Protocol: `http/protobuf`
 
-2. **Check Exporter Protocol**: This guide uses `http/protobuf`. Ensure `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` is set; the SDK defaults to gRPC if this is missing.
+2. **Check Exporter Protocol**: This guide uses `http/protobuf`. Ensure `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` is set.
 
 3. **Check Console Errors**: The OpenTelemetry SDK prints errors to stderr by default. Check your application logs for any connection refused or authentication errors.
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-06
+date: 2026-05-08
 id: opentelemetry-python
 title: Send Metrics from Python application
 description: Learn how to send metrics from Python applications (Flask, Django, FastAPI, Celery, Runtime) to SigNoz using OpenTelemetry
@@ -17,6 +17,8 @@ This guide shows you how to send metrics from your Python application (Flask, Dj
 
 - <a href="https://pypi.org/project/opentelemetry-distro/" target="_blank" rel="noopener noreferrer nofollow">Python 3.9+</a>
 - A SigNoz Cloud account or self-hosted SigNoz instance
+
+Tested with <a href="https://docs.python.org/3.11/" target="_blank" rel="noopener noreferrer nofollow">Python 3.11</a> and OpenTelemetry Python SDK <a href="https://pypi.org/project/opentelemetry-sdk/1.41.1/" target="_blank" rel="noopener noreferrer nofollow">v1.41.1</a>.
 
 ## Send metrics to SigNoz
 
@@ -36,6 +38,7 @@ Set the following environment variables to configure the OpenTelemetry exporter:
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_SERVICE_NAME="<service-name>"
 export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="none"
@@ -58,6 +61,8 @@ env:
   value: 'https://ingest.<region>.signoz.cloud:443'
 - name: OTEL_EXPORTER_OTLP_HEADERS
   value: 'signoz-ingestion-key=<your-ingestion-key>'
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: 'http/protobuf'
 - name: OTEL_SERVICE_NAME
   value: '<service-name>'
 - name: OTEL_METRICS_EXPORTER
@@ -80,6 +85,7 @@ Verify these values:
 ```powershell
 $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://ingest.<region>.signoz.cloud:443"
 $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
+$env:OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
 $env:OTEL_SERVICE_NAME = "<service-name>"
 $env:OTEL_METRICS_EXPORTER = "otlp"
 $env:OTEL_TRACES_EXPORTER = "none"
@@ -102,6 +108,7 @@ Add environment variables to your Dockerfile:
 # Set OpenTelemetry environment variables
 ENV OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 ENV OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
+ENV OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 ENV OTEL_SERVICE_NAME="<service-name>"
 ENV OTEL_METRICS_EXPORTER="otlp"
 ENV OTEL_TRACES_EXPORTER="none"
@@ -114,6 +121,7 @@ Or pass them at runtime using `docker run`:
 ```bash
 docker run -e OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443" \
     -e OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>" \
+    -e OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf" \
     -e OTEL_SERVICE_NAME="<service-name>" \
     -e OTEL_METRICS_EXPORTER="otlp" \
     -e OTEL_TRACES_EXPORTER="none" \
@@ -490,11 +498,11 @@ See the OpenTelemetry semantic conventions for the complete list:
 
 ### Metrics not appearing?
 
-1. **Check Environment Variables**: Ensure `OTEL_EXPORTER_OTLP_ENDPOINT` is set correctly:
-    - For gRPC (default): `https://ingest.<region>.signoz.cloud:443`
-    - For HTTP: `https://ingest.<region>.signoz.cloud:443/v1/metrics`
+1. **Check Environment Variables**: Ensure `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` are set correctly:
+    - Endpoint: `https://ingest.<region>.signoz.cloud:443`
+    - Protocol: `http/protobuf`
 
-2. **Check Exporter Protocol**: This guide uses `otlp-proto-grpc`. If you are behind a proxy that only supports HTTP/1.1, switch to `otlp-proto-http`.
+2. **Check Exporter Protocol**: This guide uses `http/protobuf`. Ensure `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` is set; the SDK defaults to gRPC if this is missing.
 
 3. **Check Console Errors**: The OpenTelemetry SDK prints errors to stderr by default. Check your application logs for any connection refused or authentication errors.
 


### PR DESCRIPTION
## Summary
This PR moves Python docs to use HTTP exporter

Closes: [#4857](https://github.com/SigNoz/engineering-pod/issues/4857)

Doc Links:

- [Python Logs](https://signoz-web-git-chore-update-python-doc-signoz.vercel.app/docs/logs-management/send-logs/python-logs/)
- [Python Traces](https://signoz-web-git-chore-update-python-doc-signoz.vercel.app/docs/instrumentation/opentelemetry-python/)