### PR TITLE
docs: clarify V3 Trace Details is default for all trace links

### DIFF
--- a/data/docs/userguide/span-details.mdx
+++ b/data/docs/userguide/span-details.mdx
@@ -28,7 +28,9 @@ The Trace Details Page enables you to:
 
 ## Opening a Trace
 
-Select a trace from the [Trace Explorer](https://signoz.io/docs/userguide/traces/) to open the Trace Details page. You will see two synchronized views:
+Any trace link in SigNoz — from the [Trace Explorer](https://signoz.io/docs/userguide/traces/), alerts, dashboards, or correlated logs and metrics — opens the Trace Details page directly. No separate URL or opt-in step is required.
+
+You will see two synchronized views:
 
 - **Flame Graph** — displays a hierarchical representation of the trace, showing the nested relationships between spans. The header shows the total span count and error count. It can render **100,000+ spans** at once.
 - **Waterfall Chart** — provides a detailed timeline view, illustrating the sequence and duration of each span. It supports **10,000+ spans** with virtual scrolling for smooth navigation.
@@ -114,6 +116,8 @@ You can further refine this analysis by adding more resource attributes to narro
 ### Synchronized Navigation
 
 The flame graph and waterfall views remain perfectly synchronized. Clicking a span in one view automatically highlights it in the other and opens the Span Details panel, ensuring you always see where a span fits into the overall trace timeline.
+
+Span selection is local to the view — clicking a span row in the waterfall does not refetch the trace, and the selected row stays in place. Clicking a node in the flame graph scrolls the waterfall to the matching span, including spans near the top and bottom of the visible list. Stepping through spans with the filter **prev/next** arrows or with the browser **Back/Forward** buttons scrolls the waterfall to the correct span in the same way.
 
 <Figure
   src="/img/docs/apm-and-distributed-tracing/trace-details-span-details.webp"
@@ -297,4 +301,4 @@ Click the **Metrics** tab to see infrastructure metrics (CPU usage, memory usage
 
 ## Legacy View
 
-If you prefer the previous trace details interface, click the **Legacy View** button in the top-right corner to switch back. SigNoz remembers your preference for future visits.
+The previous trace details interface is no longer the default for any trace link. If you need to access it, click the **Legacy View** button in the top-right corner of the Trace Details page. SigNoz remembers your preference for future visits.


### PR DESCRIPTION
## Summary
- Clarify in **Opening a Trace** that any trace link in SigNoz (Trace Explorer, alerts, dashboards, correlated logs/metrics) opens the V3 Trace Details page directly — no separate URL or opt-in step.
- In **Synchronized Navigation**, document the new selection/scroll behavior: clicking a span row does not refetch the trace, and flamegraph clicks plus filter prev/next and browser Back/Forward all reliably scroll the waterfall to the correct span.
- In **Legacy View**, state that the previous trace details interface is no longer the default for any trace link.

Source PRs: SigNoz/signoz#11296

## Notes
- No screenshots refreshed in this PR — the V3 UI was already documented and the linked PR is a behavioral fix (scroll/refetch), so existing captures still match what users see.
- Open questions from the deliverable (exact legacy URL path, whether V3 adds net-new capabilities beyond the scroll/refetch fixes, Cloud vs OSS scope, and a full audit of pages with embedded trace screenshots) were left unanswered — follow-up update once clarified.

Auto-generated by docs-sync pipeline (batch_20260604_063453).