### PR TITLE
[codex] docs: add dashboard cursor sync preference

### DIFF
--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -70,6 +70,21 @@ Click the **...** (three-dot) menu at the top of any dashboard to access the fol
 - **Copy as JSON** — Copy the dashboard JSON to your clipboard.
 - **Delete dashboard** — Permanently delete the dashboard.
 
+## Configure Cross-Panel Cursor Sync
+
+You can choose how panels on a dashboard respond when you hover over a chart. This preference is saved per dashboard, so each dashboard can use the sync behavior that best fits its layout and investigation workflow.
+
+1. From the sidebar, choose **Dashboards**.
+2. Open the dashboard you want to configure.
+3. Select the **Configure** icon.
+4. In the **General** settings, choose a cursor sync mode:
+
+   - **Crosshair** — Shows a vertical cursor line across panels at the hovered timestamp.
+   - **Tooltip** — Shows tooltip values for the hovered timestamp across panels.
+   - **No Sync** — Keeps hover behavior limited to the panel you are viewing.
+
+5. Select **Save**.
+
 ## Update a Custom Dashboard
 
 To update the name, description and tags:


### PR DESCRIPTION
## What changed

- Added dashboard docs for configuring cross-panel cursor sync.
- Covered Crosshair, Tooltip, and No Sync modes.
- Noted that the preference is saved per dashboard.

## Source product PR

SigNoz/signoz#11159

## Validation

- yarn check:docs-metadata
- yarn test:docs-metadata
- yarn check:doc-redirects
- yarn test:doc-redirects