### PR TITLE
fix: sync workflow failing due to peer deps

### DIFF
--- a/.github/workflows/sync-content-cms.yml
+++ b/.github/workflows/sync-content-cms.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          npm install --no-save \
+          npm install --no-save --legacy-peer-deps \
             gray-matter \
             axios \
             js-yaml \


### PR DESCRIPTION
                                                                           
  # Problem                                                                                                  
                                                                                                           
  The "Sync Content to Strapi CMS" workflow is failing at the Install Dependencies step with:              
                                                                                                           
  npm error ERESOLVE could not resolve                                                                     
  npm error While resolving: @testing-library/react@16.3.2                                               
  npm error Could not resolve dependency:                                                                  
  npm error peerOptional @types/react-dom@"^18.0.0 || ^19.0.0" from @testing-library/react@16.3.2
                                                                                                           
 # Cause                                                                                             
                                                                                                           
  The workflow runs npm install --no-save gray-matter axios js-yaml mime-types @aws-sdk/client-s3 in the   
  project root. Even though only 5 packages are requested, npm resolves dependency tree from
  package.json - including dev dependencies like @testing-library/react.                                   
                                                                                                         
  This triggers a peer dependency conflict:                                                                
   
  1. @testing-library/react@16.3.2 has peerOptional: @types/react-dom@^18.0.0 || ^19.0.0                   
  2. Resolving @types/react-dom@^19 pulls in peer: @types/react@^19.2.0                                  
  3. The project pins @types/react@^18.2.73                                                                
                                                                                                           
  and the conflict causes a failure.   
                                                                                                           
  # Fix                                                                                                      
                                                                                                         
  Add --legacy-peer-deps to the npm install command. This restores the npm v6 behavior of not failing on   
  peer dependency conflicts.