### PR TITLE
docs+blogs: optimize CLaude Code content seo

### DIFF
--- a/constants/opentelemetry_hub.json
+++ b/constants/opentelemetry_hub.json
@@ -239,6 +239,10 @@
               "title": "Bringing Observability to Claude Code: OpenTelemetry in Action"
             },
             {
+              "url": "https://signoz.io/blog/claude-code-measure-degradation-opentelemetry/",
+              "title": "Is Claude Code Getting Worse? How to Measure Degradation with OpenTelemetry"
+            },
+            {
               "url": "https://signoz.io/blog/langchain-observability-with-opentelemetry/",
               "title": "LangChain Observability: How to Monitor LLM Apps with OpenTelemetry (With Demo App)"
             },

--- a/data/blog/claude-code-measure-degradation-opentelemetry.mdx
+++ b/data/blog/claude-code-measure-degradation-opentelemetry.mdx
@@ -1,11 +1,15 @@
 ---
 title: Is Claude Code Getting Worse? How to Measure Degradation with OpenTelemetry
-date: 2026-05-08
+date: 2026-05-19
 tags: [OpenTelemetry]
 authors: [goutham_karthi]
 description: Developers report that Claude Code feels less productive over time, but anecdotes aren't actionable. Learn how to measure efficiency degradation using OpenTelemetry by tracking output-per-token ratios across commits, PRs, and lines of code to know for certain whether Claude Code is becoming less effective for your team.
 image: /img/blog/2026/05/claude-blog-cover.webp
 keywords: [Claude Code, OpenTelemetry, observability, monitoring]
+related_articles:
+  - '/blog/claude-code-monitoring-with-opentelemetry'
+  - '/blog/opentelemetry-tracing'
+  - '/blog/health-check-monitoring-with-opentelemetry'
 ---
 
 <Figure
