### PR TITLE
fix: add image quality and OTLP/HTTP-first rules to docs playbooks

### DIFF
--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -116,6 +116,7 @@ When documenting OpenTelemetry Collector changes:
 - Validate all added internal and external links before the PR.
 - Store docs images under `public/img/docs/<topic>/...`.
 - Use WebP format for all docs images. See [Creating WebP images doc](https://signoz.notion.site/Creating-webp-images-7c27a266c4ae4ea49a76a2d3ba3296a5?pvs=74) for tips and tools.
+- **Minimum image width: 1200 px** (ideally 1400–1600 px for retina sharpness). Images below 1200 px render blurry when the docs layout stretches them to the content column width. Take screenshots at 2× resolution on retina displays or use browser DevTools device toolbar set to a wide viewport.
 - Use `Figure` with descriptive alt text and a concise caption.
 
 ## Patterns And Components
@@ -141,6 +142,7 @@ Use the template in [templates/send-data-doc.md](templates/send-data-doc.md).
 - Always include a concrete `## Validate` section.
 - Mention OpenTelemetry in the URL, slug, title, and overview.
 - Use direct export to SigNoz Cloud as the primary path.
+- **Prefer OTLP/HTTP (port 4318) over OTLP/gRPC (port 4317)** as the default export protocol in examples and instructions. HTTP is simpler to configure, easier to debug, and works through more proxies and load balancers.
 - Keep Collector-based setup optional and near the bottom.
 - Include the self-hosted adaptation callout near the top.
 - Cover VM, Kubernetes, Docker, and Windows when those paths materially apply.
@@ -284,5 +286,5 @@ Use the PR snippet in [templates/pr-checklists.md#docs-changes](templates/pr-che
 - Commands and snippets explain what to do, where to do it, and the expected result.
 - Placeholders use `<...>` format and are documented.
 - Links are helpful and validated.
-- Images, if any, use the correct location and WebP format.
+- Images, if any, use the correct location, WebP format, and are at least 1200 px wide.
 - Redirect, sidebar, and discovery updates are handled when the doc URL changes or a new doc should appear in an existing surface.

--- a/contributing/docs-review.md
+++ b/contributing/docs-review.md
@@ -60,6 +60,7 @@ Review each changed doc against these checks in order:
 12. Links directly help readers complete the current step.
 13. Added or edited links resolve and use canonical production paths.
 14. Discovery surfaces are updated when the new doc should appear in an existing list or overview.
+15. Added or changed images are WebP, at least 1200 px wide, and use the `Figure` component with descriptive alt text.
 
 If a check cannot be validated from the PR context, call out the assumption and residual risk.
 
@@ -77,6 +78,7 @@ Prioritize verification for:
 - receiver, exporter, and processor names
 - environment variables and CLI flags
 - APIs, semantic conventions, versions, and deprecations
+- **OTLP export protocol**: flag gRPC (port 4317) as the default when HTTP (port 4318) should be used instead — docs should prefer OTLP/HTTP unless there is an explicit reason for gRPC
 
 When a correction depends on verification:
 
@@ -199,6 +201,9 @@ cat contributing/docs-review.md
 
 # likely docs quality issues
 rg -n "## Next steps|## Troubleshooting|KeyPointCallout|ToggleHeading|https?://|<[^>]+>" data/docs
+
+# image quality — flag images narrower than 1200 px
+identify -format '%w %f\n' public/img/docs/<topic>/*.webp 2>/dev/null | awk '$1 < 1200'
 
 # link health
 curl -sI <URL>

--- a/contributing/templates/send-data-doc.md
+++ b/contributing/templates/send-data-doc.md
@@ -27,6 +27,9 @@
 2. <Add direct export to SigNoz Cloud>
 3. <Run or restart the app>
 
+<!-- Prefer OTLP/HTTP (port 4318) over OTLP/gRPC (port 4317) as the default export protocol. -->
+<!-- HTTP is simpler to configure, easier to debug, and works through more proxies and load balancers. -->
+
 <!-- For Collector config, show only the snippet to append and tell users where to enable it. -->
 <!-- Do not present a full otel-collector-config.yaml replacement unless the page is explicitly a full clean-room setup. -->
 


### PR DESCRIPTION
## Summary
- **Image quality check**: adds minimum 1200 px width rule for docs screenshots to prevent blurry images (caught after Railway docs shipped with ~560 px images that rendered blurry on the docs site)
- **OTLP/HTTP-first rule**: docs should default to OTLP/HTTP (port 4318) over gRPC (port 4317) in examples and instructions
- Updates `docs-authoring.md` (authoring standards + author checklist), `docs-review.md` (JTBD rubric check #15, technical accuracy check, suggested command), and `send-data-doc.md` template

## Test plan
- [ ] Verify the PR review agent picks up the new checks on a future docs PR
- [ ] Confirm no formatting issues in the contributing playbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)