### PR TITLE
fix: link spacing in mdx content

### DIFF
--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -18,12 +18,7 @@ import siteMetadata from '@/data/siteMetadata'
 
 // Heroicon mini link for auto-linking headers
 const linkIcon = fromHtmlIsomorphic(
-  `<span class="content-header-link">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5 linkicon">
-        <path d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z" />
-        <path d="M11.603 7.963a.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865Z" />
-        </svg>
-    </span>`,
+  `<span class="content-header-link"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5 linkicon"><path d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z" /><path d="M11.603 7.963a.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865Z" /></svg></span>`,
   { fragment: true }
 )
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> New lines in link icon svg introduces empty space on the right misaligning title start and content below, the change inlines svg to single line to avoid this extra space



#### Screenshots / Screen Recordings (if applicable)
> TBA


#### Issues closed by this PR
> NA

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> The start of titles in mdx content are not aligned with content paragraphs in subsequent sections

#### Root Cause
> New lines in svg introduce empty spaces

#### Fix Strategy
> Inline svg in transformation pipeline

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: On preview
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: MDX pipeline link icon addition
- Potential regressions: Link icon might not render correctly
- Rollback plan: Revert the PR


---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---
