### PR TITLE
feat: remind users to verify region when copying endpoint/MCP URLs

### DIFF
--- a/components/Region/RegionAwareComponents.tsx
+++ b/components/Region/RegionAwareComponents.tsx
@@ -148,7 +148,7 @@ export const RegionAwarePre = (props: any) => {
       className="relative"
       onClickCapture={handleClickCapture}
       onMouseOver={(e) => isCopyButtonTarget(e.target) && setHintVisible(true)}
-      onMouseOut={(e) => isCopyButtonTarget(e.target) && setHintVisible(false)}
+      onMouseLeave={() => setHintVisible(false)}
     >
       <Pre {...props}>{renderedChildren}</Pre>
       {hintVisible && (

--- a/components/Region/RegionAwareComponents.tsx
+++ b/components/Region/RegionAwareComponents.tsx
@@ -4,6 +4,14 @@ import React, { Children, isValidElement, cloneElement, ReactNode } from 'react'
 import Pre from 'pliny/ui/Pre'
 import { useRegion } from './RegionContext'
 
+// pliny's <Pre> renders its copy button with this aria-label.
+const COPY_BUTTON_SELECTOR = '[aria-label="Copy code"]'
+
+// Use Element (not HTMLElement): the button's icon is an <svg>/<path>, which are
+// SVGElement, so an HTMLElement check would miss hovers/clicks on the icon itself.
+const isCopyButtonTarget = (target: EventTarget | null) =>
+  target instanceof Element && !!target.closest(COPY_BUTTON_SELECTOR)
+
 type Replacement = {
   search: string
   replace: string
@@ -90,7 +98,7 @@ const processCodeChildren = (children: ReactNode, replacements: Replacement[]): 
 }
 
 export const RegionAwarePre = (props: any) => {
-  const { region } = useRegion()
+  const { region, notifyRegionCopy } = useRegion()
 
   const replacements = React.useMemo(() => {
     const list: Replacement[] = []
@@ -100,15 +108,74 @@ export const RegionAwarePre = (props: any) => {
     return list
   }, [region])
 
+  // Only blocks that originally carry a `<region>` placeholder are region-aware.
+  // Use the combined text content (not per-node): syntax highlighting tokenizes
+  // `<region>` across separate spans, so a per-node check would miss it — the same
+  // reason processCodeChildren falls back to combined text for substitution.
+  const isRegionAware = React.useMemo(
+    () => getTextContent(props.children).includes('<region>'),
+    [props.children]
+  )
+
   const modifiedChildren = React.useMemo(() => {
     if (replacements.length === 0) return props.children
     return processCodeChildren(props.children, replacements)
   }, [props.children, replacements])
 
+  const renderedChildren = Array.isArray(modifiedChildren)
+    ? Children.toArray(modifiedChildren)
+    : modifiedChildren
+
+  const [hintVisible, setHintVisible] = React.useState(false)
+
+  if (!isRegionAware) {
+    return <Pre {...props}>{renderedChildren}</Pre>
+  }
+
+  // What the copy button actually puts on the clipboard (region already substituted).
+  const copiedText = getTextContent(modifiedChildren)
+  const selectedRegion = region && region !== 'none' ? region : ''
+
+  const handleClickCapture = (e: React.MouseEvent) => {
+    if (isCopyButtonTarget(e.target)) {
+      notifyRegionCopy(copiedText)
+    }
+  }
+
   return (
-    <Pre {...props}>
-      {Array.isArray(modifiedChildren) ? Children.toArray(modifiedChildren) : modifiedChildren}
-    </Pre>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      className="relative"
+      onClickCapture={handleClickCapture}
+      onMouseOver={(e) => isCopyButtonTarget(e.target) && setHintVisible(true)}
+      onMouseOut={(e) => isCopyButtonTarget(e.target) && setHintVisible(false)}
+    >
+      <Pre {...props}>{renderedChildren}</Pre>
+      {hintVisible && (
+        <div
+          role="tooltip"
+          className="absolute right-2 top-12 z-20 w-56 rounded-md border border-signoz_slate-500 bg-signoz_ink-400 px-3 py-2 text-xs leading-snug text-signoz_vanilla-100 shadow-[0_8px_30px_rgba(0,0,0,0.45)]"
+        >
+          {selectedRegion ? (
+            <>
+              Heads up: this snippet uses the{' '}
+              <code className="rounded bg-signoz_slate-400 px-1 py-0.5 font-semibold">
+                {selectedRegion}
+              </code>{' '}
+              region. Double-check it matches your workspace region before copying.
+            </>
+          ) : (
+            <>
+              Set your workspace region above — this snippet still uses the{' '}
+              <code className="rounded bg-signoz_slate-400 px-1 py-0.5 font-semibold">
+                &lt;region&gt;
+              </code>{' '}
+              placeholder.
+            </>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/components/Region/RegionContext.tsx
+++ b/components/Region/RegionContext.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useBrowserSearch } from '@/hooks/useBrowserSearch'
 import { isDocsOnboardingPathname } from '@/utils/docs/onboardingPath'
+import { parseCopiedRegion } from './regionCopy'
+import { RegionCopyReminder, RegionCopyReminderState } from './RegionCopyReminder'
 
 interface Cluster {
   cloud_provider: string
@@ -27,6 +29,12 @@ interface RegionContextType {
   cloudRegion: string | null
   setRegion: (region: string | null, cloudRegion: string | null) => void
   isLoading: boolean
+  /**
+   * Show the "double-check your region" reminder if the copied text carries a
+   * region-specific SigNoz URL (or the `<region>` placeholder). No-op otherwise.
+   * Called by copy buttons; Cmd/Ctrl+C is handled by a global listener below.
+   */
+  notifyRegionCopy: (copiedText: string) => void
 }
 
 const FALLBACK_REGIONS: RegionData[] = [
@@ -69,6 +77,8 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [region, setRegionState] = useState<string | null>(null)
   const [cloudRegion, setCloudRegionState] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [copyReminder, setCopyReminder] = useState<RegionCopyReminderState | null>(null)
+  const reminderIdRef = useRef(0)
 
   const router = useRouter()
   const pathname = usePathname()
@@ -131,6 +141,27 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }, [search, regions, isOnboarding])
 
+  const notifyRegionCopy = useCallback((copiedText: string) => {
+    const copied = parseCopiedRegion(copiedText)
+    if (!copied) return
+    reminderIdRef.current += 1
+    setCopyReminder({ id: reminderIdRef.current, copied })
+  }, [])
+
+  const closeReminder = useCallback(() => setCopyReminder(null), [])
+
+  // Catch Cmd/Ctrl+C (and right-click → Copy) of selected text anywhere within
+  // the provider. Copy buttons use the Clipboard API, which does not emit a
+  // `copy` event, so those notify via notifyRegionCopy() directly.
+  useEffect(() => {
+    const handleCopy = () => {
+      const selection = window.getSelection?.()?.toString()
+      if (selection) notifyRegionCopy(selection)
+    }
+    document.addEventListener('copy', handleCopy)
+    return () => document.removeEventListener('copy', handleCopy)
+  }, [notifyRegionCopy])
+
   const setRegion = (newRegion: string | null, newCloudRegion: string | null) => {
     const current = new URLSearchParams(search)
 
@@ -155,8 +186,11 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }
 
   return (
-    <RegionContext.Provider value={{ regions, region, cloudRegion, setRegion, isLoading }}>
+    <RegionContext.Provider
+      value={{ regions, region, cloudRegion, setRegion, isLoading, notifyRegionCopy }}
+    >
       {children}
+      <RegionCopyReminder reminder={copyReminder} onClose={closeReminder} />
     </RegionContext.Provider>
   )
 }

--- a/components/Region/RegionContext.tsx
+++ b/components/Region/RegionContext.tsx
@@ -190,7 +190,7 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       value={{ regions, region, cloudRegion, setRegion, isLoading, notifyRegionCopy }}
     >
       {children}
-      <RegionCopyReminder reminder={copyReminder} onClose={closeReminder} />
+      <RegionCopyReminder key={copyReminder?.id} reminder={copyReminder} onClose={closeReminder} />
     </RegionContext.Provider>
   )
 }

--- a/components/Region/RegionCopyReminder.tsx
+++ b/components/Region/RegionCopyReminder.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { cn } from 'app/lib/utils'
+import { CopiedRegion, REGION_HELP_HREF } from './regionCopy'
+
+export interface RegionCopyReminderState {
+  /** Bumped on every copy so the toast re-arms its auto-dismiss timer and re-animates. */
+  id: number
+  copied: CopiedRegion
+}
+
+interface RegionCopyReminderProps {
+  reminder: RegionCopyReminderState | null
+  onClose: () => void
+}
+
+const AUTO_DISMISS_MS = 6000
+
+const codeClass = 'rounded bg-signoz_slate-400 px-1 py-0.5 text-xs font-semibold'
+
+/**
+ * Transient reminder shown after a region-specific endpoint / MCP URL is copied
+ * (via the copy button or Cmd/Ctrl+C). Auto-dismisses like the site's other
+ * toasts and mirrors the AppTooltip surface so it reads as a native element.
+ */
+export const RegionCopyReminder = ({ reminder, onClose }: RegionCopyReminderProps) => {
+  React.useEffect(() => {
+    if (!reminder) return undefined
+    const timer = setTimeout(onClose, AUTO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [reminder, onClose])
+
+  if (!reminder || !reminder.copied) return null
+
+  const { copied } = reminder
+  const isPlaceholder = copied.kind === 'placeholder'
+  const regionCode = copied.kind === 'region' ? copied.token : ''
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'animate-in fade-in slide-in-from-top-2 duration-200',
+        'fixed left-1/2 top-5 z-[200] w-[380px] max-w-[calc(100vw-2rem)] -translate-x-1/2',
+        'rounded-lg border border-signoz_robin-500 bg-signoz_ink-400 px-4 py-3',
+        'text-sm leading-relaxed text-signoz_vanilla-100 shadow-[0_8px_30px_rgba(0,0,0,0.45)]'
+      )}
+    >
+      {isPlaceholder ? (
+        <p className="m-0">
+          This snippet still contains the <code className={codeClass}>&lt;region&gt;</code>{' '}
+          placeholder. Replace it with your workspace region before using it.
+        </p>
+      ) : (
+        <p className="m-0">
+          Copied a snippet for the <code className={codeClass}>{regionCode}</code> region.
+          Double-check this matches your SigNoz workspace region.
+        </p>
+      )}
+      <Link
+        href={REGION_HELP_HREF}
+        prefetch={false}
+        className="mt-2 inline-block text-xs font-medium text-signoz_robin-400 hover:underline"
+      >
+        How do I find my workspace region? →
+      </Link>
+    </div>
+  )
+}

--- a/components/Region/RegionTable.tsx
+++ b/components/Region/RegionTable.tsx
@@ -4,8 +4,10 @@ import React, { useState, useRef, useEffect } from 'react'
 import { useRegion } from './RegionContext'
 import { Copy, CheckCircle } from 'lucide-react'
 import Button from '@/components/ui/Button'
+import { AppTooltip } from '@/components/ui/AppTooltip'
 
 const CopyCell = ({ text }: { text: string }) => {
+  const { notifyRegionCopy } = useRegion()
   const [copied, setCopied] = useState(false)
   const isCopying = useRef(false)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -17,6 +19,7 @@ const CopyCell = ({ text }: { text: string }) => {
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)
+      notifyRegionCopy(text)
 
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
@@ -43,17 +46,25 @@ const CopyCell = ({ text }: { text: string }) => {
   return (
     <div className="group flex items-center justify-between gap-2">
       <span className="font-mono text-sm">{text}</span>
-      <Button
-        isButton
-        variant="ghost"
-        size="icon"
-        onClick={handleCopy}
-        className="h-6 w-6 p-0 text-gray-400 opacity-0 transition-opacity hover:bg-transparent hover:text-gray-600 group-hover:opacity-100 dark:text-gray-500 dark:hover:text-gray-300"
-        title="Copy to clipboard"
-        aria-label="Copy to clipboard"
-      >
-        {copied ? <CheckCircle className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-      </Button>
+      <AppTooltip content="Double-check this is your workspace region" side="top">
+        <span className="inline-flex">
+          <Button
+            isButton
+            variant="ghost"
+            size="icon"
+            onClick={handleCopy}
+            className="h-6 w-6 p-0 text-gray-400 opacity-0 transition-opacity hover:bg-transparent hover:text-gray-600 group-hover:opacity-100 dark:text-gray-500 dark:hover:text-gray-300"
+            title="Copy to clipboard"
+            aria-label="Copy to clipboard"
+          >
+            {copied ? (
+              <CheckCircle className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </span>
+      </AppTooltip>
     </div>
   )
 }

--- a/components/Region/regionCopy.ts
+++ b/components/Region/regionCopy.ts
@@ -27,8 +27,3 @@ export function parseCopiedRegion(text: string | null | undefined): CopiedRegion
   }
   return null
 }
-
-/** True when the copied text contains a region-specific SigNoz URL or the placeholder. */
-export function copiedTextHasRegion(text: string | null | undefined): boolean {
-  return parseCopiedRegion(text) !== null
-}

--- a/components/Region/regionCopy.ts
+++ b/components/Region/regionCopy.ts
@@ -1,0 +1,34 @@
+// Matches region-specific SigNoz Cloud hosts *after* region substitution, e.g.
+//   ingest.us.signoz.cloud, mcp.eu.signoz.cloud
+// The `<region>` placeholder (pre-substitution) does NOT match here because
+// `<` / `>` fall outside the character class — that case is handled separately below.
+const REGION_HOST_REGEX = /(?:ingest|mcp)\.([a-z0-9-]+)\.signoz\.cloud/i
+
+export const REGION_PLACEHOLDER = '<region>'
+
+export const REGION_HELP_HREF = '/docs/ingestion/signoz-cloud/overview/#endpoint'
+
+export type CopiedRegion = { kind: 'region'; token: string } | { kind: 'placeholder' } | null
+
+/**
+ * Inspect copied text and figure out whether it carries a SigNoz region.
+ * Returns the concrete region token (e.g. `us`) when a region-specific URL is
+ * present, a `placeholder` marker when the `<region>` token is still unfilled,
+ * or `null` when the text is not region-specific.
+ */
+export function parseCopiedRegion(text: string | null | undefined): CopiedRegion {
+  if (!text) return null
+  const match = text.match(REGION_HOST_REGEX)
+  if (match) {
+    return { kind: 'region', token: match[1].toLowerCase() }
+  }
+  if (text.includes(REGION_PLACEHOLDER)) {
+    return { kind: 'placeholder' }
+  }
+  return null
+}
+
+/** True when the copied text contains a region-specific SigNoz URL or the placeholder. */
+export function copiedTextHasRegion(text: string | null | undefined): boolean {
+  return parseCopiedRegion(text) !== null
+}


### PR DESCRIPTION
## Problem

Users copying a SigNoz Cloud **ingestion endpoint** or **MCP server URL** from the docs often don't notice the region selector, so the **default region gets copied silently** — leading to authentication failures when it doesn't match their workspace region.

## What this does

Adds a region reminder that triggers on copy, covering all three copy paths:

| Copy path | Handling |
|---|---|
| Code-block **copy button** (MCP URL, endpoint & config snippets) | `RegionAwarePre` detects the `Copy code` button click |
| **Region table** endpoint copy buttons | `RegionTable`'s `CopyCell` notifies on copy |
| **Cmd+C / Ctrl+C** (or right-click → Copy) | Global `copy` listener in `RegionProvider` reads the selection |

It fires **only** when the copied text carries a region-specific SigNoz URL (`ingest.<region>.signoz.cloud`, `mcp.<region>.signoz.cloud`) or the unfilled `<region>` placeholder — it stays silent on ordinary code blocks and prose.

Two surfaces:
- **Hover tooltip** on the copy buttons ("Heads up: this snippet uses the `us` region…").
- **Post-copy reminder** — a top-center, auto-dismissing toast naming the region actually copied (parsed from the text, so it's correct even for a non-selected region-table row), with a link to *"How do I find my workspace region?"*.

## Screenshots

> Captured on the [Vercel preview](https://signoz-web-git-feat-region-copy-reminder-signoz.vercel.app/docs/ai/signoz-mcp-server/?region=us) (`/docs/ai/signoz-mcp-server/?region=us`).

**Hover tooltip** on the copy button of the MCP URL box:

<img width="849" height="386" alt="SCR-20260607-qypj" src="https://github.com/user-attachments/assets/ac9f3322-f13a-4563-9c4a-248309c821b3" />


**Post-copy reminder** (top-center, auto-dismissing) after clicking copy / Cmd+C:

<img width="701" height="577" alt="SCR-20260607-qysd" src="https://github.com/user-attachments/assets/572deeb7-a212-48fa-948b-60a6d5bb5167" />

## Notable detail

`isRegionAware` detects region blocks via the **combined** text content (`getTextContent(...).includes('<region>')`) rather than per-node. Syntax highlighting tokenizes `<region>` across separate `<span>`s, so a per-node check missed the MCP URL box and the JSON config snippets — this matches the basis the region *substitution* already used.

## Files

- **new** `components/Region/regionCopy.ts` — region-detection helpers
- **new** `components/Region/RegionCopyReminder.tsx` — the post-copy toast
- `components/Region/RegionContext.tsx` — `notifyRegionCopy`, reminder state, global copy listener
- `components/Region/RegionAwareComponents.tsx` — copy-button detection + hover tooltip on region-aware blocks
- `components/Region/RegionTable.tsx` — notify on endpoint copy + hover tooltip

## Verification

- `yarn lint` — clean on all changed files
- `yarn check:stale-urls` / `yarn test:stale-urls` — pass
- `yarn build` — passes (the build is intermittently flaky on unrelated sitemap / `docs-markdown` route prerendering; this change touches none of those, and type-check passes consistently)

Reuses existing surface tokens (`AppTooltip` styling); no new dependencies. Agent-markdown and Copy-Markdown are unaffected (the wrapper `<div>` is transparent to HAST→markdown; the hover tooltip is only in the DOM while hovering).
