### PR TITLE
fix: date check skip for title/description-only changes was never working

### DIFF
--- a/scripts/check-docs-metadata.js
+++ b/scripts/check-docs-metadata.js
@@ -155,7 +155,14 @@ function extractFrontmatter(filePath) {
 }
 
 function getFileContentAtRef(ref, filePath) {
-  return tryRun(`git show ${ref}:"${filePath}"`)
+  try {
+    return execSync(`git show ${ref}:"${filePath}"`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+  } catch (error) {
+    return null
+  }
 }
 
 function hasOnlyTitleAndDescriptionChanges(filePath, options = {}) {
@@ -171,7 +178,7 @@ function hasOnlyTitleAndDescriptionChanges(filePath, options = {}) {
   const { frontmatter: currentFrontmatter, body: currentBody } = splitFrontmatter(currentContent)
   const { frontmatter: previousFrontmatter, body: previousBody } = splitFrontmatter(previousContent)
 
-  if (currentBody !== previousBody) {
+  if (currentBody.trimEnd() !== previousBody.trimEnd()) {
     return false
   }
 

--- a/tests/docs-metadata.test.js
+++ b/tests/docs-metadata.test.js
@@ -333,6 +333,37 @@ tags: ["test"]
       assert.strictEqual(warnings.length, 0)
     })
 
+    it('should allow older dates when previousContent has no trailing newline', () => {
+      const oldDate = new Date()
+      oldDate.setDate(oldDate.getDate() - 30)
+      const oldDateStr = oldDate.toISOString().split('T')[0]
+
+      const previousContent = `---
+title: Previous Title
+date: ${oldDateStr}
+description: Previous description
+tags: ["test"]
+---
+
+# Content`
+
+      const currentContent = `---
+title: Updated Title
+date: ${oldDateStr}
+description: Updated description
+tags: ["test"]
+---
+
+# Content
+`
+
+      const filePath = createTestFile('trimmed-previous.mdx', currentContent)
+      const { errors, warnings } = validateMetadata(filePath, { previousContent })
+
+      assert.strictEqual(errors.length, 0)
+      assert.strictEqual(warnings.length, 0)
+    })
+
     it('should still require a recent date when body content changes', () => {
       const oldDate = new Date()
       oldDate.setDate(oldDate.getDate() - 30)


### PR DESCRIPTION
## Summary

- `getFileContentAtRef` used `tryRun` which `.trim()`s output, stripping trailing newlines from `git show` output. This caused the body comparison in `hasOnlyTitleAndDescriptionChanges` to always find a mismatch (`fs.readFileSync` preserves trailing `\n`, but the git output was trimmed), so the function always returned `false` and the date check was **never actually skipped** — the fix from #3131 was dead code.
- Fix: use `execSync` directly without `.trim()` in `getFileContentAtRef`, and normalize trailing whitespace in the body comparison as a safety net.
- Added a regression test for trailing newline mismatch between file content and git content.

**Context:** PR #3321 only changed titles/descriptions but still required date bumps on 91 files — this is why.

## Test plan

- [x] `yarn test:docs-metadata` — all 25 tests pass (including new regression test)
- [x] Manual verification in a temp git repo: title/description-only changes correctly skip date validation, body changes still enforce it

🤖 Generated with [Claude Code](https://claude.com/claude-code)