### PR TITLE
perf(site): skip static build for preview/staging

### DIFF
--- a/app/(site)/(opentelemetry-hub-routes)/blog/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/blog/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
 import React from 'react'
 import { safeJsonLdStringify } from '@/utils/structuredData'
+import { shouldBuildStaticPages, dynamicParamsForEnv } from '@/utils/buildConfig'
 
 const defaultLayout = 'BlogLayout'
 const layouts = {
@@ -24,7 +25,7 @@ const layouts = {
   NewsroomLayout,
 }
 
-export const dynamicParams = false
+export const dynamicParams = dynamicParamsForEnv
 
 export async function generateMetadata({
   params,
@@ -83,6 +84,9 @@ export async function generateMetadata({
 }
 
 export const generateStaticParams = async () => {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   const paths = allBlogs.map((p) => ({ slug: p.slug?.split('/') }))
 
   return paths

--- a/app/(site)/(opentelemetry-hub-routes)/guides/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/guides/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import React from 'react'
 import GrafanaVsSigNozFloatingCard from '@/components/GrafanaVsSigNoz/GrafanaVsSigNozFloatingCard'
 import Button from '@/components/ui/Button'
 import { safeJsonLdStringify } from '@/utils/structuredData'
+import { shouldBuildStaticPages, dynamicParamsForEnv } from '@/utils/buildConfig'
 
 const defaultLayout = 'GuidesLayout'
 const layouts = {
@@ -23,7 +24,7 @@ const layouts = {
   GuidesLayout,
 }
 
-export const dynamicParams = false
+export const dynamicParams = dynamicParamsForEnv
 
 export async function generateMetadata({
   params,
@@ -81,6 +82,9 @@ export async function generateMetadata({
 }
 
 export const generateStaticParams = async () => {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   const paths = allGuides.map((p) => ({ slug: p.slug?.split('/') }))
 
   return paths

--- a/app/(site)/(opentelemetry-hub-routes)/metadata.ts
+++ b/app/(site)/(opentelemetry-hub-routes)/metadata.ts
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 import { POSTS_PER_PAGE } from './constants'
+import { shouldBuildStaticPages } from '@/utils/buildConfig'
 
 export function buildListingMetadata(section: string, page?: string): Metadata {
   const title = page ? `${section} - Page ${page}` : section
@@ -41,6 +42,9 @@ export function buildListingMetadata(section: string, page?: string): Metadata {
 }
 
 export function buildStaticPaginationParams(totalItems: number) {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   const totalPages = Math.ceil(totalItems / POSTS_PER_PAGE)
   return Array.from({ length: totalPages }, (_, i) => ({ page: (i + 1).toString() }))
 }

--- a/app/(site)/api/docs-markdown/[[...slug]]/route.ts
+++ b/app/(site)/api/docs-markdown/[[...slug]]/route.ts
@@ -3,12 +3,16 @@ import { allDocs } from 'contentlayer/generated'
 import type { Doc } from 'contentlayer/generated'
 import { renderDocMarkdownForAgents } from '@/utils/docs/renderDocMarkdownForAgents'
 import { resolveDocsMarkdownSlug } from '@/utils/docs/markdownRouting'
+import { shouldBuildStaticPages } from '@/utils/buildConfig'
 
 export const runtime = 'nodejs'
 
 const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
 
 export async function generateStaticParams() {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   return [
     { slug: [] },
     ...allDocs

--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -9,8 +9,9 @@ import { notFound } from 'next/navigation'
 import DocContent from '@/components/DocContent/DocContent'
 import Chatbase from '@/components/Chatbase'
 import { safeJsonLdStringify } from '@/utils/structuredData'
+import { shouldBuildStaticPages, dynamicParamsForEnv } from '@/utils/buildConfig'
 
-export const dynamicParams = false
+export const dynamicParams = dynamicParamsForEnv
 
 export async function generateMetadata({
   params,
@@ -45,9 +46,12 @@ export async function generateMetadata({
 }
 
 export const generateStaticParams = async () => {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   const paths = allDocs
     .filter((p) => p.slug !== 'introduction')
-    .map((p) => ({ slug: p.slug?.split('/') })) // Don't want to generate static params for introduction page
+    .map((p) => ({ slug: p.slug?.split('/') }))
 
   return paths
 }

--- a/app/(site)/tags/[tag]/page.tsx
+++ b/app/(site)/tags/[tag]/page.tsx
@@ -7,8 +7,9 @@ import tagData from 'app/tag-data.json'
 import { genPageMetadata } from 'app/(site)/seo'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import { shouldBuildStaticPages, dynamicParamsForEnv } from '@/utils/buildConfig'
 
-export const dynamicParams = false
+export const dynamicParams = dynamicParamsForEnv
 
 export async function generateMetadata({ params }: { params: { tag: string } }): Promise<Metadata> {
   const tag = decodeURI(params.tag)
@@ -25,9 +26,11 @@ export async function generateMetadata({ params }: { params: { tag: string } }):
 }
 
 export const generateStaticParams = async () => {
+  if (!shouldBuildStaticPages()) {
+    return []
+  }
   const tagCounts = tagData as Record<string, number>
   const tagKeys = Object.keys(tagCounts)
-  // Only generate pages for tags that have at least one post
   const paths = tagKeys
     .filter((tag) => tagCounts[tag] > 0)
     .map((tag) => ({

--- a/utils/buildConfig.ts
+++ b/utils/buildConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Build configuration utilities for Vercel deployments.
+ *
+ * On preview/development: skip static generation → faster builds
+ * On production: full static generation → optimal performance
+ *
+ * Override with FORCE_STATIC_BUILD env var:
+ *   - "true" or "1" → always build static pages
+ *   - "false" or "0" → never build static pages (always dynamic)
+ */
+
+/**
+ * Returns true if we should generate all static pages.
+ * False for preview/development environments to speed up builds.
+ *
+ * Can be overridden with FORCE_STATIC_BUILD env var.
+ */
+export function shouldBuildStaticPages(): boolean {
+  const forceStatic = process.env.FORCE_STATIC_BUILD
+
+  // Check override first
+  if (forceStatic === 'true' || forceStatic === '1') {
+    return true
+  }
+  if (forceStatic === 'false' || forceStatic === '0') {
+    return false
+  }
+
+  const vercelEnv = process.env.VERCEL_ENV
+
+  // Not on Vercel (local dev) or production → build all pages
+  if (!vercelEnv || vercelEnv === 'production') {
+    return true
+  }
+
+  // Preview or development → skip static generation
+  return false
+}
+
+/**
+ * Dynamic params setting based on environment.
+ * true = render unknown paths on-demand (for preview/dev)
+ * false = 404 for unknown paths (for production with full static gen)
+ */
+export const dynamicParamsForEnv = shouldBuildStaticPages() ? false : true


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Provide a concise overview of the change. -->
The initial assumption was the static build could slowdown the build by a lot, but seems like it only changes ~20s in the build time.