### PR TITLE
feat: breadcrumb ui

### DIFF
--- a/app/(site)/(opentelemetry-hub-routes)/blog/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/blog/[...slug]/page.tsx
@@ -13,7 +13,7 @@ import siteMetadata from '@/data/siteMetadata'
 import { notFound } from 'next/navigation'
 import React from 'react'
 import JsonLdScript from '@/components/JsonLdScript'
-import { generateSectionArticleBreadcrumb } from '@/utils/breadcrumbSchema'
+import { buildBreadcrumbSchema, getSectionArticleBreadcrumbs } from '@/utils/breadcrumbSchema'
 import { fetchBlogBySlug } from '@/utils/cachedData'
 import { getCachedAuthors } from '@/utils/cmsAuthors'
 import { mdxOptions } from '@/utils/mdxUtils'
@@ -111,7 +111,8 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   })
   const mainContent = coreContent(post)
   const jsonLd = post.structuredData
-  const breadcrumbJsonLd = generateSectionArticleBreadcrumb('blog', post.title, slug)
+  const breadcrumbs = getSectionArticleBreadcrumbs('blog', post.title, slug)
+  const breadcrumbJsonLd = buildBreadcrumbSchema(breadcrumbs)
 
   let compiledContent
   try {
@@ -144,6 +145,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
           toc={post.toc}
           showSidebar={hubContext.pathKey !== 'quick-start' && hubContext.items.length > 0}
           authorDirectory={authorDirectory}
+          breadcrumbs={breadcrumbs}
         >
           {compiledContent}
         </OpenTelemetryHubContent>
@@ -177,6 +179,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
         authors={authorList}
         toc={post.toc}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {compiledContent}
         {layoutName === 'NewsroomLayout' && <PageFeedback />}

--- a/app/(site)/(opentelemetry-hub-routes)/comparisons/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/comparisons/[...slug]/page.tsx
@@ -15,7 +15,7 @@ import { fetchComparisonBySlug } from '@/utils/cachedData'
 import { mdxOptions } from '@/utils/mdxUtils'
 import { compileMDX, MDXRemoteProps } from 'next-mdx-remote/rsc'
 import JsonLdScript from '@/components/JsonLdScript'
-import { generateSectionArticleBreadcrumb } from '@/utils/breadcrumbSchema'
+import { buildBreadcrumbSchema, getSectionArticleBreadcrumbs } from '@/utils/breadcrumbSchema'
 import { getCachedAuthors } from '@/utils/cmsAuthors'
 
 const defaultLayout = 'ComparisonsLayout'
@@ -111,7 +111,8 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   })
   const mainContent = coreContent(post)
   const jsonLd = post.structuredData
-  const breadcrumbJsonLd = generateSectionArticleBreadcrumb('comparisons', post.title, slug)
+  const breadcrumbs = getSectionArticleBreadcrumbs('comparisons', post.title, slug)
+  const breadcrumbJsonLd = buildBreadcrumbSchema(breadcrumbs)
 
   const hubContext = await getHubContextForRoute(currentRoute)
 
@@ -140,6 +141,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
           toc={post.toc}
           showSidebar={hubContext.pathKey !== 'quick-start' && hubContext.items.length > 0}
           authorDirectory={authorDirectory}
+          breadcrumbs={breadcrumbs}
         >
           {compiledContent}
         </OpenTelemetryHubContent>
@@ -168,6 +170,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
         authors={authorList}
         toc={post.toc}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {compiledContent}
       </Layout>

--- a/app/(site)/(opentelemetry-hub-routes)/guides/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/guides/[...slug]/page.tsx
@@ -15,10 +15,8 @@ import { fetchGuideBySlug } from '@/utils/cachedData'
 import { mdxOptions } from '@/utils/mdxUtils'
 import { compileMDX, MDXRemoteProps } from 'next-mdx-remote/rsc'
 import JsonLdScript from '@/components/JsonLdScript'
-import { generateSectionArticleBreadcrumb } from '@/utils/breadcrumbSchema'
+import { buildBreadcrumbSchema, getSectionArticleBreadcrumbs } from '@/utils/breadcrumbSchema'
 import GrafanaVsSigNozFloatingCard from '@/components/GrafanaVsSigNoz/GrafanaVsSigNozFloatingCard'
-import Button from '@/components/ui/Button'
-import { SidebarIcons } from '@/components/sidebar-icons/icons'
 import { getCachedAuthors } from '@/utils/cmsAuthors'
 
 const defaultLayout = 'GuidesLayout'
