### PR TITLE
[codex] docs: mention infra list total count

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-22
+date: 2026-05-13
 id: overview
 title: Infrastructure Monitoring
 description: Learn how SigNoz Infrastructure Monitoring helps you analyze host and Kubernetes performance, traces, and logs.
@@ -180,6 +180,7 @@ The **Pods View** provides real-time visibility into pod resource utilization, e
 - **Search & Filtering**: Quickly locate specific pods using various filters.
 - **Group By Attribute**: Group pods by Namespace, Node, or Deployment.
 - **Sortable Metrics**: Sort columns for better trend analysis.
+- **Total Item Count**: See the total number of matching records alongside pagination on Kubernetes list pages.
 
 ### Filtering and Selection Panel
 


### PR DESCRIPTION
## What changed

- Updated Infrastructure Monitoring docs to mention that Kubernetes list pages show the total number of matching records alongside pagination.
- Kept the wording scoped to Kubernetes list pages because the source product PR changes `K8sBaseList.tsx` and table pagination behavior.

## Source product PR

SigNoz/signoz#11212

## Validation

- yarn check:docs-metadata
- yarn test:docs-metadata
- yarn check:doc-redirects
- yarn test:doc-redirects
- git diff --check
