### PR TITLE
[codex] docs: update service account role assignment

### DIFF
--- a/data/docs/manage/administrator-guide/iam/service-accounts.mdx
+++ b/data/docs/manage/administrator-guide/iam/service-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-15
+date: 2026-05-13
 id: service-accounts
 title: Service Accounts
 description: Create and manage service accounts for programmatic API access in SigNoz
@@ -37,11 +37,13 @@ Service account names must be unique within the workspace.
     <figcaption><i>Service Accounts list page</i></figcaption>
 </figure>
 
-### Step 2: Assign a Role
+### Step 2: Assign Roles
 
 1. Click the newly created service account to open its details.
-2. In the **Overview** tab, use the **Roles** dropdown to assign a role.
+2. In the **Overview** tab, use the **Roles** dropdown to assign one or more roles.
 3. Click **Save** to apply your changes.
+
+When you assign multiple roles, the service account can perform actions allowed by any of its assigned roles. Assign only the roles required by the automation, integration, or API workflow that will use the service account key.
 
 The available roles are:
 


### PR DESCRIPTION
## What changed

- Updated Service Accounts docs to say service accounts can be assigned one or more roles.
- Renamed the step from singular role assignment to role assignment in plural.
- Added least-privilege guidance for assigning only the roles required by the automation or integration.

## Source product PR

SigNoz/signoz#11231

## Validation

- yarn check:docs-metadata
- yarn test:docs-metadata
- yarn check:doc-redirects
- yarn test:doc-redirects
- git diff --check