@@ -116,7 +114,8 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   })
   const mainContent = coreContent(post)
   const jsonLd = post.structuredData
-  const breadcrumbJsonLd = generateSectionArticleBreadcrumb('guides', post.title, slug)
+  const breadcrumbs = getSectionArticleBreadcrumbs('guides', post.title, slug)
+  const breadcrumbJsonLd = buildBreadcrumbSchema(breadcrumbs)
 
   const hubContext = await getHubContextForRoute(currentRoute)
 
@@ -145,6 +144,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
           toc={post.toc}
           showSidebar={hubContext.pathKey !== 'quick-start' && hubContext.items.length > 0}
           authorDirectory={authorDirectory}
+          breadcrumbs={breadcrumbs}
         >
           {compiledContent}
           {isGrafanaOrPrometheusArticle && <GrafanaVsSigNozFloatingCard />}
@@ -169,21 +169,13 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
       <JsonLdScript data={jsonLd} />
       <JsonLdScript data={breadcrumbJsonLd} />
 
-      <div className="container mx-auto">
-        <Button variant={'ghost'} to={`/guides/`} className="ml-3.5 mt-10 hover:bg-transparent">
-          <span className="flex items-center">
-            <SidebarIcons.ArrowLeft />
-            <span className="pl-1.5 text-sm">Back to Guides</span>
-          </span>
-        </Button>
-      </div>
-
       <Layout
         content={mainContent}
         authorDetails={authorDetails}
         authors={authorList}
         toc={post.toc}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {compiledContent}
       </Layout>

--- a/app/(site)/(opentelemetry-hub-routes)/opentelemetry/[...slug]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/opentelemetry/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import { getHubContextForRoute } from '@/utils/opentelemetryHub'
 import { fetchMDXContentByPath, MDXContent } from '@/utils/strapi'
 import { generateStructuredData } from '@/utils/structuredData'
 import JsonLdScript from '@/components/JsonLdScript'
+import { buildBreadcrumbSchema, getSectionArticleBreadcrumbs } from '@/utils/breadcrumbSchema'
 import { compileMDX, MDXRemoteProps } from 'next-mdx-remote/rsc'
 import readingTime from 'reading-time'
 import { CoreContent } from 'pliny/utils/contentlayer'
@@ -215,6 +216,9 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
       }
     : null
 
