### PR TITLE
update: rewrite apache log guide

### DIFF
--- a/data/guides/apache-log.mdx
+++ b/data/guides/apache-log.mdx
@@ -1,494 +1,325 @@
 ---
 
 title: Complete Guide to Apache Logs - Access, Analyze, and Manage
-date: 2024-07-16
-tags: [logging]
-authors: [simran_kumari]
-description: Master Apache logs with our comprehensive guide. Learn to access, analyze, and manage Apache log files, understand logging levels, and implement advanced log management techniques.
-keywords: [Apache logs, clear Apache logs, analyze Apache logs, manage Apache logs, Apache logging levels, Apache log files, access Apache logs, Apache log analysis, Apache log management, Apache error logs]
-related_articles:
-  - '/guides/apache-monitoring'
-  - '/guides/java-log'
-  - '/guides/error-log'
-  - '/blog/docker-logging'
-  - '/guides/how-can-i-limit-the-size-of-apache-access-log-and-limit-the-number-of-archived-logs-it-keeps'
-  - '/blog/structured-logs'
+slug: apache-log
+date: 2026-05-20
+tags: [apache, logging]
+authors: [aayush_sharma]
+description: Learn how to access, configure, and analyze Apache log files. This guide covers Apache access log formats, error log structures, log rotation, and how to monitor Apache logs with OpenTelemetry and SigNoz.
+keywords: [Apache logs, Apache log file, Apache access log, Apache log format, Apache log analysis, Apache access log format, Apache log management, Apache log file analysis, Apache access log analytics, Apache error logs]
+
 ---
 
+Apache logs are plain text files that capture every request and every error your Apache HTTP Server handles. When something goes wrong, the logs tell you which client triggered it, when it started, and whether it was a one-off or a pattern that had been building up.
 
-Apache logs are crucial for understanding and managing the behavior of your web server. They provide detailed records of server activity, capturing essential data such as client IP addresses, request methods, requested URLs, response status codes, user agents, and timestamps. This information is invaluable for troubleshooting issues, performing security analysis, and optimizing performance, making Apache logs an essential component of server management.
+Log entries by default report who made the request (client IP), what they requested (URL and request method like GET or POST), how the server responded (status code like 200 or 500), how much data was sent back (response size), and when it happened (timestamp). If you configure a richer log format, you also get where the request came from and what browser or tool made it. That extra context helps when you need to figure out if a traffic spike is coming from a bot or real users.
 
-This guide aims to provide a thorough understanding of Apache logs, covering everything from their basic structure to advanced analysis and automation techniques using tools like SigNoz.
+In this article, we'll explore how to get all of this working. How you can configure Apache logging, read access and error logs, and ship them to a central backend like SigNoz once grepping through individual files stops being practical.
 
-## Understanding Apache Logs
+### Common Use Cases for Apache Log Analysis
 
-Understanding Apache logs is essential for effectively managing and maintaining an Apache web server. These logs provide valuable insights into server operations, performance, and security. In this section, you will dive into the world of Apache logs.
+Apache log analysis helps you answer specific operational questions that other monitoring tools cannot. Here are the situations where Apache log file analysis matters most:
 
-### What are Apache logs?
+1. **Performance debugging** - Your p99 response times jumped from 200ms to 3s. The Apache access log shows which endpoints are slow and whether the problem correlates with specific client IPs, user agents, or time windows.
+2. **Security investigation** - You see failed login attempts in your application logs but need the source IPs and request patterns. Apache access log analytics on your log data reveals brute force patterns, path traversal attempts, and automated scanner activity.
+3. **Capacity planning** - You need to decide whether to add another server. Apache access log analytics on request volume, peak traffic hours, and response sizes tell you whether you are running out of headroom.
+4. **Error triage** - Users report intermittent failures but your application logs look clean. The Apache error log catches upstream timeouts, permission denials, and module crashes that happen below the application layer.
 
-Apache logs are records of various events and activities that occur on an Apache web server. They capture information about requests made to the server, errors encountered, and other server operations. These logs are invaluable for system administrators and developers for monitoring server health, troubleshooting problems, and ensuring optimal performance and security.
+<Figure src="/img/guides/2024/07/apache-log-Untitled.webp" alt="Common use cases for Apache log analysis" caption="Common use cases for Apache log analysis" />
 
-### Types of Apache Logs
+## Types of Apache Log Files
 
-Apache logs come in different types, each serving a specific purpose. The two primary types of logs are access logs and error logs.
+### Apache Access Logs
 
-1. Access Logs
-    - Access logs record all requests made to the server. They typically include information such as the IP address of the client, request time, requested URL, HTTP status code, and user agent.
-    - Example:
-        
-        ```bash
-        127.0.0.1 - frank [18/Jul/2024:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
-        ```
-        
-        Explanation of Components:
-        
-        - 127.0.0.1: The IP address of the client making the request.
-        - frank: The user identifier for the client, typically provided by HTTP authentication.
-        - [18/Jul/2024:13:55:36 -0700]: The date and time when the request was made, followed by the time zone offset.
-        - "GET /apache_pb.gif HTTP/1.0": The request line from the client. This includes:
-            - GET: The HTTP method used.
-            - /apache_pb.gif: The requested URL.
-            - HTTP/1.0: The HTTP protocol version used.
-        - 200: The HTTP status code returned by the server, indicating the result of the request (200 means OK).
-        - 2326: The size of the response in bytes, excluding headers.
-2. Error Logs
-    - Error logs capture issues that the server encounters while processing requests. This includes errors such as file not found, server misconfigurations, and more.
-    - Example:
-        
-        ```bash
-        [Fri Jul 14 14:32:14.873076 2024] [core:notice] [pid 1234] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
-        ```
-        
-        Explanation of Components:
-        
-        - [Fri Jul 14 14:32:14.873076 2024]: The date and time when the error occurred, down to microseconds.
-        - [core]: The module and the severity level of the message.
-            - core: The module where the error or notice originated.
-            - notice: The severity level of the message, indicating its importance.
-        - [pid 1234]: The process ID of the server process that encountered the issue.
-        - AH00094: The unique identifier for the specific error or notice.
-        - Command line: '/usr/sbin/httpd -D FOREGROUND': The command line that was used to start the server.
+The Apache access log is the primary data source for understanding how clients interact with your server. Every line represents one completed request-response cycle, and patterns across those lines tell you what is working and what is not. 
 
