### PR TITLE
chore: do not render tooltip and toast in product onbonboarding

### DIFF
--- a/components/Region/RegionAwareComponents.tsx
+++ b/components/Region/RegionAwareComponents.tsx
@@ -98,7 +98,7 @@ const processCodeChildren = (children: ReactNode, replacements: Replacement[]): 
 }
 
 export const RegionAwarePre = (props: any) => {
-  const { region, notifyRegionCopy } = useRegion()
+  const { region, notifyRegionCopy, isOnboarding } = useRegion()
 
   const replacements = React.useMemo(() => {
     const list: Replacement[] = []
@@ -128,7 +128,7 @@ export const RegionAwarePre = (props: any) => {
 
   const [hintVisible, setHintVisible] = React.useState(false)
 
-  if (!isRegionAware) {
+  if (!isRegionAware || isOnboarding) {
     return <Pre {...props}>{renderedChildren}</Pre>
   }
 

--- a/components/Region/RegionContext.tsx
+++ b/components/Region/RegionContext.tsx
@@ -29,10 +29,12 @@ interface RegionContextType {
   cloudRegion: string | null
   setRegion: (region: string | null, cloudRegion: string | null) => void
   isLoading: boolean
+  isOnboarding: boolean
   /**
    * Show the "double-check your region" reminder if the copied text carries a
    * region-specific SigNoz URL (or the `<region>` placeholder). No-op otherwise.
    * Called by copy buttons; Cmd/Ctrl+C is handled by a global listener below.
+   * No-op when source=onboarding (embedded in-product docs).
    */
   notifyRegionCopy: (copiedText: string) => void
 }
@@ -141,12 +143,16 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }, [search, regions, isOnboarding])
 
-  const notifyRegionCopy = useCallback((copiedText: string) => {
-    const copied = parseCopiedRegion(copiedText)
-    if (!copied) return
-    reminderIdRef.current += 1
-    setCopyReminder({ id: reminderIdRef.current, copied })
-  }, [])
+  const notifyRegionCopy = useCallback(
+    (copiedText: string) => {
+      if (isOnboarding) return
+      const copied = parseCopiedRegion(copiedText)
+      if (!copied) return
+      reminderIdRef.current += 1
+      setCopyReminder({ id: reminderIdRef.current, copied })
+    },
+    [isOnboarding]
+  )
 
   const closeReminder = useCallback(() => setCopyReminder(null), [])
 
@@ -187,7 +193,7 @@ export const RegionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   return (
     <RegionContext.Provider
-      value={{ regions, region, cloudRegion, setRegion, isLoading, notifyRegionCopy }}
+      value={{ regions, region, cloudRegion, setRegion, isLoading, isOnboarding, notifyRegionCopy }}
     >
       {children}
       <RegionCopyReminder key={copyReminder?.id} reminder={copyReminder} onClose={closeReminder} />


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> The tooltip and toast notification for copy should not be shown in product onboarding docs



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Extends https://github.com/SigNoz/signoz.io/pull/3434 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Docs copy button tooltip and toast
- Potential regressions: None
- Rollback plan: Revert PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Added an `isOnboarding` check to avoid rendering tooltip and toast in Region aware components

---