+  const breadcrumbs = getSectionArticleBreadcrumbs('opentelemetry', content.title, path)
+  const breadcrumbJsonLd = buildBreadcrumbSchema(breadcrumbs)
+
   const hubContext = await getHubContextForRoute(currentRoute)
 
   if (hubContext) {
@@ -222,6 +226,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
     return (
       <>
         {jsonLd && <JsonLdScript data={jsonLd} />}
+        <JsonLdScript data={breadcrumbJsonLd} />
         <OpenTelemetryHubContent
           content={mainContent}
           authorDetails={authorDetails}
@@ -229,6 +234,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
           toc={toc}
           showSidebar={showSidebar}
           authorDirectory={authorDirectory}
+          breadcrumbs={breadcrumbs}
         >
           <div className="prose max-w-none dark:prose-invert prose-headings:scroll-mt-16">
             {compiledContent}
@@ -246,12 +252,14 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   return (
     <>
       {jsonLd && <JsonLdScript data={jsonLd} />}
+      <JsonLdScript data={breadcrumbJsonLd} />
       <Layout
         content={mainContent}
         authorDetails={authorDetails as any}
         authors={authorList}
         toc={toc}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         <div className="prose max-w-none dark:prose-invert prose-headings:scroll-mt-16">
           {compiledContent}

--- a/app/(site)/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
+++ b/app/(site)/(opentelemetry-hub-routes)/opentelemetry/page/[page]/page.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../../content'
 import { buildListingMetadata } from '../../../metadata'
 import { fetchMDXContentByPath, type MDXContent, type MDXContentApiResponse } from '@/utils/strapi'
+import { generateSectionHubBreadcrumb } from '@/utils/breadcrumbSchema'
+import JsonLdScript from '@/components/JsonLdScript'
 
 export const revalidate = 86400 // 1 day — see CMS_REVALIDATE_INTERVAL
 
@@ -58,17 +60,22 @@ export default async function Page(props: { params: Promise<{ page: string }> })
 
   allArticles.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
+  const breadcrumbJsonLd = generateSectionHubBreadcrumb('opentelemetry', params.page)
+
   return (
-    <ListingPageLayout>
-      <ListingWithSearch
-        posts={allArticles}
-        pageNumber={parseInt(params.page)}
-        pageRoute="opentelemetry"
-        title="OpenTelemetry"
-        description="Articles on OpenTelemetry concepts, implementation, and its use cases."
-        searchPlaceholder="Search for an article..."
-        gridTitle="All Articles"
-      />
-    </ListingPageLayout>
+    <>
+      <JsonLdScript data={breadcrumbJsonLd} />
+      <ListingPageLayout>
+        <ListingWithSearch
+          posts={allArticles}
+          pageNumber={parseInt(params.page)}
+          pageRoute="opentelemetry"
+          title="OpenTelemetry"
+          description="Articles on OpenTelemetry concepts, implementation, and its use cases."
+          searchPlaceholder="Search for an article..."
+          gridTitle="All Articles"
+        />
+      </ListingPageLayout>
+    </>
   )
 }

--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -9,7 +9,7 @@ import { notFound } from 'next/navigation'
 import DocContent from '@/components/DocContent/DocContent'
 import Chatbase from '@/components/Chatbase'
 import JsonLdScript from '@/components/JsonLdScript'
-import { generateDocsBreadcrumb } from '@/utils/breadcrumbSchema'
+import { buildBreadcrumbSchema, getDocsBreadcrumbs } from '@/utils/breadcrumbSchema'
 
 export const dynamicParams = false
 
@@ -66,7 +66,8 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   const toc = post?.toc || []
   const { title, hide_table_of_contents } = mainContent
   const jsonLd = post.structuredData
-  const breadcrumbJsonLd = generateDocsBreadcrumb(slug, title)
+  const breadcrumbs = getDocsBreadcrumbs(slug, title)
+  const breadcrumbJsonLd = buildBreadcrumbSchema(breadcrumbs)
 
   return (
     <>
@@ -79,6 +80,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
           toc={toc}
           hideTableOfContents={hide_table_of_contents || false}
           editLink={`https://github.com/SigNoz/signoz-web/edit/main/data/docs/${slug}.mdx`}
+          breadcrumbs={breadcrumbs}
         />
       </div>
       <Chatbase disableFloatingMessages />

--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,3 @@
-'use client'
 
 import React from 'react'
 import Link from 'next/link'

--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { Home, ChevronRight } from 'lucide-react'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
+import { BASE_URL } from '@/utils/breadcrumbSchema'
+
+interface BreadcrumbProps {
+  crumbs: BreadcrumbCrumb[]
+}
+
+const toRelativePath = (url: string): string => {
+  if (url.startsWith(BASE_URL)) {
+    return url.slice(BASE_URL.length) || '/'
+  }
+  return url
+}
+
+const Separator = () => (
+  <ChevronRight size={12} className="shrink-0 text-signoz_vanilla-400/40" aria-hidden="true" />
+)
+
+export default function Breadcrumb({ crumbs }: BreadcrumbProps) {
+  if (!crumbs || crumbs.length === 0) return null
+
+  // When > 4 crumbs, on mobile: show first + "..." + last 2
+  const truncate = crumbs.length > 4
+  const hiddenStart = 1
+  const hiddenEnd = crumbs.length - 3 // inclusive
+
+  const items: React.ReactNode[] = []
+
+  crumbs.forEach((crumb, index) => {
+    const isFirst = index === 0
+    const isLast = index === crumbs.length - 1
+    const isHiddenOnMobile = truncate && index >= hiddenStart && index <= hiddenEnd
+
+    // Insert mobile-only ellipsis before the first hidden crumb
+    if (truncate && index === hiddenStart) {
+      items.push(
+        <li key="ellipsis" className="flex items-center gap-1.5 md:hidden" aria-hidden="true">
+          <Separator />
+          <span className="text-signoz_vanilla-400">...</span>
+        </li>
+      )
+    }
+
+    items.push(
+      <li
+        key={`${index}-${crumb.name}`}
+        className={`items-center gap-1.5 ${isHiddenOnMobile ? 'hidden md:flex' : 'flex'}`}
+      >
+        {!isFirst && <Separator />}
+
+        {isLast ? (
+          <span
+            aria-current="page"
+            className="max-w-[300px] truncate font-medium text-signoz_vanilla-100"
+          >
+            {crumb.name}
+          </span>
+        ) : isFirst ? (
+          <Link
+            href={toRelativePath(crumb.url)}
+            className="flex items-center text-signoz_vanilla-400 transition-colors hover:text-signoz_robin-400"
+          >
+            <Home size={14} aria-label="Home" />
+          </Link>
+        ) : (
+          <Link
+            href={toRelativePath(crumb.url)}
+            className="whitespace-nowrap text-signoz_vanilla-400 transition-colors hover:text-signoz_robin-400"
+          >
+            {crumb.name}
+          </Link>
+        )}
+      </li>
+    )
+  })
+
+  return (
+    <nav aria-label="Breadcrumb" className="not-prose mb-4">
+      <ol className="flex flex-wrap items-center gap-1.5 p-0 text-sm">{items}</ol>
+    </nav>
+  )
+}

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -69,7 +69,7 @@ const DocContent: React.FC<{
         className={`box-border min-w-0 flex-[1_1_auto] [&_details+details]:mt-8 ${isOnboarding ? '!w-full px-4' : ''}`}
       >
         {breadcrumbs && !isOnboarding && <Breadcrumb crumbs={breadcrumbs} />}
-        <div className="mb-4 flex items-center justify-between gap-2">
+        <div className="m-0 flex items-center justify-between gap-2">
           <div className="flex flex-col items-start gap-2">
             <h1 className="mt-2 text-3xl leading-tight">{title}</h1>
           </div>

--- a/components/DocContent/DocContent.tsx
+++ b/components/DocContent/DocContent.tsx
@@ -14,6 +14,8 @@ import TagsWithTooltips from '@/components/TagsWithTooltips/TagsWithTooltips'
 import { usePathname } from 'next/navigation'
 import { buildCopyMarkdownFromRendered } from '@/utils/docs/buildCopyMarkdownFromRendered'
 import { isDocsOnboardingPathname } from '@/utils/docs/onboardingPath'
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 const DocContent: React.FC<{
   title: string
@@ -21,7 +23,8 @@ const DocContent: React.FC<{
   toc: any
   hideTableOfContents: boolean
   editLink?: string
-}> = ({ title, post, toc, hideTableOfContents, editLink }) => {
+  breadcrumbs?: BreadcrumbCrumb[]
+}> = ({ title, post, toc, hideTableOfContents, editLink, breadcrumbs }) => {
   const pathname = usePathname()
   const lastUpdatedDate = post?.lastmod || post?.date
   const formattedDate = lastUpdatedDate
@@ -65,11 +68,9 @@ const DocContent: React.FC<{
       <div
         className={`box-border min-w-0 flex-[1_1_auto] [&_details+details]:mt-8 ${isOnboarding ? '!w-full px-4' : ''}`}
       >
+        {breadcrumbs && !isOnboarding && <Breadcrumb crumbs={breadcrumbs} />}
         <div className="mb-4 flex items-center justify-between gap-2">
           <div className="flex flex-col items-start gap-2">
-            {!isOnboarding && post.docTags && post.docTags.length > 0 && (
-              <TagsWithTooltips tags={post.docTags} />
-            )}
             <h1 className="mt-2 text-3xl leading-tight">{title}</h1>
           </div>
           {!isIntroductionPage && post.body?.raw && (
@@ -82,7 +83,10 @@ const DocContent: React.FC<{
             />
           )}
         </div>
-        <article ref={articleRef} className="prose prose-slate max-w-none pb-6 dark:prose-invert">
+        {!isOnboarding && post.docTags && post.docTags.length > 0 && (
+          <TagsWithTooltips tags={post.docTags} />
+        )}
+        <article ref={articleRef} className="prose prose-slate max-w-none py-6 dark:prose-invert">
           <MDXLayoutRenderer code={post.body.code} components={components} toc={post.toc || []} />
         </article>
         <div className="mt-8 flex items-center justify-between text-sm">

--- a/layouts/ArticleLayout.tsx
+++ b/layouts/ArticleLayout.tsx
@@ -193,8 +193,8 @@ export default function ArticleLayout({
           <div className="mx-auto box-border w-full min-w-0 max-w-[780px] flex-auto md:px-0 lg:px-4">
             {hasToc && <div className="mb-4 lg:hidden" />}
 
-            <article className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert">
               {breadcrumbs && <Breadcrumb crumbs={breadcrumbs} />}
+            <article className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert">
               <h1 className="text-3xl font-bold">{title}</h1>
               {(formattedUpdatedDate || readingTimeText) && (
                 <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">

--- a/layouts/ArticleLayout.tsx
+++ b/layouts/ArticleLayout.tsx
@@ -18,6 +18,8 @@ import { ProgressBar } from '@/components/ProgressBar/ProgressBar'
 import NewsletterSubscription from '@/components/NewsletterSubscription/NewsletterSubscription'
 import { useScrollToHash } from '@/hooks/useScrollToHash'
 import PageFeedback from '@/components/PageFeedback/PageFeedback'
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 const MAIN_CONTENT_ID = 'article-main'
 
@@ -45,6 +47,7 @@ interface LayoutProps {
   showNewsletter?: boolean
   showRelatedArticles?: boolean
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 const buildRenderedAuthors = (
@@ -117,6 +120,7 @@ export default function ArticleLayout({
   showNewsletter = true,
   showRelatedArticles = true,
   authorDirectory = {},
+  breadcrumbs,
 }: LayoutProps) {
   const { title, relatedArticles } = content
   const mainRef = useRef<HTMLElement | null>(null)
@@ -190,6 +194,7 @@ export default function ArticleLayout({
             {hasToc && <div className="mb-4 lg:hidden" />}
 
             <article className="prose prose-slate max-w-none px-3 py-6 dark:prose-invert">
+              {breadcrumbs && <Breadcrumb crumbs={breadcrumbs} />}
               <h1 className="text-3xl font-bold">{title}</h1>
               {(formattedUpdatedDate || readingTimeText) && (
                 <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">

--- a/layouts/BlogLayout.tsx
+++ b/layouts/BlogLayout.tsx
@@ -3,6 +3,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { AuthorDetail, Blog } from '../types/transformedContent'
 import ArticleLayout, { TocItemProps } from './ArticleLayout'
 import { RegionProvider } from '@/components/Region/RegionContext'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 interface LayoutProps {
   content: CoreContent<Blog>
@@ -11,6 +12,7 @@ interface LayoutProps {
   children: ReactNode
   toc: TocItemProps[]
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 export default function BlogLayout({
@@ -20,6 +22,7 @@ export default function BlogLayout({
   children,
   toc,
   authorDirectory,
+  breadcrumbs,
 }: LayoutProps) {
   return (
     <RegionProvider>
@@ -32,6 +35,7 @@ export default function BlogLayout({
         showNewsletter={true}
         showRelatedArticles={true}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {children}
       </ArticleLayout>

--- a/layouts/ComparisonsLayout.tsx
+++ b/layouts/ComparisonsLayout.tsx
@@ -3,6 +3,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import ArticleLayout, { TocItemProps } from './ArticleLayout'
 import { RegionProvider } from '@/components/Region/RegionContext'
 import type { AuthorDetail, Comparison } from '../types/transformedContent'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 interface LayoutProps {
   content: CoreContent<Comparison>
@@ -11,6 +12,7 @@ interface LayoutProps {
   children: ReactNode
   toc: TocItemProps[]
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 export default function ComparisonsLayout({
@@ -20,6 +22,7 @@ export default function ComparisonsLayout({
   children,
   toc,
   authorDirectory,
+  breadcrumbs,
 }: LayoutProps) {
   return (
     <RegionProvider>
@@ -32,6 +35,7 @@ export default function ComparisonsLayout({
         showNewsletter={true}
         showRelatedArticles={true}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {children}
       </ArticleLayout>

--- a/layouts/GuidesLayout.tsx
+++ b/layouts/GuidesLayout.tsx
@@ -3,6 +3,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import ArticleLayout, { TocItemProps } from './ArticleLayout'
 import { RegionProvider } from '@/components/Region/RegionContext'
 import type { AuthorDetail, Guide } from '../types/transformedContent'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 interface LayoutProps {
   content: CoreContent<Guide>
@@ -11,6 +12,7 @@ interface LayoutProps {
   children: ReactNode
   toc: TocItemProps[]
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 export default function GuidesLayout({
@@ -20,6 +22,7 @@ export default function GuidesLayout({
   children,
   toc,
   authorDirectory,
+  breadcrumbs,
 }: LayoutProps) {
   return (
     <RegionProvider>
@@ -32,6 +35,7 @@ export default function GuidesLayout({
         showNewsletter={true}
         showRelatedArticles={true}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {children}
       </ArticleLayout>

--- a/layouts/OpenTelemetryHubLayout.tsx
+++ b/layouts/OpenTelemetryHubLayout.tsx
@@ -144,8 +144,8 @@ export default function OpenTelemetryHubContent({
       >
         {(showSidebar || hasToc) && <div id={MOBILE_TRIGGER_ID} className="mb-4 lg:hidden" />}
 
-        <article className="prose prose-slate w-full min-w-0 max-w-full break-words px-3 py-6 dark:prose-invert">
           {breadcrumbs && <Breadcrumb crumbs={breadcrumbs} />}
+        <article className="prose prose-slate w-full min-w-0 max-w-full break-words px-3 py-6 dark:prose-invert">
           <h1 className="text-3xl font-bold">{title}</h1>
           {(formattedUpdatedDate || readingTimeText) && (
             <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">

--- a/layouts/OpenTelemetryHubLayout.tsx
+++ b/layouts/OpenTelemetryHubLayout.tsx
@@ -8,6 +8,8 @@ import ArticleMetaDetailsCard, {
 } from '@/components/ArticleMetaDetailsCard/ArticleMetaDetailsCard'
 import OpenTelemetryTocClient from './open-telemetry-hub/OpenTelemetryTocClient'
 import PageFeedback from '@/components/PageFeedback/PageFeedback'
+import Breadcrumb from '@/components/Breadcrumb/Breadcrumb'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 const MOBILE_TRIGGER_ID = 'ot-hub-mobile-trigger'
 
@@ -26,6 +28,7 @@ export interface HubContentProps {
   toc: { url: string; depth: number; value: string }[]
   showSidebar: boolean
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 export function buildRenderedAuthors(
@@ -103,6 +106,7 @@ export default function OpenTelemetryHubContent({
   toc,
   showSidebar,
   authorDirectory = {},
+  breadcrumbs,
 }: HubContentProps) {
   const title = content.title || ''
   const hasToc = Array.isArray(toc) && toc.length > 0
@@ -141,6 +145,7 @@ export default function OpenTelemetryHubContent({
         {(showSidebar || hasToc) && <div id={MOBILE_TRIGGER_ID} className="mb-4 lg:hidden" />}
 
         <article className="prose prose-slate w-full min-w-0 max-w-full break-words px-3 py-6 dark:prose-invert">
+          {breadcrumbs && <Breadcrumb crumbs={breadcrumbs} />}
           <h1 className="text-3xl font-bold">{title}</h1>
           {(formattedUpdatedDate || readingTimeText) && (
             <div className="mb-2 mt-3 flex flex-wrap gap-3 text-xs text-gray-400 lg:hidden">

--- a/layouts/OpenTelemetryLayout.tsx
+++ b/layouts/OpenTelemetryLayout.tsx
@@ -3,6 +3,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { AuthorDetail, Blog } from '../types/transformedContent'
 import ArticleLayout, { TocItemProps } from './ArticleLayout'
 import { RegionProvider } from '@/components/Region/RegionContext'
+import type { BreadcrumbCrumb } from '@/utils/breadcrumbSchema'
 
 interface LayoutProps {
   content: CoreContent<Blog>
@@ -11,6 +12,7 @@ interface LayoutProps {
   children: ReactNode
   toc: TocItemProps[]
   authorDirectory?: Record<string, { name?: string; url?: string; image_url?: string }>
+  breadcrumbs?: BreadcrumbCrumb[]
 }
 
 export default function OpenTelemetryLayout({
@@ -20,6 +22,7 @@ export default function OpenTelemetryLayout({
   children,
   toc,
   authorDirectory,
+  breadcrumbs,
 }: LayoutProps) {
   return (
     <RegionProvider>
@@ -32,6 +35,7 @@ export default function OpenTelemetryLayout({
         showNewsletter={true}
         showRelatedArticles={true}
         authorDirectory={authorDirectory}
+        breadcrumbs={breadcrumbs}
       >
         {children}
       </ArticleLayout>

--- a/utils/breadcrumbSchema.ts
+++ b/utils/breadcrumbSchema.ts
@@ -9,7 +9,7 @@ type NavItem =
     }
   | string
 
-type BreadcrumbCrumb = {
+export type BreadcrumbCrumb = {
   name: string
   url: string
 }
@@ -27,7 +27,7 @@ type BreadcrumbListSchema = {
   itemListElement: BreadcrumbItem[]
 }
 
-const BASE_URL = 'https://signoz.io'
+export const BASE_URL = 'https://signoz.io'
 
 const SECTION_CONFIG: Record<string, BreadcrumbCrumb> = {
   docs: { name: 'Docs', url: `${BASE_URL}/docs/introduction/` },
@@ -152,7 +152,7 @@ export function buildBreadcrumbSchema(crumbs: BreadcrumbCrumb[]): BreadcrumbList
   }
 }
 
-export function generateDocsBreadcrumb(slug: string, pageTitle: string): BreadcrumbListSchema {
+export function getDocsBreadcrumbs(slug: string, pageTitle: string): BreadcrumbCrumb[] {
   const targetRoute = normalizeDocsRoute(`/docs/${slug}`)
   const map = getAncestryMap()
 
@@ -161,12 +161,10 @@ export function generateDocsBreadcrumb(slug: string, pageTitle: string): Breadcr
   if (targetRoute) {
     const ancestry = map.get(targetRoute)
     if (ancestry && ancestry.length > 0) {
-      // Ancestry includes the target item itself; replace its name with pageTitle
       const ancestors = ancestry.slice(0, -1)
       crumbs.push(...ancestors)
       crumbs.push({ name: pageTitle, url: `${BASE_URL}/docs/${slug}/` })
     } else {
-      // Fallback: derive breadcrumb from URL segments
       const segments = slug.split('/').filter(Boolean)
       if (segments.length > 0) {
         crumbs.push({ name: pageTitle, url: `${BASE_URL}/docs/${slug}/` })
@@ -176,7 +174,24 @@ export function generateDocsBreadcrumb(slug: string, pageTitle: string): Breadcr
     crumbs.push({ name: pageTitle, url: `${BASE_URL}/docs/${slug}/` })
   }
 
-  return buildBreadcrumbSchema(crumbs)
+  return crumbs
+}
+
+export function generateDocsBreadcrumb(slug: string, pageTitle: string): BreadcrumbListSchema {
+  return buildBreadcrumbSchema(getDocsBreadcrumbs(slug, pageTitle))
+}
+
+export function getSectionArticleBreadcrumbs(
+  section: 'blog' | 'guides' | 'comparisons',
+  title: string,
+  slug: string
+): BreadcrumbCrumb[] {
+  const config = SECTION_CONFIG[section]
+  return [
+    HOME_CRUMB,
+    { name: config.name, url: config.url },
+    { name: title, url: `${BASE_URL}/${section}/${slug}/` },
+  ]
 }
 
 export function generateSectionArticleBreadcrumb(
@@ -184,12 +199,7 @@ export function generateSectionArticleBreadcrumb(
   title: string,
   slug: string
 ): BreadcrumbListSchema {
-  const config = SECTION_CONFIG[section]
-  return buildBreadcrumbSchema([
-    HOME_CRUMB,
-    { name: config.name, url: config.url },
-    { name: title, url: `${BASE_URL}/${section}/${slug}/` },
-  ])
+  return buildBreadcrumbSchema(getSectionArticleBreadcrumbs(section, title, slug))
 }
 
 export function generateSectionHubBreadcrumb(

--- a/utils/breadcrumbSchema.ts
+++ b/utils/breadcrumbSchema.ts
@@ -34,6 +34,7 @@ const SECTION_CONFIG: Record<string, BreadcrumbCrumb> = {
   blog: { name: 'Blog', url: `${BASE_URL}/blog/` },
   guides: { name: 'Guides', url: `${BASE_URL}/guides/` },
   comparisons: { name: 'Comparisons', url: `${BASE_URL}/comparisons/` },
+  opentelemetry: { name: 'OpenTelemetry', url: `${BASE_URL}/opentelemetry/` },
 }
 
 const HOME_CRUMB: BreadcrumbCrumb = { name: 'SigNoz', url: `${BASE_URL}/` }
@@ -182,7 +183,7 @@ export function generateDocsBreadcrumb(slug: string, pageTitle: string): Breadcr
 }
 
 export function getSectionArticleBreadcrumbs(
-  section: 'blog' | 'guides' | 'comparisons',
+  section: 'blog' | 'guides' | 'comparisons' | 'opentelemetry',
   title: string,
   slug: string
 ): BreadcrumbCrumb[] {
@@ -195,7 +196,7 @@ export function getSectionArticleBreadcrumbs(
 }
 
 export function generateSectionArticleBreadcrumb(
-  section: 'blog' | 'guides' | 'comparisons',
+  section: 'blog' | 'guides' | 'comparisons' | 'opentelemetry',
   title: string,
   slug: string
 ): BreadcrumbListSchema {
@@ -203,7 +204,7 @@ export function generateSectionArticleBreadcrumb(
 }
 
 export function generateSectionHubBreadcrumb(
-  section: 'blog' | 'guides' | 'comparisons',
+  section: 'blog' | 'guides' | 'comparisons' | 'opentelemetry',
   page?: string
 ): BreadcrumbListSchema {
   const config = SECTION_CONFIG[section]


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Adds a visible breadcrumb navigation UI across all content pages - docs, blog, guides, and comparisons. Previously, breadcrumb data was only used for structured data (JSON-LD SEO schema). This PR refactors the breadcrumb utils to expose the crumb arrays, creates a new `Breadcrumb` component, and threads it through all page types and layouts. Also removes the now-redundant "Back to Guides" button, removes top margin from docs titles, and repositions doc tags below the title header.

#### Screenshots / Screen Recordings (if applicable)

**Docs - What is SigNoz (shallow breadcrumb)**
<img width="1918" height="933" alt="Screenshot 2026-05-29 at 20 09 00" src="https://github.com/user-attachments/assets/571fa417-c15b-4c9f-8fea-396e5bbf3dc5" />

**Docs - Configuration (deep nested breadcrumb)**
<img width="1440" height="900" alt="docs-deep-nested" src="https://github.com/user-attachments/assets/3518c7a3-0c15-4962-8de7-92913fad4abe" />

**Docs - Instrumentation Overview**
<img width="1440" height="900" alt="docs-instrumentation" src="https://github.com/user-attachments/assets/910f6720-f74b-41aa-ab0e-0222c29ca9da" />

**Blog**
<img width="1440" height="900" alt="blog-article" src="https://github.com/user-attachments/assets/6ab6d955-2416-4273-80b8-42fd7b8f47a8" />

**Guides**
<img width="1440" height="900" alt="guides-article" src="https://github.com/user-attachments/assets/a43f4f9d-0068-406d-83ad-ad8e6dc90a4f" />

**Comparisons**
<img width="1440" height="900" alt="comparisons-article" src="https://github.com/user-attachments/assets/3410e5e4-4d80-48ba-a410-e87b6a78a7b6" />

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> N/A — not a bug fix

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (UI component, visual verification)
- Manual verification: Verified breadcrumb rendering on Vercel preview across sample docs, blog, guides, and comparisons pages
- Edge cases covered: Mobile truncation (>4 crumbs shows ellipsis on mobile), pages with no breadcrumbs (graceful null return), onboarding docs pages (breadcrumb hidden)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: All content pages (docs, blog, guides, comparisons) — adds a visual breadcrumb above the title
- Potential regressions: Visual parity
- Rollback plan: Revert PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**Key changes by area:**

1. **New `Breadcrumb` component** (`components/Breadcrumb/Breadcrumb.tsx`):
   - Renders a `Home icon > Section > ... > Page` breadcrumb trail using `next/link`
   - Mobile-responsive truncation: when >4 crumbs, shows first + "..." + last 2 on mobile, full trail on desktop

2. **Refactored `utils/breadcrumbSchema.ts`**:
   - Exported `BreadcrumbCrumb` type and `BASE_URL` constant
   - Split `generateDocsBreadcrumb` into `getDocsBreadcrumbs` (returns crumb array) + `buildBreadcrumbSchema` (wraps in JSON-LD)
   - Split `generateSectionArticleBreadcrumb` into `getSectionArticleBreadcrumbs` + `buildBreadcrumbSchema`
   - Original functions preserved for backward compatibility

3. **Layout integration** - `breadcrumbs` prop threaded through:
   - `DocContent` (docs pages)
   - `ArticleLayout` → used internally in `BlogLayout`, `GuidesLayout`, `ComparisonsLayout`, `OpenTelemetryLayout`
   - `OpenTelemetryHubLayout` (hub content pages)

4. **Minor layout changes in `DocContent`**:
   - Doc tags (`TagsWithTooltips`) moved from above the title to below it
   - "Back to Guides" button removed from guides page (breadcrumb replaces it)
   - Breadcrumb not rendered on docs-onboarding

---
