### PR TITLE
[codex] Use server Algolia key for 404 suggestions

### DIFF
--- a/components/not-found/suggestions.ts
+++ b/components/not-found/suggestions.ts
@@ -9,14 +9,15 @@ import type { AlgoliaHit, SuggestedDoc } from './types'
 export const hasAlgoliaConfig = (): boolean => {
   return Boolean(
     process.env.NEXT_PUBLIC_ALGOLIA_APP_ID &&
-      process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY &&
+      (process.env.ALGOLIA_SEARCH_API_KEY || process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY) &&
       process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME
   )
 }
 
 const getAlgoliaConfig = (): { appId: string; apiKey: string; indexName: string } | null => {
   const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID
-  const apiKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY
+  const apiKey =
+    process.env.ALGOLIA_SEARCH_API_KEY || process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY
   const indexName = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME
 
   if (!appId || !apiKey || !indexName) {


### PR DESCRIPTION
## What changed

- Updated 404 page suggestion lookup to prefer `ALGOLIA_SEARCH_API_KEY` for server-side Algolia requests.
- Kept `NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY` as a fallback so existing environments continue to work.

## Why

The normal docs search runs in the browser and can use the referer-restricted public key. 404 suggestions run server-side, so they need a server-safe search key without browser referer restrictions.

## Validation

- `yarn lint`
