### PR TITLE
bugfix: anchor link styling in mdx pipeline

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -210,6 +210,10 @@ input:-webkit-autofill:focus {
   overflow: auto hidden;
 }
 
+.content-header > a:first-child {
+  text-decoration: none;
+}
+
 .content-header-link {
   opacity: 0;
   margin-left: -24px;


### PR DESCRIPTION
## Summary
Bugfix for small underscored dash when hovering links in blogs, guides, comparison pages

## Motivation / Problem
<img width="652" height="83" alt="Screenshot 2026-05-19 at 22 16 25" src="https://github.com/user-attachments/assets/1d480e35-1090-492f-9c61-22aa7126c02f" />
There is a small underscore line visible after link icon and before title when hovering on titles in content

## Type of Change
<!-- Check all that apply -->

- [ ] **Docs** – Changes to `data/docs/**`
- [ ] **Blog** – Changes to `data/blog/**`
- [x] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
<!-- Who or what is affected by this change? -->
- [ ] Documentation only
- [x] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

## Context & Screenshots
Before:
<img width="652" height="83" alt="Screenshot 2026-05-19 at 22 16 25" src="https://github.com/user-attachments/assets/1d480e35-1090-492f-9c61-22aa7126c02f" />
After:
<img width="429" height="42" alt="Screenshot 2026-05-19 at 22 17 39" src="https://github.com/user-attachments/assets/876bc017-2976-4b06-8503-552fc03ae05a" />

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