@@ -68,7 +72,7 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 ```
 
-This works with any OTLP-compatible backend. Check out detailed instructions on [setting up OpenTelemetry for Claude Code](https://signoz.io/docs/claude-code-monitoring/).
+This works with any OTLP-compatible backend. Check out the [Claude Code monitoring guide](https://signoz.io/docs/claude-code-monitoring/) for detailed setup instructions.
 
 The metrics that form the foundation of efficiency monitoring are:
 

--- a/data/blog/claude-code-monitoring-with-opentelemetry.mdx
+++ b/data/blog/claude-code-monitoring-with-opentelemetry.mdx
@@ -1,11 +1,12 @@
 ---
 title: 'Bringing Observability to Claude Code: OpenTelemetry in Action'
-date: 2025-09-03
+date: 2026-05-19
 tags: [OpenTelemetry, Claude Code, SigNoz]
 authors: [goutham_karthi]
 description: Monitor Claude Code usage with OpenTelemetry and SigNoz. This blog walks you through implementing comprehensive observability for your Claude Code activity using OpenTelemetry and SigNoz.
 keywords: [monitor, observe, opentelemetry, Claude Code, integrations, SigNoz]
 related_articles:
+  - '/blog/claude-code-measure-degradation-opentelemetry'
   - '/guides/claude-api-latency'
   - '/guides/observability-as-code'
   - '/blog/opentelemetry-tracing'
@@ -68,7 +69,7 @@ By combining OpenTelemetry's standardized data collection with SigNoz's rich vis
 
 ## Monitoring Claude Code
 
-Check out detailed instructions on how to set up OpenTelemetry instrumentation for your Claude Code usage over [here](https://docs.anthropic.com/en/docs/claude-code/monitoring-usage). 
+Check out the [Claude Code monitoring guide](https://signoz.io/docs/claude-code-monitoring/) for detailed instructions on setting up OpenTelemetry instrumentation.
 
 ### Option 1 (VSCode)
 

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -3,7 +3,7 @@ date: 2026-05-19
 id: claude-code-monitoring-with-opentelemetry
 
 title: Claude Code Monitoring & Observability with OpenTelemetry
-description: Claude Code monitoring and observability with OpenTelemetry and SigNoz. Track token usage, costs, API performance, and session activity across your engineering team.
+description: Learn how to monitor Claude Code sessions using OpenTelemetry and SigNoz. Track token usage, costs, API performance, and session activity across your engineering team.
 doc_type: howto
 ---
 

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -4,6 +4,7 @@ id: claude-code-monitoring-with-opentelemetry
 
 title: Claude Code Monitoring & Observability with OpenTelemetry
 description: Claude Code monitoring and observability with OpenTelemetry and SigNoz. Track token usage, costs, API performance, and session activity across your engineering team.
+doc_type: howto
 ---
 
 ## Overview

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -1,16 +1,23 @@
 ---
-date: 2026-05-18
+date: 2026-05-19
 id: claude-code-monitoring-with-opentelemetry
 
 title: Claude Code Monitoring & Observability with OpenTelemetry
-description: Learn how to monitor Claude Code sessions using OpenTelemetry and SigNoz. Track coding activity, performance trends, and error rates in real time.
+description: Claude Code monitoring and observability with OpenTelemetry and SigNoz. Track token usage, costs, API performance, and session activity across your engineering team.
 ---
 
 ## Overview
 
-This guide walks you through enabling monitoring and observability in Claude Code and exporting logs and metrics to SigNoz using OpenTelemetry. Once set up, you’ll be able to track coding session activity, log outputs, and system-level metrics in SigNoz, giving you visibility into performance trends, error rates, and usage patterns directly from your development workflow.
+Claude Code monitoring with OpenTelemetry gives you full visibility into how Claude is used across your engineering team. This guide walks you through exporting Claude Code logs and metrics to SigNoz, so you can track the signals that matter most:
 
-Instrumenting Claude Code with telemetry provides full observability into how coding assistance is used in practice. This is especially useful for engineering teams building AI-assisted developer tools, where insights into latency, error handling, and user behavior are critical. With SigNoz, you can correlate logs and metrics in a single dashboard, set up alerts, and analyze historical data to continuously improve reliability, efficiency, and user experience.
+- **Token usage & costs** — break down spend by user, model, or subagent
+- **Session & request activity** — track adoption, active time, and request volumes
+- **Performance** — monitor API latency, cache hit rates, and tool execution times
+- **Quota & limits** — stay ahead of rate limits before they impact developers
+- **Tool decisions** — see accept/reject rates across Edit, Write, and other tools
+- **Errors & retries** — detect API failures and retry exhaustion before they snowball
+
+Once set up, all of this flows into SigNoz dashboards where you can correlate logs and metrics, set alerts, and analyze trends over time.
 
 ## Prerequisites
 
@@ -157,7 +164,7 @@ Your Claude Code activity should now automatically emit logs and metrics.
 Finally, you should be able to view logs in Signoz Cloud under the logs tab:
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-logs-view.webp" alt="Logs View" />
+  <img src="/img/docs/llm/claude/claude-logs-view.webp" alt="Claude Code monitoring logs in SigNoz" />
   <figcaption>
     <i>Logs View of your Claude Code Activity</i>
   </figcaption>
@@ -166,28 +173,28 @@ Finally, you should be able to view logs in Signoz Cloud under the logs tab:
 When you click on any of these logs in SigNoz, you'll see a detailed view of the log, including attributes:
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-logs-detailed-4.webp" alt="Detailed Logs View 1" />
+  <img src="/img/docs/llm/claude/claude-logs-detailed-4.webp" alt="Claude Code user_prompt event details in SigNoz" />
   <figcaption>
     <i>Detailed Logs View of claude_code.user_prompt</i>
   </figcaption>
 </figure>
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-logs-detailed-1.webp" alt="Detailed Logs View 2" />
+  <img src="/img/docs/llm/claude/claude-logs-detailed-1.webp" alt="Claude Code api_request event details in SigNoz" />
   <figcaption>
     <i>Detailed Logs View of claude_code.api_request</i>
   </figcaption>
 </figure>
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-logs-detailed-2.webp" alt="Detailed Logs View 3" />
+  <img src="/img/docs/llm/claude/claude-logs-detailed-2.webp" alt="Claude Code tool_decision event details in SigNoz" />
   <figcaption>
     <i>Detailed Logs View of claude_code.tool_decision</i>
   </figcaption>
 </figure>
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-logs-detailed-3.webp" alt="Detailed Logs View 4" />
+  <img src="/img/docs/llm/claude/claude-logs-detailed-3.webp" alt="Claude Code tool_result event details in SigNoz" />
   <figcaption>
     <i>Detailed Logs View of claude_code.tool_result</i>
   </figcaption>
@@ -196,7 +203,7 @@ When you click on any of these logs in SigNoz, you'll see a detailed view of the
 You should be able to see Claude Code related metrics in Signoz Cloud under the metrics tab:
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-metrics.webp" alt="Metrics View" />
+  <img src="/img/docs/llm/claude/claude-metrics.webp" alt="Claude Code metrics in SigNoz" />
   <figcaption>
     <i>Metrics View of your Claude Code Activity</i>
   </figcaption>
@@ -205,7 +212,7 @@ You should be able to see Claude Code related metrics in Signoz Cloud under the 
 When you click on any of these metrics in SigNoz, you'll see a detailed view of the metric, including attributes:
 
 <figure data-zoomable align="center">
-  <img src="/img/docs/llm/claude/claude-metrics-detailed.webp" alt="Detailed Metrics View" />
+  <img src="/img/docs/llm/claude/claude-metrics-detailed.webp" alt="Claude Code token usage and cost metrics detail in SigNoz" />
   <figcaption>
     <i>Detailed Metrics View of your Claude Code Activity</i>
   </figcaption>
@@ -224,3 +231,108 @@ You can also check out our custom Claude Code dashboard [here](https://signoz.io
     <i>Claude Code Dashboard - Credit: <a href="https://github.com/mikelane">Mike Lane</a></i>
   </figcaption>
 </figure>
+
+## Telemetry Data
+
+Claude Code emits the following metrics and events via OpenTelemetry. For the full upstream specification, see the <a href="https://docs.anthropic.com/en/docs/claude-code/monitoring-usage" target="_blank" rel="noopener noreferrer nofollow">Claude Code monitoring docs</a>.
+
+### Standard Attributes
+
+Every metric and event includes these attributes:
+
+| Attribute | Description |
+|---|---|
+| `session.id` | Unique session identifier |
+| `user.id` | Anonymous device/installation identifier |
+| `user.email` | User email address (when authenticated via OAuth) |
+| `user.account_uuid` | Account UUID (when authenticated) |
+| `user.account_id` | Account ID matching Anthropic admin APIs (when authenticated) |
+| `organization.id` | Organization UUID (when authenticated) |
+| `terminal.type` | Terminal type, e.g. `vscode`, `iTerm.app`, `cursor`, `tmux` |
+| `app.version` | Claude Code version (opt-in via `OTEL_METRICS_INCLUDE_VERSION=true`) |
+
+### Metrics
+
+| Metric | Description | Unit | Key Attributes |
+|---|---|---|---|
+| `claude_code.session.count` | Sessions started | count | `start_type` (`fresh`, `resume`, `continue`) |
+| `claude_code.token.usage` | Tokens used per API request | tokens | `type` (`input`, `output`, `cacheRead`, `cacheCreation`), `model`, `query_source`, `speed` |
+| `claude_code.cost.usage` | Estimated cost per API request | USD | `model`, `query_source`, `speed`, `agent.name`, `skill.name`, `effort` |
+| `claude_code.lines_of_code.count` | Lines of code added or removed | count | `type` (`added`, `removed`) |
+| `claude_code.commit.count` | Git commits created | count | — |
+| `claude_code.pull_request.count` | Pull requests or merge requests created | count | — |
+| `claude_code.code_edit_tool.decision` | Edit/Write/NotebookEdit permission decisions | count | `tool_name`, `decision` (`accept`/`reject`), `source`, `language` |
+| `claude_code.active_time.total` | Active usage time | seconds | `type` (`user` for keyboard input, `cli` for tool/AI response time) |
+
+### Events
+
+Claude Code emits these events via the OpenTelemetry logs/events protocol (when `OTEL_LOGS_EXPORTER` is configured):
+
+| Event | Emitted When | Key Attributes |
+|---|---|---|
+| `claude_code.user_prompt` | User submits a prompt | `prompt_length`, `command_name`, `command_source`, `prompt` (redacted by default — enable with `OTEL_LOG_USER_PROMPTS=1`) |
+| `claude_code.api_request` | API request to Claude completes | `model`, `cost_usd`, `duration_ms`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `request_id`, `speed`, `query_source` |
+| `claude_code.api_error` | API request fails after all retries | `model`, `error`, `status_code`, `duration_ms`, `attempt`, `speed`, `query_source` |
+| `claude_code.api_retries_exhausted` | All retry attempts are exhausted | `model`, `error`, `total_attempts`, `total_retry_duration_ms`, `status_code` |
+| `claude_code.tool_result` | Tool execution completes | `tool_name`, `success`, `duration_ms`, `decision_type`, `decision_source`, `error_type`, `tool_input_size_bytes`, `tool_result_size_bytes` |
+| `claude_code.tool_decision` | Tool permission is accepted or rejected | `tool_name`, `decision` (`accept`/`reject`), `source` (`config`, `hook`, `user_permanent`, `user_temporary`, `user_abort`, `user_reject`) |
+| `claude_code.permission_mode_changed` | Permission mode switches | `from_mode`, `to_mode`, `trigger` (`shift_tab`, `exit_plan_mode`, `auto_gate_denied`, `auto_opt_in`) |
+| `claude_code.mcp_server_connection` | MCP server connects, fails, or disconnects | `status` (`connected`, `failed`, `disconnected`), `transport_type`, `server_scope`, `duration_ms`, `error_code` |
+| `claude_code.auth` | `/login` or `/logout` completes | `action` (`login`/`logout`), `success`, `auth_method`, `error_category` |
+| `claude_code.compaction` | Conversation compaction completes | `trigger` (`auto`/`manual`), `success`, `pre_tokens`, `post_tokens`, `duration_ms` |
+| `claude_code.internal_error` | Unexpected internal error is caught | `error_name`, `error_code` |
+| `claude_code.plugin_installed` | Plugin finishes installing | `plugin.name`, `marketplace.name`, `install.trigger` |
+| `claude_code.plugin_loaded` | Plugin is active at session start | `plugin.name`, `plugin.scope`, `plugin.version`, `enabled_via` |
+| `claude_code.skill_activated` | Skill is invoked by Claude or as a `/` command | `skill.name`, `invocation_trigger`, `skill.source` |
+| `claude_code.hook_execution_complete` | All hooks for a hook event finish | `hook_event`, `hook_name`, `num_hooks`, `num_success`, `num_blocking`, `total_duration_ms` |
+| `claude_code.feedback_survey` | Session quality survey is shown or answered | `event_type`, `survey_type`, `response` |
+
+<Admonition type="info">
+  All events share a `prompt.id` attribute, a UUID that links every event produced while processing a single user prompt. Filter by `prompt.id` in SigNoz to correlate all API requests and tool executions triggered by one prompt.
+</Admonition>
+
+## Troubleshooting
+
+If you don't see your telemetry data in SigNoz:
+
+1. **Check `CLAUDE_CODE_ENABLE_TELEMETRY`** - This must be set to `1`. Telemetry is opt-in and nothing is exported without it
+2. **Verify your region and ingestion key** - An incorrect `<region>` or `<your-ingestion-key>` will silently drop all data. Double-check against your [SigNoz Cloud settings](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+3. **Check both exporters are set** - `OTEL_METRICS_EXPORTER` controls metrics and `OTEL_LOGS_EXPORTER` controls events. If only one is set, the other signal will not appear
+4. **Try a console exporter** - Set `OTEL_METRICS_EXPORTER=console` and `OTEL_LOGS_EXPORTER=console` to confirm Claude Code is generating telemetry locally before sending to SigNoz
+5. **Wait for the export interval** - The default metrics export interval is 60 seconds. During setup, set `OTEL_METRIC_EXPORT_INTERVAL=10000` to flush every 10 seconds instead
+6. **Confirm env vars are set before launch** - Environment variables must be set before launching `claude` or `code .`. Variables exported after launch have no effect
+
+## FAQs
+
+### Does Claude Code have built-in monitoring?
+A. Yes. Claude Code has native OpenTelemetry support that you opt into by setting `CLAUDE_CODE_ENABLE_TELEMETRY=1`. Once enabled, it emits metrics (token usage, costs, session counts, lines of code, commits) and structured log events (API requests, tool executions, permission decisions) via the standard OTLP protocol to any compatible backend including SigNoz.
+
+### How do I track Claude Code token usage?
+A. Claude Code emits a `claude_code.token.usage` metric after every API request, broken down by `type` (`input`, `output`, `cacheRead`, `cacheCreation`), `model`, and `query_source`. In SigNoz, filter this metric by user or model to see exactly where tokens are going. See the [Telemetry Data](#telemetry-data) section for the full attribute list.
+
+### Can I monitor Claude Code costs with OpenTelemetry?
+A. Yes. The `claude_code.cost.usage` metric tracks estimated USD cost per API request and includes attributes for `model`, `agent.name`, `skill.name`, and `query_source`, so you can break down spend by team, model, or workflow. Note that these are approximations — for billing data, refer to your Anthropic Console or cloud provider.
+
+### How do I monitor Claude Code across an entire team?
+A. Use the Administrator Configuration section to deploy a managed settings file (`managed-settings.json`) via MDM or your device management solution. This sets `CLAUDE_CODE_ENABLE_TELEMETRY=1` and the SigNoz endpoint centrally for all users, without requiring each developer to configure env vars individually.
+
+### What is the difference between Claude Code metrics and events?
+A. Metrics (like `claude_code.token.usage` and `claude_code.cost.usage`) are numeric time-series data, ideal for dashboards, aggregations, and alerts. Events (like `claude_code.api_request` and `claude_code.tool_result`) are structured log records emitted per action, ideal for audit trails, debugging, and tracing individual sessions. Both are exported via OpenTelemetry but require separate exporter configuration (`OTEL_METRICS_EXPORTER` vs `OTEL_LOGS_EXPORTER`).
+
+## Related Articles
+
+<DocCardContainer>
+
+<DocCard
+    title="Bringing Observability to Claude Code: OpenTelemetry in Action"
+    description="A practical walkthrough of how to connect Claude Code's monitoring hooks with OpenTelemetry and visualize usage, costs, and performance in SigNoz dashboards."
+    href="https://signoz.io/blog/claude-code-monitoring-with-opentelemetry/"
+/>
+
+<DocCard
+    title="Is Claude Code Getting Worse? How to Measure Degradation with OpenTelemetry"
+    description="Learn how to track output-per-token ratios across commits, PRs, and lines of code to detect whether Claude Code's efficiency is degrading over time."
+    href="https://signoz.io/blog/claude-code-measure-degradation-opentelemetry/"
+/>
+
+</DocCardContainer>


### PR DESCRIPTION
## Summary
Add telemetry reference tables, Troubleshooting, FAQs, and Related Articles to the Claude Code monitoring doc; update two related blog posts to cross-link; add degradation blog to the OpenTelemetry hub.

## Motivation / Problem
The Claude Code monitoring doc lacked a machine-readable telemetry reference (metrics + events), had no troubleshooting or FAQ section, and the two companion blog posts didn't point to each other or to the updated docs page.

## Changes
- **docs/claude-code-monitoring**: rewrite overview with benefit-focused bullets, improve image alt texts for SEO, add full Telemetry Data section (metrics + events reference tables), Troubleshooting section, FAQs section, and Related Articles with DocCards
- **blog/claude-code-measure-degradation-opentelemetry**: update publish date, add `related_articles` frontmatter, improve link anchor text
- **blog/claude-code-monitoring-with-opentelemetry**: update publish date, add degradation blog as related article, point link to SigNoz docs
- **constants/opentelemetry_hub.json**: add degradation blog entry

## Type of Change

- [x] **Docs** – Changes to `data/docs/**`
- [x] **Blog** – Changes to `data/blog/**`
- [ ] **Site Code** – Changes to `app/**`, `components/**`, `hooks/**`, `utils/**`, config, etc.
- [ ] **Redirects** – Renamed/moved docs or updated `next.config.js` redirects
- [ ] **Dependencies / CI / Scripts**
- [ ] **Other** – Explain below

## Impact
- [x] Documentation only
- [ ] UI changes
- [ ] Developer workflow
- [ ] Performance impact
- [ ] Breaking change

## Context & Screenshots
<!-- Add screenshots for UI or docs changes when helpful -->

## Checklist

### General
- [ ] Branch is up to date with `main`
- [x] PR title follows conventional format (`type: description`)
- [x] Self-reviewed the code
- [ ] Comments added for complex logic

### For all changes
- [ ] Built locally (`yarn build`) with no errors
- [ ] Ran `yarn lint` and fixed any issues
- [ ] Pre-commit hooks passed (or ran `yarn check:doc-redirects` / `yarn check:docs-metadata` if applicable)

### For docs changes (`data/docs/**`)
- [x] Followed the docs author checklist in [contributing/docs-authoring.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/docs-authoring.md)
- [ ] Added/updated the page in `constants/docsSideNav.ts` if adding or moving a doc
- [x] Any added docs images use WebP format and live under `public/img/docs/<topic>/`

### For blog changes
- [x] Followed the blog workflow in [contributing/blog-workflow.md](https://github.com/SigNoz/signoz.io/blob/main/contributing/blog-workflow.md)
- [x] Frontmatter includes `title`, `date`, `author`, `tags` (and `canonicalUrl` if applicable)
- [x] Images use WebP format and live under `public/img/blog/<YYYY-MM>/`

## Testing
- [x] Tested locally
- [x] Existing functionality verified

## Additional Context
No redirects needed — doc URL unchanged. The `related_articles` frontmatter on both blogs drives the "Related Articles" widget at the bottom of each post.

---

**Note:** Submit as Draft by default. Mark "Ready for review" when checks pass and content is ready.
