### PR TITLE
docs: add title and description guidelines to contributing docs

### DIFF
--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -71,10 +71,9 @@ The `title` field is both the page heading and the meta title shown in search re
   - Lead with the primary keyword.
   - Use action words: Learn, Setup, Guide, Monitor, Debug, Optimize.
   - Include a feature or benefit qualifier when it fits naturally: Fast, Real-time, Open-source, Distributed.
-- **Examples:**
-  - `Monitor Kubernetes Pod Metrics with OpenTelemetry`
-  - `Debug Slow Traces in Trace Explorer`
-  - `Setup Log Pipelines for JSON Parsing`
+- **Example:** `Logs Pipelines - Parse & Transform Logs`
+  - URL: `https://signoz.io/docs/logs-pipelines/introduction/`
+  - In search results: *Logs Pipelines - Parse & Transform Logs | SigNoz Docs*
 
 ### Description Guidelines
 
@@ -87,9 +86,8 @@ The `description` field appears as the meta description in search results and li
   - Use action-oriented language.
   - Highlight benefits.
   - Include primary keywords naturally — do not stuff them.
-- **Examples:**
-  - `Learn how to send Kubernetes pod metrics to SigNoz using OpenTelemetry Collector. Monitor CPU, memory, and network with pre-built dashboards.`
-  - `Debug slow traces using filters, trace matching, and flamegraph views in SigNoz Trace Explorer. Identify bottlenecks across microservices.`
+- **Example:** `Learn how SigNoz Logs Pipelines parse and transform logs into structured data for better debugging and observability.`
+  - URL: `https://signoz.io/docs/logs-pipelines/introduction/`
 
 Tags:
 

--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -61,6 +61,36 @@ Required keys:
 - `description`
 - `doc_type`
 
+### Title Guidelines
+
+The `title` field is both the page heading and the meta title shown in search results.
+
+- **Length:** 50–60 characters.
+- **Structure:** Primary keyword + feature or action. No brand suffix — "SigNoz Docs" is appended programmatically.
+- **Best practices:**
+  - Lead with the primary keyword.
+  - Use action words: Learn, Setup, Guide, Monitor, Debug, Optimize.
+  - Include a feature or benefit qualifier when it fits naturally: Fast, Real-time, Open-source, Distributed.
+- **Examples:**
+  - `Monitor Kubernetes Pod Metrics with OpenTelemetry`
+  - `Debug Slow Traces in Trace Explorer`
+  - `Setup Log Pipelines for JSON Parsing`
+
+### Description Guidelines
+
+The `description` field appears as the meta description in search results and link previews.
+
+- **Length:** 120–160 characters.
+- **Structure:** What the page covers + what the reader will learn or do + benefit.
+- **Best practices:**
+  - Clearly explain what the page is about and what the user will learn.
+  - Use action-oriented language.
+  - Highlight benefits.
+  - Include primary keywords naturally — do not stuff them.
+- **Examples:**
+  - `Learn how to send Kubernetes pod metrics to SigNoz using OpenTelemetry Collector. Monitor CPU, memory, and network with pre-built dashboards.`
+  - `Debug slow traces using filters, trace matching, and flamegraph views in SigNoz Trace Explorer. Identify bottlenecks across microservices.`
+
 Tags:
 
 - omit `tags` when the doc applies to both Cloud and Self-Host
@@ -280,6 +310,8 @@ node --test tests/component-items-sync.test.js
 Use the PR snippet in [templates/pr-checklists.md#docs-changes](templates/pr-checklists.md#docs-changes) when preparing or reviewing docs work.
 
 - Frontmatter includes `date`, `id`, `title`, `description`, `doc_type`, and correct tags.
+- Title is 50–60 characters, leads with the primary keyword, and uses an action word.
+- Description is 120–160 characters, action-oriented, and explains what the page covers and what the reader will learn.
 - Content matches the chosen `doc_type`.
 - The primary job is clear and the happy path is easy to follow end to end.
 - Steps are concise, minimal, and ordered for first success.

--- a/contributing/docs-review.md
+++ b/contributing/docs-review.md
@@ -46,21 +46,23 @@ Shared snippets imported into docs should **prefer React (`.tsx`)** over new **`
 
 Review each changed doc against these checks in order:
 
-1. Intended personas are clear from the content and assumptions.
-2. The primary job is obvious and the page does not mix unrelated jobs in one mandatory flow.
-3. The happy path is easy to follow end to end.
-4. Time-to-first-success is short and the default path is clear.
-5. Steps are concrete, concise, and unambiguous.
-6. Only required actions stay in the main path.
-7. Recommended defaults are the default, and advanced options are moved out of the main flow.
-8. Critical prerequisites, attributes, or concepts have a direct step or high-value link.
-9. Troubleshooting starts from symptoms and points to exact next actions.
-10. Validation tells users what success looks like in SigNoz.
-11. Next steps help users complete the broader job.
-12. Links directly help readers complete the current step.
-13. Added or edited links resolve and use canonical production paths.
-14. Discovery surfaces are updated when the new doc should appear in an existing list or overview.
-15. Added or changed images are WebP, at least 1200 px wide, and use the `Figure` component with descriptive alt text.
+1. Title is 50–60 characters, leads with the primary keyword, and uses an action word. No brand suffix.
+2. Description is 120–160 characters, explains what the page covers and what the reader will learn, and uses action-oriented language.
+3. Intended personas are clear from the content and assumptions.
+4. The primary job is obvious and the page does not mix unrelated jobs in one mandatory flow.
+5. The happy path is easy to follow end to end.
+6. Time-to-first-success is short and the default path is clear.
+7. Steps are concrete, concise, and unambiguous.
+8. Only required actions stay in the main path.
+9. Recommended defaults are the default, and advanced options are moved out of the main flow.
+10. Critical prerequisites, attributes, or concepts have a direct step or high-value link.
+11. Troubleshooting starts from symptoms and points to exact next actions.
+12. Validation tells users what success looks like in SigNoz.
+13. Next steps help users complete the broader job.
+14. Links directly help readers complete the current step.
+15. Added or edited links resolve and use canonical production paths.
+16. Discovery surfaces are updated when the new doc should appear in an existing list or overview.
+17. Added or changed images are WebP, at least 1200 px wide, and use the `Figure` component with descriptive alt text.
 
 If a check cannot be validated from the PR context, call out the assumption and residual risk.
 


### PR DESCRIPTION
## Summary
- Added **Title Guidelines** and **Description Guidelines** subsections to `contributing/docs-authoring.md` under Required Frontmatter — covers length targets, structure, best practices, and examples
- Added title/description quality checks (items 1–2) to the JTBD-First Rubric in `contributing/docs-review.md`
- Added title/description checks to the Docs Author Checklist in `contributing/docs-authoring.md`

## Test plan
- [ ] Verify `contributing/docs-authoring.md` renders correctly with the new subsections
- [ ] Verify `contributing/docs-review.md` rubric numbering is sequential (1–17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)