### PR TITLE
docs: fix sidebar navigation and add overview items

### DIFF
--- a/components/AWS/AWSMonitoringListicle.tsx
+++ b/components/AWS/AWSMonitoringListicle.tsx
@@ -63,7 +63,7 @@ export default function AWSMonitoringListicle() {
     '/docs/aws-monitoring/dynamodb': <SiAmazondynamodb className="h-7 w-7 text-blue-500" />,
     '/docs/aws-monitoring/elasticache': <MdMemory className="h-7 w-7 text-blue-500" />,
     '/docs/aws-monitoring/alb': <MdRouter className="h-7 w-7 text-purple-500" />,
-    '/docs/aws-monitoring/elb-logs': <MdRouter className="h-7 w-7 text-purple-500" />,
+    '/docs/aws-monitoring/elb': <MdRouter className="h-7 w-7 text-purple-500" />,
     '/docs/aws-monitoring/vpc': <MdSecurity className="h-7 w-7 text-green-500" />,
     '/docs/aws-monitoring/api-gateway': <MdHttp className="h-7 w-7 text-purple-500" />,
     '/docs/aws-monitoring/msk': <MdCloudQueue className="h-7 w-7 text-black dark:text-white" />,

--- a/constants/componentItems/awsMonitoring.ts
+++ b/constants/componentItems/awsMonitoring.ts
@@ -22,7 +22,7 @@ export const AWS_MONITORING_ITEMS = {
   ] satisfies ComponentItem[],
   networking: [
     { name: 'ALB', href: '/docs/aws-monitoring/alb', clickName: 'ALB Monitoring Link' },
-    { name: 'ELB', href: '/docs/aws-monitoring/elb-logs', clickName: 'ELB Monitoring Link' },
+    { name: 'ELB', href: '/docs/aws-monitoring/elb', clickName: 'ELB Monitoring Link' },
     { name: 'VPC', href: '/docs/aws-monitoring/vpc', clickName: 'VPC Monitoring Link' },
     {
       name: 'API Gateway',

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -8,6 +8,7 @@ const docsSideNav = [
     type: 'category',
     isExpanded: false,
     label: 'Overview',
+    route: '/docs/what-is-signoz',
     items: [
       {
         type: 'doc',
@@ -45,6 +46,11 @@ const docsSideNav = [
     label: 'Setup',
     route: '/docs/install/',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/install/',
+        label: 'Overview',
+      },
       {
         type: 'category',
         isExpanded: false,
@@ -219,6 +225,11 @@ const docsSideNav = [
     isExpanded: false,
     route: '/docs/manage/overview',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/manage/overview',
+        label: 'Overview',
+      },
       {
         type: 'category',
         isExpanded: false,
@@ -617,6 +628,11 @@ const docsSideNav = [
     isExpanded: false,
     route: '/docs/opentelemetry-collection-agents/get-started',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/opentelemetry-collection-agents/get-started',
+        label: 'Overview',
+      },
       {
         type: 'category',
         isExpanded: false,
@@ -3961,6 +3977,11 @@ const docsSideNav = [
     isExpanded: false,
     route: '/docs/migration/migrate-to-signoz',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/migration/migrate-to-signoz',
+        label: 'Overview',
+      },
       {
         label: 'From Datadog',
         type: 'category',

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -1992,6 +1992,7 @@ const docsSideNav = [
     label: 'Cost Meter',
     type: 'category',
     isExpanded: false,
+    route: '/docs/cost-meter/overview',
     items: [
       {
         type: 'doc',
@@ -2050,7 +2051,7 @@ const docsSideNav = [
     label: 'Dashboards',
     type: 'category',
     isExpanded: false,
-    // route: '',
+    route: '/docs/dashboards/overview',
     items: [
       {
         type: 'doc',
@@ -2564,7 +2565,7 @@ const docsSideNav = [
     label: 'Querying Data',
     type: 'category',
     isExpanded: false,
-    // route: '',
+    route: '/docs/querying/overview',
     items: [
       {
         type: 'doc',
@@ -2874,6 +2875,11 @@ const docsSideNav = [
 
     items: [
       {
+        route: '/docs/llm-observability',
+        label: 'Overview',
+        type: 'doc',
+      },
+      {
         route: '/docs/agno-monitoring',
         label: 'Agno',
         type: 'doc',
@@ -3179,6 +3185,11 @@ const docsSideNav = [
     items: [
       {
         type: 'doc',
+        route: '/docs/aws-monitoring/overview',
+        label: 'Overview',
+      },
+      {
+        type: 'doc',
         route: '/docs/aws-monitoring/one-click-vs-manual',
         label: 'One-Click vs Manual',
       },
@@ -3342,6 +3353,11 @@ const docsSideNav = [
     items: [
       {
         type: 'doc',
+        route: '/docs/frontend-monitoring',
+        label: 'Overview',
+      },
+      {
+        type: 'doc',
         route: '/docs/frontend-monitoring/sending-logs-with-opentelemetry',
         label: 'Sending Logs',
       },
@@ -3388,6 +3404,11 @@ const docsSideNav = [
     items: [
       {
         type: 'doc',
+        route: '/docs/mobile-monitoring',
+        label: 'Overview',
+      },
+      {
+        type: 'doc',
         label: 'Swift UI',
         route: '/docs/instrumentation/mobile-instrumentation/opentelemetry-swiftui',
       },
@@ -3414,6 +3435,11 @@ const docsSideNav = [
     isExpanded: false,
     route: '/docs/integrations/integrations-list',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/integrations/integrations-list',
+        label: 'Overview',
+      },
       {
         type: 'category',
         isExpanded: false,
@@ -3644,7 +3670,7 @@ const docsSideNav = [
     label: 'Messaging Queues',
     type: 'category',
     isExpanded: false,
-    // route: '',
+    route: '/docs/messaging-queues/overview',
     items: [
       {
         type: 'doc',
@@ -3716,6 +3742,7 @@ const docsSideNav = [
     label: 'External API Monitoring',
     type: 'category',
     isExpanded: false,
+    route: '/docs/external-api-monitoring/overview',
     items: [
       {
         type: 'doc',
@@ -3725,23 +3752,6 @@ const docsSideNav = [
       {
         type: 'doc',
         route: '/docs/external-api-monitoring/setup',
-        label: 'Setup',
-      },
-    ],
-  },
-  {
-    label: 'Trace Funnels',
-    type: 'category',
-    isExpanded: false,
-    items: [
-      {
-        type: 'doc',
-        route: '/docs/trace-funnels/overview',
-        label: 'Overview',
-      },
-      {
-        type: 'doc',
-        route: '/docs/trace-funnels/setup',
         label: 'Setup',
       },
     ],
@@ -3824,6 +3834,7 @@ const docsSideNav = [
     label: 'Ingestion',
     type: 'category',
     isExpanded: false,
+    route: '/docs/ingestion/signoz-cloud/overview',
     items: [
       {
         label: 'SigNoz Cloud',
@@ -4129,6 +4140,11 @@ const docsSideNav = [
     route: '/docs/azure-monitoring',
     items: [
       {
+        type: 'doc',
+        route: '/docs/azure-monitoring',
+        label: 'Overview',
+      },
+      {
         type: 'category',
         isExpanded: false,
         label: 'Bootstrapping',
@@ -4284,6 +4300,11 @@ const docsSideNav = [
     isExpanded: false,
     route: '/docs/gcp-monitoring',
     items: [
+      {
+        type: 'doc',
+        route: '/docs/gcp-monitoring',
+        label: 'Overview',
+      },
       {
         type: 'category',
         isExpanded: false,

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -2875,9 +2875,9 @@ const docsSideNav = [
 
     items: [
       {
+        type: 'doc',
         route: '/docs/llm-observability',
         label: 'Overview',
-        type: 'doc',
       },
       {
         route: '/docs/agno-monitoring',

--- a/data/docs/frontend-monitoring.mdx
+++ b/data/docs/frontend-monitoring.mdx
@@ -1,41 +1,53 @@
 ---
-date: 2025-11-11
+date: 2026-05-25
 id: frontend-monitoring
-title: Monitor your Frontend applications
-
-description: Learn how to instrument your frontend application with OpenTelemetry.
+title: Frontend Monitoring
+description: Monitor your frontend applications with SigNoz using OpenTelemetry to collect logs, traces, metrics, and Web Vitals.
 ---
 
+## Overview
+
+SigNoz provides frontend monitoring powered by OpenTelemetry, giving you visibility into your web application's performance, errors, and user experience. By instrumenting your frontend with OpenTelemetry, you can collect and correlate logs, traces, and metrics alongside your backend telemetry for end-to-end observability.
+
+### What You Can Monitor
+
+- **Logs** — Capture frontend errors, warnings, and custom log events
+- **Traces** — Track user interactions, API calls, and page navigations with distributed tracing
+- **Metrics** — Collect custom frontend metrics for dashboards and alerts
+- **Web Vitals** — Monitor Core Web Vitals (LCP, FID, CLS, INP, TTFB) to measure real user experience
+- **Document Load** — Track page load performance including DNS, TCP, and resource timing
+
+## Get Started
 
 <DocCardContainer>
 
 <DocCard
-    title="📄️ Sending Logs"
-    description="Send logs from your frontend application using SigNoz"
+    title="Sending Logs"
+    description="Send logs from your frontend application using OpenTelemetry"
     href="/docs/frontend-monitoring/sending-logs-with-opentelemetry"
 />
 
 <DocCard
-    title="📄️ Sending Traces"
-    description="Send traces from your frontend application using SigNoz"
+    title="Sending Traces"
+    description="Send traces from your frontend application using OpenTelemetry"
     href="/docs/frontend-monitoring/sending-traces-with-opentelemetry"
 />
 
 <DocCard
-    title="📄️ Sending Metrics"
-    description="Send metrics from your frontend application using SigNoz"
+    title="Sending Metrics"
+    description="Send metrics from your frontend application using OpenTelemetry"
     href="/docs/frontend-monitoring/sending-metrics-with-opentelemetry"
 />
 
 <DocCard
-    title="📄️ Web Vitals"
-    description="Monitor your application's web vitals using SigNoz"
+    title="Web Vitals"
+    description="Monitor Core Web Vitals to measure real user experience"
     href="/docs/frontend-monitoring/opentelemetry-web-vitals"
 />
 
 <DocCard
-    title="📄️ Document Load"
-    description="Send document load times from your frontend application using SigNoz"
+    title="Document Load"
+    description="Track page load performance with document load instrumentation"
     href="/docs/frontend-monitoring/document-load"
 />
 

--- a/data/docs/livekit-observability.mdx
+++ b/data/docs/livekit-observability.mdx
@@ -36,14 +36,14 @@ Get started with a sample LiveKit starter project by following the <a href="http
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 
 
-### **Step 1:** Clone the sample voice agent project and setup dependencies
+### Step 1: Clone the sample voice agent project and setup dependencies
 
 ```bash
 git clone https://github.com/livekit-examples/agent-starter-python
 cd agent-starter-python
 uv sync
 ```
-### **Step 2:** Setup Credentials
+### Step 2: Setup Credentials
 
 Copy .env.example to .env.local and filling in the required keys:
 
@@ -57,14 +57,14 @@ lk cloud auth
 lk app env -w -d .env.local
 ```
 
-### **Step 3:** Add Automatic Instrumentation
+### Step 3: Add Automatic Instrumentation
 
 ```bash
 uv pip install opentelemetry-distro opentelemetry-exporter-otlp
 uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 ```
 
-### **Step 4:** Instrument your LiveKit application
+### Step 4: Instrument your LiveKit application
 
 **Metrics:**
 
@@ -88,7 +88,7 @@ set_tracer_provider(trace.get_tracer_provider())
 
 See this <a href="https://github.com/livekit/agents/blob/main/examples/voice_agents/langfuse_trace.py" target="_blank" rel="noopener noreferrer nofollow">example repo</a> for more details on how to configure instrumentation.
 
-### **Step 5:** Your `agent.py` should look something like this:
+### Step 5: Your `agent.py` should look something like this:
 
 ```python
 import logging
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
 ```
 
-### **Step 6:** Run your application with auto-instrumentation
+### Step 6: Run your application with auto-instrumentation
 
 Before your first run, you must download certain models such as Silero VAD and the LiveKit turn detector:
 
@@ -235,14 +235,14 @@ OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true \
 
 Code-based instrumentation gives you fine-grained control over your telemetry configuration. Use this approach when you need to customize resource attributes, sampling strategies, or integrate with existing observability infrastructure.
 
-### **Step 1:** Clone the sample voice agent project and setup dependencies
+### Step 1: Clone the sample voice agent project and setup dependencies
 
 ```bash
 git clone https://github.com/livekit-examples/agent-starter-python
 cd agent-starter-python
 uv sync
 ```
-### **Step 2:** Setup Credentials
+### Step 2: Setup Credentials
 
 Copy .env.example to .env.local and filling in the required keys:
 
@@ -257,7 +257,7 @@ lk app env -w -d .env.local
 ```
 
 
-### **Step 3:** Install additional OpenTelemetry dependencies
+### Step 3: Install additional OpenTelemetry dependencies
 
 ```bash
 uv pip install \
@@ -268,7 +268,7 @@ uv pip install \
   opentelemetry-instrumentation-system-metrics
 ```
 
-### **Step 4:** Import the necessary modules in your Python application
+### Step 4: Import the necessary modules in your Python application
 
 **Traces:**
 
@@ -301,7 +301,7 @@ from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrument
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 ```
 
-### **Step 5:** Set up the OpenTelemetry Tracer Provider to send traces directly to SigNoz Cloud
+### Step 5: Set up the OpenTelemetry Tracer Provider to send traces directly to SigNoz Cloud
 
 ```python
 from opentelemetry.sdk.resources import Resource
@@ -333,7 +333,7 @@ trace.set_tracer_provider(provider)
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>.
 </Admonition>
 
-### **Step 6**: Setup Logs
+### Step 6: Setup Logs
 
 ```python
 import logging
@@ -372,7 +372,7 @@ logger = logging.getLogger(__name__)
   <a href="/docs/ingestion/cloud-vs-self-hosted#cloud-to-self-hosted">Cloud → Self-Hosted</a>.
 </Admonition>
 
-### **Step 7**: Setup Metrics
+### Step 7: Setup Metrics
 
 ```python
 from opentelemetry.sdk.resources import Resource
@@ -411,7 +411,7 @@ HTTPXClientInstrumentor().instrument()
 
 > 📌 Note: SystemMetricsInstrumentor provides system metrics (CPU, memory, etc.), and HTTPXClientInstrumentor provides outbound HTTP request metrics such as request duration. If you want to add custom metrics to your LiveKit application, see [Python Custom Metrics](https://signoz.io/opentelemetry/python-custom-metrics/).
 
-### **Step 8:** Instrument your LiveKit application
+### Step 8: Instrument your LiveKit application
 
 **Metrics:**
 
@@ -435,7 +435,7 @@ set_tracer_provider(trace.get_tracer_provider())
 
 See this <a href="https://github.com/livekit/agents/blob/main/examples/voice_agents/langfuse_trace.py" target="_blank" rel="noopener noreferrer nofollow">example repo</a> for more details on how to configure instrumentation.
 
-### **Step 9:** Run your example `agent.py`
+### Step 9: Run your example `agent.py`
 
 Before your first run, you must download certain models such as Silero VAD and the LiveKit turn detector:
 

--- a/data/docs/mobile-monitoring.mdx
+++ b/data/docs/mobile-monitoring.mdx
@@ -1,33 +1,47 @@
 ---
-date: 2024-06-06
+date: 2026-05-25
 id: mobile-instrumentation
-title: Monitor your Mobile applications
+title: Mobile Monitoring
+description: Monitor your mobile applications with SigNoz using OpenTelemetry to collect traces, logs, and performance data from iOS and Android apps.
 ---
 
+## Overview
+
+SigNoz supports mobile application monitoring through OpenTelemetry instrumentation. By adding the OpenTelemetry SDK to your iOS or Android app, you can send traces, logs, and performance data to SigNoz — giving you visibility into app behavior, API call latency, errors, and crashes alongside your backend telemetry.
+
+### Supported Platforms
+
+- **iOS** — Swift UI applications using the OpenTelemetry Swift SDK
+- **Android** — Java and Kotlin applications using the OpenTelemetry Android SDK
+- **Cross-Platform** — Flutter applications for both iOS and Android
+
+## Get Started
+
+Choose your platform to set up mobile instrumentation:
 
 <DocCardContainer>
 
 <DocCard
-    title="📄️ Swift UI"
-    description="Send events from your Swift iOS Mobile App to SigNoz."
+    title="Swift UI"
+    description="Send events from your Swift iOS mobile app to SigNoz"
     href="/docs/instrumentation/mobile-instrumentation/opentelemetry-swiftui"
 />
 
 <DocCard
-    title="📄️ Java"
-    description="Send events from your Java Android Mobile App to SigNoz."
+    title="Java"
+    description="Send events from your Java Android mobile app to SigNoz"
     href="/docs/instrumentation/mobile-instrumentation/opentelemetry-java"
 />
 
 <DocCard
-    title="📄️ Kotlin"
-    description="Send events from your Kotlin Android Mobile App to SigNoz."
+    title="Kotlin"
+    description="Send events from your Kotlin Android mobile app to SigNoz"
     href="/docs/instrumentation/mobile-instrumentation/opentelemetry-kotlin"
 />
 
 <DocCard
-    title="📄️ Flutter"
-    description="Send events from your Flutter Android/iOS Mobile App to SigNoz."
+    title="Flutter"
+    description="Send events from your Flutter Android/iOS mobile app to SigNoz"
     href="/docs/instrumentation/mobile-instrumentation/opentelemetry-flutter"
 />
 


### PR DESCRIPTION
[Doc](https://signoz-web-git-docs-fix-sidebar-navigation-signoz.vercel.app/docs/opentelemetry-collection-agents/get-started/)
## Summary
- **Direct-open routes**: Clicking Cost Meter, Dashboards, Querying Data, Messaging Queues, External API Monitoring, and Ingestion in the sidebar now opens the overview page directly (like Alerts does)
- **Overview items added**: LLM Observability, AWS Monitoring, Frontend Monitoring, Mobile Monitoring, Integrations, Azure Monitoring, and GCP Monitoring now show an Overview entry in the sidebar
- **Removed stale Trace Funnels**: Standalone sidebar category removed (entries under APM/Traces remain)
- **ELB listicle fix**: AWS overview page ELB link corrected from `/elb-logs` to `/elb`

## Test plan
- [ ] Verify each sidebar category opens its overview page on click
- [ ] Verify Overview items appear as the first entry in each updated section
- [ ] Verify Trace Funnels no longer appears as a standalone sidebar category
- [ ] Verify AWS overview page ELB card links to correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)