-### Common Use Cases for Log Analysis
-
-Analyzing Apache logs is essential for various aspects of web server management. Here are some common use cases for log analysis:
-
-1. Performance Monitoring: Analyze access logs to monitor server load, response times, and traffic patterns. This helps identify performance bottlenecks and optimize server configurations.
-2. Security Auditing: Review logs to detect unauthorized access attempts, suspicious activities, and potential security breaches. Error logs, in particular, can highlight attempts to exploit server vulnerabilities.
-3. Troubleshooting: Use error logs to diagnose and resolve issues such as server misconfigurations, missing files, or application errors. This aids in maintaining server reliability and uptime.
-4. Traffic Analysis: Analyze access logs by analyzing user behaviour, popular pages, and traffic sources. This information can be used to improve user experience and strategic planning.
-
-<Figure src="/img/guides/2024/07/apache-log-Untitled.webp" alt="Common use case for Apache log analysis" caption="Common use case for Apache log analysis" />
-
-## Configuring Apache Logging
-
-Configuring Apache logging is crucial for ensuring that log data is properly captured and stored for analysis. This section covers default log locations on different operating systems, changing the default log location, and configuring log file paths and names in the `httpd.conf` or `apache2.conf` file.
-
-### Default Log Locations
-
-Knowing the default log locations helps in quickly accessing the logs for initial setup and troubleshooting. The default log locations vary between operating systems.
-
-- Linux
-    - Access Logs: `/var/log/apache2/access.log` or `/var/log/httpd/access_log`
-    - Error Logs: `/var/log/apache2/error.log` or `/var/log/httpd/error_log`
-- Windows
-    - Access Logs: `C:\Program Files\Apache Group\Apache2\logs\access.log`
-    - Error Logs: `C:\Program Files\Apache Group\Apache2\logs\error.log`
-
-### Changing the Default Apache Log Location
-
-Changing the default log location can help organize logs better or direct them to a [centralized logging system](https://signoz.io/blog/centralized-logging/).
-
-1. Open the Apache configuration file (typically `httpd.conf` or `apache2.conf`).
-2. Locate the `CustomLog` directive for access logs and the `ErrorLog` directive for error logs.
-3. Modify the file paths as needed.
-
-Example:
-
-```bash
-ErrorLog "/path/to/new/error.log"
-CustomLog "/path/to/new/access.log" common
-```
-
-- ErrorLog: This directive specifies the file path where the error logs will be written. Changing it to `"/path/to/new/error.log"` directs Apache to store error logs in the specified location.
-- CustomLog: This directive specifies the file path for access logs and the log format. The `"common"` keyword indicates that the access log entries will be in the Common Log Format (CLF), a standardized format used for web server log files.
-
-### Configuring Log File Paths and Names in `httpd.conf`
-
-Customizing log file paths and names in the `httpd.conf` file allows for better log management and clarity.
-
-1. Open the `httpd.conf` file in a text editor.
-2. Define the log file paths and names using the `ErrorLog` and `CustomLog` directives.
-
-Example configuration:
-
-```bash
-# Define the error log file
-ErrorLog "/var/log/apache2/custom_error.log"
-
-# Define the access log file with a custom log format
-LogFormat "%h %l %u %t \"%r\" %>s %b" custom
-CustomLog "/var/log/apache2/custom_access.log" custom
-```
-
-ErrorLog "/var/log/apache2/custom_error.log"
-
-- ErrorLog: This directive specifies where the server should write [error logs](https://signoz.io/guides/error-log/).
-- "/var/log/apache2/custom_error.log": This path sets a custom location and name for the error log file. By specifying this path, the error logs will be written to `/var/log/apache2/custom_error.log`.
-
-LogFormat "%h %l %u %t "%r" %>s %b" custom
-
-- LogFormat: This directive defines the format of log entries.
-- "%h %l %u %t "%r" %>s %b": This format string specifies what data to include in the log entries.
-    - %h: Remote host (IP address)
-    - %l: Remote logname (usually)``
-    - %u: Remote user (if authenticated)
-    - %t: Time the request was received
-    - "%r": The request line from the client (e.g., `GET / HTTP/1.0`)
-    - %>s: Status code sent to the client
-    - %b: Size of the response in bytes, excluding HTTP headers
-- custom: This keyword assigns a name to this custom log format, which can be referenced later.
-
-CustomLog "/var/log/apache2/custom_access.log" custom
-
-- CustomLog: This directive specifies where the server should write access logs and what format to use.
-- "/var/log/apache2/custom_access.log": This path sets a custom location and name for the access log file. By specifying this path, the access logs will be written to `/var/log/apache2/custom_access.log`.
-- custom: This references the custom log format defined earlier.
-
-### Using Piped Logs
-
-Piped logs provide a powerful way to manage log data by directing log entries through an external program, allowing for real-time processing and more flexible handling of log files.
-
-Piped logs use an external program to handle log entries. This is useful for advanced logging requirements, such as real-time log analysis or integration with centralized logging systems.
-
-To configure piped logs, use the pipe symbol (`|`) followed by the path to the external program in the `ErrorLog` and `CustomLog` directives.
-
-Example configuration:
-
-```bash
-# Define piped error log
-ErrorLog "|/usr/bin/rotatelogs /var/log/apache2/error_log.%Y-%m-%d 86400"
-
-# Define piped access log with a custom log format
-CustomLog "|/usr/bin/rotatelogs /var/log/apache2/access_log.%Y-%m-%d 86400" custom
-```
-
-- ErrorLog "|/usr/bin/rotatelogs /var/log/apache2/error_log.%Y-%m-%d 86400"
-    - This configuration uses `rotatelogs`, a utility that manages log file rotation.
-    - "|/usr/bin/rotatelogs": The pipe symbol (`|`) directs the log output to the `rotatelogs` program.
-    - "/var/log/apache2/error_log.%Y-%m-%d": The log file name pattern includes the date, creating a new log file daily.
-    - 86400: The time in seconds (86400 seconds = 24 hours) to rotate the log file.
-- CustomLog "|/usr/bin/rotatelogs /var/log/apache2/access_log.%Y-%m-%d 86400" custom
-    - This configuration similarly uses `rotatelogs` for the access log.
-    - "|/usr/bin/rotatelogs": The pipe symbol (`|`) directs the log output to the `rotatelogs` program.
-    - "/var/log/apache2/access_log.%Y-%m-%d": The log file name pattern includes the date, creating a new log file daily.
-    - custom: This references the previously defined custom log format.
-
-### Log rotation and management with `logrotate`
-
-To ensure Apache logs do not consume excessive disk space, integrating `logrotate` is essential. This utility automates the rotation, compression, and removal of old log files. Proper configuration of `logrotate` helps maintain manageable log file sizes while preserving necessary data for analysis and troubleshooting.
-
-### Configuring `logrotate` for Apache Logs:
-
-1. Install `logrotate`: Ensure `logrotate` is installed on your system. It is typically pre-installed on most Linux distributions. If not, you can install it using the package manager:
-    
-    ```bash
-    sudo yum install logrotate
-    ```
-    
-2. Create a Logrotate Configuration File: Create a configuration file `/etc/logrotate/httpd` for Apache logs. This file will define how and when logs are rotated.
-    
-    Example Configuration:
-    
-    ```
-    /var/log/httpd/*.log {
-        daily
-        rotate 7
-        compress
-        delaycompress
-        missingok
-        notifempty
-        create 0640 root adm
-        sharedscripts
-        postrotate
-            /etc/init.d/httpd reload > /dev/null
-        endscript
-    }
-    ```
-    
-    - Explanation of Configuration Options:
-        - /var/log/httpd/*.log: Specifies the log files to be rotated.
-        - daily: Rotates the logs daily.
-        - rotate 7: Keeps seven days’ worth of old log files before deleting them.
-        - compress: Compresses the rotated log files to save space.
-        - delaycompress: Delays compression of the log file until the next rotation cycle.
-        - missingok: Ignores the error if the log file is missing.
-        - notifempty: Does not rotate the log file if it is empty.
-        - create 0640 root adm: Sets permissions for the new log file and specifies the owner and group.
-        - sharedscripts: Ensures that the postrotate script is run only once, even if multiple log files are rotated.
-        - postrotate/endscript: Defines a script to be run after log rotation. In this case, it reloads the Apache server to ensure it starts writing to the new log file.
-3. Test the Configuration: You can manually test your `logrotate` configuration to ensure it works as expected.
-    
-    ```bash
-    sudo logrotate -d /etc/logrotate.d/httpd
-    ```
-    
-
-Note: You will have to replace the occurrences of `httpd` with `apache2`based on your system. 
-
-By implementing `logrotate` with the appropriate configuration, you can ensure efficient log management in Apache environments, preventing log files from consuming excessive disk space and maintaining the server’s performance and stability.
-
-## Apache Log Formats
-
-Understanding Apache log formats is essential for effective log analysis and monitoring. Different formats capture various levels of detail about web server activity. Below are the main log formats used by Apache.
-
-### Common Log Format (CLF)
-
-The Common Log Format is a standardized format that provides essential information about each request. It includes:
-
-- Format: `%h %l %u %t \"%r\" %>s %b`
-    - `%h`: Remote host (IP address)
-    - `%l`: Remote logname (usually)``
-    - `%u`: Remote user (authenticated user)
-    - `%t`: Time the request was received
-    - `%r`: Request line from the client (method, resource, protocol)
-    - `%>s`: Status code sent to the client
-    - `%b`: Size of the object sent to the client (excluding headers)
-- Example:
-    
-    ```bash
-    127.0.0.1 - - [14/Jul/2024:12:34:56 +0000] "GET /index.html HTTP/1.1" 200 1043
-    ```
-    
-
-<Figure src="/img/guides/2024/07/apache-log-napkin-selection_(2).webp" alt="common log format" caption="Common Log Format" />
-
-### Combined Log Format
-
-The Combined Log Format (CLF) builds on the Common Log Format to give you a richer view of your web traffic. It includes not only the basic details of each request but also the referrer and user agent, providing a more comprehensive understanding of your users and their behaviors.
-
-### Understanding the Combined Log Format:
-
-Imagine you run a popular online store. You want to know not just how many people visit your site, but also where they come from and what devices they use. The Combined Log Format can help you answer these questions.
-
-- Referrer Insight: The referrer field tells you which page a visitor was on before they arrived at your site. This can help you identify which external links or marketing campaigns are driving traffic to your store.
-- User Agent Details: The user agent string reveals information about the visitor's browser and operating system. Knowing this helps you optimize your site for the most popular devices and troubleshoot compatibility issues
-- Format: `%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"`
-    - `%h`, `%l`, `%u`, `%t`, `%r`, `%>s`, `%b`: Same as in CLF
-    - `%{Referer}i`: Referrer URL
-    - `%{User-Agent}i`: User agent string
-- Example:
-    
-    ```bash
-    127.0.0.1 - - [14/Jul/2024:12:34:56 +0000] "GET /index.html HTTP/1.1" 200 1043 "http://example.com" "Mozilla/5.0"
-    ```
-    
-
-Real-Life Example:
-
-Let’s say you see the following log entry:
-
-```bash
-127.0.0.1 - frank [18/Jul/2024:13:55:36 -0700] "GET /product/123 HTTP/1.1" 200 2326 "http://example.com/promo" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-```
-
-From this single line, you can glean a wealth of information:
-
-- Visitor Identity: The request came from a user identified as 'frank' at IP address `127.0.0.1`.
-- Timing: The request was made on July 18, 2024, at 1:55 PM.
-- Action: Frank requested the product page for item 123.
-- Outcome: The server successfully delivered the page (status code 200) with a size of 2326 bytes.
-- Origin: Frank arrived from a promotional page (`http://example.com/promo`).
-- Device: He used a Chrome browser on a Windows 10 machine.
-
-With this information, you can:
-
-- Track the effectiveness of your promotions.
-- See which products are getting the most views.
-- Ensure your site performs well on popular browsers and devices.
-
-### Custom Log Formats
-
-Custom log formats allow you to tailor the information logged to meet your specific needs. This flexibility is invaluable for fine-tuning your analysis and gaining insights that matter most to your business.
-
-### Tailored Logging:
-
-Imagine you're running a tech blog and want to track not just the traffic but also the search terms visitors use to find your articles. By customizing your log format, you can capture this specific data.
-
-- Example: You might define a custom log format that includes the search term as a custom field. This could look like:
-    
-    ```bash
-    "%h %t \"%r\" %>s %b \"%{User-Agent}i\" \"%{Search-Term}i\""
-    ```
-    
-- Real-Life Scenario:
-    
-    ```arduino
-    192.168.1.1 [18/Jul/2024:14:00:00 -0700] "GET /article/seo-tips HTTP/1.1" 200 5120 "Mozilla/5.0
-    ```
-    
-
-By leveraging custom log formats, you can transform raw server data into actionable insights, making your web analytics as detailed and relevant as you need them to be.
-
-## Analyzing Apache Access Logs
-
-Analyzing Apache access logs is essential for understanding web server activity and user interactions. This section outlines the structure of access logs and key fields that provide valuable insights.
-
-### Structure of Access Logs
-
-Apache access logs are structured as a series of plain text entries, with each line representing an individual request to the server. The logs follow a predefined format (e.g., Common or Combined Log Format) that makes it easy to parse and analyze.
-
-Sample Log Entry:
+Every access log entry follows the log format you configured (CLF, Combined, or custom):
 
 ```bash
 127.0.0.1 - - [14/Jul/2024:12:34:56 +0000] "GET /index.html HTTP/1.1" 200 1043 "http://example.com" "Mozilla/5.0"
 ```
 
-### Key Fields and Their Meanings
+<KeyPointCallout title="Access Log Field Reference" defaultCollapsed="true">
 
-| Field | Example | Meaning |
-| --- | --- | --- |
-| IP Address | 127.0.0.1 | Identifies the client making the request. |
-| Request Method | GET | Type of HTTP request (e.g., GET, POST). |
-| Requested URL | /index.html | Resource being requested from the server. |
-| HTTP Version | HTTP/1.1 | Version of the HTTP protocol used. |
-| Status Code | 200 | Response status indicating success (200 OK). |
-| Response Size | 1043 | Size of the response in bytes (excluding headers). |
-| User-Agent | "Mozilla/5.0" | Information about the client's browser/application. |
-| Referrer | "http://example.com" | Previous page that linked to the requested resource. |
+| **Field** | **Example** | **What It Tells You** |
+|---|---|---|
+| IP Address | `127.0.0.1` | Which client made the request |
+| Request Method | `GET` | What type of HTTP operation was performed |
+| Requested URL | `/index.html` | Which resource the client asked for |
+| HTTP Version | `HTTP/1.1` | Protocol version the client supports |
+| Status Code | `200` | Whether the server fulfilled the request successfully |
+| Response Size | `1043` | How much data was sent back (bytes, excluding headers) |
+| Referrer | `http://example.com` | Where the client came from |
+| User-Agent | `Mozilla/5.0` | What browser or tool the client is using |
 
-## Analyzing Apache Error Logs
+</KeyPointCallout>
 
-Analyzing Apache error logs is vital for diagnosing server issues and ensuring smooth operation. This section outlines the structure of error logs and common error messages.
+The Referrer and User-Agent fields are especially useful when you need to figure out if a traffic spike is coming from a bot or real users.
 
-### Structure of Error Logs
+When analyzing access logs, focus on status code distributions first. A sudden increase in 4xx codes points to broken links or missing assets. A spike in 5xx codes means your application or server configuration has a problem that needs immediate attention. Pairing status codes with timestamps lets you correlate these patterns to specific deployments or traffic events.
 
-Apache error logs contain entries that record server errors and issues encountered during request processing. Each entry typically includes a timestamp, log level, message, and the file or resource associated with the error.
+### Apache Error Logs
 
-Sample Log Entry:
+The Apache error log is where you look when something fails silently. A user reports a blank page, your monitoring shows elevated error rates, but the access log only shows a 500 status code with no explanation. The error log fills in the details that the access log cannot:
+
 
 ```bash
 [Wed Jul 14 12:34:56.123456 2024] [error] [client 127.0.0.1] File does not exist: /var/www/html/missing.html
 ```
 
-### Common Error Messages and Their Interpretations
+Each part of this entry tells you something different:
 
-| Error Message | Example | Interpretation |
-| --- | --- | --- |
-| File Does Not Exist | File does not exist: /var/www/html/missing.html | The requested file was not found on the server. |
-| Permission Denied | Permission denied: /var/www/html/protected.html | The server does not have permission to access the file. |
-| Internal Server Error | Internal Server Error: /index.php | A general error occurred; check the application for issues. |
-| Script Not Found | script not found or unable to stat: /cgi-bin/script.cgi | The specified CGI script is missing or not executable. |
-| Maximum File Size Exceeded | client exceeded max request body size: /upload | The client uploaded a file that exceeds the server's maximum allowed size. |
-| Connection Timeout | Connection timed out: /path/to/resource | The server took too long to respond to the request. |
+- `[Wed Jul 14 12:34:56.123456 2024]` is the timestamp down to microsecond precision
+- `[error]` is the severity level, which follows Apache's LogLevel hierarchy from most to least severe: `emerg`, `alert`, `crit`, `error`, `warn`, `notice`, `info`, `debug`
+- `[client 127.0.0.1]` is the IP of the client whose request triggered the error
+- The rest is the human-readable error message
 
-By understanding these error messages, administrators can quickly diagnose issues and take appropriate actions to resolve them, ensuring the server operates efficiently.
+You control which severity levels get written to the error log using the `LogLevel` directive in your configuration file.
 
-### Tip
+<KeyPointCallout title="Common Apache Error Log Messages" defaultCollapsed="true">
 
-CGI stands for Common Gateway Interface. It is a standard protocol used to interface external applications with web servers. CGI scripts are programs that run on a web server and generate web content dynamically. When a web server receives a request for a CGI script, it executes the script and sends the output back to the client.
+| **Error Message** | **What It Means** | **Likely Cause** |
+|---|---|---|
+| File does not exist: `/path/to/file` | The server could not find the requested resource | Broken link, deleted file, or typo in the URL |
+| Permission denied: `/path/to/file` | The Apache process does not have read access to the file | Incorrect file ownership or permissions |
+| Internal Server Error: `/path` | A catch-all failure during request processing | Application crash, bad .htaccess rule, or module error |
+| script not found or unable to stat: `/cgi-bin/script.cgi` | The CGI script is missing or not executable | Deleted script, wrong path, or missing execute permission |
+| client exceeded max request body size | The uploaded file exceeds the **LimitRequestBody** setting | User uploading a file bigger than the server allows |
+| Connection timed out: `/path` | The server did not respond within the timeout window | Slow upstream, overloaded backend, or network issue |
 
-## Practical Applications
+**Note on CGI scripts:** CGI (Common Gateway Interface) scripts are external programs that the web server executes to generate dynamic content. If your server does not use CGI, you can safely ignore CGI-related messages in your error log.
 
-Analyzing Apache logs provides valuable insights that can significantly enhance server management and website performance. Here are some key practical applications:
+</KeyPointCallout>
 
-- Monitoring Web Traffic and User Behavior:  By analyzing access logs, administrators can track user interactions, popular pages, and traffic patterns. This information helps in understanding user behavior, optimizing content delivery, and making informed decisions about website changes.
-- Identifying and Mitigating Security Threats: Error logs and access logs are crucial for identifying potential security threats. By monitoring for unusual patterns, such as repeated failed login attempts or access to non-existent pages, administrators can detect and respond to attacks like brute force or SQL injection attempts.
-- Performance Optimization Through Log Analysis: Log analysis allows for performance monitoring by identifying slow requests, high error rates, or resource-intensive pages. This information can guide optimization efforts, such as caching strategies, code improvements, or server configuration adjustments, leading to a more efficient and responsive web application.
+## Configuring Apache Logging
 
-<Figure src="/img/guides/2024/07/apache-log-napkin-selection_(1).webp" alt="Practical applications of Analyzing Apache logs" caption="Practical applications of Analyzing Apache logs" />
+Apache log management starts with knowing where your Apache log files live and how to control what gets written to them.
 
-Practical applications of Analyzing Apache logs
+### Default Apache Log File Locations
+
+Apache log files land in different directories depending on your OS.
+
+| OS | Access Log | Error Log |
+|----|-----------|-----------|
+| Debian/Ubuntu | `/var/log/apache2/access.log` | `/var/log/apache2/error.log` |
+| RHEL/CentOS/Amazon Linux | `/var/log/httpd/access_log` | `/var/log/httpd/error_log` |
+| Windows | `C:\Program Files\Apache Group\Apache2\logs\access.log` | `C:\Program Files\Apache Group\Apache2\logs\error.log` |
+
+The rest of this guide uses RHEL/CentOS paths (`httpd`). If you are running Debian/Ubuntu, replace `httpd` with `apache2` and adjust file names to use the `.log` extension.
+
+### Changing the Apache Log File Location
+
+You control where Apache writes logs through two directives in your configuration file (`/etc/httpd/conf/httpd.conf` on RHEL, `/etc/apache2/apache2.conf` on Debian).
+
+```bash
+ErrorLog "/var/log/custom/apache_error.log"
+CustomLog "/var/log/custom/apache_access.log" combined
+```
+
+`ErrorLog` sets the error log path. `CustomLog` takes the access log path and an Apache log format name (`common`, `combined`, or a custom name you define).
+
+### Apache Log Formats
+
+The Apache log format determines what data each Apache log entry contains. Apache ships with two built-in formats, and you can define your own.
+
+1. **Common Log Format (CLF)** captures the basics without referrer or user agent data.
+
+```bash
+# Format string
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+# Example Apache access log entry
+127.0.0.1 - - [14/Jul/2024:12:34:56 +0000] "GET /index.html HTTP/1.1" 200 1043
+```
+
+<KeyPointCallout title="CLF Specifier Reference" defaultCollapsed="true">
+
+| Specifier | Data |
+|-----------|------|
+| `%h` | Client IP address |
+| `%l` | Remote logname (rarely populated) |
+| `%u` | Authenticated username |
+| `%t` | Request timestamp |
+| `%r` | Full request line (method, URL, protocol) |
+| `%>s` | Final HTTP status code |
+| `%b` | Response body size in bytes |
+
+</KeyPointCallout>
+
+This Apache access log format works for simple traffic counting but does not tell you where users came from or what browser they used, which limits the depth of Apache log analysis you can perform.
+
+<Figure src="/img/guides/2024/07/apache-log-napkin-selection_(2).webp" alt="Common Log Format structure" caption="Common Log Format" />
+
+2. **Combined Log Format** extends CLF with referrer and user agent fields, making it the standard Apache access log format for production because it supports both basic Apache log analysis and deeper Apache log file analysis.
+
+```bash
+# Format string
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+
+# Example Apache access log entry
+127.0.0.1 - frank [18/Jul/2024:13:55:36 -0700] "GET /product/123 HTTP/1.1" 200 2326 "http://example.com/promo" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+```
+
+From this single Apache log entry you can tell that user `frank` requested product page 123, arrived from a promotional page at `example.com/promo`, and used Chrome on Windows 10. The server returned 200 with a 2326-byte body. This level of detail is why the Combined Apache access log format is the default for most deployments and the starting point for serious Apache log analysis.
+
+**Custom Apache log formats** let you go further. If your application sets custom response headers, you can include them in the Apache access log. For example, to log response time and a custom search term header alongside standard fields:
+
+```bash
+LogFormat "%h %t \"%r\" %>s %b %D \"%{X-Search-Term}o\"" searchlog
+CustomLog "/var/log/httpd/search_access.log" searchlog
+```
+
+<KeyPointCallout title="Custom Specifier Reference" defaultCollapsed="true">
+
+| Specifier | Data | Use Case |
+|-----------|------|----------|
+| `%D` | Response time in microseconds | Latency analysis per request |
+| `%T` | Response time in seconds | Coarser latency tracking |
+| `%{HeaderName}i` | Any request header value | Capture `Authorization`, `X-Request-ID`, etc. |
+| `%{HeaderName}o` | Any response header value | Capture `X-Search-Term`, `X-Cache-Status`, etc. |
+| `%{VARNAME}e` | Environment variable value | Log server-side variables set by `mod_rewrite` or app logic |
+
+</KeyPointCallout>
+
+Custom Apache log formats let you tailor Apache log file analysis and Apache access log analytics to whatever your application needs to expose.
+
+### Apache Log Rotation
+
+Unmanaged Apache log files grow until they fill your disk. There are two ways to handle this.
+
+**Option 1: Piped logs with rotatelogs**
+
+Apache's built-in `rotatelogs` utility creates a new Apache log file on a time interval without needing external tools.
+
+```bash
+ErrorLog "|/usr/bin/rotatelogs /var/log/httpd/error_log.%Y-%m-%d 86400"
+CustomLog "|/usr/bin/rotatelogs /var/log/httpd/access_log.%Y-%m-%d 86400" combined
+```
+
+The pipe symbol (`|`) sends log output to `rotatelogs`, which creates a new file every 86400 seconds (24 hours) with the date in the filename.
+
+**Option 2: logrotate (recommended for production)**
+
+`logrotate` gives you more control over Apache log management, including compression, retention policies, and post-rotation hooks.
+
+```bash
+# Install if not present
+sudo yum install logrotate   # RHEL/CentOS
+sudo apt install logrotate   # Debian/Ubuntu
+```
+
+Create a configuration at `/etc/logrotate.d/httpd` (or `/etc/logrotate.d/apache2` on Debian):
+
+```
+/var/log/httpd/*.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 root adm
+    sharedscripts
+    postrotate
+        /etc/init.d/httpd reload > /dev/null
+    endscript
+}
+```
+
+This rotates Apache log files daily, keeps seven days of history, compresses old files, and reloads Apache so it writes to the fresh file. Test with `sudo logrotate -d /etc/logrotate.d/httpd` before relying on it (the `-d` flag runs in debug mode without actually rotating).
 
 ## Monitoring Apache Logs with SigNoz
 
-[Monitoring Apache](https://signoz.io/blog/opentelemetry-apache-server-metrics-monitoring/) logs is vital for ensuring the optimal performance and security of your web server. Apache logs provide insights into server activities, access requests, and potential issues that could affect user experience or indicate security threats.
+Reading Apache log files manually works for debugging individual requests, but production servers generate thousands of Apache log entries per minute. Manual Apache log file analysis does not scale when you are managing dozens of servers. For Apache log management at scale, you need a centralized platform where you can search, filter, and set alerts on Apache log data in real time.
 
-SigNoz enhances Apache log monitoring by offering real-time visibility, advanced querying, and alerting capabilities. This integration allows administrators to quickly identify and respond to anomalies, track performance metrics, and maintain comprehensive observability over their web server operations. SigNoz's centralized logging system simplifies the monitoring process, making it easier to correlate logs from Apache with other system logs for a holistic view of your infrastructure.
+[SigNoz](https://signoz.io/) is an observability platform that ingests Apache logs via the OpenTelemetry Collector, giving you full-text search, field-level filtering, and alerting on error patterns across all your [Apache log files](https://signoz.io/blog/opentelemetry-apache-server-metrics-monitoring/).
 
-Compared to other tools, SigNoz stands out as an open-source platform, offering flexibility, comprehensive observability with metrics and tracing, and an intuitive interface that facilitates ease of use. It is cost-effective and supported by an active community, making it a reliable choice for effective log management and system monitoring.
-
-To set up monitoring for Apache logs in SigNoz, follow these steps:
+This section walks through setting up Apache log monitoring with SigNoz Cloud using the OpenTelemetry Collector as the log shipper.
 
 ### Prerequisites
 
-- Ensure you have a SigNoz account. Sign up [here](https://signoz.io/teams/).
-- Root or sudo access to the server.
-
-To send Apache logs to SigNoz, you'll need to follow these steps. The process involves setting up Apache to generate logs, installing and configuring the OpenTelemetry Collector to send logs to SigNoz, and ensuring that everything is working correctly.
+- A SigNoz account ([sign up here](https://signoz.io/teams/))
+- Root or sudo access on the server running Apache
+- Apache installed and generating Apache log files
 
 ### Step 1: Set Up Apache to Generate Logs
 
-- First, install the Apache server if it is not already installed using the command:
+If Apache is not already installed, install it on your server:
 
 ```bash
-yum install httpd -y
+# RHEL/CentOS/Amazon Linux
+sudo yum install httpd -y
+
+# Debian/Ubuntu
+sudo apt install apache2 -y
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 1.webp" alt="Installing Apache server" caption="Installing Apache server" />
+<Figure src="/img/guides/2024/07/apache-log-Untitled%201.webp" alt="Installing Apache server" caption="Installing Apache server" />
 
-- Start and enable the Apache service by running the command:
+Start and enable the Apache service:
 
 ```bash
-systemctl start httpd
-systemctl enable httpd
-systemctl status httpd
+# RHEL/CentOS
+sudo systemctl start httpd
+sudo systemctl enable httpd
+sudo systemctl status httpd
+
+# Debian/Ubuntu
+sudo systemctl start apache2
+sudo systemctl enable apache2
+sudo systemctl status apache2
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 2.webp" alt="Starting and enabling Apache server" caption="Starting and enabling Apache server" />
+<Figure src="/img/guides/2024/07/apache-log-Untitled%202.webp" alt="Starting and enabling Apache server" caption="Starting and enabling Apache server" />
 
-- Access Log Configuration:
-    - By default, Apache logs access information to `/var/log/httpd/access_log`.
-    - Ensure that the `CustomLog` directive is enabled in your Apache configuration file (usually found at `/etc/httpd/conf/httpd.conf`):
-        
-        ```
-        CustomLog logs/access_log combined
-        ```
-        
+Verify that Apache logging is enabled by checking the directives in your Apache configuration file.
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 3.webp" alt="CustomLog directive in Apache Configuration File" caption="CustomLog directive in Apache Configuration File" /> 
+For the Apache access log, confirm the `CustomLog` directive is present:
 
-- Error Log Configuration:
-    - Apache logs error information to `/var/log/httpd/error_log`.
-    - Ensure that the `ErrorLog` directive is enabled in your Apache configuration file (found at `/etc/httpd/conf/httpd.conf`)
-        
-        ```
-        ErrorLog logs/error_log
-        ```
-        
+```
+CustomLog logs/access_log combined
+```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 4.webp" alt="ErrorLog Configuration in Apache Configuration File" caption="ErrorLog Configuration in Apache Configuration File" />
+<Figure src="/img/guides/2024/07/apache-log-Untitled%203.webp" alt="CustomLog directive in Apache Configuration File" caption="CustomLog directive in Apache configuration file" />
 
-### Step 2: Install and Configure OpenTelemetry Collector
+For the Apache error log, confirm the `ErrorLog` directive is present:
 
-Install the OpenTelemetry Collector on your EC2 instance.
+```
+ErrorLog logs/error_log
+```
 
-1. Update Packages:
-    
-    ```
-    sudo yum update -y
-    ```
-    
+<Figure src="/img/guides/2024/07/apache-log-Untitled%204.webp" alt="ErrorLog Configuration in Apache Configuration File" caption="ErrorLog directive in Apache configuration file" />
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 5.webp" alt="Updating packages" caption="Updating packages" />
+### Step 2: Install and Configure the OpenTelemetry Collector
 
-1. Download and Install OpenTelemetry Collector:
-    - Ensure you have the OpenTelemetry Collector installed on your system. If not, install it using the following commands:
-        
-        ```bash
-        wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
-        mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
-        ```
-        
-    
-    <Figure src="/img/guides/2024/07/apache-log-Untitled 6.webp" alt="Installing OpenTelemetry collector" caption="Installing OpenTelemetry collector" />
-    
-    *Installing OpenTelemetry collector*
-    
-    Note: Ensure you have the latest version of the OpenTelemetry Collector. The commands above use version 0.116.0, which is the latest at the time of writing. To verify and download the most current version, visit the <a href="https://github.com/open-telemetry/opentelemetry-collector-releases" rel="noopener noreferrer nofollow" target="_blank">OpenTelemetry Collector Releases</a> page.
-    
-2. Create Configuration File:
-    - Create the [OpenTelemetry](https://signoz.io/opentelemetry/) configuration file, `config.yaml` in the folder otelcol-contrib with the below content in it.
+The [OpenTelemetry](https://signoz.io/opentelemetry/) Collector reads your Apache log files and ships them to SigNoz over OTLP.
+
+**Update system packages:**
+
+```bash
+# RHEL/CentOS
+sudo yum update -y
+
+# Debian/Ubuntu
+sudo apt update -y
+```
+
+<Figure src="/img/guides/2024/07/apache-log-Untitled%205.webp" alt="Updating packages" caption="Updating system packages" />
+
+**Download and extract the OpenTelemetry Collector:**
+
+```bash
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.116.0/otelcol-contrib_0.116.0_linux_amd64.tar.gz
+mkdir otelcol-contrib && tar xvzf otelcol-contrib_0.116.0_linux_amd64.tar.gz -C otelcol-contrib
+```
+
+<Figure src="/img/guides/2024/07/apache-log-Untitled%206.webp" alt="Installing OpenTelemetry collector" caption="Installing OpenTelemetry Collector" />
+
+Check the <a href="https://github.com/open-telemetry/opentelemetry-collector-releases/releases" rel="noopener noreferrer nofollow" target="_blank">OpenTelemetry Collector Releases</a> page for the latest version and replace `0.116.0` in the commands above if a newer release is available.
+
+**Create the collector configuration file** at `otelcol-contrib/config.yaml`. The key section is the `filelog` receiver, which points at your Apache log files. The rest is standard OTel Collector boilerplate for metrics, traces, and exporting to SigNoz.
+
+<KeyPointCallout title="Full config.yaml" defaultCollapsed="true">
 
 ```yaml
 receivers:
@@ -523,9 +354,9 @@ receivers:
             - targets:
               # - localhost:8888
   filelog:
-    include: 
-	    - /var/log/httpd/access_log
-	    - /var/log/httpd/error_log
+    include:
+      - /var/log/httpd/access_log
+      - /var/log/httpd/error_log
     start_at: end
 
 processors:
@@ -539,7 +370,7 @@ processors:
       hostname_sources: [os]
 
 extensions:
-  health_check: 
+  health_check:
     endpoint: "0.0.0.0:13134"
   zpages:
     endpoint: "127.0.0.1:55680"
@@ -555,7 +386,7 @@ exporters:
 service:
   telemetry:
     metrics:
-      address: 0.0.0.0:8888  # Metrics telemetry address
+      address: 0.0.0.0:8888
   extensions: [health_check, zpages]
   pipelines:
     metrics:
@@ -563,7 +394,7 @@ service:
       processors: [batch]
       exporters: [otlp]
     metrics/internal:
-      receivers: [prometheus, hostmetrics]  # Ensure receivers are defined
+      receivers: [prometheus, hostmetrics]
       processors: [resourcedetection, batch]
       exporters: [otlp]
     traces:
@@ -571,156 +402,113 @@ service:
       processors: [batch]
       exporters: [otlp]
     logs:
-      receivers: [otlp, filelog]  # Include filelog receiver here
+      receivers: [otlp, filelog]
       processors: [batch]
       exporters: [otlp]
 ```
 
-Replace the endpoint and ingestion key value with the actual OTLP endpoint and token provided by SigNoz.
+</KeyPointCallout>
 
-- To run otel-collector, run the following command inside the `otelcol-contrib` directory:
-    
-    ```bash
-    ./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$!" > otel-pid
-    ```
-    
+Replace `<cloud endpoint goes here>` with your SigNoz OTLP endpoint and `<ingestion key goes here>` with your ingestion key from the SigNoz dashboard (Settings > General).
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 7.webp" alt="Running Otel-collector" caption="Running Otel-collector" />
+If you are on Debian/Ubuntu, update the `filelog.include` paths to `/var/log/apache2/access.log` and `/var/log/apache2/error.log`.
 
-### Step 3: Testing Apache Logs on SigNoz
+**Start the collector:**
 
-1. Generate Traffic to Apache Server
-
-- Use the `curl` command to generate multiple requests to your Apache server.
-
+```bash
+./otelcol-contrib --config ./config.yaml &> otelcol-output.log & echo "$!" > otel-pid
 ```
+
+<Figure src="/img/guides/2024/07/apache-log-Untitled%207.webp" alt="Running OpenTelemetry Collector" caption="Running the OpenTelemetry Collector" />
+
+### Step 3: Verify Apache Logs in SigNoz
+
+**Generate traffic** against your Apache server to produce Apache log entries:
+
+```bash
 for i in {1..10}; do curl http://localhost/; done
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 8.webp" alt="Sending GET requests to Apache server" caption="Sending GET requests to Apache server" /> 
+<Figure src="/img/guides/2024/07/apache-log-Untitled%208.webp" alt="Sending GET requests to Apache server" caption="Sending GET requests to Apache server" />
 
-- Replace `localhost` with your server's IP address or domain name if you are testing from a different machine.
-- Generate different types of HTTP requests to test various logging scenarios.
+Test different HTTP methods to produce varied Apache access log entries:
 
-```
+```bash
 curl -X GET http://localhost/
 curl -X POST http://localhost/
 curl -X PUT http://localhost/
 curl -X DELETE http://localhost/
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 9.webp" alt="Sending POST requests to Apache server" caption="Sending POST requests to Apache server" /> 
+<Figure src="/img/guides/2024/07/apache-log-Untitled%209.webp" alt="Sending POST requests to Apache server" caption="Sending POST requests to Apache server" />
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 10.webp" alt="Sending PUT requests to Apache server" caption="Sending PUT requests to Apache server" /> 
+<Figure src="/img/guides/2024/07/apache-log-Untitled%2010.webp" alt="Sending PUT requests to Apache server" caption="Sending PUT requests to Apache server" />
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 11.webp" alt="Sending DELETE requests to Apache server" caption="Sending DELETE requests to Apache server" /> 
+<Figure src="/img/guides/2024/07/apache-log-Untitled%2011.webp" alt="Sending DELETE requests to Apache server" caption="Sending DELETE requests to Apache server" />
 
-2. Verify Logs in Apache
+**Verify locally** that Apache is writing log entries to the Apache log files:
 
-- Verify that the requests are being logged in the `access_log` file.
-
-```
+```bash
 sudo tail -f /var/log/httpd/access_log
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-01e06ec6-e80a-4add-b463-5051fd10c75c.webp" alt="Verifying access logs in Apache" caption="Verifying access logs in Apache" />
+<Figure src="/img/guides/2024/07/apache-log-01e06ec6-e80a-4add-b463-5051fd10c75c.webp" alt="Verifying access logs in Apache" caption="Verifying Apache access log entries" />
 
-You should see entries corresponding to the requests you generated.
+Check the Apache error log as well:
 
-- Similarly, verify that any errors (if any) are being logged in the `error_log` file.
-
-```
+```bash
 sudo tail -f /var/log/httpd/error_log
 ```
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 12.webp" alt="Verifying Error logs in Apache" caption="Verifying Error logs in Apache" />
+<Figure src="/img/guides/2024/07/apache-log-Untitled%2012.webp" alt="Verifying error logs in Apache" caption="Verifying Apache error log entries" />
 
-3. Verify Logs in SigNoz
+**Check SigNoz** by logging in to your SigNoz Cloud dashboard and navigating to the Logs section. Your Apache log entries should appear in the log explorer within a few seconds of being written to the Apache log files.
 
-- Log in to your SigNoz cloud and navigate to the logs section.
-- Verify that you can see the Apache access and error logs in the SigNoz dashboard.
+<Figure src="/img/guides/2024/07/apache-log-Untitled%2013.webp" alt="Visualizing and monitoring Apache logs in SigNoz Dashboard" caption="Apache logs visible in the SigNoz log explorer" />
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 13.webp" alt="Visualizing and monitoring Apache logs in Signoz Dashboard" caption="Visualizing and monitoring Apache logs in Signoz Dashboard" /> 
+Use the search and filter controls to narrow down Apache log entries by log file name, status code, or any text pattern in the Apache log data.
 
-- Use the search and filter options to find specific log entries related to the requests you generated.
+<Figure src="/img/guides/2024/07/apache-log-Untitled%2014.webp" alt="Filtering Apache logs based on log file name" caption="Filtering Apache log entries by log file name in SigNoz" />
 
-<Figure src="/img/guides/2024/07/apache-log-Untitled 14.webp" alt="Filtering Apache logs based on log file name" caption="Filtering Apache logs based on log file name" />
+With your Apache logs flowing into SigNoz, you can build dashboards for Apache access log analytics, set up alerts on error rate thresholds, and correlate Apache log data with metrics and traces from other services in your infrastructure. This turns SigNoz into the single platform for all your Apache log analysis, Apache log management, and Apache log file analysis needs across your entire fleet.
 
 ## Conclusion
 
-This guide outlines the significance of monitoring Apache logs to maintain optimal server performance and security.
+Apache log files are the primary record of what your web server does. The Apache access log captures every request and response, while the Apache error log captures every failure and warning. 
 
-Some key takeaways include:
-
-- Apache logs are vital in tracking server activity, with access logs detailing client requests and error logs capturing server issues.
-- The two primary types of Apache logs are access logs, which record client requests and server responses, and error logs, which capture server issues and errors encountered during processing.
-- Proper configuration of log paths and formats in the `httpd.conf` file is essential for effective log management and analysis.
-- Analyzing Apache logs aids in performance monitoring, security auditing, troubleshooting, and understanding user behavior through traffic insights.
-- Integrating Apache logs with SigNoz provides real-time visibility, advanced querying, and alerting capabilities, making log management more efficient.
+Configuring the right Apache log format, setting up rotation with logrotate for proper Apache log management, and shipping Apache logs to a centralized platform like SigNoz turns raw text files into a searchable, alertable system for ongoing Apache log analysis and Apache access log analytics across your entire infrastructure.
 
 ## FAQs
 
-### What are Apache logs?
+**Where are Apache log files stored?**
 
-Apache logs are text files generated by the Apache HTTP Server that record various events, requests, and errors occurring on the server. They provide valuable insights into server performance and user activity.
+`/var/log/apache2/` on Debian/Ubuntu, `/var/log/httpd/` on RHEL/CentOS. The exact paths are controlled by the `ErrorLog` and `CustomLog` directives.
 
-### What is Apache log viewer analysis?
+**How do I check Apache access logs in real time?**
 
-Apache log viewer analysis involves examining the entries in Apache log files to understand server performance, troubleshoot issues, and monitor user behavior. This can be done using various tools or scripts that parse and visualize log data.
+Run `tail -f /var/log/httpd/access_log` (RHEL) or `tail -f /var/log/apache2/access.log` (Debian).
 
-### How to check access logs?
+**What are the two types of Apache log files?**
 
-You can check access logs by using command-line tools such as `cat`, `tail`, or `less` on the log file, typically located at `/var/log/apache2/access.log` or `/var/log/httpd/access_log`. For example, use `tail -f /var/log/apache2/access.log` to view logs in real-time.
+The access log (records every client request) and the error log (records server-side failures, warnings, and diagnostics).
 
-### What is the referrer Apache log?
+**What is the difference between Common and Combined Apache access log format?**
 
-The referrer Apache log refers to the URL of the webpage that directed a user to the requested resource. It is logged in the access log and helps track user navigation and traffic sources.
+Common Log Format captures IP, username, timestamp, request, status, and size. The Combined format adds the referrer URL and user agent string, making it better for traffic analysis.
 
-### Where are Apache logs kept?
+**What are the Apache logging levels?**
 
-Apache logs are usually stored in the `/var/log/apache2/` directory on Debian-based systems or `/var/log/httpd/` on Red Hat-based systems. The specific log file names typically include `access.log` and `error.log`.
+Eight levels from most to least severe: `emerg`, `alert`, `crit`, `error`, `warn`, `notice`, `info`, `debug`. Set via the `LogLevel` directive.
 
-### What is Apache and why is it used?
+**How do I rotate Apache log files?**
 
-Apache is an open-source web server software that serves web content over the internet. It is widely used for hosting websites and applications due to its flexibility, reliability, and robust community support.
+Use `logrotate` with a config in `/etc/logrotate.d/`, or use Apache's built-in `rotatelogs` via piped logs. Both are covered in the Apache Log Rotation section above.
 
-### How do I open Apache logs?
+**Where is APACHE_LOG_DIR defined?**
 
-You can open Apache logs using text editors or command-line tools. For example, use `nano /var/log/apache2/access.log` to edit with Nano, or `tail -f /var/log/apache2/error.log` to view logs in real-time.
-
-### What are the two types of log files Apache keeps?
-
-Apache primarily keeps two types of log files: access logs, which record all requests received by the server, and error logs, which capture issues and errors encountered during processing requests.
-
-### What are the Apache LogLevel values?
-
-Apache LogLevel values determine the verbosity of logged messages. Common LogLevel values include `emerg`, `alert`, `crit`, `error`, `warn`, `notice`, `info`, and `debug`.
-
-### Where is Apache_Log_Dir?
-
-The `Apache_Log_Dir` is usually set in the Apache configuration file (`httpd.conf` or `apache2.conf`) and typically points to the directory where log files are stored, commonly `/var/log/apache2/` or `/var/log/httpd/`.
-
-### What are user logs?
-
-User logs refer to entries in the access log that detail individual user requests to the server, including the requested URL, timestamp, response status, and user agent information.
-
-### What is a server log?
-
-A server log is a record of events and transactions processed by a server. It provides insights into server operations, user activity, and system performance.
-
-### What is the purpose of server logs?
-
-The purpose of server logs is to monitor server activity, diagnose issues, analyze traffic patterns, enhance security, and provide a historical record of server operations.
-
-### What are the Apache logging levels?
-
-Apache logging levels indicate the severity of events logged. They range from high-severity levels like `emerg` and `alert` to lower-severity levels like `info` and `debug`.
-
-### Are Apache logs owned by root?
-
-Yes, Apache logs are typically owned by the root user or the Apache user (such as `www-data` or `apache`), depending on the server configuration. This ensures proper permissions and security for log file access.
+In `/etc/apache2/envvars` on Debian/Ubuntu (defaults to `/var/log/apache2`). On RHEL/CentOS it is set directly in `httpd.conf`.
 
 ## Resources
 
-- [Log Management using SigNoz](https://signoz.io/docs/logs-management/overview/)
-- [Collecting Logs from Files and Monitoring using SigNoz](https://signoz.io/docs/userguide/collect_logs_from_file/)
+- [How to Monitor Apache Server Metrics with OpenTelemetry](https://signoz.io/blog/opentelemetry-apache-server-metrics-monitoring/)
+- [How to Limit Apache Access Log Size and Archives](https://signoz.io/guides/how-can-i-limit-the-size-of-apache-access-log-and-limit-the-number-of-archived-logs-it-keeps/)


### PR DESCRIPTION
## Summary
- Complete rewrite of the Apache logs guide (`data/guides/apache-log.mdx`) with practical examples and OpenTelemetry focus
- Removed AI-generated filler content, replaced with grounded explanations and real-world config examples
- Added OpenTelemetry Collector setup for shipping Apache logs to SigNoz
- Updated frontmatter (date, author, keywords, description)

## Test plan
- [ ] Verify page renders correctly at `/guides/apache-log`
- [ ] Check all code blocks render properly (Apache config, LogFormat directives, OTel Collector YAML)
- [ ] Verify internal and external links work
- [ ] Confirm images/figures render if any exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)