### PR TITLE
fix: duplicate | SigNoz entries in pages

### DIFF
--- a/app/(site)/about-us/page.tsx
+++ b/app/(site)/about-us/page.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'About us - SigNoz',
+  title: 'About us',
   description: 'About us - SigNoz',
 }
 

--- a/app/(site)/contact-us/page.tsx
+++ b/app/(site)/contact-us/page.tsx
@@ -3,7 +3,7 @@ import ContactUsLayout from './ContactUsLayout'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Enterprise Grade Observability at any scale | SigNoz',
+  title: 'Enterprise Grade Observability at any scale',
   description:
     'Enterprise cloud environment, BYOC (managed by SigNoz in your cloud), or self-hosted options with dedicated support, volume discounts, and dashboard migration.',
   openGraph: {

--- a/app/(site)/datadog-pricing-calculator/page.tsx
+++ b/app/(site)/datadog-pricing-calculator/page.tsx
@@ -4,7 +4,7 @@ import DatadogPricingCalculator from '@/components/DatadogPricingCalculator/Data
 import DatadogVsSigNoz from '@/components/DatadogVsSigNoz/DatadogVsSigNoz'
 
 export const metadata = {
-  title: 'Datadog Pricing Calculator | SigNoz',
+  title: 'Datadog Pricing Calculator',
   description:
     'Estimate your Datadog costs with our interactive pricing calculator. Compare Datadog pricing for logs, APM, and infrastructure monitoring.',
 }

--- a/app/(site)/enterprise/metadata.ts
+++ b/app/(site)/enterprise/metadata.ts
@@ -1,7 +1,9 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'SigNoz Enterprise | Built for Scale',
+  title: {
+    absolute: 'SigNoz Enterprise | Built for Scale',
+  },
   openGraph: {
     title: 'SigNoz Enterprise | Built for Scale',
     description:

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -21,7 +21,9 @@ const softwareAppId = `${siteUrl}/#software`
 const webpageId = `${siteUrl}/#webpage`
 
 export const metadata: Metadata = {
-  title: 'SigNoz | The Open Source Datadog Alternative',
+  title: {
+    absolute: 'SigNoz | The Open Source Datadog Alternative',
+  },
   openGraph: {
     title: 'SigNoz | The Open Source Datadog Alternative',
     description:

--- a/app/(site)/startups/page.tsx
+++ b/app/(site)/startups/page.tsx
@@ -4,7 +4,9 @@ import StartUpsLayout from './StartUpsLayout'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "SigNoz for Startups | Observability That Doesn't Burn Your Budget",
+  title: {
+    absolute: "SigNoz for Startups | Observability That Doesn't Burn Your Budget",
+  },
   description:
     'Special pricing for startups: $19/month for the first 12 months (regularly $49) so lean teams get full-stack observability without overspending.',
   openGraph: {


### PR DESCRIPTION

## Motivation / Problem
Homepage title appears broken with | SigNoz appearing at the end, while it should read "SigNoz | ..." and not "SigNoz | ... | SigNoz"

## Why the homepage title was broken                                                                        
                                                                                                           
The root layout (app/layout.tsx) 
  defines a title template %s | SigNoz that auto-appends "| SigNoz" to all pages in subfolders — but not to
   pages sitting next to the layout itself. Before the move, the homepage was exempt; after the move, it   
  fell under the template, producing "SigNoz | The Open Source Datadog Alternative | SigNoz".              
                                                                                                         
###  Fix: Use title: { absolute: '...' } which tells Next.js to skip the template and use the title as-is.    
  
  Other pages fixed: contact-us, about-us, and datadog-pricing-calculator also had duplicates. Removed the redundant | SigNoz from their plain-string titles so the layout template appends it exactly once.    