### PR TITLE
fix: clarify Tabs entityName guidance in docs-authoring

### DIFF
--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -122,7 +122,10 @@ When documenting OpenTelemetry Collector changes:
 ## Patterns And Components
 
 - Use `Admonition` for notes, warnings, tips, and supplementary or optional material. Do not use `KeyPointCallout`.
-- Use `Tabs` and `TabItem` only when flows materially differ by platform or environment. Always provide an `entityName` prop on `<Tabs>` (e.g., `<Tabs entityName="environment">`). Ensure for vm, docker, kubernetes it is environment.
+- Use `Tabs` and `TabItem` only when flows materially differ by platform or environment. Always provide an `entityName` prop on `<Tabs>` that matches what the tabs represent:
+  - `entityName="environment"` — deployment infrastructure tabs: VM, Kubernetes, Docker, Windows. Only use this when the tabs distinguish between these deployment environments.
+  - `entityName="plans"` — SigNoz Cloud vs Self-Hosted tabs.
+  - For other tab groupings, use a short descriptive name (e.g., `"language"`, `"signal"`, `"setup"`).
 - Prefer numbered steps for procedures and bullets for reference content.
 - Keep headings short and meaningful.
 


### PR DESCRIPTION
## Summary
- Clarifies the `entityName` prop guidance for `<Tabs>` in `contributing/docs-authoring.md`
- Spells out the three common `entityName` values and when to use each:
  - `"environment"` — only for VM/Kubernetes/Docker/Windows deployment tabs
  - `"plans"` — for SigNoz Cloud vs Self-Hosted tabs
  - Descriptive names (e.g., `"language"`, `"signal"`) — for other groupings
- Prevents misuse like using `entityName="environment"` for Cloud/Self-Hosted tabs (as flagged in the dify-observability PR review)

## Test plan
- [ ] Verify the updated guidance is clear and matches existing codebase conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)