### PR TITLE
refactor: feature page components, double border issues

### DIFF
--- a/.agents/skills/signoz-feature-page-builder/SKILL.md
+++ b/.agents/skills/signoz-feature-page-builder/SKILL.md
@@ -53,14 +53,17 @@ Every feature page should follow this structure (order matters):
 ```
 FeaturePageLayout
   ├── 1. Header (FeaturePageHeader)
-  │     └── Title + description + primary/secondary buttons + hero image
+  │     └── Title + description + buttons (from constants) + hero image
   │
-  ├── 2. Feature Sections (SectionLayout variant="bordered")
-  │     ├── Feature section (split: text + image)
-  │     ├── Feature section (split: image + text)  ← alternate sides
-  │     ├── Feature section (card grid or carousel)
-  │     ├── ... more features as needed
-  │     └── CTA Banner (centered title + ButtonGroup)
+  ├── 2. Feature Sections (SectionLayout variant="bordered" className="!px-0")
+  │     ├── <Divider />
+  │     ├── FeatureShowcase / SplitSection  ← spread data from constants
+  │     ├── <Divider />
+  │     ├── FeatureShowcase / SplitSection  ← alternate sides for splits
+  │     ├── <Divider />
+  │     ├── HeroCards / CarouselCards       ← card grid or carousel
+  │     ├── <Divider />
+  │     └── CTABanner                       ← buttons from constants
   │
   ├── 3. UsageBasedPricing
   │     └── show={['logs', 'traces', 'metrics']} — pick relevant signal types
@@ -76,13 +79,22 @@ FeaturePageLayout
 
 Choose the right component for each section:
 
-- **Alternating text + image feature explanation** → `GridLayout variant="split"` with text on one side, `Image` on the other
+- **Full-width title + description + screenshot** → `FeatureShowcase` (spread data from constants)
+- **Side-by-side text + image** → `SplitSection` (left/right as panel configs or ReactNode)
+- **Two side-by-side feature explanations** → `SplitSection` with `withVerticalDivider`
 - **3+ feature highlights as cards** → `HeroCards` with `FeatureCard` items
 - **Step-by-step interactive walkthrough** → `CarouselCards` with image transitions
 - **Detailed feature explanations with icons** → `IconTitleDescriptionCard` in a grid
-- **CTA banner between sections** → Centered `h2` + `ButtonGroup` in a bordered div
+- **CTA banner** → `CTABanner` (title + buttons from constants)
+- **Section dividers** → `<Divider />` placed between sections in parent composition
 - **Pricing information** → `UsageBasedPricing` component
 - **Social proof** → `CustomerStoriesSection` component
+
+**Do NOT use:**
+- Raw `GridLayout variant="split"` for text+image sections — use `SplitSection` instead
+- Inline `border-t-1 border-dashed border-signoz_slate-400` divs — use `<Divider />` instead
+- Inline `h2` + `ButtonGroup` for CTA banners — use `CTABanner` instead
+- `flex-center` CSS class — use `BUTTON_CLASS_NAME` Tailwind constant instead
 
 ## Content Guidelines
 

--- a/.agents/skills/signoz-feature-page-builder/references/content-patterns.md
+++ b/.agents/skills/signoz-feature-page-builder/references/content-patterns.md
@@ -2,133 +2,148 @@
 
 ## Section Composition Patterns
 
-### Split Feature Section (Text + Image)
+Content sections are built using four shared components: `FeatureShowcase`, `SplitSection`, `CTABanner`, and `HeroCards`. Section dividers are handled by the parent page using `<Divider />`.
 
-The most common section pattern. Text on one side, product screenshot on the other.
+### FeatureShowcase — Full-Width Feature Section
+
+For features where the screenshot needs full width below the text.
 
 ```tsx
-const FeatureSection: React.FC = () => {
-  return (
-    <div className="mt-12 border-y-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-10">
-      <GridLayout variant="split">
-        {/* Text Column */}
-        <div className="flex h-full w-full flex-col justify-center px-6">
-          <div className="flex flex-col justify-between">
-            <h2 className="mb-6 text-signoz_vanilla-100">Section Title</h2>
-            <p className="leading-relaxed text-signoz_vanilla-400">
-              Description paragraph explaining the feature.
-            </p>
-          </div>
-        </div>
-
-        {/* Image Column */}
-        <div className="h-full w-full px-6">
-          <Image
-            src="/img/feature/screenshot.png"
-            alt="Descriptive alt text"
-            width={10000}
-            height={10000}
-          />
-        </div>
-      </GridLayout>
-    </div>
-  )
+// In .constants.tsx
+export const FEATURE_SHOWCASE = {
+  title: 'Section Title',
+  description: 'Description text explaining the feature in 2-3 sentences.',
+  image: '/img/feature/wide-screenshot.png',
+  imageAlt: 'Descriptive alt text',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
 }
-```
 
-**Rules:**
-- Alternate text/image sides between sections for visual rhythm
-- Text column: `flex flex-col justify-center px-6`
-- Image column: `h-full w-full px-6`
-- Wrapper: `border-y-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-10`
-- First section often uses `mt-12` for spacing from header
+// In page component — simplest usage
+const FeatureSection: React.FC = () => {
+  return <FeatureShowcase {...FEATURE_SHOWCASE} />
+}
 
-### Full-Width Feature Section (Text + Wide Image Below)
-
-For features where the screenshot needs full width.
-
-```tsx
-const WideFeatureSection: React.FC = () => {
+// With children (e.g., HeroCards grid between text and image)
+const FeatureWithCards: React.FC = () => {
   return (
-    <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-      <div className="mb-8 max-w-4xl">
-        <h2 className="mb-6 text-signoz_vanilla-100">Section Title</h2>
-        <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-          Description text.
-        </p>
-        <Button variant="secondary" rounded="full" className="flex w-fit items-center gap-2" asChild>
-          <TrackingLink href="/docs/feature/" {...trackingProps}>
-            Read Documentation
-            <ArrowRight size={14} />
-          </TrackingLink>
-        </Button>
-      </div>
-      <Image
-        src="/img/feature/wide-screenshot.png"
-        alt="Descriptive alt text"
-        width={10000}
-        height={10000}
-        className="mb-8"
-      />
-    </div>
+    <FeatureShowcase {...SHOWCASE_DATA} className="px-6 pb-0 pt-6" imageClassName="mb-0">
+      <HeroCards cards={CARDS} layoutVariant="no-border" cols={2} />
+    </FeatureShowcase>
   )
 }
 ```
 
 **Rules:**
 - Text constrained by `max-w-4xl` for readable line length
-- Image sits below text at full section width
+- Image sits below children at full section width
 - Optional inline CTA button between text and image
+- Content data lives in `.constants.tsx`, JSX composition stays in page
 
-### CTA Banner Section
+### SplitSection — Text + Image Side-by-Side
 
-Centered call-to-action between feature sections.
+The most common section pattern. Text on one side, product screenshot on the other.
 
 ```tsx
-const CTABanner: React.FC = () => {
-  const ctaButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'Feature Banner Start Trial',
-        clickLocation: 'Feature Bottom Banner',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/feature/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'Feature Banner Docs',
-        clickLocation: 'Feature Bottom Banner',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
+// In .constants.tsx
+export const LEFT_PANEL = {
+  title: 'Feature Title',
+  description: 'Description paragraph explaining the feature.',
+  button: { text: 'Read Documentation', href: '/docs/feature/' },
+}
 
+export const RIGHT_IMAGE = {
+  src: '/img/feature/screenshot.png',
+  alt: 'Descriptive alt text',
+}
+
+// In page component — panel config + custom ReactNode
+const FeatureSection: React.FC = () => {
   return (
-    <div className="flex flex-col items-center justify-center border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6 py-20">
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        Compelling CTA Headline
-      </h2>
-      <ButtonGroup buttons={ctaButtons} />
-    </div>
+    <SplitSection
+      className="py-10"
+      left={LEFT_PANEL}
+      right={
+        <div className="h-full w-full px-6">
+          <Image src={RIGHT_IMAGE.src} alt={RIGHT_IMAGE.alt} width={10000} height={10000} />
+        </div>
+      }
+    />
+  )
+}
+
+// Two panel configs with vertical divider
+const TwoPanelSection: React.FC = () => {
+  return (
+    <SplitSection
+      className="py-16"
+      left={FINE_TUNE_PANEL}
+      right={MAINTENANCE_PANEL}
+      withVerticalDivider
+    />
   )
 }
 ```
 
 **Rules:**
-- Centered layout with `flex flex-col items-center justify-center`
-- Generous padding: `py-20`
-- Title: `text-center text-4xl text-signoz_vanilla-100`
-- ButtonGroup below title with `mb-6` spacing
+- Alternate text/image sides between sections for visual rhythm
+- Use `withVerticalDivider` when both sides have title+description
+- Panel configs go in `.constants.tsx`; custom ReactNode children stay in JSX
+- First section often uses `className="py-10"`, with the `<Divider className="mt-12" />` above it for spacing
+
+### CTABanner — Call-to-Action Section
+
+Centered call-to-action between feature sections.
+
+```tsx
+// In .constants.tsx
+const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'
+
+export const CTA_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Feature Banner Start Trial',
+      clickLocation: 'Feature Bottom Banner',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Feature Banner Docs',
+      clickLocation: 'Feature Bottom Banner',
+      clickText: 'Read Documentation',
+    },
+  },
+]
+
+// In page component
+const Banner: React.FC = () => {
+  return (
+    <CTABanner
+      title={<>Compelling CTA Headline</>}
+      buttons={CTA_BUTTONS}
+    />
+  )
+}
+```
+
+**Rules:**
+- Title accepts ReactNode — use `<br />` for line breaks
+- Buttons defined in constants with tracking objects
+- Use `BUTTON_CLASS_NAME` constant for button className (Tailwind replacement for `flex-center`)
 
 ### Card Grid Section
 
@@ -153,7 +168,84 @@ const FeatureHighlights: React.FC = () => {
 - `variant="combined"` for connected card look, `"default"` for separated cards
 - Cards defined in constants file
 
+### Section Dividers
+
+Dividers are placed by the parent page between content sections. Content components (`FeatureShowcase`, `SplitSection`, `CTABanner`) do NOT render their own dividers.
+
+```tsx
+// Page composition pattern
+<SectionLayout variant="bordered" className="!px-0">
+  <Divider />
+  <FeatureSection1 />
+  <Divider />
+  <FeatureSection2 />
+  <Divider className="mt-12" />   {/* Extra top margin when needed */}
+  <SplitSection ... />
+  <Divider />
+  <CTABanner ... />
+</SectionLayout>
+```
+
 ## Constants File Patterns
+
+### Button Arrays
+
+```tsx
+// Shared button className constant — Tailwind replacement for `flex-center`
+const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'
+
+export const HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Primary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+]
+```
+
+### FeatureShowcase Data
+
+```tsx
+export const FEATURE_SHOWCASE = {
+  title: 'Section Title',
+  description: 'Description text — string or JSX.',
+  image: '/img/feature/screenshot.png',
+  imageAlt: 'Alt text',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    tracking: { clickType: 'Secondary CTA', ... },  // optional
+  },
+}
+```
+
+### SplitSectionPanel Data
+
+```tsx
+export const PANEL = {
+  title: 'Panel Title',
+  description: 'Panel description — string or JSX with <p> tags.',
+  image: '/img/feature/panel.png',
+  imageAlt: 'Alt text',
+  imageClassName: 'mb-8',  // optional
+  button: { text: 'Read Documentation', href: '/docs/feature/' },  // optional
+}
+
+// Image reference (for custom right-column rendering)
+export const PANEL_IMAGE = {
+  src: '/img/feature/panel.png',
+  alt: 'Alt text',
+}
+```
 
 ### Card Data Structure
 

--- a/.agents/skills/signoz-feature-page-builder/references/copy-to-page-workflow.md
+++ b/.agents/skills/signoz-feature-page-builder/references/copy-to-page-workflow.md
@@ -36,28 +36,35 @@ Read through all the copy and tag each block:
 
 ### Step 2: Count and decide layout
 
-| Content shape | Recommended layout |
+| Content shape | Recommended component |
 |--------------|-------------------|
-| 2-4 `FEATURE_SPLIT` blocks | Alternating split sections (text + image) |
+| Feature with 2+ sentence description + wide screenshot | `FeatureShowcase` (title + desc + image below) |
+| 2-4 `FEATURE_SPLIT` blocks | `SplitSection` (alternating text + image sides) |
+| Two features side-by-side with equal weight | `SplitSection` with `withVerticalDivider` |
 | 3+ `FEATURE_CARD` blocks (short) | `HeroCards` grid (3 cols if 3/6/9 items, 2 cols if 2/4) |
 | 3-5 sequential steps | `CarouselCards` with step images |
-| Mix of splits + cards | Split sections first, then card grid, then CTA |
-| 6+ features, all similar length | Group into 2-3 split sections + 1 card grid |
+| Mix of splits + cards | Split/showcase sections first, then card grid, then CTA |
+| 6+ features, all similar length | Group into 2-3 FeatureShowcase/SplitSection + 1 card grid |
+| CTA text | `CTABanner` with button array from constants |
 
 ### Step 3: Arrange in page order
 
 Always follow this arrangement:
 
 ```
-1. HERO → FeaturePageHeader
-2. Primary FEATURE_SPLIT sections (alternating left/right) → GridLayout split
-3. FEATURE_CARD group (if any) → HeroCards grid
-4. Secondary FEATURE_SPLIT sections → GridLayout split
-5. FEATURE_CAROUSEL (if any) → CarouselCards
-6. CTA → CTA Banner
-7. UsageBasedPricing (auto-added)
-8. SigNozStats (auto-added)
-9. CustomerStoriesSection (auto-added)
+1. HERO → FeaturePageHeader (buttons from constants)
+2. <Divider />
+3. Primary feature sections → FeatureShowcase or SplitSection (data from constants)
+4. <Divider />
+5. FEATURE_CARD group (if any) → HeroCards grid
+6. <Divider />
+7. Secondary feature sections → FeatureShowcase or SplitSection
+8. FEATURE_CAROUSEL (if any) → CarouselCards
+9. <Divider />
+10. CTA → CTABanner (buttons from constants)
+11. UsageBasedPricing (auto-added)
+12. SigNozStats (auto-added)
+13. CustomerStoriesSection (auto-added)
 ```
 
 **Arrangement heuristics:**

--- a/.agents/skills/signoz-feature-page-builder/references/design-checklist.md
+++ b/.agents/skills/signoz-feature-page-builder/references/design-checklist.md
@@ -70,14 +70,25 @@ Run through this checklist before considering a feature page complete.
 
 ## Components
 
-- [ ] Uses shared components from `shared/components/molecules/FeaturePages/` — no custom layout primitives
+- [ ] Uses shared components from `shared/components/molecules/FeaturePages/` — no custom layout primitives or inline section markup
 - [ ] `FeaturePageHeader` for hero section
-- [ ] `ButtonGroup` for grouped CTA buttons
+- [ ] `FeatureShowcase` for title + description + image sections (NOT raw `div` + `h2` + `p` + `Image`)
+- [ ] `SplitSection` for side-by-side text + image layouts (NOT raw `GridLayout variant="split"` with manual columns)
+- [ ] `CTABanner` for CTA sections (NOT inline `div` + `h2` + `ButtonGroup`)
+- [ ] `Divider` between sections (NOT inline `border-t-1 border-dashed border-signoz_slate-400` divs)
 - [ ] `HeroCards` for feature card grids
-- [ ] `GridLayout variant="split"` for text + image sections
+- [ ] `ButtonGroup` for grouped CTA buttons (with `BUTTON_CLASS_NAME` constant, NOT `flex-center`)
 - [ ] `UsageBasedPricing` with relevant signal types
 - [ ] `SigNozStats` present
 - [ ] `CustomerStoriesSection` present as final section
+
+## Data Separation
+
+- [ ] Section content (titles, descriptions, images, button configs) in `.constants.tsx` file
+- [ ] `BUTTON_CLASS_NAME` constant used instead of `flex-center` CSS class
+- [ ] FeatureShowcase data spread as props: `<FeatureShowcase {...SHOWCASE_DATA} />`
+- [ ] SplitSection panel configs as data objects, not inline JSX
+- [ ] Button arrays (header, CTA) defined in constants with tracking objects
 
 ## Build Verification
 

--- a/.agents/skills/signoz-feature-page-builder/references/page-architecture.md
+++ b/.agents/skills/signoz-feature-page-builder/references/page-architecture.md
@@ -67,27 +67,58 @@ export default function Page() {
 'use client'
 
 import React from 'react'
-// ... imports
+import Image from 'next/image'
+import {
+  HEADER_BUTTONS, FEATURE_SHOWCASE, PANEL_DATA, PANEL_IMAGE, CTA_BUTTONS,
+} from './FeatureNamePage.constants'
+import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
+import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
+import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
+import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
+import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
+import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
 
-// Section components (defined in same file or extracted if large)
-const Header: React.FC = () => { /* ... */ }
-const FeatureSection1: React.FC = () => { /* ... */ }
-const FeatureSection2: React.FC = () => { /* ... */ }
-const CTABanner: React.FC = () => { /* ... */ }
+// Section components use shared components + spread constants
+const Header: React.FC = () => (
+  <FeaturePageHeader title={...} description={...} buttons={HEADER_BUTTONS} heroImage="..." />
+)
 
-// Main page component
+const FeatureSection1: React.FC = () => (
+  <FeatureShowcase {...FEATURE_SHOWCASE} />
+)
+
+const FeatureSection2: React.FC = () => (
+  <SplitSection
+    className="py-10"
+    left={PANEL_DATA}
+    right={<div className="h-full w-full px-6"><Image src={PANEL_IMAGE.src} ... /></div>}
+  />
+)
+
+const Banner: React.FC = () => (
+  <CTABanner title={<>CTA Headline</>} buttons={CTA_BUTTONS} />
+)
+
+// Main page — composes sections with <Divider /> between them
 const FeatureNamePage: React.FC = () => {
   return (
     <FeaturePageLayout>
       <Header />
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider />
         <FeatureSection1 />
+        <Divider />
         <FeatureSection2 />
-        <CTABanner />
+        <Divider />
+        <Banner />
       </SectionLayout>
       <UsageBasedPricing show={['logs', 'traces', 'metrics']} />
       <SigNozStats />
-      <CustomerStoriesSection tracking={{ /* ... */ }} />
+      <CustomerStoriesSection tracking={{ clickName: '...', clickLocation: '...' }} />
     </FeaturePageLayout>
   )
 }
@@ -98,8 +129,8 @@ export default FeatureNamePage
 **Key rules:**
 - Marked `'use client'` — required for interactivity and hooks
 - Section components are defined as `React.FC` in the same file (co-located)
-- Sections are only extracted to separate files if they become very large (50+ lines)
-- Main component composes sections in the standard flow
+- Content data is spread from constants: `<FeatureShowcase {...SHOWCASE_DATA} />`
+- `<Divider />` is placed between sections in the main composition — content components do NOT render their own dividers
 - `SectionLayout variant="bordered" className="!px-0"` wraps all feature sections
 
 ## File 3: `<FeatureName>Page.constants.tsx`
@@ -107,6 +138,55 @@ export default FeatureNamePage
 ```tsx
 import { IconName1, IconName2, IconName3 } from 'lucide-react'
 
+const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'
+
+// Button arrays for header and CTA sections
+export const HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Primary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+]
+
+// FeatureShowcase data — spread into component as props
+export const FEATURE_SHOWCASE = {
+  title: 'Section Title',
+  description: 'Section description.',
+  image: '/img/feature/screenshot.png',
+  imageAlt: 'Screenshot alt text',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+}
+
+// SplitSection panel data
+export const LEFT_PANEL = {
+  title: 'Panel Title',
+  description: 'Panel description.',
+  image: '/img/feature/panel.png',
+  imageAlt: 'Panel screenshot',
+  button: { text: 'Read Documentation', href: '/docs/feature/' },
+}
+
+// Separate image reference (when using custom ReactNode for the other panel)
+export const PANEL_IMAGE = {
+  src: '/img/feature/image.png',
+  alt: 'Image alt text',
+}
+
+// Card arrays for HeroCards grids
 export const FEATURE_CARDS = [
   {
     icon: <IconName1 />,
@@ -116,23 +196,46 @@ export const FEATURE_CARDS = [
   // ... more cards
 ]
 
+// Carousel data
 export const CAROUSEL_DATA = [
   {
     id: 0,
     title: 'Step title',
     description: 'Step description',
-    image: '/img/<feature-name>/step-1.png',
+    image: '/img/feature/step-1.png',
     isActive: true,
   },
   // ... more items
+]
+
+// CTA button arrays
+export const CTA_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { ... },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { ... },
+  },
 ]
 ```
 
 **Key rules:**
 - Named exports (not default) — allows selective importing
-- Icons imported from `lucide-react` and rendered as JSX in the data
+- `BUTTON_CLASS_NAME` constant at file top — Tailwind replacement for the old `flex-center` CSS class
+- FeatureShowcase data objects are spread as props: `<FeatureShowcase {...SHOWCASE} />`
+- SplitSection panel configs have `title`, `description`, optional `image`/`button`/`imageClassName`
+- Image references as `{ src, alt }` objects for cases where images are rendered as custom ReactNode
+- Icons imported from `lucide-react` and rendered as JSX in card data
 - Image paths are absolute from `public/` root
-- Card/carousel data follows the type structure expected by shared components
+- SCREAMING_SNAKE_CASE for all constant names
 
 ## Image Directory
 

--- a/.agents/skills/signoz-feature-page-builder/references/shared-components.md
+++ b/.agents/skills/signoz-feature-page-builder/references/shared-components.md
@@ -2,6 +2,238 @@
 
 All components are in `shared/components/molecules/FeaturePages/`. Import with the `@/shared/components/molecules/FeaturePages/` path alias.
 
+## Section Content Components
+
+These are the primary building blocks for feature page content sections. Use these instead of writing custom inline sections.
+
+### FeatureShowcase
+
+Full-width section with title, description, optional button, optional children, and optional image below. Replaces the old inline "title + description + image" pattern.
+
+```tsx
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+
+// Simplest: spread a constants object
+<FeatureShowcase {...SET_MULTIPLE_SEVERITY_THRESHOLDS_SHOWCASE} />
+
+// With children inserted between text and image
+<FeatureShowcase {...CREATE_ALERTS_SHOWCASE} className="px-6 pb-0 pt-6" imageClassName="mb-0">
+  <HeroCards cards={CARDS} layoutVariant="no-border" variant="default" cols={2} />
+</FeatureShowcase>
+
+// Image-only (no title/description) — used as a section intro above a CarouselCards
+<FeatureShowcase
+  {...DRILL_INTO_DOMAINS_SHOWCASE}
+  className="!mx-auto !w-[80vw] px-6 pb-0 pt-6"
+  contentClassName="mb-0"
+/>
+
+// With custom imageElement instead of image path
+<FeatureShowcase
+  {...QUERY_BUILDER_SHOWCASE}
+  imageElement={
+    <>
+      <Image src={IMAGE.src} alt={IMAGE.alt} width={10000} height={10000} className="mb-8" />
+      <HeroCards cards={CARDS} layoutVariant="no-border" variant="combined" />
+    </>
+  }
+/>
+```
+
+**Props:**
+- `title?` (ReactNode): Section heading
+- `description?` (ReactNode): Section body text
+- `image?` (string): Image path — rendered below children
+- `imageAlt?` (string): Alt text for image
+- `imageElement?` (ReactNode): Custom image element — overrides `image`/`imageAlt`
+- `button?` (object): `{ text, href, tracking? }` — renders a secondary CTA button with ArrowRight icon. If `tracking` is provided, wraps in `TrackingLink`.
+- `children?` (ReactNode): Custom content rendered between text/button and image
+- `className?` (string): Override wrapper classes (default: `bg-signoz_ink-500 p-6`)
+- `contentClassName?` (string): Override the title+description+button wrapper (default: `mb-8 max-w-4xl`)
+- `imageClassName?` (string): Override image classes (default: `mb-8`)
+
+**Render order:** title → description → button → children → imageElement/image
+
+**When to use:** Any section that shows a title + description + screenshot. This is the most common section type.
+
+**Constants pattern:**
+```tsx
+// In .constants.tsx
+export const FEATURE_SHOWCASE = {
+  title: 'Section Title',
+  description: 'Section description text.',
+  image: '/img/feature/screenshot.png',
+  imageAlt: 'Descriptive alt text',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+}
+```
+
+### SplitSection
+
+Side-by-side layout with two panels. Each panel can be a config object (auto-rendered with title/description/button/image) or a custom ReactNode. Replaces the old `GridLayout variant="split"` + manual column markup.
+
+```tsx
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
+
+// Both panels as config objects, with vertical divider
+<SplitSection
+  className="py-16"
+  left={FINE_TUNE_PANEL}
+  right={MAINTENANCE_WINDOWS_PANEL}
+  withVerticalDivider
+/>
+
+// Left panel as config, right panel as custom ReactNode
+<SplitSection
+  className="py-10"
+  left={DEFINE_SEQUENCES_PANEL}
+  right={
+    <div className="h-full w-full px-6">
+      <Image src={IMAGE.src} alt={IMAGE.alt} width={10000} height={10000} />
+    </div>
+  }
+/>
+
+// Spreading a panel with extra props merged
+<SplitSection
+  className="py-6"
+  left={{ ...MANAGE_AS_CODE_PANEL, className: 'justify-center' }}
+  right={<div className="h-full w-full px-6">...</div>}
+/>
+
+// Right panel with custom imageElement override
+<SplitSection
+  className="py-16"
+  left={FILTER_PANEL}
+  right={{
+    ...DETECTION_PANEL,
+    imageElement: <div className="flex h-full flex-col items-center justify-center pb-16">...</div>,
+  }}
+  withVerticalDivider
+/>
+```
+
+**Props:**
+- `left` (SplitSectionPanel | ReactNode): Left column content
+- `right` (SplitSectionPanel | ReactNode): Right column content
+- `withVerticalDivider?` (boolean, default: `false`): Show a vertical `<Divider>` between panels
+- `className?` (string): Override wrapper classes (default: `bg-signoz_ink-500`)
+
+**SplitSectionPanel config object:**
+- `title` (ReactNode): Panel heading
+- `description` (ReactNode): Panel body text — can be a string or JSX with multiple `<p>` tags
+- `image?` (string): Image path
+- `imageAlt?` (string): Alt text
+- `imageElement?` (ReactNode): Custom image content — overrides `image`
+- `button?` (object): `{ text, href, tracking? }` — secondary CTA button
+- `className?` (string): Override the panel wrapper (e.g., `'justify-center'`)
+- `contentClassName?` (string): Override the title+description wrapper
+- `imageClassName?` (string): Override image classes
+
+**How panel detection works:** If the value has `title` and `description` keys (and is not a React element), it's treated as a `SplitSectionPanel` config and auto-rendered. Otherwise it's rendered as-is.
+
+**When to use:** Two-column text+image layouts, or two side-by-side feature explanations. Use `withVerticalDivider` when both sides have their own title+description.
+
+**Constants pattern:**
+```tsx
+// In .constants.tsx
+export const LEFT_PANEL = {
+  title: 'Panel Title',
+  description: 'Panel description.',
+  image: '/img/feature/panel-left.png',
+  imageAlt: 'Panel left',
+  button: { text: 'Read Documentation', href: '/docs/feature/' },
+}
+```
+
+### CTABanner
+
+Centered call-to-action banner with title and button group. Replaces all inline CTA banner sections.
+
+```tsx
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
+
+<CTABanner
+  title={<>Stop alert fatigue. <br /> Start catching real issues.</>}
+  buttons={STOP_ALERT_FATIGUE_BUTTONS}
+/>
+```
+
+**Props:**
+- `title` (ReactNode): Centered heading — use `<br />` for line breaks
+- `buttons` (ButtonGroupButton[]): Array of button configs passed to `ButtonGroup`
+- `className?` (string): Override wrapper classes
+
+**Renders:** Centered flex column with `py-20` padding, `text-4xl` title, and `ButtonGroup` below.
+
+**When to use:** Bottom-of-page CTA, or mid-page conversion banners.
+
+**Constants pattern:**
+```tsx
+// In .constants.tsx — define button arrays in constants for reuse
+const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'
+
+export const CTA_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Primary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/feature/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: { clickType: 'Secondary CTA', clickName: '...', clickLocation: '...', clickText: '...' },
+  },
+]
+```
+
+### Divider
+
+Replaces inline `border-t-1 border-dashed border-signoz_slate-400` divs. Use between sections inside a `SectionLayout`.
+
+```tsx
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+
+// Default horizontal dashed divider
+<Divider />
+
+// With extra spacing (e.g., after a section with its own top margin)
+<Divider className="mt-12" />
+
+// Solid variant (used for decorative lines like VS dividers)
+<Divider variant="solid" className="h-px flex-1 border-signoz_sakura-600" />
+
+// Vertical (used inside SplitSection internally, rarely needed directly)
+<Divider orientation="vertical" />
+```
+
+**Props:**
+- `orientation?`: `'horizontal'` (default) | `'vertical'`
+- `variant?`: `'dashed'` (default) | `'solid'`
+- `className?` (string): Additional classes
+
+**When to use:** Between every content section inside `SectionLayout variant="bordered"`. The parent page controls dividers — content components like `FeatureShowcase` and `SplitSection` do NOT render their own dividers.
+
+**Pattern in page composition:**
+```tsx
+<SectionLayout variant="bordered" className="!px-0">
+  <Divider />
+  <FeatureSection1 />
+  <Divider />
+  <FeatureSection2 />
+  <Divider />
+  <CTABanner ... />
+</SectionLayout>
+```
+
 ## Layout Components
 
 ### FeaturePageLayout
@@ -24,7 +256,7 @@ import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/Featur
 
 ### SectionLayout
 
-Container for content sections with consistent width and border treatment.
+Container for content sections with consistent width and border treatment. Manages side-rail borders and max-width — NOT section dividers (use `<Divider />` for those).
 
 ```tsx
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
@@ -47,7 +279,7 @@ import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLay
 
 ### GridLayout
 
-Responsive grid wrapper for multi-column layouts.
+Responsive grid wrapper for multi-column layouts. Rarely used directly — prefer `SplitSection` for two-column layouts.
 
 ```tsx
 import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
@@ -62,7 +294,7 @@ import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 - `className` (string): Additional classes
 
 **Behavior:**
-- `split`: `grid-cols-1 lg:grid-cols-2` — for text + image sections
+- `split`: `grid-cols-1 lg:grid-cols-2` — used internally by `SplitSection`
 - `default`: `grid-cols-1 md:grid-cols-{cols}` — for card grids
 - Gap: `gap-y-8 md:gap-y-16`
 
@@ -78,7 +310,7 @@ import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/Featur
 <FeaturePageHeader
   title={<>Create Visual Funnels from Traces</>}
   description={<>The only tracing tool that tracks multi-step flows.</>}
-  buttons={headerButtons}
+  buttons={HEADER_BUTTONS}
   heroImage="/img/feature/hero.webp"
   heroImageAlt="Feature hero image"
 />
@@ -89,10 +321,11 @@ import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/Featur
 - `description` (ReactNode): Subtitle text
 - `buttons` (array): Button config objects for `ButtonGroup`
 - `buttonGroup` (ReactNode): Custom button component (alternative to `buttons`)
-- `heroImage` (string): Path to hero image
+- `heroImage` (string | ReactNode): Path to hero image, or custom image element
 - `heroImageAlt` (string): Alt text for hero image
-- `buttonDescription` (string): Optional text below buttons
+- `buttonDescription` (string | ReactNode): Optional text below buttons
 - `sectionLayoutVariant`, `sectionLayoutClassName`: Override SectionLayout defaults
+- `align`: `'center'` (default) | `'left'`
 
 ### ButtonGroup
 
@@ -101,12 +334,15 @@ Renders an array of buttons with tracking support.
 ```tsx
 import ButtonGroup from '@/shared/components/molecules/FeaturePages/ButtonGroup'
 
+// Buttons are typically defined in .constants.tsx
+const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'
+
 const buttons = [
   {
     text: 'Start your free trial',
     href: '/teams/',
     variant: 'default' as const,
-    className: 'flex-center',
+    className: BUTTON_CLASS_NAME,
     tracking: {
       clickType: 'Primary CTA',
       clickName: 'Feature Hero Start Trial',
@@ -118,7 +354,7 @@ const buttons = [
     text: 'Read Documentation',
     href: '/docs/feature/',
     variant: 'secondary' as const,
-    className: 'flex-center',
+    className: BUTTON_CLASS_NAME,
     tracking: {
       clickType: 'Secondary CTA',
       clickName: 'Feature Hero Docs',
@@ -135,7 +371,7 @@ const buttons = [
 - `buttons` (array): Each with `text`, `href`, `variant`, `className`, optional `tracking`, optional `icon`
 - `className` (string): Additional wrapper classes
 
-Auto-adds `ArrowRight` icon if no custom icon provided.
+Auto-adds `ArrowRight` icon if no custom icon provided. Use `BUTTON_CLASS_NAME` constant (Tailwind equivalent of `flex-center`) for button className.
 
 ## Card Components
 
@@ -156,7 +392,7 @@ import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 
 **Props:**
 - `cards` (array): Objects with `icon`, `title`, `description`
-- `variant`: `'default'` | `'combined'` — `combined` merges card borders
+- `variant`: `'default'` | `'combined'` — `combined` removes card borders
 - `layoutVariant`: Passed to inner SectionLayout
 - `cols` (number): Grid columns (default: 3)
 - `className` (string): Additional classes

--- a/.agents/skills/signoz-visual-review/SKILL.md
+++ b/.agents/skills/signoz-visual-review/SKILL.md
@@ -73,8 +73,11 @@ On dark backgrounds, sections blend together without explicit visual breaks:
 - **Button hierarchy**: Primary = solid default variant, Secondary = outline/secondary variant, both with `ArrowRight` icon
 - **Hero pattern**: `FeaturePageHeader` with gradient text title, max 2 buttons, hero image below
 - **Image sizing**: Use `width={10000} height={10000}` pattern for responsive images within containers
-- **Split layouts**: `GridLayout variant="split"` for alternating text + image — alternate sides for rhythm
-- **CTA banners**: Centered text with `ButtonGroup`, `py-20` padding
+- **Full-width sections**: `FeatureShowcase` — title + description + optional button + image below
+- **Split layouts**: `SplitSection` for alternating text + image — alternate sides for rhythm; use `withVerticalDivider` for side-by-side features
+- **CTA banners**: `CTABanner` component — centered title + `ButtonGroup`, `py-20` padding
+- **Section dividers**: `<Divider />` placed between sections by the parent page (NOT inside content components)
+- **Data separation**: Section content in `.constants.tsx`, JSX composition in page file
 - **Standard page tail**: `UsageBasedPricing` → `SigNozStats` → `CustomerStoriesSection`
 
 ### Comparison Page Patterns

--- a/app/(site)/agent-native-observability/AgentNativeObservabilityPage.tsx
+++ b/app/(site)/agent-native-observability/AgentNativeObservabilityPage.tsx
@@ -439,16 +439,18 @@ const BottomCTA: React.FC = () => {
 
 const AgentNativeObservabilityPage: React.FC = () => {
   return (
-    <FeaturePageLayout showProductNav={false}>
+    <FeaturePageLayout showProductNav={false} fullWidth>
       <Header />
-      <TrustedByTeams />
-      <InContextObservability />
+      <div className="relative mx-auto max-w-8xl">
+        <TrustedByTeams />
+        <InContextObservability />
 
-      <SectionLayout variant="bordered" className="!px-0">
-        <FeatureSections />
-        <Divider />
-        <BottomCTA />
-      </SectionLayout>
+        <SectionLayout variant="bordered" className="!px-0">
+          <FeatureSections />
+          <Divider />
+          <BottomCTA />
+        </SectionLayout>
+      </div>
     </FeaturePageLayout>
   )
 }

--- a/app/(site)/agent-native-observability/AgentNativeObservabilityPage.tsx
+++ b/app/(site)/agent-native-observability/AgentNativeObservabilityPage.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image'
 import { useHubspotCustomForm } from '@/components/hubspot-custom-form/useHubspotCustomForm'
 import DitherCanvas from '@/components/DitherCanvas/DitherCanvas'
 import agentNativeHeroImageUrl from '@/public/img/platform/AgentNativeObservabilityMeta.svg?url'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
 
 const Header: React.FC = () => {
   const headerButtonGroup = (
@@ -98,7 +99,7 @@ const Header: React.FC = () => {
 
 const TrustedByTeams: React.FC = () => {
   return (
-    <div className="!border-b-1 relative mx-auto flex max-w-8xl flex-col items-center justify-center gap-10 overflow-hidden border !border-t-0 border-dashed border-signoz_slate-400 py-16 md:w-[80vw]">
+    <div className="relative mx-auto flex max-w-8xl flex-col items-center justify-center gap-10 overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 py-16">
       <div className="text-center text-sm font-semibold uppercase tracking-[0.05em] text-signoz_vanilla-400">
         Trusted by the <span className="text-signoz_vanilla-100">best platform teams</span>
       </div>
@@ -134,6 +135,7 @@ const TrustedByTeams: React.FC = () => {
           </TrackingLink>
         </Button>
       </div>
+      <Divider className="absolute bottom-0 left-0" />
     </div>
   )
 }
@@ -444,6 +446,7 @@ const AgentNativeObservabilityPage: React.FC = () => {
 
       <SectionLayout variant="bordered" className="!px-0">
         <FeatureSections />
+        <Divider />
         <BottomCTA />
       </SectionLayout>
     </FeaturePageLayout>

--- a/app/(site)/alerts-management/AlertsPage.constants.tsx
+++ b/app/(site)/alerts-management/AlertsPage.constants.tsx
@@ -1,10 +1,111 @@
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
+
+export const ALERTS_HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/alerts/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+  },
+]
+
 export const ALERTS_MANAGEMENT_CARDS = [
   {
-    title: "Create alerts from metrics, logs, traces, and exceptions",
-    description: "Set threshold-based alerts on metrics, logs, traces, and exceptions. For metrics, use anomaly detection to catch unexpected deviations from historical patterns."
+    title: 'Create alerts from metrics, logs, traces, and exceptions',
+    description:
+      'Set threshold-based alerts on metrics, logs, traces, and exceptions. For metrics, use anomaly detection to catch unexpected deviations from historical patterns.',
   },
   {
-    title: "Define sophisticated alert conditions",
-    description: "Combine multiple queries with formulas to calculate error rates, latency percentiles, or custom metrics using Query Builder, ClickHouse SQL, or PromQL."
+    title: 'Define sophisticated alert conditions',
+    description:
+      'Combine multiple queries with formulas to calculate error rates, latency percentiles, or custom metrics using Query Builder, ClickHouse SQL, or PromQL.',
   },
-];
+]
+
+export const CREATE_ALERTS_SHOWCASE = {
+  image: '/img/alerts-management/create-alerts.png',
+  imageAlt: 'Create alerts',
+}
+
+export const SET_MULTIPLE_SEVERITY_THRESHOLDS_SHOWCASE = {
+  title: 'Set multiple severity thresholds in one alert rule',
+  description:
+    'Define warning, critical, and info thresholds in a single alert rule. Control how conditions are evaluated (trigger at least once, all the time, on average, or in total) and set evaluation windows to reduce false positives.',
+  image: '/img/alerts-management/set-multiple-severity-thresholds.png',
+  imageAlt: 'Set multiple severity thresholds in one alert rule',
+}
+
+export const ROUTE_ALERTS_DYNAMICALLY_SHOWCASE = {
+  title: 'Route alerts dynamically with label-based policies',
+  description:
+    'Define routing policies that match alerts based on service, environment, severity, Kubernetes labels, or custom attributes. Automatically send notifications to the right teams and channels based on alert context. One alert can match multiple policies and notify different channels.',
+  image: '/img/alerts-management/route-alerts-dynamically.png',
+  imageAlt: 'Route alerts dynamically with label-based policies',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/alerts-management/routing-policy/',
+  },
+}
+
+export const ANALYZE_ALERT_PATTERNS_SHOWCASE = {
+  title: 'Analyze alert patterns with history and timelines',
+  description:
+    'Understand why alerts fire repeatedly, identify which services or pods are contributing most, and jump directly to related logs, traces, or metrics for faster root cause analysis.',
+  image: '/img/alerts-management/analyze-alert-patterns.png',
+  imageAlt: 'Analyze alert patterns',
+}
+
+export const FINE_TUNE_ALERT_BEHAVIOR_PANEL = {
+  title: 'Fine-tune alert behavior',
+  description:
+    'Set evaluation frequency and minimum data point requirements. Set alert when data stops flowing and test notifications before saving.',
+  image: '/img/alerts-management/fine-tune-alert-behavior.png',
+  imageAlt: 'Fine-tune alert behavior',
+  imageClassName: 'mb-8',
+  className: 'py-16',
+}
+
+export const MAINTENANCE_WINDOWS_PANEL = {
+  title: 'Schedule maintenance windows',
+  description:
+    'Schedule one-time or recurring maintenance windows. Silence all alerts or select specific ones during planned downtime.',
+  image: '/img/alerts-management/schedule-maintenance-windows.png',
+  imageAlt: 'Schedule maintenance windows',
+  className: 'py-16',
+}
+
+export const MANAGE_ALERTS_AS_CODE_PANEL = {
+  title: 'Manage alerts as code with Terraform',
+  description:
+    'Define alerts as Terraform resources with full version control. Import existing alerts from the UI into your codebase. Deploy consistent alert configurations across environments through standard Terraform workflows.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/alerts-management/terraform-provider-signoz/',
+  },
+}
+
+export const MANAGE_ALERTS_AS_CODE_IMAGE = {
+  src: '/img/alerts-management/manage-alerts-as-code.png',
+  alt: 'Manage alerts as code',
+}
+
+export const STOP_ALERT_FATIGUE_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/alerts/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+  },
+]

--- a/app/(site)/alerts-management/AlertsPage.tsx
+++ b/app/(site)/alerts-management/AlertsPage.tsx
@@ -1,37 +1,34 @@
 'use client'
 
 import React from 'react'
-import { ArrowRight } from 'lucide-react'
-import Button from '@/components/ui/Button'
 import Image from 'next/image'
-import { ALERTS_MANAGEMENT_CARDS } from './AlertsPage.constants'
+import {
+  ALERTS_HEADER_BUTTONS,
+  ALERTS_MANAGEMENT_CARDS,
+  ANALYZE_ALERT_PATTERNS_SHOWCASE,
+  CREATE_ALERTS_SHOWCASE,
+  FINE_TUNE_ALERT_BEHAVIOR_PANEL,
+  MAINTENANCE_WINDOWS_PANEL,
+  MANAGE_ALERTS_AS_CODE_IMAGE,
+  MANAGE_ALERTS_AS_CODE_PANEL,
+  ROUTE_ALERTS_DYNAMICALLY_SHOWCASE,
+  SET_MULTIPLE_SEVERITY_THRESHOLDS_SHOWCASE,
+  STOP_ALERT_FATIGUE_BUTTONS,
+} from './AlertsPage.constants'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
-import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
-import ButtonGroup from '@/shared/components/molecules/FeaturePages/ButtonGroup'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
 
 // Main Component Sections
 const Header: React.FC = () => {
-  const headerButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/trace-funnels/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-    },
-  ]
-
   return (
     <FeaturePageHeader
       title={
@@ -46,7 +43,7 @@ const Header: React.FC = () => {
           any attribute.
         </>
       }
-      buttons={headerButtons}
+      buttons={ALERTS_HEADER_BUTTONS}
       heroImage="/img/platform/AlertsManagementMeta.webp"
       heroImageAlt="Alerts management hero"
     />
@@ -55,233 +52,72 @@ const Header: React.FC = () => {
 
 const ManageAlertsAsCode: React.FC = () => {
   return (
-    <div className="bg-signoz_ink-500 py-6">
-      <GridLayout variant="split">
-        {/* Left Column */}
-        <div className="flex h-full w-full flex-col justify-center px-6">
-          <div className="flex flex-col justify-between">
-            <h2 className="mb-6 text-signoz_vanilla-100">Manage alerts as code with Terraform</h2>
-            <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-              Define alerts as Terraform resources with full version control. Import existing alerts
-              from the UI into your codebase. Deploy consistent alert configurations across
-              environments through standard Terraform workflows.
-            </p>
-          </div>
-
-          <Button
-            variant="secondary"
-            rounded="full"
-            className="flex w-fit items-center gap-2"
-            to="/docs/alerts-management/terraform-provider-signoz/"
-          >
-            Read Documentation
-            <ArrowRight size={14} />
-          </Button>
-        </div>
-
-        {/* Right Column */}
+    <SplitSection
+      className="py-6"
+      left={{
+        ...MANAGE_ALERTS_AS_CODE_PANEL,
+        className: 'justify-center',
+      }}
+      right={
         <div className="h-full w-full px-6">
           <Image
-            src="/img/alerts-management/manage-alerts-as-code.png"
-            alt="Manage alerts as code"
+            src={MANAGE_ALERTS_AS_CODE_IMAGE.src}
+            alt={MANAGE_ALERTS_AS_CODE_IMAGE.alt}
             width={10000}
             height={10000}
           />
         </div>
-      </GridLayout>
-    </div>
+      }
+    />
   )
 }
 
 const CreateAlertsAndDefineConditions: React.FC = () => {
   return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 px-6 pt-6">
-        <HeroCards
-          cards={ALERTS_MANAGEMENT_CARDS}
-          layoutVariant={'no-border'}
-          variant="default"
-          cols={2}
-          className="!-ml-6 -mt-6"
-        />
-
-        <Image
-          src="/img/alerts-management/create-alerts.png"
-          alt="Create alerts"
-          width={10000}
-          height={10000}
-        />
-      </div>
-    </>
+    <FeatureShowcase {...CREATE_ALERTS_SHOWCASE} className="px-6 pb-0 pt-6" imageClassName="mb-0">
+      <HeroCards
+        cards={ALERTS_MANAGEMENT_CARDS}
+        layoutVariant={'no-border'}
+        variant="default"
+        cols={2}
+        className="!-ml-6 -mt-6"
+      />
+    </FeatureShowcase>
   )
 }
 
 const RouteAlertsDynamically: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Route alerts dynamically with label-based policies
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            Define routing policies that match alerts based on service, environment, severity,
-            Kubernetes labels, or custom attributes. Automatically send notifications to the right
-            teams and channels based on alert context. One alert can match multiple policies and
-            notify different channels.
-          </p>
-        </div>
-
-        <Button
-          variant="secondary"
-          rounded="full"
-          className="flex w-fit items-center gap-2"
-          to="/docs/alerts-management/routing-policy/"
-        >
-          Read Documentation
-          <ArrowRight size={14} />
-        </Button>
-
-        <Image
-          src="/img/alerts-management/route-alerts-dynamically.png"
-          alt="Route alerts dynamically with label-based policies"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...ROUTE_ALERTS_DYNAMICALLY_SHOWCASE} />
 }
 
 const AnalyzeAlertPatterns: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Analyze alert patterns with history and timelines
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            Understand why alerts fire repeatedly, identify which services or pods are contributing
-            most, and jump directly to related logs, traces, or metrics for faster root cause
-            analysis.
-          </p>
-        </div>
-
-        <Image
-          src="/img/alerts-management/analyze-alert-patterns.png"
-          alt="Analyze alert patterns"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...ANALYZE_ALERT_PATTERNS_SHOWCASE} />
 }
 
 const SetMultipleSeverityThresholds: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Set multiple severity thresholds in one alert rule
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            Define warning, critical, and info thresholds in a single alert rule. Control how
-            conditions are evaluated (trigger at least once, all the time, on average, or in total)
-            and set evaluation windows to reduce false positives.
-          </p>
-        </div>
-
-        <Image
-          src="/img/alerts-management/set-multiple-severity-thresholds.png"
-          alt="Set multiple severity thresholds in one alert rule"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...SET_MULTIPLE_SEVERITY_THRESHOLDS_SHOWCASE} />
 }
 
 const StopAlertFatigueBanner: React.FC = () => {
-  const stopAlertFatigueButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/alerts/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-    },
-  ]
-
   return (
-    <div className="border-t-1 flex flex-col items-center justify-center border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6 py-20">
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        Stop alert fatigue. <br /> Start catching real issues.
-      </h2>
-      <ButtonGroup buttons={stopAlertFatigueButtons} />
-    </div>
+    <CTABanner
+      title={
+        <>
+          Stop alert fatigue. <br /> Start catching real issues.
+        </>
+      }
+      buttons={STOP_ALERT_FATIGUE_BUTTONS}
+    />
   )
 }
 
 const FineTuneAndMaintainenceWindows: React.FC = () => {
   return (
-    <>
-      <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-16">
-        <GridLayout variant="split">
-          {/* Left Column */}
-          <div className="flex flex-col px-6">
-            <div className="flex flex-col justify-between">
-              <div>
-                <h2 className="mb-6 text-signoz_vanilla-100">Fine-tune alert behavior</h2>
-                <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                  Set evaluation frequency and minimum data point requirements. Set alert when data
-                  stops flowing and test notifications before saving.
-                </p>
-              </div>
-            </div>
-
-            <Image
-              src="/img/alerts-management/fine-tune-alert-behavior.png"
-              alt="Fine-tune alert behavior"
-              width={10000}
-              height={10000}
-              className="mb-8"
-            />
-          </div>
-
-          {/* Right Column */}
-          <div className="border-l-1 -my-16 flex flex-col border-dashed border-signoz_slate-400 px-6 pt-16">
-            <div className="flex flex-col justify-between">
-              <div>
-                <h2 className="mb-6 text-signoz_vanilla-100">Schedule maintenance windows</h2>
-                <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                  Schedule one-time or recurring maintenance windows. Silence all alerts or select
-                  specific ones during planned downtime.
-                </p>
-              </div>
-            </div>
-
-            <Image
-              src="/img/alerts-management/schedule-maintenance-windows.png"
-              alt="Schedule maintenance windows"
-              width={10000}
-              height={10000}
-            />
-          </div>
-        </GridLayout>
-      </div>
-    </>
+    <SplitSection
+      left={FINE_TUNE_ALERT_BEHAVIOR_PANEL}
+      right={MAINTENANCE_WINDOWS_PANEL}
+      withVerticalDivider
+    />
   )
 }
 
@@ -292,17 +128,25 @@ const AlertsManagement: React.FC = () => {
       <Header />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider />
         <CreateAlertsAndDefineConditions />
+        <Divider />
         <SetMultipleSeverityThresholds />
+        <Divider />
         <RouteAlertsDynamically />
+        <Divider />
         <AnalyzeAlertPatterns />
+        <Divider className="mt-12" />
         <FineTuneAndMaintainenceWindows />
+        <Divider />
         <ManageAlertsAsCode />
+        <Divider />
         <StopAlertFatigueBanner />
       </SectionLayout>
 
       <UsageBasedPricing show={['traces', 'metrics', 'logs']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection />
     </FeaturePageLayout>
   )

--- a/app/(site)/clickstack-alternative/ClickStackAlternativePage.tsx
+++ b/app/(site)/clickstack-alternative/ClickStackAlternativePage.tsx
@@ -22,9 +22,11 @@ import {
 } from './ClickStackAlternativePage.constants'
 import TrackingLink from '@/components/TrackingLink'
 import Image from 'next/image'
-import ButtonGroup from '@/shared/components/molecules/FeaturePages/ButtonGroup'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 import Link from 'next/link'
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
 
 const Header: React.FC = () => {
   const headerButtons = [
@@ -32,7 +34,7 @@ const Header: React.FC = () => {
       text: 'Start your free trial',
       href: '/teams/',
       variant: 'default' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Primary CTA',
         clickName: 'ClickStack Alternative Hero Start Trial',
@@ -44,7 +46,7 @@ const Header: React.FC = () => {
       text: 'Read Documentation',
       href: '/docs/',
       variant: 'secondary' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Secondary CTA',
         clickName: 'ClickStack Alternative Hero Docs',
@@ -76,7 +78,7 @@ const QuickEvaluation: React.FC = () => {
   return (
     <SectionLayout
       variant="full-width"
-      className="relative mx-auto w-[100vw] overflow-hidden border-b border-dashed border-signoz_slate-400 md:w-[80vw]"
+      className="relative mx-auto overflow-hidden border-b border-dashed border-signoz_slate-400"
     >
       <div className="relative flex flex-col gap-6 pt-32 md:py-20">
         <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
@@ -84,10 +86,7 @@ const QuickEvaluation: React.FC = () => {
             <h2 className="my-6 text-center text-4xl font-semibold text-signoz_sakura-100">
               A Quick Evaluation
             </h2>
-            <SectionLayout
-              variant="no-border"
-              className="!mx-auto flex items-center justify-center"
-            >
+            <SectionLayout variant="no-border" className="flex items-center justify-center">
               <ComparisonTable
                 vendors={VENDORS}
                 rows={CLICKSTACK_COMPARISON_TABLE_ROWS}
@@ -104,10 +103,7 @@ const QuickEvaluation: React.FC = () => {
 const CostComparison: React.FC = () => {
   return (
     <>
-      <SectionLayout
-        variant="full-width"
-        className="flex flex-col gap-y-9 border-y border-dashed border-signoz_slate-400 !px-0"
-      >
+      <SectionLayout variant="full-width" className="flex flex-col gap-y-9 !px-0">
         <div className="flex flex-col gap-4 px-10 py-12 md:px-12">
           <h2 className="text-5xl font-normal text-signoz_vanilla-300">Pricing</h2>
           <h4 className="m-0 text-xl font-bold text-signoz_vanilla-100">
@@ -119,40 +115,43 @@ const CostComparison: React.FC = () => {
             is free.
           </div>
         </div>
-        <div className="border-t-1 flex flex-col border-dashed border-signoz_slate-400 sm:flex-row">
-          <div className="!w-[100%] flex-1 md:!w-[300px] md:min-w-fit">
-            <div className="sticky top-[100px] flex min-w-fit flex-col items-start justify-start gap-4 px-10 py-10 md:px-0 md:pl-12">
-              <h2 className="text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl">
-                ClickStack's <br className="hidden md:block" /> billing{' '}
-                <br className="hidden md:block" /> complexity
-              </h2>
-              <Button asChild variant="secondary" rounded="full">
-                <TrackingLink
-                  href="/blog/clickstack-managed-pricing-compute-costs/"
-                  clickType="Secondary CTA"
-                  clickName="ClickStack Alternative Cost Comparison ClickStack Pricing Details Button"
-                  clickLocation="ClickStack Alternative Cost Comparison"
-                  clickText="ClickStack pricing details"
-                >
-                  ClickStack pricing details <ArrowRight size={16} />
-                </TrackingLink>
-              </Button>
-            </div>
-          </div>
-          <div className="flex-[2_2_0%]">
-            <div className="border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
-              <div className="flex flex-col gap-4 px-10 py-10">
-                {CLICKSTACK_BILLING_CARDS.map((card) => (
-                  <Card
-                    key={card.title}
-                    className="rounded-md p-0 [&>*]:rounded-md [&>*]:border-solid [&>*]:border-signoz_slate-500"
+        <div>
+          <Divider />
+          <div className="flex flex-col sm:flex-row">
+            <div className="!w-[100%] flex-1 md:!w-[300px] md:min-w-fit">
+              <div className="sticky top-[100px] flex min-w-fit flex-col items-start justify-start gap-4 px-10 py-10 md:px-0 md:pl-12">
+                <h2 className="text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl">
+                  ClickStack's <br className="hidden md:block" /> billing{' '}
+                  <br className="hidden md:block" /> complexity
+                </h2>
+                <Button asChild variant="secondary" rounded="full">
+                  <TrackingLink
+                    href="/blog/clickstack-managed-pricing-compute-costs/"
+                    clickType="Secondary CTA"
+                    clickName="ClickStack Alternative Cost Comparison ClickStack Pricing Details Button"
+                    clickLocation="ClickStack Alternative Cost Comparison"
+                    clickText="ClickStack pricing details"
                   >
-                    <div className="p-6">
-                      <h4 className="mb-2 font-semibold text-signoz_vanilla-100">{card.title}</h4>
-                      <p className="m-0 text-sm text-signoz_vanilla-400">{card.description}</p>
-                    </div>
-                  </Card>
-                ))}
+                    ClickStack pricing details <ArrowRight size={16} />
+                  </TrackingLink>
+                </Button>
+              </div>
+            </div>
+            <div className="flex-[2_2_0%]">
+              <div className="border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
+                <div className="flex flex-col gap-4 px-10 py-10">
+                  {CLICKSTACK_BILLING_CARDS.map((card) => (
+                    <Card
+                      key={card.title}
+                      className="rounded-md p-0 [&>*]:rounded-md [&>*]:border-solid [&>*]:border-signoz_slate-500"
+                    >
+                      <div className="p-6">
+                        <h4 className="mb-2 font-semibold text-signoz_vanilla-100">{card.title}</h4>
+                        <p className="m-0 text-sm text-signoz_vanilla-400">{card.description}</p>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -164,7 +163,7 @@ const CostComparison: React.FC = () => {
 
 const DashboardsThatHelpYouInvestigate: React.FC = () => {
   return (
-    <section className="relative mx-auto max-w-8xl overflow-hidden md:w-[80vw]">
+    <section className="relative mx-auto max-w-8xl overflow-hidden">
       <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 py-16 text-center md:py-20">
         <div className="flex flex-col items-center gap-14 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
           <div className="flex flex-col items-center gap-4">
@@ -177,15 +176,19 @@ const DashboardsThatHelpYouInvestigate: React.FC = () => {
               with all your filters intact.
             </div>
           </div>
-          <SectionLayout
-            variant="no-border"
-            className="!mx-auto flex items-center justify-center !p-0"
-          >
-            <IconTitleDescriptionCardGrid
-              cards={DASHBOARD_HELP_YOU_INVESTIGATE_CARDS}
-              variant="lg"
-            />
-          </SectionLayout>
+          <div>
+            <Divider />
+            <SectionLayout
+              variant="no-border"
+              className="!mx-auto flex items-center justify-center !p-0"
+            >
+              <IconTitleDescriptionCardGrid
+                cards={DASHBOARD_HELP_YOU_INVESTIGATE_CARDS}
+                variant="lg"
+              />
+            </SectionLayout>
+            <Divider />
+          </div>
         </div>
       </div>
     </section>
@@ -194,7 +197,7 @@ const DashboardsThatHelpYouInvestigate: React.FC = () => {
 
 const AlertingThatTellsYouWhatMatters: React.FC = () => {
   return (
-    <section className="relative mx-auto max-w-8xl overflow-hidden md:w-[80vw]">
+    <section className="relative mx-auto max-w-8xl overflow-hidden">
       <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center">
         <div className="flex flex-col items-center gap-14 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
           <div className="flex flex-col items-center gap-4">
@@ -208,7 +211,9 @@ const AlertingThatTellsYouWhatMatters: React.FC = () => {
             </div>
           </div>
           <SectionLayout variant="no-border" className="!mx-auto !p-0">
+            <Divider />
             <IconTitleDescriptionCardGrid cards={ALERTING_ABOVE_HISTORY_CARDS} variant="lg" />
+            <Divider />
             <div className="flex flex-col items-start gap-4 border-dashed border-signoz_slate-400 px-8 py-6 text-left">
               <h4 className="m-0 p-0 font-semibold text-signoz_vanilla-100">Alert history</h4>
               <p className="m-0 p-0 text-sm text-signoz_vanilla-400">
@@ -228,6 +233,7 @@ const AlertingThatTellsYouWhatMatters: React.FC = () => {
                 className="rounded-md"
               />
             </div>
+            <Divider />
             <IconTitleDescriptionCardGrid cards={ALERTING_BELOW_HISTORY_CARDS} variant="lg" />
           </SectionLayout>
         </div>
@@ -242,7 +248,7 @@ const BetterChoiceBanner: React.FC = () => {
       text: 'Start your free trial',
       href: '/teams/',
       variant: 'default' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Primary CTA',
         clickName: 'ClickStack Alternative Better Choice Banner Start Trial',
@@ -254,7 +260,7 @@ const BetterChoiceBanner: React.FC = () => {
       text: 'Read Documentation',
       href: '/docs/introduction/',
       variant: 'secondary' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Secondary CTA',
         clickName: 'ClickStack Alternative Better Choice Banner Read Documentation',
@@ -265,19 +271,23 @@ const BetterChoiceBanner: React.FC = () => {
   ]
 
   return (
-    <SectionLayout variant="bordered" className="flex flex-col items-center justify-center !py-20">
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        ClickStack or HyperDX? <br />
-        Either way, SigNoz is the better choice.
-      </h2>
-      <ButtonGroup buttons={betterChoiceButtons} />
+    <SectionLayout variant="bordered" className="!px-0">
+      <CTABanner
+        title={
+          <>
+            ClickStack or HyperDX? <br />
+            Either way, SigNoz is the better choice.
+          </>
+        }
+        buttons={betterChoiceButtons}
+      />
     </SectionLayout>
   )
 }
 
 const QueryYourData: React.FC = () => {
   return (
-    <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-16">
+    <div className="bg-signoz_ink-500 py-16">
       <div className="mx-auto my-8 max-w-4xl p-6">
         <h2 className="my-4 text-center text-4xl font-semibold text-signoz_sakura-100">
           Query Your Data, Any Way You Want
@@ -316,7 +326,9 @@ const ClickStackAlternativePage: React.FC = () => {
         <QuickEvaluation />
         <DashboardsThatHelpYouInvestigate />
         <AlertingThatTellsYouWhatMatters />
+        <Divider />
         <QueryYourData />
+        <Divider />
         <CostComparison />
       </SectionLayout>
 
@@ -343,7 +355,9 @@ const ClickStackAlternativePage: React.FC = () => {
         }
       />
       <BetterChoiceBanner />
+      <Divider />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'ClickStack Alternative Customer Stories Button',

--- a/app/(site)/cloudwatch-alternative/CloudwatchAlternativePage.tsx
+++ b/app/(site)/cloudwatch-alternative/CloudwatchAlternativePage.tsx
@@ -20,6 +20,8 @@ import {
   DEPLOYMENT_AND_DATA_RESIDENCY_CARDS_BELOW,
 } from './CloudwatchAlternativePage.constants'
 import TrackingLink from '@/components/TrackingLink'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
 
 const Header: React.FC = () => {
   const headerButtons = [
@@ -27,7 +29,7 @@ const Header: React.FC = () => {
       text: 'Start your free trial',
       href: '/teams/',
       variant: 'default' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Primary CTA',
         clickName: 'Cloudwatch Alternative Hero Start Trial',
@@ -39,7 +41,7 @@ const Header: React.FC = () => {
       text: 'Read Documentation',
       href: '/docs/cloud/',
       variant: 'secondary' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Secondary CTA',
         clickName: 'Cloudwatch Alternative Hero Docs',
@@ -76,24 +78,21 @@ const Header: React.FC = () => {
 
 const WhyTeamsSwitchFromCloudWatch: React.FC = () => {
   return (
-    <SectionLayout
-      variant="full-width"
-      className="bg-blur-ellipse-388 relative mx-auto w-[100vw] overflow-hidden md:w-[80vw]"
-    >
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
-      <div className="relative flex flex-col gap-6 pt-32 md:py-20">
-        <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
-          <div className="flex flex-col items-center gap-12 text-2xl leading-[3.25rem]">
-            <h2 className="my-6 py-10 text-center text-4xl font-normal text-signoz_vanilla-300">
-              Why Teams Switch From CloudWatch
-            </h2>
-            <SectionLayout variant="no-border" className="!mx-auto p-0">
-              <IconTitleDescriptionCardGrid cards={TEAM_SWITCH_CARDS} variant="xl" />
-            </SectionLayout>
-          </div>
+    <div className="relative flex flex-col gap-6 pt-32 md:py-20">
+      <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+        <div className="flex flex-col items-center gap-12 text-2xl leading-[3.25rem]">
+          <h2 className="my-6 py-10 text-center text-4xl font-normal text-signoz_vanilla-300">
+            Why Teams Switch From CloudWatch
+          </h2>
+
+          <SectionLayout variant="no-border" className="!mx-auto p-0">
+            <Divider />
+            <IconTitleDescriptionCardGrid cards={TEAM_SWITCH_CARDS} variant="xl" />
+            <Divider />
+          </SectionLayout>
         </div>
       </div>
-    </SectionLayout>
+    </div>
   )
 }
 
@@ -112,13 +111,13 @@ const DeploymentAndDataResidency: React.FC = () => {
           variant="xl"
         />
         <div className="relative hidden w-full items-center gap-0 md:flex">
-          <div className="h-px flex-1 border-t border-dashed border-signoz_sakura-600" />
+          <Divider className="h-px flex-1 border-signoz_sakura-600" />
           <div className="absolute z-[1] flex w-full items-center justify-center">
             <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 border-white bg-signoz_sakura-600 text-xl font-bold text-white">
               VS
             </span>
           </div>
-          <div className="h-px flex-1 border-t border-dashed border-signoz_sakura-600" />
+          <Divider className="h-px flex-1 border-signoz_sakura-600" />
         </div>
         <IconTitleDescriptionCardGrid
           cards={DEPLOYMENT_AND_DATA_RESIDENCY_CARDS_BELOW}
@@ -132,23 +131,21 @@ const DeploymentAndDataResidency: React.FC = () => {
 const CostComparison: React.FC = () => {
   return (
     <>
-      <SectionLayout
-        variant="full-width"
-        className="flex flex-col gap-y-9 border-y border-dashed border-signoz_slate-400 !px-0"
-      >
-        <div className="flex flex-col gap-4 px-10 py-12 md:px-12">
-          <h2 className="text-5xl font-normal text-signoz_vanilla-300">Pricing</h2>
-          <h4 className="m-0 text-xl font-bold text-signoz_vanilla-100">
-            You shouldn't pay to look at your own data
-          </h4>
-          <div className="text-sm text-signoz_vanilla-400">
-            CloudWatch bills across 12+ separate components for ingestion, storage, queries,
-            metrics, alarms, dashboards, and API access. SigNoz charges $0.30/GB for logs and
-            traces, $0.10 per million samples for metrics. Once data is ingested, query it unlimited
-            times at no extra charge.
-          </div>
+      <div className="flex flex-col gap-4 px-10 py-12 md:px-12">
+        <h2 className="text-5xl font-normal text-signoz_vanilla-300">Pricing</h2>
+        <h4 className="m-0 text-xl font-bold text-signoz_vanilla-100">
+          You shouldn't pay to look at your own data
+        </h4>
+        <div className="text-sm text-signoz_vanilla-400">
+          CloudWatch bills across 12+ separate components for ingestion, storage, queries, metrics,
+          alarms, dashboards, and API access. SigNoz charges $0.30/GB for logs and traces, $0.10 per
+          million samples for metrics. Once data is ingested, query it unlimited times at no extra
+          charge.
         </div>
-        <div className="border-t-1 flex flex-col border-dashed border-signoz_slate-400 sm:flex-row">
+      </div>
+      <div>
+        <Divider />
+        <div className="flex flex-col sm:flex-row">
           <div className="!w-[100%] flex-1 md:!w-[300px] md:min-w-fit">
             <div className="sticky top-[100px] flex min-w-fit flex-col items-start justify-start gap-4 px-10 py-10 md:px-0 md:pl-12">
               <h2 className="text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl">
@@ -186,15 +183,14 @@ const CostComparison: React.FC = () => {
             </div>
           </div>
         </div>
-      </SectionLayout>
+      </div>
     </>
   )
 }
 
 const ArchitectureAndApproach: React.FC = () => {
   return (
-    <section className="bg-blur-ellipse-388 relative mx-auto max-w-8xl overflow-hidden md:w-[80vw]">
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
+    <section className="bg-blur-ellipse-388 relative mx-auto max-w-8xl overflow-hidden">
       <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 py-16 text-center md:py-20">
         <div className="flex flex-col items-center gap-14 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
           <div className="flex flex-col items-center gap-4">
@@ -227,7 +223,9 @@ const CloudwatchAlternativePage: React.FC = () => {
 
       <SectionLayout variant="bordered" className="!px-0">
         <WhyTeamsSwitchFromCloudWatch />
+        <Divider />
         <ArchitectureAndApproach />
+        <Divider />
         <CostComparison />
       </SectionLayout>
 
@@ -248,7 +246,9 @@ const CloudwatchAlternativePage: React.FC = () => {
         }
       />
       <DeploymentAndDataResidency />
+      <Divider />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'Cloudwatch Alternative Customer Stories Button',

--- a/app/(site)/datadog-migration-tool/DatadogMigrationTool.tsx
+++ b/app/(site)/datadog-migration-tool/DatadogMigrationTool.tsx
@@ -5,7 +5,6 @@ import { ArrowRight } from 'lucide-react'
 import Button from '@/components/ui/Button'
 import { AppModal as Modal } from '@/components/ui/Modal'
 import { useDisclosure } from '@/hooks/useDisclosure'
-import ProductNav from '@/components/ProductNav/ProductNav'
 import Image from 'next/image'
 import {
   CARDS,
@@ -15,11 +14,13 @@ import {
 } from './DatadogMigrationTool.constants'
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
-import TestimonialCards from '@/shared/components/molecules/FeaturePages/TestimonialCard'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 import HubspotCustomForm from '@/components/hubspot-custom-form/HubspotCustomForm'
 import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
+import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
 
 const RequestEarlyAccessButton: React.FC<{ className?: string }> = ({ className = '' }) => {
   const { isOpen, onOpen, onOpenChange } = useDisclosure()
@@ -61,27 +62,29 @@ const RequestEarlyAccessButton: React.FC<{ className?: string }> = ({ className 
 
 const ReadyToMigrateBanner: React.FC = () => {
   return (
-    <SectionLayout
-      variant="no-border"
-      className="!border-t-1 !border-x-0 !border-dashed !border-signoz_slate-400 py-10"
-    >
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        Ready to Migrate from Datadog?
-      </h2>
-      <RequestEarlyAccessButton className="!mx-auto" />
-    </SectionLayout>
+    <>
+      <SectionLayout variant="bordered" className="pb-10">
+        <h2 className="mb-6 pt-10 text-center text-4xl text-signoz_vanilla-100">
+          Ready to Migrate from Datadog?
+        </h2>
+
+        <RequestEarlyAccessButton className="!mx-auto" />
+      </SectionLayout>
+    </>
   )
 }
 
 // Main Component Sections
 const Header: React.FC = () => {
   return (
-    <header className="relative !mx-auto mt-16 !w-[100vw] max-w-8xl md:!w-[80vw]">
-      {/* Border decorations */}
+    <header className="relative">
+      {/* Main content */}
       <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[0] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
 
-      {/* Main content */}
-      <div className="relative !mx-auto flex !w-[100vw] max-w-8xl flex-col items-center border !border-b-0 border-dashed border-signoz_slate-400 px-2 pb-4 pt-12 text-center md:!w-[80vw] md:px-5 md:pt-[4rem]">
+      <SectionLayout
+        variant="bordered"
+        className="relative !mx-auto flex flex-col items-center px-2 pb-4 pt-12 text-center"
+      >
         <h1 className="text-gradient z-[1] my-4 !p-3 text-2xl font-semibold tracking-tight dark:text-white sm:my-2 sm:my-5 sm:text-3xl md:leading-[3.5rem] lg:text-[44px]">
           Migrate from Datadog to SigNoz <br className="hidden md:block" /> in Minutes
         </h1>
@@ -91,10 +94,10 @@ const Header: React.FC = () => {
           <br className="hidden md:block" /> SigNoz through a simple UI, preserving your
           configurations, queries, and panels.
         </p>
-      </div>
+      </SectionLayout>
 
       {/* Buttons */}
-      <RequestEarlyAccessButton className="!mx-auto !w-[100vw] max-w-8xl border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5 md:!w-[80vw]" />
+      <RequestEarlyAccessButton className="!mx-auto max-w-8xl border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 pb-12 pt-4 md:mx-5" />
 
       {/* Hero image */}
       <SectionLayout variant="bordered" className="!mt-0 max-md:-mb-[3rem]">
@@ -112,26 +115,22 @@ const Header: React.FC = () => {
 
 const TopHeroSection: React.FC = () => {
   return (
-    <SectionLayout
-      variant="bordered"
-      className="!border-b-1 !border-t-1 !border-dashed !border-signoz_slate-400"
-    >
+    <SectionLayout variant="bordered" className="!px-0">
+      <Divider />
       <div className="mb-8 text-center">
         <h2 className="mb-6 pt-12 text-4xl font-semibold text-signoz_sienna-100">
           Typical Migration Pain
         </h2>
       </div>
       <HeroCards cards={CARDS} layoutVariant={'no-border'} variant="combined" />
+      <Divider />
     </SectionLayout>
   )
 }
 
 const LlmPoweredIntelligenceSection: React.FC = () => {
   return (
-    <SectionLayout
-      variant="full-width"
-      className="border-t border-dashed border-signoz_slate-400 bg-signoz_ink-500"
-    >
+    <SectionLayout variant="bordered" className="bg-signoz_ink-500 !px-0">
       <div className="mb-6 max-w-4xl px-8 py-6">
         <h2 className="mb-6 text-4xl font-semibold text-signoz_sienna-100">
           LLM-Powered Intelligence
@@ -148,59 +147,6 @@ const LlmPoweredIntelligenceSection: React.FC = () => {
         variant="combined"
       />
     </SectionLayout>
-  )
-}
-
-const CustomerStories: React.FC = () => {
-  return (
-    <>
-      {/* Featured testimonial */}
-      <section className="bg-blur-ellipse-388 relative mx-auto w-[100vw] max-w-8xl overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:w-[80vw]">
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
-
-        <div className="relative">
-          <div className="container pb-16">
-            <div className="flex flex-col gap-6 py-32">
-              <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
-                <div className="flex flex-col items-center gap-12 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
-                  <Image
-                    src="/img/case_study/logos/shaped-logo.svg"
-                    alt="Shaped"
-                    width={100}
-                    height={100}
-                  />
-                  Every single time we have an issue, SigNoz is always the first place to check. It
-                  was super straightforward to migrate - just updating the exporter configuration,
-                  basically three lines of code.
-                  <span className="text-sm text-signoz_vanilla-400">
-                    <span className="font-semibold">Karl Lyons</span> <br /> Senior SRE, Shaped
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Testimonials grid */}
-      <SectionLayout variant="bordered" className="!mx-auto p-0 max-md:-mb-[3rem]">
-        <div className="container pb-16">
-          <TestimonialCards />
-
-          <div className="z-5 relative -mt-[25rem] flex h-96 items-end justify-center bg-gradient-to-t from-signoz_ink-500 to-transparent py-6 max-md:py-16">
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="flex items-center gap-2"
-              to="/case-study/"
-            >
-              Read customer stories
-              <ArrowRight size={14} />
-            </Button>
-          </div>
-        </div>
-      </SectionLayout>
-    </>
   )
 }
 
@@ -303,10 +249,7 @@ const WhatWeSupportSection: React.FC = () => {
   }
 
   return (
-    <SectionLayout
-      variant="no-border"
-      className="!border-t-1 !border-x-0 !border-dashed !border-signoz_slate-400"
-    >
+    <SectionLayout variant="bordered">
       <div className="px-6 py-8">
         <h2 className="mb-6 text-4xl font-semibold text-signoz_sienna-100">What We Support</h2>
         <p className="leading-relaxed text-signoz_vanilla-400">
@@ -334,31 +277,26 @@ const WhatWeSupportSection: React.FC = () => {
 // Main Component
 const DatadogMigrationTool: React.FC = () => {
   return (
-    <main className="!mt-[-10px] mb-auto">
-      <ProductNav />
-
-      <div className="relative bg-signoz_ink-500">
-        {/* Background decorations */}
-        <div className="bg-dot-pattern masked-dots absolute top-0 flex h-screen w-full items-center justify-center" />
-        <div className="absolute left-0 right-0 top-0 mx-auto h-[450px] w-full flex-shrink-0 rounded-[956px] bg-gradient-to-b from-[rgba(190,107,241,1)] to-[rgba(69,104,220,0)] bg-[length:110%] bg-no-repeat opacity-30 blur-[300px] sm:bg-[center_-500px] md:h-[956px]" />
-
-        {/* Main sections */}
-        <Header />
-        <TopHeroSection />
-
-        <SimpleAutomatedMigrationSection />
-
-        <SectionLayout variant="bordered" className="!px-0">
-          <WhatWeSupportSection />
-          <LlmPoweredIntelligenceSection />
-          <ReadyToMigrateBanner />
-        </SectionLayout>
-
-        <UsageBasedPricing show={['logs', 'traces', 'metrics']} />
-        <SigNozStats />
-        <CustomerStories />
-      </div>
-    </main>
+    <FeaturePageLayout showProductNav={false}>
+      <Header />
+      <TopHeroSection />
+      <SimpleAutomatedMigrationSection />
+      <Divider />
+      <WhatWeSupportSection />
+      <Divider />
+      <LlmPoweredIntelligenceSection />
+      <Divider />
+      <ReadyToMigrateBanner />
+      <UsageBasedPricing show={['logs', 'traces', 'metrics']} />
+      <SigNozStats />
+      <Divider />
+      <CustomerStoriesSection
+        tracking={{
+          clickName: 'Customer Stories Button',
+          clickLocation: 'Datadog Migration Tool Page',
+        }}
+      />
+    </FeaturePageLayout>
   )
 }
 

--- a/app/(site)/distributed-tracing/DistributedTracingPage.constants.tsx
+++ b/app/(site)/distributed-tracing/DistributedTracingPage.constants.tsx
@@ -1,4 +1,4 @@
-import { Atom, DatabaseZap, ListTree, TextSearch } from "lucide-react";
+import { Atom, DatabaseZap, ListTree, TextSearch } from 'lucide-react'
 import {
   SiPython,
   SiGo,
@@ -10,117 +10,221 @@ import {
   SiApachekafka,
   SiRabbitmq,
 } from 'react-icons/si'
-import { BiLogoPostgresql } from "react-icons/bi";
-import { GrMysql } from "react-icons/gr";
-import { CarouselCard } from "@/shared/components/molecules/FeaturePages/CarouselCards";
-
+import { BiLogoPostgresql } from 'react-icons/bi'
+import { GrMysql } from 'react-icons/gr'
+import { CarouselCard } from '@/shared/components/molecules/FeaturePages/CarouselCards'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
 
 export const CLOUD_ICONS = [
-  { src: "/img/icons/aws-icon.svg", alt: "AWS" },
-  { src: "/img/icons/gcp-icon.svg", alt: "Google Cloud" },
-  { src: "/img/icons/azure-icon.svg", alt: "Azure" }
-];
+  { src: '/img/icons/aws-icon.svg', alt: 'AWS' },
+  { src: '/img/icons/gcp-icon.svg', alt: 'Google Cloud' },
+  { src: '/img/icons/azure-icon.svg', alt: 'Azure' },
+]
 
 export const CONTAINER_ICONS = [
-  { src: <SiDjango className="h-7 w-7 text-[#44B78B]" />, alt: "Django" },
-  { src: <SiFlask className="h-7 w-7" />, alt: "Flask" },
-  { src: <SiSpringboot className="h-7 w-7 text-[#6DB33F]" />, alt: "Springboot" },
-  { src: <SiExpress className="h-7 w-7" />, alt: "Express" },
-];
+  { src: <SiDjango className="h-7 w-7 text-[#44B78B]" />, alt: 'Django' },
+  { src: <SiFlask className="h-7 w-7" />, alt: 'Flask' },
+  { src: <SiSpringboot className="h-7 w-7 text-[#6DB33F]" />, alt: 'Springboot' },
+  { src: <SiExpress className="h-7 w-7" />, alt: 'Express' },
+]
 
 export const POPULAR_TOOLS_ICONS = [
-  { src: <BiLogoPostgresql className="h-7 w-7 text-blue-600" />, alt: "Postgres" },
-  { src: "/img/icons/redis-icon.svg", alt: "Redis" },
-  { src: <SiApachekafka className="h-7 w-7" />, alt: "Apache Kafka" },
-  { src: "/img/icons/grpc-icon.svg", alt: "gRPC"},
-  { src: <GrMysql className="h-7 w-7 text-cyan-600" />, alt: "MySQL" },
-  { src: "/img/icons/mongo-icon.svg", alt: "Mongo" },
-  { src: <SiRabbitmq className="h-7 w-7 text-orange-600" />, alt: "RabbitMQ" },
-  { src: "/img/icons/elastic-icon.svg", alt: "Elastic" }
-];
+  { src: <BiLogoPostgresql className="h-7 w-7 text-blue-600" />, alt: 'Postgres' },
+  { src: '/img/icons/redis-icon.svg', alt: 'Redis' },
+  { src: <SiApachekafka className="h-7 w-7" />, alt: 'Apache Kafka' },
+  { src: '/img/icons/grpc-icon.svg', alt: 'gRPC' },
+  { src: <GrMysql className="h-7 w-7 text-cyan-600" />, alt: 'MySQL' },
+  { src: '/img/icons/mongo-icon.svg', alt: 'Mongo' },
+  { src: <SiRabbitmq className="h-7 w-7 text-orange-600" />, alt: 'RabbitMQ' },
+  { src: '/img/icons/elastic-icon.svg', alt: 'Elastic' },
+]
 
 export const LEGACY_FORMAT_SUPPORT_ICONS = [
-  { src: "/img/icons/jaeger-stag-face-icon.svg", alt: "Jaeger" },
-  { src: "/img/icons/zipkin-icon.svg", alt: "Zipkin" },
-  { src: "/img/icons/opencensus-icon.svg", alt: "OpenCensus" }
-];
+  { src: '/img/icons/jaeger-stag-face-icon.svg', alt: 'Jaeger' },
+  { src: '/img/icons/zipkin-icon.svg', alt: 'Zipkin' },
+  { src: '/img/icons/opencensus-icon.svg', alt: 'OpenCensus' },
+]
 
 export const LANGUAGES_ICONS = [
-  { src: <SiPython className="h-5 w-5 text-blue-500" />, alt: "Python" },
-  { src: "/img/icons/java-icon.svg", alt: "Java" },
-  { src: <SiGo className="h-7 w-7 text-cyan-500" />, alt: "Golang" },
-  { src: <SiDotnet className="h-7 w-7" />, alt: "Dotnet" }
-];
+  { src: <SiPython className="h-5 w-5 text-blue-500" />, alt: 'Python' },
+  { src: '/img/icons/java-icon.svg', alt: 'Java' },
+  { src: <SiGo className="h-7 w-7 text-cyan-500" />, alt: 'Golang' },
+  { src: <SiDotnet className="h-7 w-7" />, alt: 'Dotnet' },
+]
 
-export const DIRECT_INTEGRATIONS = [
-  "OTLP",
-  "gRPC", 
-  "HTTP"
-];
+export const DIRECT_INTEGRATIONS = ['OTLP', 'gRPC', 'HTTP']
+
+export const DISTRIBUTED_TRACING_HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Distributed Tracing Hero Start Trial',
+      clickLocation: 'Distributed Tracing Hero',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/instrumentation/overview/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Distributed Tracing Hero Docs',
+      clickLocation: 'Distributed Tracing Hero',
+      clickText: 'Read Documentation',
+    },
+  },
+]
 
 export const CARDS = [
   {
-    icon: <DatabaseZap />, 
-    title: "High-Volume Ingestion", 
-    description: "Sustain 20,000 spans per second intake. Battle-tested architecture handles enterprise scale without forced sampling."
-  }, 
+    icon: <DatabaseZap />,
+    title: 'High-Volume Ingestion',
+    description:
+      'Sustain 20,000 spans per second intake. Battle-tested architecture handles enterprise scale without forced sampling.',
+  },
   {
-    icon: <ListTree />, 
-    title: "Trace Funnels", 
-    description: "Compare error vs success patterns across services. Industry-first feature for analyzing conversion through distributed systems."
-  }, 
+    icon: <ListTree />,
+    title: 'Trace Funnels',
+    description:
+      'Compare error vs success patterns across services. Industry-first feature for analyzing conversion through distributed systems.',
+  },
   {
-    icon: <TextSearch />, 
-    title: "Full-Text Search on Span Events", 
-    description: "Query span events across structured and unstructured data with CONTAINS and wildcards, no pre-indexing required."
-  }
-];
+    icon: <TextSearch />,
+    title: 'Full-Text Search on Span Events',
+    description:
+      'Query span events across structured and unstructured data with CONTAINS and wildcards, no pre-indexing required.',
+  },
+]
 
+export const INSTRUMENT_SERVICES_PANEL = {
+  title: 'Instrument services in minutes',
+  description:
+    'Auto-instrument your applications with OpenTelemetry across all major languages and frameworks. Change one environment variable to start sending traces to SigNoz.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/instrumentation/overview/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Distributed Tracing Instrumentation Docs Button',
+      clickLocation: 'Distributed Tracing Instrumentation Section',
+      clickText: 'Read Documentation',
+    },
+  },
+}
 
 export const FILTER_AND_ANALYZE_CARDS = [
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Entry Points & Smart Filtering",
-    description: "Toggle entry point spans to isolate where requests first enter each service, eliminating noise from internal downstream calls. Build complex AND/OR filter chains to pinpoint exact failure patterns across multiple services simultaneously."
+    icon: <Atom />,
+    title: 'Entry Points & Smart Filtering',
+    description:
+      'Toggle entry point spans to isolate where requests first enter each service, eliminating noise from internal downstream calls. Build complex AND/OR filter chains to pinpoint exact failure patterns across multiple services simultaneously.',
   },
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Latency & Error Analysis",
-    description: "Calculate P95/P99 latencies between any two spans to identify slow handoffs between services. Group traces by deployment version, region, or customer segment to surface systemic issues. Compare error rates against success rates using multi-query formulas."
+    icon: <Atom />,
+    title: 'Latency & Error Analysis',
+    description:
+      'Calculate P95/P99 latencies between any two spans to identify slow handoffs between services. Group traces by deployment version, region, or customer segment to surface systemic issues. Compare error rates against success rates using multi-query formulas.',
   },
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Trace Funnels & Flow Analysis",
-    description: "Trace Funnels reveal conversion rates through distributed workflows with unlimited steps, showing exactly where requests fail in multi-service journeys. Apply Direct/InDirect Descendant operators to map request propagation and validate service dependencies."
-  }
-];
+    icon: <Atom />,
+    title: 'Trace Funnels & Flow Analysis',
+    description:
+      'Trace Funnels reveal conversion rates through distributed workflows with unlimited steps, showing exactly where requests fail in multi-service journeys. Apply Direct/InDirect Descendant operators to map request propagation and validate service dependencies.',
+  },
+]
+
+export const MASSIVE_TRACES_SHOWCASE = {
+  title: 'Load traces with million spans without browser crashes',
+  description:
+    'Virtualized rendering and progressive loading handle traces with 1M+ spans without UI degradation. Synchronized flame graph and waterfall views update together as you navigate, with span events appearing as timeline indicators. Hierarchical flame graphs provide topology overview while detailed waterfall views show exact timing. Scroll and drill down with instant response times.',
+}
+
+export const TRACE_QUERY_BUILDER_SHOWCASE = {
+  title: 'Find and analyze traces with powerful queries',
+  description:
+    'Filter traces by session ID, user ID, HTTP headers, or custom tags with auto-complete suggesting from your telemetry data as you type. Build complex queries visually, run aggregations like P95 latency calculations grouped by service or region, apply HAVING clauses to filter results, then dive deeper with trace operators to understand parent-child span relationships across your distributed system.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/userguide/query-builder-v5/#multi-query-analysis-advanced-comparisons',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Distributed Tracing Query Builder Docs Button',
+      clickLocation: 'Distributed Tracing Query Builder Section',
+      clickText: 'Read Documentation',
+    },
+  },
+}
+
+export const TRACE_QUERY_BUILDER_IMAGE = {
+  src: '/img/distributed-tracing/find-and-analyze-traces-with-powerful-queries.png',
+  alt: 'Find and analyze traces with powerful queries',
+}
+
+export const RELATED_LOGS_PANEL = {
+  title: 'See related logs of every span',
+  description:
+    'Click any span to see correlated logs instantly. OpenTelemetry automatically injects trace context into your logs, connecting traces and logs in both directions. Jump from traces to logs with one click, or click `trace_id` in any log to view the complete distributed trace.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/traces-management/guides/correlate-traces-and-logs/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Distributed Tracing Correlate Logs Docs Button',
+      clickLocation: 'Distributed Tracing Storage Section',
+      clickText: 'Read Documentation',
+    },
+  },
+  image: '/img/distributed-tracing/see-related-logs-of-every-span.png',
+  imageAlt: 'See related logs of every span',
+  imageClassName: '-mt-8',
+  className: 'py-6',
+}
+
+export const CONTROL_TRACES_VOLUME_PANEL = {
+  title: 'Control traces volume',
+  description:
+    "Drop spans you don't need to optimize costs further. Define filter rules to exclude health checks, internal endpoints, or noisy traces. Remove sensitive attributes before storage, or drop entire spans based on service, operation name, or custom span attributes.",
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/traces-management/guides/drop-spans/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Distributed Tracing Drop Spans Docs Button',
+      clickLocation: 'Distributed Tracing Storage Section',
+      clickText: 'Read Documentation',
+    },
+  },
+  image: '/img/distributed-tracing/control-traces-volume.png',
+  imageAlt: 'Control traces volume',
+  className: 'py-6',
+}
 
 export const CORRELATION_CAROUSEL_DATA: Array<CarouselCard> = [
   {
     id: 0,
-    title: "Handle massive traces",
-    description: "Smooth navigation through 1M+ spans.",
-    image: "/img/distributed-tracing/handle-massive-traces.png",
-    isActive: true
+    title: 'Handle massive traces',
+    description: 'Smooth navigation through 1M+ spans.',
+    image: '/img/distributed-tracing/handle-massive-traces.png',
+    isActive: true,
   },
   {
     id: 1,
-    title: "Synchronized flame graph and waterfall",
-    description: "Click one, see everywhere.",
-    image: "/img/distributed-tracing/synchronized-flame-graph-and-waterfall.png",
-    isActive: false
+    title: 'Synchronized flame graph and waterfall',
+    description: 'Click one, see everywhere.',
+    image: '/img/distributed-tracing/synchronized-flame-graph-and-waterfall.png',
+    isActive: false,
   },
   {
     id: 2,
-    title: "Span events on timeline",
-    description: "Event indicators directly on timelines.",
-    image: "/img/distributed-tracing/span-events-on-timeline.png",
-    isActive: false
-  }
-];
+    title: 'Span events on timeline',
+    description: 'Event indicators directly on timelines.',
+    image: '/img/distributed-tracing/span-events-on-timeline.png',
+    isActive: false,
+  },
+]

--- a/app/(site)/distributed-tracing/DistributedTracingPage.constants.tsx
+++ b/app/(site)/distributed-tracing/DistributedTracingPage.constants.tsx
@@ -14,11 +14,22 @@ import { BiLogoPostgresql } from 'react-icons/bi'
 import { GrMysql } from 'react-icons/gr'
 import { CarouselCard } from '@/shared/components/molecules/FeaturePages/CarouselCards'
 import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
+import awsIconUrl from '@/public/img/icons/aws-icon.svg?url'
+import gcpIconUrl from '@/public/img/icons/gcp-icon.svg?url'
+import azureIconUrl from '@/public/img/icons/azure-icon.svg?url'
+import redisIconUrl from '@/public/img/icons/redis-icon.svg?url'
+import grpcIconUrl from '@/public/img/icons/grpc-icon.svg?url'
+import mongoIconUrl from '@/public/img/icons/mongo-icon.svg?url'
+import elasticIconUrl from '@/public/img/icons/elastic-icon.svg?url'
+import jaegerIconUrl from '@/public/img/icons/jaeger-stag-face-icon.svg?url'
+import zipkinIconUrl from '@/public/img/icons/zipkin-icon.svg?url'
+import opencensusIconUrl from '@/public/img/icons/opencensus-icon.svg?url'
+import javaIconUrl from '@/public/img/icons/java-icon.svg?url'
 
 export const CLOUD_ICONS = [
-  { src: '/img/icons/aws-icon.svg', alt: 'AWS' },
-  { src: '/img/icons/gcp-icon.svg', alt: 'Google Cloud' },
-  { src: '/img/icons/azure-icon.svg', alt: 'Azure' },
+  { src: awsIconUrl, alt: 'AWS' },
+  { src: gcpIconUrl, alt: 'Google Cloud' },
+  { src: azureIconUrl, alt: 'Azure' },
 ]
 
 export const CONTAINER_ICONS = [
@@ -30,24 +41,24 @@ export const CONTAINER_ICONS = [
 
 export const POPULAR_TOOLS_ICONS = [
   { src: <BiLogoPostgresql className="h-7 w-7 text-blue-600" />, alt: 'Postgres' },
-  { src: '/img/icons/redis-icon.svg', alt: 'Redis' },
+  { src: redisIconUrl, alt: 'Redis' },
   { src: <SiApachekafka className="h-7 w-7" />, alt: 'Apache Kafka' },
-  { src: '/img/icons/grpc-icon.svg', alt: 'gRPC' },
+  { src: grpcIconUrl, alt: 'gRPC' },
   { src: <GrMysql className="h-7 w-7 text-cyan-600" />, alt: 'MySQL' },
-  { src: '/img/icons/mongo-icon.svg', alt: 'Mongo' },
+  { src: mongoIconUrl, alt: 'Mongo' },
   { src: <SiRabbitmq className="h-7 w-7 text-orange-600" />, alt: 'RabbitMQ' },
-  { src: '/img/icons/elastic-icon.svg', alt: 'Elastic' },
+  { src: elasticIconUrl, alt: 'Elastic' },
 ]
 
 export const LEGACY_FORMAT_SUPPORT_ICONS = [
-  { src: '/img/icons/jaeger-stag-face-icon.svg', alt: 'Jaeger' },
-  { src: '/img/icons/zipkin-icon.svg', alt: 'Zipkin' },
-  { src: '/img/icons/opencensus-icon.svg', alt: 'OpenCensus' },
+  { src: jaegerIconUrl, alt: 'Jaeger' },
+  { src: zipkinIconUrl, alt: 'Zipkin' },
+  { src: opencensusIconUrl, alt: 'OpenCensus' },
 ]
 
 export const LANGUAGES_ICONS = [
   { src: <SiPython className="h-5 w-5 text-blue-500" />, alt: 'Python' },
-  { src: '/img/icons/java-icon.svg', alt: 'Java' },
+  { src: javaIconUrl, alt: 'Java' },
   { src: <SiGo className="h-7 w-7 text-cyan-500" />, alt: 'Golang' },
   { src: <SiDotnet className="h-7 w-7" />, alt: 'Dotnet' },
 ]

--- a/app/(site)/distributed-tracing/DistributedTracingPage.tsx
+++ b/app/(site)/distributed-tracing/DistributedTracingPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { ArrowRight, MonitorDown, Shovel } from 'lucide-react'
+import { MonitorDown, Shovel } from 'lucide-react'
 import Button from '@/components/ui/Button'
 import TrackingLink from '@/components/TrackingLink'
 import { Card } from '@/components/ui/Card'
@@ -12,15 +12,21 @@ import {
   CONTAINER_ICONS,
   CORRELATION_CAROUSEL_DATA,
   DIRECT_INTEGRATIONS,
+  DISTRIBUTED_TRACING_HEADER_BUTTONS,
   LANGUAGES_ICONS,
   LEGACY_FORMAT_SUPPORT_ICONS,
+  CONTROL_TRACES_VOLUME_PANEL,
   POPULAR_TOOLS_ICONS,
   FILTER_AND_ANALYZE_CARDS,
+  INSTRUMENT_SERVICES_PANEL,
+  MASSIVE_TRACES_SHOWCASE,
+  RELATED_LOGS_PANEL,
+  TRACE_QUERY_BUILDER_IMAGE,
+  TRACE_QUERY_BUILDER_SHOWCASE,
 } from './DistributedTracingPage.constants'
 import TabItem from '@/components/TabItem'
 import Tabs from '@/components/Tabs'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
-import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 import IconGrid from '@/shared/components/molecules/FeaturePages/IconGrid'
 import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
@@ -29,36 +35,12 @@ import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import CarouselCards from '@/shared/components/molecules/FeaturePages/CarouselCards'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
 
 // Main Component Sections
 const Header: React.FC = () => {
-  const headerButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'Distributed Tracing Hero Start Trial',
-        clickLocation: 'Distributed Tracing Hero',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/instrumentation/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'Distributed Tracing Hero Docs',
-        clickLocation: 'Distributed Tracing Hero',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
     <FeaturePageHeader
       title={
@@ -72,7 +54,7 @@ const Header: React.FC = () => {
           traces with logs and metrics to find root cause in distributed systems.
         </>
       }
-      buttons={headerButtons}
+      buttons={DISTRIBUTED_TRACING_HEADER_BUTTONS}
       heroImage="/img/distributed-tracing/DistributedTracingHero.webp"
       heroImageAlt="Distributed tracing hero"
     />
@@ -82,16 +64,13 @@ const Header: React.FC = () => {
 const LogProcessingSection: React.FC = () => {
   const sourcesTabContent = (
     <div className="flex min-h-52 flex-col gap-4">
-      <div className="grid grid-cols-2 gap-4">
-        <IconGrid
-          icons={LANGUAGES_ICONS}
-          title="LANGUAGES"
-          className="border-r-1 border-dashed border-signoz_slate-400 pr-4"
-        />
+      <div className="grid grid-cols-[1fr_auto_1fr] gap-4">
+        <IconGrid icons={LANGUAGES_ICONS} title="LANGUAGES" className="pr-4" />
+        <Divider orientation="vertical" />
         <IconGrid icons={CONTAINER_ICONS} title="FRAMEWORKS" />
       </div>
 
-      <div className="border-b-1 border-dashed border-signoz_slate-400" />
+      <Divider />
 
       <IconGrid
         icons={POPULAR_TOOLS_ICONS}
@@ -178,39 +157,10 @@ const LogProcessingSection: React.FC = () => {
   )
 
   return (
-    <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-10">
-      <GridLayout variant="split">
-        {/* Left Column - Ingestion */}
-        <div className="flex flex-col px-6">
-          <div className="flex min-h-72 flex-col justify-between">
-            <div>
-              <h2 className="mb-6 text-signoz_vanilla-100">Instrument services in minutes</h2>
-              <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                Auto-instrument your applications with OpenTelemetry across all major languages and
-                frameworks. Change one environment variable to start sending traces to SigNoz.
-              </p>
-            </div>
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="mb-8 flex w-fit items-center gap-2"
-              asChild
-            >
-              <TrackingLink
-                href="/docs/instrumentation/overview/"
-                clickType="Secondary CTA"
-                clickName="Distributed Tracing Instrumentation Docs Button"
-                clickLocation="Distributed Tracing Instrumentation Section"
-                clickText="Read Documentation"
-              >
-                Read Documentation
-                <ArrowRight size={14} />
-              </TrackingLink>
-            </Button>
-          </div>
-        </div>
-
-        {/* Right Column - Processing */}
+    <SplitSection
+      className="py-10"
+      left={INSTRUMENT_SERVICES_PANEL}
+      right={
         <div className="-my-10 flex flex-col px-6 py-8">
           <div className="flex min-h-72 flex-col justify-between">
             <div>
@@ -219,7 +169,7 @@ const LogProcessingSection: React.FC = () => {
                   <TabItem
                     value="supported-sources"
                     label={
-                      <span className="flex-center">
+                      <span className="flex h-full w-full items-center justify-center gap-1">
                         <MonitorDown /> Supported Languages & Frameworks
                       </span>
                     }
@@ -229,7 +179,7 @@ const LogProcessingSection: React.FC = () => {
                   <TabItem
                     value="collection-methods"
                     label={
-                      <span className="flex-center">
+                      <span className="flex h-full w-full items-center justify-center gap-1">
                         <Shovel /> Collection Methods
                       </span>
                     }
@@ -241,55 +191,25 @@ const LogProcessingSection: React.FC = () => {
             </div>
           </div>
         </div>
-      </GridLayout>
-    </div>
+      }
+    />
   )
 }
 
 const VisualQueryBuilder: React.FC = () => {
   return (
     <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Find and analyze traces with powerful queries
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            Filter traces by session ID, user ID, HTTP headers, or custom tags with auto-complete
-            suggesting from your telemetry data as you type. Build complex queries visually, run
-            aggregations like P95 latency calculations grouped by service or region, apply HAVING
-            clauses to filter results, then dive deeper with trace operators to understand
-            parent-child span relationships across your distributed system.
-          </p>
-          <Button
-            variant="secondary"
-            rounded="full"
-            className="flex w-fit items-center gap-2"
-            asChild
-          >
-            <TrackingLink
-              href="/docs/userguide/query-builder-v5/#multi-query-analysis-advanced-comparisons"
-              clickType="Secondary CTA"
-              clickName="Distributed Tracing Query Builder Docs Button"
-              clickLocation="Distributed Tracing Query Builder Section"
-              clickText="Read Documentation"
-            >
-              Read Documentation
-              <ArrowRight size={14} />
-            </TrackingLink>
-          </Button>
-        </div>
-
+      <FeatureShowcase {...TRACE_QUERY_BUILDER_SHOWCASE}>
         <Image
-          src="/img/distributed-tracing/find-and-analyze-traces-with-powerful-queries.png"
-          alt="Find and analyze traces with powerful queries"
+          src={TRACE_QUERY_BUILDER_IMAGE.src}
+          alt={TRACE_QUERY_BUILDER_IMAGE.alt}
           width={10000}
           height={10000}
           className="mb-8"
         />
 
         {/* <HeroCards cards={FILTER_AND_ANALYZE_CARDS} layoutVariant={null} variant="combined" /> */}
-      </div>
+      </FeatureShowcase>
       <HeroCards cards={FILTER_AND_ANALYZE_CARDS} layoutVariant={'no-border'} variant="combined" />
     </>
   )
@@ -297,81 +217,14 @@ const VisualQueryBuilder: React.FC = () => {
 
 const StorageSection: React.FC = () => {
   return (
-    <div className="border-y-1 mb-12 border-dashed border-signoz_slate-400 bg-transparent p-0">
-      <div className="flex h-full flex-col items-start gap-8 px-6 md:flex-row">
-        <div className="border-r-1 flex h-full w-full flex-col justify-between border-dashed border-signoz_slate-400 py-6 pr-6">
-          <h2 className="mb-6 font-semibold text-signoz_vanilla-100">
-            See related logs of every span
-          </h2>
-          <p className="mb-6 leading-relaxed text-signoz_vanilla-400">
-            Click any span to see correlated logs instantly. OpenTelemetry automatically injects
-            trace context into your logs, connecting traces and logs in both directions. Jump from
-            traces to logs with one click, or click `trace_id` in any log to view the complete
-            distributed trace.
-          </p>
-          <div className="flex flex-col">
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="z-10 flex w-fit items-center gap-2"
-              asChild
-            >
-              <TrackingLink
-                href="/docs/traces-management/guides/correlate-traces-and-logs/"
-                clickType="Secondary CTA"
-                clickName="Distributed Tracing Correlate Logs Docs Button"
-                clickLocation="Distributed Tracing Storage Section"
-                clickText="Read Documentation"
-              >
-                Read Documentation
-                <ArrowRight size={14} />
-              </TrackingLink>
-            </Button>
-            <Image
-              src="/img/distributed-tracing/see-related-logs-of-every-span.png"
-              alt="See related logs of every span"
-              width={10000}
-              height={10000}
-              className="-mt-8"
-            />
-          </div>
-        </div>
-
-        <div className="flex h-full w-full flex-col justify-between py-6">
-          <h2 className="mb-6 font-semibold text-signoz_vanilla-100">Control traces volume</h2>
-          <p className="mb-6 leading-relaxed text-signoz_vanilla-400">
-            Drop spans you don't need to optimize costs further. Define filter rules to exclude
-            health checks, internal endpoints, or noisy traces. Remove sensitive attributes before
-            storage, or drop entire spans based on service, operation name, or custom span
-            attributes.
-          </p>
-          <div className="flex flex-col">
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="flex w-fit items-center gap-2"
-              asChild
-            >
-              <TrackingLink
-                href="/docs/traces-management/guides/drop-spans/"
-                clickType="Secondary CTA"
-                clickName="Distributed Tracing Drop Spans Docs Button"
-                clickLocation="Distributed Tracing Storage Section"
-                clickText="Read Documentation"
-              >
-                Read Documentation
-                <ArrowRight size={14} />
-              </TrackingLink>
-            </Button>
-            <Image
-              src="/img/distributed-tracing/control-traces-volume.png"
-              alt="Control traces volume"
-              width={10000}
-              height={10000}
-            />
-          </div>
-        </div>
-      </div>
+    <div>
+      <Divider />
+      <SplitSection
+        className="bg-transparent"
+        left={RELATED_LOGS_PANEL}
+        right={CONTROL_TRACES_VOLUME_PANEL}
+        withVerticalDivider
+      />
     </div>
   )
 }
@@ -381,35 +234,35 @@ const DistributedTracing: React.FC = () => {
   return (
     <FeaturePageLayout>
       <Header />
-      <HeroCards cards={CARDS} />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider />
+        <HeroCards layoutVariant="no-border" cards={CARDS} />
+        <Divider className="mb-12" />
+        <Divider />
         <LogProcessingSection />
 
-        <SectionLayout variant="full-width" className="px-6 pt-6">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Load traces with million spans without browser crashes
-          </h2>
-          <p className="mb-2 leading-relaxed text-signoz_vanilla-400">
-            Virtualized rendering and progressive loading handle traces with 1M+ spans without UI
-            degradation. Synchronized flame graph and waterfall views update together as you
-            navigate, with span events appearing as timeline indicators. Hierarchical flame graphs
-            provide topology overview while detailed waterfall views show exact timing. Scroll and
-            drill down with instant response times.
-          </p>
-        </SectionLayout>
+        <Divider />
+        <FeatureShowcase
+          {...MASSIVE_TRACES_SHOWCASE}
+          className="!mx-auto px-6 pb-0 pt-6"
+          contentClassName="mb-0"
+        />
+        <Divider orientation="vertical" />
 
         <CarouselCards
           cards={CORRELATION_CAROUSEL_DATA}
           buttonLink="/opentelemetry/correlating-traces-logs-metrics-nodejs/"
           buttonText="Read Blog"
         />
+        <Divider />
         <VisualQueryBuilder />
         <StorageSection />
+        <Divider className="pb-12" />
       </SectionLayout>
-
       <UsageBasedPricing show={['traces']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'Distributed Tracing Customer Stories Button',

--- a/app/(site)/external-apis/ExternalApisPage.constants.tsx
+++ b/app/(site)/external-apis/ExternalApisPage.constants.tsx
@@ -1,4 +1,46 @@
 import { CarouselCard } from '@/shared/components/molecules/FeaturePages/CarouselCards'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
+
+export const EXTERNAL_APIS_HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'External APIs Hero Start Trial',
+      clickLocation: 'External APIs Hero',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/external-api-monitoring/overview/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'External APIs Hero Docs',
+      clickLocation: 'External APIs Hero',
+      clickText: 'Read Documentation',
+    },
+  },
+]
+
+export const VIEW_ALL_EXTERNAL_API_DOMAINS_SHOWCASE = {
+  title: 'View all external API domains',
+  description:
+    'View all external domains with endpoints in use, last accessed time, operations per second, error percentage, and average latency.',
+  image: '/img/external-apis/view-all-external-api-domains.png',
+  imageAlt: 'View all external API domains',
+}
+
+export const DRILL_INTO_DOMAINS_SHOWCASE = {
+  title: 'Drill into domains to see endpoints and their performance',
+  description:
+    'Click any domain to see all endpoints with call counts, latency, last used time, and error percentage. View performance visualizations including call response status, status code breakdown, rate over time, and latency trends.',
+}
 
 export const CORRELATION_CAROUSEL_DATA: Array<CarouselCard> = [
   {
@@ -22,4 +64,60 @@ export const CORRELATION_CAROUSEL_DATA: Array<CarouselCard> = [
   //   image: "/img/log-management/APM-to-Logs.png",
   //   isActive: false
   // }
+]
+
+export const FILTER_BY_ENVIRONMENT_PANEL = {
+  title: 'Filter by environment, service or method',
+  description:
+    'Use the left panel to filter domains by Deployment Environment, Service Name, or RPC Method. When viewing endpoints for a domain, search for specific endpoints or filter by suggested attributes like deployment environment, host, status code, and more.',
+  image: '/img/external-apis/filter-by-environment-service-or-method.png',
+  imageAlt: 'Filter by environment, service or method',
+  className: 'py-16',
+}
+
+export const AUTOMATIC_DETECTION_PANEL = {
+  title: 'Automatic detection of external calls',
+  description:
+    "External API calls are automatically identified using OpenTelemetry's span.kind attribute to detect client spans. API details like domain, endpoint, and URL are extracted from semantic convention attributes (server.address, url.full).",
+  className: 'py-16',
+}
+
+export const AUTOMATIC_DETECTION_IMAGE = {
+  src: '/img/external-apis/automatic-detection-of-external-calls.png',
+  alt: 'Automatic detection of external calls',
+}
+
+export const SEE_SERVICES_CALLING_APIS_SHOWCASE = {
+  title: 'See which services call your API and jump to traces',
+  description:
+    'View call counts, latency, error rates, and request rates for each service calling an external API. Click any service name to open its dashboard in a new tab. Click any chart to view traces. Correlation is automatic via shared client spans.',
+  image: '/img/external-apis/see-services-calling-apis.png',
+  imageAlt: 'See which services call your API and jump to traces',
+}
+
+export const READY_TO_MONITOR_EXTERNAL_APIS_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'External APIs Banner Start Trial',
+      clickLocation: 'External APIs Bottom Banner',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/external-api-monitoring/overview/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'External APIs Banner Docs',
+      clickLocation: 'External APIs Bottom Banner',
+      clickText: 'Read Documentation',
+    },
+  },
 ]

--- a/app/(site)/external-apis/ExternalApisPage.tsx
+++ b/app/(site)/external-apis/ExternalApisPage.tsx
@@ -2,46 +2,31 @@
 
 import React from 'react'
 import Image from 'next/image'
-import { CORRELATION_CAROUSEL_DATA } from './ExternalApisPage.constants'
+import {
+  AUTOMATIC_DETECTION_IMAGE,
+  AUTOMATIC_DETECTION_PANEL,
+  CORRELATION_CAROUSEL_DATA,
+  DRILL_INTO_DOMAINS_SHOWCASE,
+  EXTERNAL_APIS_HEADER_BUTTONS,
+  FILTER_BY_ENVIRONMENT_PANEL,
+  READY_TO_MONITOR_EXTERNAL_APIS_BUTTONS,
+  SEE_SERVICES_CALLING_APIS_SHOWCASE,
+  VIEW_ALL_EXTERNAL_API_DOMAINS_SHOWCASE,
+} from './ExternalApisPage.constants'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
-import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
-import ButtonGroup from '@/shared/components/molecules/FeaturePages/ButtonGroup'
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import CarouselCards from '@/shared/components/molecules/FeaturePages/CarouselCards'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
 
 // Main Component Sections
 const Header: React.FC = () => {
-  const headerButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'External APIs Hero Start Trial',
-        clickLocation: 'External APIs Hero',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/external-api-monitoring/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'External APIs Hero Docs',
-        clickLocation: 'External APIs Hero',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
     <FeaturePageHeader
       title={
@@ -55,7 +40,7 @@ const Header: React.FC = () => {
           Click any metric to view the service making the call or the underlying trace.
         </>
       }
-      buttons={headerButtons}
+      buttons={EXTERNAL_APIS_HEADER_BUTTONS}
       heroImageAlt="External APIs hero"
       heroImage="/img/platform/ExternalApisMeta.webp"
     />
@@ -63,147 +48,45 @@ const Header: React.FC = () => {
 }
 
 const ViewAllExternalApiDomains: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6 max-md:mt-12">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">View all external API domains</h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            View all external domains with endpoints in use, last accessed time, operations per
-            second, error percentage, and average latency.
-          </p>
-        </div>
-
-        <Image
-          src="/img/external-apis/view-all-external-api-domains.png"
-          alt="View all external API domains"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...VIEW_ALL_EXTERNAL_API_DOMAINS_SHOWCASE} />
 }
 
 const SeeServicesCallingApis: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            See which services call your API and jump to traces
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            View call counts, latency, error rates, and request rates for each service calling an
-            external API. Click any service name to open its dashboard in a new tab. Click any chart
-            to view traces. Correlation is automatic via shared client spans.
-          </p>
-        </div>
-
-        <Image
-          src="/img/external-apis/see-services-calling-apis.png"
-          alt="See which services call your API and jump to traces"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...SEE_SERVICES_CALLING_APIS_SHOWCASE} />
 }
 
 const ReadyToMonitorYourExternalApisBanner: React.FC = () => {
-  const stopLosingUsersButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'External APIs Banner Start Trial',
-        clickLocation: 'External APIs Bottom Banner',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/external-api-monitoring/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'External APIs Banner Docs',
-        clickLocation: 'External APIs Bottom Banner',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
-    <div className="border-t-1 flex flex-col items-center justify-center border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6 py-20">
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        Ready to Monitor Your <br /> External APIs?
-      </h2>
-      <ButtonGroup buttons={stopLosingUsersButtons} />
-    </div>
+    <CTABanner
+      title={
+        <>
+          Ready to Monitor Your <br /> External APIs?
+        </>
+      }
+      buttons={READY_TO_MONITOR_EXTERNAL_APIS_BUTTONS}
+    />
   )
 }
 
 const FilterAndAutomaticDetectionSection: React.FC = () => {
   return (
-    <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-16">
-      <GridLayout variant="split">
-        {/* Left Column - Ingestion */}
-        <div className="flex flex-col px-6">
-          <div className="flex min-h-56 flex-col justify-between">
-            <div>
-              <h2 className="mb-6 text-signoz_vanilla-100">
-                Filter by environment, service or method
-              </h2>
-              <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                Use the left panel to filter domains by Deployment Environment, Service Name, or RPC
-                Method. When viewing endpoints for a domain, search for specific endpoints or filter
-                by suggested attributes like deployment environment, host, status code, and more.
-              </p>
-            </div>
-          </div>
-
-          <Image
-            src="/img/external-apis/filter-by-environment-service-or-method.png"
-            alt="Filter by environment, service or method"
-            width={10000}
-            height={10000}
-          />
-        </div>
-
-        {/* Right Column - Processing */}
-        <div className="border-l-1 -my-16 flex flex-col border-dashed border-signoz_slate-400 px-6 pt-16">
-          <div className="flex min-h-56 flex-col justify-between">
-            <div>
-              <h2 className="mb-6 text-signoz_vanilla-100">
-                Automatic detection of external calls
-              </h2>
-              <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                External API calls are automatically identified using OpenTelemetry's span.kind
-                attribute to detect client spans. API details like domain, endpoint, and URL are
-                extracted from semantic convention attributes (server.address, url.full).
-              </p>
-            </div>
-          </div>
-
+    <SplitSection
+      left={FILTER_BY_ENVIRONMENT_PANEL}
+      right={{
+        ...AUTOMATIC_DETECTION_PANEL,
+        imageElement: (
           <div className="flex h-full flex-col items-center justify-center pb-16">
             <Image
-              src="/img/external-apis/automatic-detection-of-external-calls.png"
-              alt="Automatic detection of external calls"
+              src={AUTOMATIC_DETECTION_IMAGE.src}
+              alt={AUTOMATIC_DETECTION_IMAGE.alt}
               width={10000}
               height={10000}
             />
           </div>
-        </div>
-      </GridLayout>
-    </div>
+        ),
+      }}
+      withVerticalDivider
+    />
   )
 }
 
@@ -214,27 +97,27 @@ const ExternalApis: React.FC = () => {
       <Header />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider className="max-md:mt-12" />
         <ViewAllExternalApiDomains />
 
-        <div className="!mx-auto !w-[80vw] px-6 pt-6">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Drill into domains to see endpoints and their performance
-          </h2>
-          <p className="mb-2 leading-relaxed text-signoz_vanilla-400">
-            Click any domain to see all endpoints with call counts, latency, last used time, and
-            error percentage. View performance visualizations including call response status, status
-            code breakdown, rate over time, and latency trends.
-          </p>
-        </div>
+        <FeatureShowcase
+          {...DRILL_INTO_DOMAINS_SHOWCASE}
+          className="!mx-auto !w-[80vw] px-6 pb-0 pt-6"
+          contentClassName="mb-0"
+        />
 
         <CarouselCards cards={CORRELATION_CAROUSEL_DATA} />
+        <Divider className="mt-12" />
         <FilterAndAutomaticDetectionSection />
+        <Divider />
         <SeeServicesCallingApis />
+        <Divider />
         <ReadyToMonitorYourExternalApisBanner />
       </SectionLayout>
 
       <UsageBasedPricing show={['traces', 'metrics', 'logs']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'External APIs Customer Stories Button',

--- a/app/(site)/llm-observability/LlmObservabilityPage.tsx
+++ b/app/(site)/llm-observability/LlmObservabilityPage.tsx
@@ -20,6 +20,8 @@ import TrackingLink from '@/components/TrackingLink'
 import ComparisonTable from '@/shared/components/molecules/FeaturePages/ComparisonTable'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
 
 const Header: React.FC = () => {
   const headerButtons = [
@@ -27,7 +29,7 @@ const Header: React.FC = () => {
       text: 'Start your free trial',
       href: '/teams/',
       variant: 'default' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Primary CTA',
         clickName: 'LLM Observability Hero Start Trial',
@@ -39,7 +41,7 @@ const Header: React.FC = () => {
       text: 'Read Documentation',
       href: '/docs/llm-observability/',
       variant: 'secondary' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Secondary CTA',
         clickName: 'LLM Observability Hero Docs',
@@ -75,8 +77,10 @@ const Header: React.FC = () => {
 
 const EverythingYouNeedCards: React.FC = () => {
   return (
-    <section className="bg-blur-ellipse-388 relative mx-auto w-[100vw] max-w-8xl overflow-hidden md:w-[80vw]">
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
+    <SectionLayout
+      variant="bordered"
+      className="bg-blur-ellipse-388 relative mx-auto max-w-8xl overflow-hidden"
+    >
       <div className="relative">
         <div className="container">
           <div className="flex flex-col gap-6 pt-32">
@@ -86,61 +90,66 @@ const EverythingYouNeedCards: React.FC = () => {
                   Everything You Need to <br className="hidden md:block" /> Monitor LLM Applications
                 </h2>
                 <SectionLayout variant="no-border" className="!mx-auto p-0">
+                  <Divider />
                   <IconTitleDescriptionCardGrid cards={LLM_OBSERVABILITY_CARDS} />
+                  <Divider />
                 </SectionLayout>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </section>
+    </SectionLayout>
   )
 }
 
 const WorksWithYourFavoriteLLMTools: React.FC = () => {
   return (
     <>
-      <section className="bg-blur-ellipse-388 relative mx-auto w-[100vw] max-w-8xl overflow-hidden md:w-[80vw]">
+      <SectionLayout
+        variant="bordered"
+        className="bg-blur-ellipse-388 relative mx-auto max-w-8xl overflow-hidden"
+      >
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
         <div className="relative">
-          <div className="container">
-            <div className="flex flex-col gap-6">
-              <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
-                <div className="flex flex-col items-center gap-8 font-medium leading-[3.25rem] text-signoz_sienna-100">
-                  <h2 className="text-center text-4xl font-semibold text-signoz_sakura-100">
-                    Works with Your Favorite LLM Tools
-                  </h2>
-                  <p className="text-sm leading-relaxed text-signoz_vanilla-400">
-                    Automatic instrumentation for every part of your LLM stack. From model{' '}
-                    <br className="hidden md:block" /> providers to vector databases to agent
-                    frameworks, get instant visibility <br className="hidden md:block" /> without
-                    writing custom telemetry code.
-                  </p>
-                  <Button
-                    variant="secondary"
-                    rounded="full"
-                    className="flex w-fit items-center gap-2"
-                    asChild
+          <div className="flex flex-col gap-6">
+            <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+              <div className="flex flex-col items-center gap-8 font-medium leading-[3.25rem] text-signoz_sienna-100">
+                <h2 className="text-center text-4xl font-semibold text-signoz_sakura-100">
+                  Works with Your Favorite LLM Tools
+                </h2>
+
+                <p className="text-sm leading-relaxed text-signoz_vanilla-400">
+                  Automatic instrumentation for every part of your LLM stack. From model{' '}
+                  <br className="hidden md:block" /> providers to vector databases to agent
+                  frameworks, get instant visibility <br className="hidden md:block" /> without
+                  writing custom telemetry code.
+                </p>
+                <Button
+                  variant="secondary"
+                  rounded="full"
+                  className="flex w-fit items-center gap-2"
+                  asChild
+                >
+                  <TrackingLink
+                    href="/docs/llm-observability/"
+                    clickType="Secondary CTA"
+                    clickName="LLM Observability Integrations Button"
+                    clickLocation="LLM Observability Integrations Section"
+                    clickText="See All Integrations"
                   >
-                    <TrackingLink
-                      href="/docs/llm-observability/"
-                      clickType="Secondary CTA"
-                      clickName="LLM Observability Integrations Button"
-                      clickLocation="LLM Observability Integrations Section"
-                      clickText="See All Integrations"
-                    >
-                      <BookOpen className="h-5 w-5 text-signoz_vanilla-400" />
-                      See All Integrations
-                      <ArrowRight className="h-5 w-5 text-signoz_vanilla-400" />
-                    </TrackingLink>
-                  </Button>
-                </div>
+                    <BookOpen className="h-5 w-5 text-signoz_vanilla-400" />
+                    See All Integrations
+                    <ArrowRight className="h-5 w-5 text-signoz_vanilla-400" />
+                  </TrackingLink>
+                </Button>
               </div>
             </div>
           </div>
         </div>
-      </section>
-      <SectionLayout variant="full-width" className="!mx-auto mt-10 p-0">
+      </SectionLayout>
+      <SectionLayout variant="bordered" className="!mx-auto mt-10 p-0">
+        <Divider />
         <GridLayout variant="split" className="!gap-y-0">
           {LLM_TOOLS_DATA.map((section, index) => {
             const isDesktopRow1 = index < 2
@@ -183,7 +192,10 @@ const WorksWithYourFavoriteLLMTools: React.FC = () => {
 
 const HowSigNozCompares: React.FC = () => {
   return (
-    <section className="bg-blur-ellipse-388 relative mx-auto w-[100vw] max-w-8xl overflow-hidden md:w-[80vw]">
+    <SectionLayout
+      variant="bordered"
+      className="bg-blur-ellipse-388 relative mx-auto max-w-8xl overflow-hidden"
+    >
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-signoz_ink-500/50 via-signoz_ink-500/25 to-signoz_ink-500/90" />
       <div className="relative">
         <div className="container pb-16">
@@ -204,7 +216,7 @@ const HowSigNozCompares: React.FC = () => {
           </div>
         </div>
       </div>
-    </section>
+    </SectionLayout>
   )
 }
 
@@ -214,7 +226,7 @@ const StartMonitoring: React.FC = () => {
       text: 'Start your free trial',
       href: '/teams/',
       variant: 'default' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Primary CTA',
         clickName: 'LLM Observability Bottom CTA Start Trial',
@@ -226,7 +238,7 @@ const StartMonitoring: React.FC = () => {
       text: 'Read Documentation',
       href: '/docs/llm-observability/',
       variant: 'secondary' as const,
-      className: 'flex-center',
+      className: BUTTON_CLASS_NAME,
       tracking: {
         clickType: 'Secondary CTA',
         clickName: 'LLM Observability Bottom CTA Docs',
@@ -236,10 +248,8 @@ const StartMonitoring: React.FC = () => {
     },
   ]
   return (
-    <SectionLayout
-      variant="bordered"
-      className="!border-t-1 border-dashed border-signoz_slate-400 !px-0"
-    >
+    <SectionLayout variant="bordered" className="!px-0">
+      <Divider />
       <div className="flex flex-col sm:flex-row">
         <div className="!w-[100%] flex-1 md:!w-[300px]">
           <p className="sticky top-[100px] px-10 pt-10 text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl md:px-12">
@@ -247,7 +257,7 @@ const StartMonitoring: React.FC = () => {
           </p>
         </div>
         <div className="flex-[2_2_0%]">
-          <div className="border-b border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
+          <div className="border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
             <div className="grid grid-cols-1 lg:grid-cols-3">
               <div className="col-span-2 flex flex-col gap-6 p-10">
                 <h3 className="m-0 text-2xl font-semibold text-signoz_vanilla-100">
@@ -294,16 +304,14 @@ const LlmObservabilityPage: React.FC = () => {
   return (
     <FeaturePageLayout>
       <Header />
-
-      <SectionLayout variant="bordered" className="!px-0">
-        <EverythingYouNeedCards />
-        <HowSigNozCompares />
-        <WorksWithYourFavoriteLLMTools />
-      </SectionLayout>
+      <EverythingYouNeedCards />
+      <HowSigNozCompares />
+      <WorksWithYourFavoriteLLMTools />
 
       <StartMonitoring />
       <UsageBasedPricing show={['traces', 'metrics', 'logs']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'LLM Observability Customer Stories Button',

--- a/app/(site)/log-management/LogManagement.constants.tsx
+++ b/app/(site)/log-management/LogManagement.constants.tsx
@@ -1,5 +1,33 @@
 import { Atom, Coins, DatabaseZap } from 'lucide-react'
 import { CarouselCard } from '@/shared/components/molecules/FeaturePages/CarouselCards'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
+
+export const LOG_MANAGEMENT_HEADER_BUTTONS = [
+  {
+    text: 'Get Started - Free',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Log Management Hero Start Trial',
+      clickLocation: 'Log Management Hero',
+      clickText: 'Get Started - Free',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/introduction/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Log Management Hero Docs',
+      clickLocation: 'Log Management Hero',
+      clickText: 'Read Documentation',
+    },
+  },
+]
 
 export const CARDS = [
   {
@@ -19,6 +47,48 @@ export const CARDS = [
       'Configure hot retention periods to balance query performance with storage costs for compliance.',
   },
 ]
+
+export const INGEST_LOGS_PANEL = {
+  title: 'Ingest logs from anywhere',
+  description:
+    'OTel-native architecture supports extensive data source integration through multiple collection patterns, eliminating vendor lock-in while providing superior correlation capabilities.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/logs-management/send-logs-to-signoz/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Ingest Logs Read Docs Button',
+      clickLocation: 'Log Management Ingestion Section',
+      clickText: 'Read Documentation',
+    },
+  },
+  className: 'py-6',
+}
+
+export const PROCESS_LOGS_PANEL = {
+  title: 'Parse and transform logs before storage',
+  description:
+    "Create processing pipelines through a visual UI to parse unstructured logs, extract attributes, flatten nested JSON, and mask sensitive data. Apply processors like Grok patterns, regex, and JSON parsers to transform logs before they're stored and indexed.",
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/logs-pipelines/concepts/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Log Processing Read Docs Button',
+      clickLocation: 'Log Management Processing Section',
+      clickText: 'Read Documentation',
+    },
+  },
+  image: '/img/log-management/process-logs.png',
+  imageAlt: 'Log Processing',
+  className: 'py-6',
+}
+
+export const LOG_CORRELATION_SHOWCASE = {
+  title: 'Automatic correlation between logs, metrics, and traces',
+  description:
+    'Use OpenTelemetry semantic conventions to automatically link logs with traces and metrics. Jump from APM traces to their related logs, from infrastructure metrics to log context, and from alerts to root cause with consistent trace ID correlation.',
+}
 
 export const QUERY_BUILDER_CARDS = [
   {
@@ -40,6 +110,27 @@ export const QUERY_BUILDER_CARDS = [
       'Query nested JSON fields using dot notation like `attributes.user.id`. Create dashboard panels directly from query results or export to CSV for external analysis.',
   },
 ]
+
+export const LOG_QUERY_BUILDER_SHOWCASE = {
+  title: 'Build ClickHouse queries visually with auto-complete for log attributes',
+  description:
+    'Run aggregations grouped by multiple dimensions, filter with regex and LIKE patterns, query nested JSON with dot notation, and work directly with the generated SQL. Create dashboards directly from query results or export to CSV for analysis.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/userguide/query-builder-v5/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Visual Query Builder Read Docs Button',
+      clickLocation: 'Log Management Query Builder Section',
+      clickText: 'Read Documentation',
+    },
+  },
+}
+
+export const LOG_QUERY_BUILDER_IMAGE = {
+  src: '/img/log-management/logs-explorer-qb.png',
+  alt: 'Query Builder',
+}
 
 export const CORRELATION_CAROUSEL_DATA: Array<CarouselCard> = [
   {

--- a/app/(site)/log-management/LogManagement.tsx
+++ b/app/(site)/log-management/LogManagement.tsx
@@ -1,52 +1,33 @@
 'use client'
 
 import React from 'react'
-import { ArrowRight } from 'lucide-react'
-import Button from '@/components/ui/Button'
-import TrackingLink from '@/components/TrackingLink'
-import { Card } from '@/components/ui/Card'
 import Image from 'next/image'
-import { CARDS, CORRELATION_CAROUSEL_DATA, QUERY_BUILDER_CARDS } from './LogManagement.constants'
+import {
+  CARDS,
+  CORRELATION_CAROUSEL_DATA,
+  INGEST_LOGS_PANEL,
+  LOG_CORRELATION_SHOWCASE,
+  LOG_MANAGEMENT_HEADER_BUTTONS,
+  LOG_QUERY_BUILDER_IMAGE,
+  LOG_QUERY_BUILDER_SHOWCASE,
+  PROCESS_LOGS_PANEL,
+  QUERY_BUILDER_CARDS,
+} from './LogManagement.constants'
 import SourcesTabsGrid from '@/shared/components/molecules/SourcesTabsGrid'
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
-import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 import CarouselCards from '@/shared/components/molecules/FeaturePages/CarouselCards'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
 
 // Main Component Sections
 const Header: React.FC = () => {
-  const headerButtons = [
-    {
-      text: 'Get Started - Free',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'Log Management Hero Start Trial',
-        clickLocation: 'Log Management Hero',
-        clickText: 'Get Started - Free',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/introduction/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'Log Management Hero Docs',
-        clickLocation: 'Log Management Hero',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
     <FeaturePageHeader
       title={
@@ -60,7 +41,7 @@ const Header: React.FC = () => {
           builder backed by ClickHouse, and correlate your logs with other signals.
         </>
       }
-      buttons={headerButtons}
+      buttons={LOG_MANAGEMENT_HEADER_BUTTONS}
       heroImage="/img/log-management/LogManagementHero.svg"
       heroImageAlt="Log management hero"
     />
@@ -69,127 +50,34 @@ const Header: React.FC = () => {
 
 const LogProcessingSection: React.FC = () => {
   return (
-    <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-16">
-      <GridLayout variant="split">
-        {/* Left Column - Ingestion */}
-        <div className="flex flex-col px-6">
-          <div className="flex min-h-72 flex-col justify-between">
-            <div>
-              <h2 className="mb-6 text-signoz_vanilla-100">Ingest logs from anywhere</h2>
-              <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                OTel-native architecture supports extensive data source integration through multiple
-                collection patterns, eliminating vendor lock-in while providing superior correlation
-                capabilities.
-              </p>
-            </div>
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="mb-8 flex w-fit items-center gap-2"
-              asChild
-            >
-              <TrackingLink
-                href="/docs/logs-management/send-logs-to-signoz/"
-                clickType="Secondary CTA"
-                clickName="Ingest Logs Read Docs Button"
-                clickLocation="Log Management Ingestion Section"
-                clickText="Read Documentation"
-              >
-                Read Documentation
-                <ArrowRight size={14} />
-              </TrackingLink>
-            </Button>
-          </div>
-
-          <SourcesTabsGrid />
-        </div>
-
-        {/* Right Column - Processing */}
-        <div className="border-l-1 -my-16 flex flex-col border-dashed border-signoz_slate-400 px-6 pt-16">
-          <div className="flex min-h-72 flex-col justify-between">
-            <div>
-              <h2 className="mb-6 text-signoz_vanilla-100">
-                Parse and transform logs before storage
-              </h2>
-              <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-                Create processing pipelines through a visual UI to parse unstructured logs, extract
-                attributes, flatten nested JSON, and mask sensitive data. Apply processors like Grok
-                patterns, regex, and JSON parsers to transform logs before they're stored and
-                indexed.
-              </p>
-            </div>
-            <Button
-              variant="secondary"
-              rounded="full"
-              className="mb-8 flex w-fit items-center gap-2"
-              asChild
-            >
-              <TrackingLink
-                href="/docs/logs-pipelines/introduction/"
-                clickType="Secondary CTA"
-                clickName="Log Processing Read Docs Button"
-                clickLocation="Log Management Processing Section"
-                clickText="Read Documentation"
-              >
-                Read Documentation
-                <ArrowRight size={14} />
-              </TrackingLink>
-            </Button>
-          </div>
-
-          <Image
-            src="/img/log-management/process-logs.png"
-            alt="Log Processing"
-            width={10000}
-            height={10000}
-          />
-        </div>
-      </GridLayout>
-    </div>
+    <SplitSection
+      left={{
+        ...INGEST_LOGS_PANEL,
+        imageElement: <SourcesTabsGrid />,
+      }}
+      right={PROCESS_LOGS_PANEL}
+      withVerticalDivider
+    />
   )
 }
 
 const VisualQueryBuilder: React.FC = () => {
   return (
-    <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-      <div className="mb-8 max-w-4xl">
-        <h2 className="mb-6 text-signoz_vanilla-100">
-          Build ClickHouse queries visually with auto-complete for log attributes
-        </h2>
-        <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-          Run aggregations grouped by multiple dimensions, filter with regex and LIKE patterns,
-          query nested JSON with dot notation, and work directly with the generated SQL. Create
-          dashboards directly from query results or export to CSV for analysis.
-        </p>
-        <Button
-          variant="secondary"
-          rounded="full"
-          className="flex w-fit items-center gap-2"
-          asChild
-        >
-          <TrackingLink
-            href="/docs/userguide/query-builder-v5/"
-            clickType="Secondary CTA"
-            clickName="Visual Query Builder Read Docs Button"
-            clickLocation="Log Management Query Builder Section"
-            clickText="Read Documentation"
-          >
-            Read Documentation
-            <ArrowRight size={14} />
-          </TrackingLink>
-        </Button>
-      </div>
-
-      <Image
-        src="/img/log-management/logs-explorer-qb.png"
-        alt="Query Builder"
-        width={10000}
-        height={10000}
-        className="mb-8"
-      />
-
-      <HeroCards cards={QUERY_BUILDER_CARDS} layoutVariant={'no-border'} variant="combined" />
-    </div>
+    <FeatureShowcase
+      {...LOG_QUERY_BUILDER_SHOWCASE}
+      imageElement={
+        <>
+          <Image
+            src={LOG_QUERY_BUILDER_IMAGE.src}
+            alt={LOG_QUERY_BUILDER_IMAGE.alt}
+            width={10000}
+            height={10000}
+            className="mb-8"
+          />
+          <HeroCards cards={QUERY_BUILDER_CARDS} layoutVariant={'no-border'} variant="combined" />
+        </>
+      }
+    />
   )
 }
 
@@ -201,25 +89,24 @@ const LogsManagement: React.FC = () => {
       <HeroCards cards={CARDS} />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider className="mt-12" />
         <LogProcessingSection />
+        <Divider />
 
-        <div className="!mx-auto !w-[80vw] px-6 pt-6">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Automatic correlation between logs, metrics, and traces
-          </h2>
-          <p className="mb-2 leading-relaxed text-signoz_vanilla-400">
-            Use OpenTelemetry semantic conventions to automatically link logs with traces and
-            metrics. Jump from APM traces to their related logs, from infrastructure metrics to log
-            context, and from alerts to root cause with consistent trace ID correlation.
-          </p>
-        </div>
+        <FeatureShowcase
+          {...LOG_CORRELATION_SHOWCASE}
+          className="!mx-auto !w-[80vw] px-6 pb-0 pt-6"
+          contentClassName="mb-0"
+        />
 
         <CarouselCards cards={CORRELATION_CAROUSEL_DATA} />
+        <Divider />
         <VisualQueryBuilder />
       </SectionLayout>
 
       <UsageBasedPricing show={['logs']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'Log Management Customer Stories Button',

--- a/app/(site)/log-management/LogManagement.tsx
+++ b/app/(site)/log-management/LogManagement.tsx
@@ -86,9 +86,10 @@ const LogsManagement: React.FC = () => {
   return (
     <FeaturePageLayout>
       <Header />
-      <HeroCards cards={CARDS} />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <HeroCards cards={CARDS} layoutVariant="no-border" />
+        <Divider />
         <Divider className="mt-12" />
         <LogProcessingSection />
         <Divider />

--- a/app/(site)/pricing/pricingv1/PricingV1.tsx
+++ b/app/(site)/pricing/pricingv1/PricingV1.tsx
@@ -12,19 +12,17 @@ import StartupProgram from './components/StartupProgram'
 import SigNozCloudPricingOverview from './components/SigNozCloudPricingOverview'
 import InstrumentationSupport from './components/InstrumentationSupport'
 import PricingCalculator from './components/PricingCalculator'
+import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
 
 export default function PricingV1Page() {
   return (
-    <div className="relative bg-signoz_ink-500">
-      {/* Same background as original pricing page */}
-      <div className="bg-dot-pattern masked-dots absolute top-0 flex h-screen w-full items-center justify-center" />
-      <div className="absolute left-0 right-0 top-0 mx-auto h-[450px] w-full flex-shrink-0 rounded-[956px] bg-gradient-to-b from-[rgba(190,107,241,1)] to-[rgba(69,104,220,0)] bg-[length:110%] bg-no-repeat opacity-30 blur-[300px] sm:bg-[center_-500px] md:h-[956px]" />
-
+    <FeaturePageLayout showProductNav={false}>
       <div title="SigNoz Plans">
-        <div className="relative !mx-auto flex !w-[100vw] flex-col items-center border !border-b-0 border-dashed border-signoz_slate-400 px-0 pt-12 md:!w-[80vw] md:px-5 md:pt-24">
+        <div className="relative !mx-auto flex flex-col items-center border !border-b-0 border-dashed border-signoz_slate-400 px-0 pt-12 md:px-5 md:pt-24">
           {/* Header */}
           <div className="mx-auto mb-5 flex max-w-4xl flex-col items-center text-center">
-            <div className="absolute top-[-80px] z-[0] h-[7rem] !w-[80vw] border !border-l-0 !border-r-0 !border-t-0 border-dashed border-signoz_slate-400" />
             <Heading type={1} className="z-[1]">
               Simple Usage-based Predictable Observability Costs
             </Heading>
@@ -67,11 +65,14 @@ export default function PricingV1Page() {
         <StartupProgram />
         <InstrumentationSupport />
         <WhySelectSignoz isInPricingPage />
+        <Divider />
 
         <FAQ />
 
-        <QuickStartCloud />
+        <SectionLayout variant="bordered">
+          <QuickStartCloud />
+        </SectionLayout>
       </div>
-    </div>
+    </FeaturePageLayout>
   )
 }

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -707,109 +707,104 @@ const ExploreAllFeatures: React.FC = () => {
           'Exploring SigNoz Pricing or Features? Share your usecase to find the right plan for you and see the relevant docs.',
         ]}
       />
-      <div
-        id="all-features"
-        className="relative !m-0 !mx-auto !w-[100vw] border !border-t-0 border-dashed border-signoz_slate-400 md:!w-[80vw]"
-      >
-        <div className="mx-auto mb-10 mt-6 ">
-          {/* Header - Using CSS sticky positioning for smoother scrolling */}
-          <div className="sticky top-[74px] z-20 bg-[#0f1013]">
-            <div className="my-12">
-              <div className="grid grid-cols-1">
-                <div className="mx-6 flex justify-center">
-                  <TrackingLink
-                    href="/teams/"
-                    className="absolute -top-10 my-6 cursor-pointer rounded-full border border-signoz_slate-400 bg-signoz_ink-400 px-6 py-3 text-center transition-all duration-200 hover:border-signoz_robin-500/50 hover:bg-signoz_ink-300 hover:shadow-lg"
-                    clickType="Secondary CTA"
-                    clickName="Pro Tip Pill"
-                    clickText="Most teams start with Teams Cloud free trial to test with real data, then decide based on their specific needs. You can always migrate between options as your requirements evolve!"
-                    clickLocation="Explore All Features Pro Tip"
-                    id="btn-pro-tip-teams-link"
-                  >
-                    <p className="m-0 text-xs text-signoz_vanilla-400 hover:text-signoz_vanilla-300">
-                      <span className="font-medium text-signoz_vanilla-200">💡 Pro tip:</span> Most
-                      teams start with Teams Cloud free trial to test with real data, then decide
-                      based on their specific needs. You can always migrate between options as your
-                      requirements evolve!
-                    </p>
-                  </TrackingLink>
-                </div>
+      <div className="mx-auto mb-10 mt-6" id="all-features">
+        {/* Header - Using CSS sticky positioning for smoother scrolling */}
+        <div className="sticky top-[74px] z-20 bg-[#0f1013]">
+          <div className="my-12">
+            <div className="grid grid-cols-1">
+              <div className="mx-6 flex justify-center">
+                <TrackingLink
+                  href="/teams/"
+                  className="absolute -top-10 my-6 cursor-pointer rounded-full border border-signoz_slate-400 bg-signoz_ink-400 px-6 py-3 text-center transition-all duration-200 hover:border-signoz_robin-500/50 hover:bg-signoz_ink-300 hover:shadow-lg"
+                  clickType="Secondary CTA"
+                  clickName="Pro Tip Pill"
+                  clickText="Most teams start with Teams Cloud free trial to test with real data, then decide based on their specific needs. You can always migrate between options as your requirements evolve!"
+                  clickLocation="Explore All Features Pro Tip"
+                  id="btn-pro-tip-teams-link"
+                >
+                  <p className="m-0 text-xs text-signoz_vanilla-400 hover:text-signoz_vanilla-300">
+                    <span className="font-medium text-signoz_vanilla-200">💡 Pro tip:</span> Most
+                    teams start with Teams Cloud free trial to test with real data, then decide
+                    based on their specific needs. You can always migrate between options as your
+                    requirements evolve!
+                  </p>
+                </TrackingLink>
               </div>
             </div>
-            <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
-              {ALL_FEATURES_DATA.HEADER.map((header, idx) => (
-                <div
-                  key={idx}
-                  className={`${
-                    idx === 2
-                      ? `relative z-10 flex scale-105 transform flex-col justify-between rounded-lg !rounded-b-none border border-signoz_slate-400/20 bg-signoz_ink-500 p-3 shadow-2xl sm:bg-[#16181d]`
-                      : idx !== 0
-                        ? `flex flex-col justify-between rounded-lg p-3 bg-opacity-${idx * 10}`
-                        : 'hidden md:block'
-                  }`}
-                >
-                  <div className="flex flex-col gap-1">
-                    <h2 className="m-0 text-sm max-sm:h-16 md:text-base">{header.heading}</h2>
-                    <p className="text-xs text-signoz_vanilla-400">{header.desc}</p>
+          </div>
+          <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
+            {ALL_FEATURES_DATA.HEADER.map((header, idx) => (
+              <div
+                key={idx}
+                className={`${
+                  idx === 2
+                    ? `relative z-10 flex scale-105 transform flex-col justify-between rounded-lg !rounded-b-none border border-signoz_slate-400/20 bg-signoz_ink-500 p-3 shadow-2xl sm:bg-[#16181d]`
+                    : idx !== 0
+                      ? `flex flex-col justify-between rounded-lg p-3 bg-opacity-${idx * 10}`
+                      : 'hidden md:block'
+                }`}
+              >
+                <div className="flex flex-col gap-1">
+                  <h2 className="m-0 text-sm max-sm:h-16 md:text-base">{header.heading}</h2>
+                  <p className="text-xs text-signoz_vanilla-400">{header.desc}</p>
+                </div>
+                <div className="flex w-full justify-center">{header.action}</div>
+              </div>
+            ))}
+          </div>
+          <Line />
+        </div>
+
+        {/* Feature sections */}
+        {ALL_FEATURES_DATA.ROWS.map((section, sectionIdx) => (
+          <div
+            key={sectionIdx}
+            id={section.section === 'Choose When' ? 'choose-when-section' : undefined}
+          >
+            {/* Section header */}
+            <div className="sticky top-[220px] z-10 bg-[#0f1013]">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 md:grid-cols-[3fr_1fr_1fr_1fr]">
+                <div className="mb-3 mt-8 py-2 pl-6 pr-2 text-center text-sm font-medium sm:text-lg md:text-left">
+                  {section.section}
+                </div>
+                <div></div>
+                <div className="relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]"></div>
+                <div></div>
+              </div>
+            </div>
+            <Line />
+
+            {/* Features in this section */}
+            <div className="grid grid-cols-1">
+              {section.features.map((feature, featureIdx) => (
+                <div key={featureIdx}>
+                  <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
+                    <h4 className="col-span-3 m-0 py-4 pl-6 pr-2 text-center text-sm font-normal text-signoz_vanilla-400 sm:py-5 md:col-span-1 md:text-left">
+                      {feature.feature}
+                    </h4>
+                    <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
+                      {feature.inCommunity}
+                    </div>
+                    <div className="relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-[#16181d] sm:p-5">
+                      {feature.inTeams}
+                    </div>
+                    <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
+                      {feature.inEnterprise}
+                    </div>
                   </div>
-                  <div className="flex w-full justify-center">{header.action}</div>
+                  <Line />
                 </div>
               ))}
             </div>
-            <Line />
           </div>
+        ))}
 
-          {/* Feature sections */}
-          {ALL_FEATURES_DATA.ROWS.map((section, sectionIdx) => (
-            <div
-              key={sectionIdx}
-              id={section.section === 'Choose When' ? 'choose-when-section' : undefined}
-            >
-              {/* Section header */}
-              <div className="sticky top-[220px] z-10 bg-[#0f1013]">
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 md:grid-cols-[3fr_1fr_1fr_1fr]">
-                  <div className="mb-3 mt-8 py-2 pl-6 pr-2 text-center text-sm font-medium sm:text-lg md:text-left">
-                    {section.section}
-                  </div>
-                  <div></div>
-                  <div className="relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]"></div>
-                  <div></div>
-                </div>
-              </div>
-              <Line />
-
-              {/* Features in this section */}
-              <div className="grid grid-cols-1">
-                {section.features.map((feature, featureIdx) => (
-                  <div key={featureIdx}>
-                    <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
-                      <h4 className="col-span-3 m-0 py-4 pl-6 pr-2 text-center text-sm font-normal text-signoz_vanilla-400 sm:py-5 md:col-span-1 md:text-left">
-                        {feature.feature}
-                      </h4>
-                      <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
-                        {feature.inCommunity}
-                      </div>
-                      <div className="relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-[#16181d] sm:p-5">
-                        {feature.inTeams}
-                      </div>
-                      <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
-                        {feature.inEnterprise}
-                      </div>
-                    </div>
-                    <Line />
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-
-          {/* Bottom rounded corner for Teams column */}
-          <div className="grid h-[18px] grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
-            <div />
-            <div />
-            <div className="relative z-10 scale-105 transform rounded-lg !rounded-t-none border-x border-b border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]" />
-            <div />
-          </div>
+        {/* Bottom rounded corner for Teams column */}
+        <div className="grid h-[18px] grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
+          <div />
+          <div />
+          <div className="relative z-10 scale-105 transform rounded-lg !rounded-t-none border-x border-b border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]" />
+          <div />
         </div>
       </div>
     </>

--- a/app/(site)/pricing/pricingv1/components/FAQ.tsx
+++ b/app/(site)/pricing/pricingv1/components/FAQ.tsx
@@ -5,7 +5,7 @@ import FAQBody from '@/components/FAQPricing'
 
 export default function FAQ() {
   return (
-    <section className="relative !m-0 !mx-auto !w-[100vw] border !border-t-0 border-dashed border-signoz_slate-400 md:!w-[80vw]">
+    <section className="relative !m-0 !mx-auto border !border-t-0 border-dashed border-signoz_slate-400">
       <div className="mx-auto min-w-0 max-w-full">
         <div className="flex w-full min-w-0 flex-col sm:flex-row">
           <div className="w-full shrink-0 sm:w-[300px] sm:max-w-[300px]">

--- a/app/(site)/pricing/pricingv1/components/InstrumentationSupport.tsx
+++ b/app/(site)/pricing/pricingv1/components/InstrumentationSupport.tsx
@@ -77,7 +77,7 @@ const InstrumentationSupport = () => {
   )
 
   return (
-    <div className="section-container !mx-auto !w-[100vw] border !border-b-0 border-dashed border-signoz_slate-400 !px-0 md:!w-[80vw]">
+    <div className="section-container !mx-auto border !border-b-0 border-dashed border-signoz_slate-400 !px-0">
       <div className="flex w-full min-w-0 flex-col sm:flex-row">
         <div className="w-full shrink-0 sm:w-[300px] sm:max-w-[300px] md:!w-[300px]">
           <p className="sticky top-[100px] px-8 pl-0 pt-10 text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl md:px-0 md:pl-8">

--- a/app/(site)/pricing/pricingv1/components/StartupProgram.tsx
+++ b/app/(site)/pricing/pricingv1/components/StartupProgram.tsx
@@ -6,7 +6,7 @@ import featureGraphicOtelWebp from '@/public/img/graphics/homepage/feature-graph
 
 const StartupProgram = () => {
   return (
-    <div className="section-container !mx-auto !w-[100vw] border !border-b-0 border-dashed border-signoz_slate-400 !px-0 md:!w-[80vw]">
+    <div className="section-container !mx-auto border !border-b-0 border-dashed border-signoz_slate-400 !px-0">
       <div className="flex w-full min-w-0 flex-col sm:flex-row">
         <div className="w-full shrink-0 sm:w-[300px] sm:max-w-[300px] md:!w-[300px]">
           <p className="sticky top-[100px] px-8 pl-0 pt-10 text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl md:px-0 md:pl-8">

--- a/app/(site)/trace-funnels/TraceFunnelsPage.constants.tsx
+++ b/app/(site)/trace-funnels/TraceFunnelsPage.constants.tsx
@@ -1,25 +1,145 @@
-import { Atom } from "lucide-react";
+import { Atom } from 'lucide-react'
+import { BUTTON_CLASS_NAME } from '@/shared/components/molecules/FeaturePages/constants'
+
+export const TRACE_FUNNELS_HEADER_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Trace Funnels Hero Start Trial',
+      clickLocation: 'Trace Funnels Hero',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/trace-funnels/overview/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Trace Funnels Hero Docs',
+      clickLocation: 'Trace Funnels Hero',
+      clickText: 'Read Documentation',
+    },
+  },
+]
+
+export const DEFINE_MULTI_STEP_SEQUENCES_PANEL = {
+  title: 'Define multi-step sequences',
+  description: (
+    <>
+      <p className="leading-relaxed text-signoz_vanilla-400">
+        Build funnels with unlimited steps. Each step filters traces by service name, operation,
+        HTTP status code, or any custom attribute from your instrumentation. Use operators like
+        CONTAINS, REGEX, IN, or EXISTS.
+      </p>
+      <p className="leading-relaxed text-signoz_vanilla-400">
+        Save funnel definitions to reuse across different time ranges or share with your team.
+      </p>
+    </>
+  ),
+  className: 'justify-center',
+}
+
+export const DEFINE_MULTI_STEP_SEQUENCES_IMAGE = {
+  src: '/img/trace-funnels/funnel_step_definition.png',
+  alt: 'Defining funnel steps',
+}
+
+export const IDENTIFY_PROBLEM_TRACES_PANEL = {
+  title: 'Identify problem traces',
+  description:
+    'See the top 5 slowest traces for each step transition and view all traces with errors separately. Each trace shows its transition duration, making it easy to spot outliers. Click any trace ID to jump to the full trace visualization for detailed debugging.',
+}
+
+export const IDENTIFY_PROBLEM_TRACES_IMAGE = {
+  src: '/img/trace-funnels/identify-problem-traces.png',
+  alt: 'Identify problem traces',
+}
+
+export const ANALYZE_REQUEST_FLOWS_SHOWCASE = {
+  title: 'Analyze request flows across multiple trace ids',
+  description:
+    'A single trace shows one request. Trace funnels aggregate thousands of traces with the same request flow to reveal system-wide issues that individual trace inspection misses.',
+  button: {
+    text: 'Read Documentation',
+    href: '/docs/trace-funnels/overview/',
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Trace Funnels Analyze Request Docs Button',
+      clickLocation: 'Trace Funnels Analyze Section',
+      clickText: 'Read Documentation',
+    },
+  },
+}
+
+export const ANALYZE_REQUEST_FLOWS_IMAGES = [
+  {
+    src: '/img/trace-funnels/analyze-request-flows-across-multiple-trace-ids-1.png',
+    alt: 'Analyze request flows across multiple trace ids',
+  },
+  {
+    src: '/img/trace-funnels/analyze-request-flows-across-multiple-trace-ids-2.png',
+    alt: 'Analyze request flows across multiple trace ids',
+  },
+]
 
 export const ANALYZE_REQUEST_FLOW_CARDS = [
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Step Transition Analysis",
-    description: "Compare performance between different step transitions. See if Step 1→2 takes 100ms while Step 2→3 takes 1ms across all matching traces."
+    icon: <Atom />,
+    title: 'Step Transition Analysis',
+    description:
+      'Compare performance between different step transitions. See if Step 1→2 takes 100ms while Step 2→3 takes 1ms across all matching traces.',
   },
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Error Clustering",
-    description: "View which step transitions generate how many errors and see the trace IDs causing failures at each transition point.."
+    icon: <Atom />,
+    title: 'Error Clustering',
+    description:
+      'View which step transitions generate how many errors and see the trace IDs causing failures at each transition point..',
   },
   {
-    icon: (
-      <Atom />
-    ),
-    title: "Conversion Tracking",
-    description: "See what percentage of traces complete each step. A 32% drop between steps reveals systematic problems, not isolated incidents."
-  }
-];
+    icon: <Atom />,
+    title: 'Conversion Tracking',
+    description:
+      'See what percentage of traces complete each step. A 32% drop between steps reveals systematic problems, not isolated incidents.',
+  },
+]
+
+export const SEE_DROP_OFFS_SHOWCASE = {
+  title: 'See drop-offs between steps',
+  description:
+    'Each funnel step shows how many traces reached it and what percentage converted from the previous step. View aggregate metrics like average rate, average duration, error count and p99 latency for each transition. Visualize where traces drop off in your sequence and compare performance between different steps to identify bottlenecks.',
+  image: '/img/trace-funnels/see-drop-offs-between-steps.png',
+  imageAlt: 'See drop-offs between steps',
+}
+
+export const STOP_LOSING_USERS_BUTTONS = [
+  {
+    text: 'Start your free trial',
+    href: '/teams/',
+    variant: 'default' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Primary CTA',
+      clickName: 'Trace Funnels Banner Start Trial',
+      clickLocation: 'Trace Funnels Bottom Banner',
+      clickText: 'Start your free trial',
+    },
+  },
+  {
+    text: 'Read Documentation',
+    href: '/docs/trace-funnels/overview/',
+    variant: 'secondary' as const,
+    className: BUTTON_CLASS_NAME,
+    tracking: {
+      clickType: 'Secondary CTA',
+      clickName: 'Trace Funnels Banner Docs',
+      clickLocation: 'Trace Funnels Bottom Banner',
+      clickText: 'Read Documentation',
+    },
+  },
+]

--- a/app/(site)/trace-funnels/TraceFunnelsPage.tsx
+++ b/app/(site)/trace-funnels/TraceFunnelsPage.tsx
@@ -1,50 +1,33 @@
 'use client'
 
 import React from 'react'
-import { ArrowRight } from 'lucide-react'
-import Button from '@/components/ui/Button'
-import TrackingLink from '@/components/TrackingLink'
 import Image from 'next/image'
-import { ANALYZE_REQUEST_FLOW_CARDS } from './TraceFunnelsPage.constants'
+import {
+  ANALYZE_REQUEST_FLOW_CARDS,
+  ANALYZE_REQUEST_FLOWS_IMAGES,
+  ANALYZE_REQUEST_FLOWS_SHOWCASE,
+  DEFINE_MULTI_STEP_SEQUENCES_IMAGE,
+  DEFINE_MULTI_STEP_SEQUENCES_PANEL,
+  IDENTIFY_PROBLEM_TRACES_IMAGE,
+  IDENTIFY_PROBLEM_TRACES_PANEL,
+  SEE_DROP_OFFS_SHOWCASE,
+  STOP_LOSING_USERS_BUTTONS,
+  TRACE_FUNNELS_HEADER_BUTTONS,
+} from './TraceFunnelsPage.constants'
 import SectionLayout from '@/shared/components/molecules/FeaturePages/SectionLayout'
-import GridLayout from '@/shared/components/molecules/FeaturePages/GridLayout'
 import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/FeaturePageHeader'
-import ButtonGroup from '@/shared/components/molecules/FeaturePages/ButtonGroup'
 import HeroCards from '@/shared/components/molecules/FeaturePages/HeroCards'
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
+import Divider from '@/shared/components/molecules/FeaturePages/Divider'
+import FeatureShowcase from '@/shared/components/molecules/FeaturePages/FeatureShowcase'
+import SplitSection from '@/shared/components/molecules/FeaturePages/SplitSection'
+import CTABanner from '@/shared/components/molecules/FeaturePages/CTABanner'
 
 // Main Component Sections
 const Header: React.FC = () => {
-  const headerButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'Trace Funnels Hero Start Trial',
-        clickLocation: 'Trace Funnels Hero',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/trace-funnels/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'Trace Funnels Hero Docs',
-        clickLocation: 'Trace Funnels Hero',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
     <FeaturePageHeader
       title={
@@ -58,7 +41,7 @@ const Header: React.FC = () => {
           traces succeed, where they fail, and where they drop off.
         </>
       }
-      buttons={headerButtons}
+      buttons={TRACE_FUNNELS_HEADER_BUTTONS}
       heroImageAlt="Trace funnels hero"
       heroImage="/img/platform/TraceFunnelsMeta.webp"
     />
@@ -67,115 +50,59 @@ const Header: React.FC = () => {
 
 const DefineMultiStepSequences: React.FC = () => {
   return (
-    <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-10">
-      <GridLayout variant="split">
-        {/* Left Column - Ingestion */}
-        <div className="flex h-full w-full flex-col justify-center px-6">
-          <div className="flex flex-col justify-between">
-            <h2 className="mb-6 text-signoz_vanilla-100">Define multi-step sequences</h2>
-            <p className="leading-relaxed text-signoz_vanilla-400">
-              Build funnels with unlimited steps. Each step filters traces by service name,
-              operation, HTTP status code, or any custom attribute from your instrumentation. Use
-              operators like CONTAINS, REGEX, IN, or EXISTS.
-            </p>
-            <p className="leading-relaxed text-signoz_vanilla-400">
-              Save funnel definitions to reuse across different time ranges or share with your team.
-            </p>
-          </div>
-        </div>
-
-        {/* Right Column */}
+    <SplitSection
+      className="py-10"
+      left={DEFINE_MULTI_STEP_SEQUENCES_PANEL}
+      right={
         <div className="h-full w-full px-6">
           <Image
-            src="/img/trace-funnels/funnel_step_definition.png"
-            alt="Defining funnel steps"
+            src={DEFINE_MULTI_STEP_SEQUENCES_IMAGE.src}
+            alt={DEFINE_MULTI_STEP_SEQUENCES_IMAGE.alt}
             width={10000}
             height={10000}
           />
         </div>
-      </GridLayout>
-    </div>
+      }
+    />
   )
 }
 
 const IdentifyProblemTraces: React.FC = () => {
   return (
-    <div className="border-y-1 mt-12 border-dashed border-signoz_slate-400 bg-signoz_ink-500 py-10">
-      <GridLayout variant="split">
-        {/* Left Column */}
+    <SplitSection
+      className="py-10"
+      left={
         <div className="h-full w-full px-6">
           <Image
-            src="/img/trace-funnels/identify-problem-traces.png"
-            alt="Identify problem traces"
+            src={IDENTIFY_PROBLEM_TRACES_IMAGE.src}
+            alt={IDENTIFY_PROBLEM_TRACES_IMAGE.alt}
             width={10000}
             height={10000}
           />
         </div>
-
-        {/* Right Column */}
-        <div className="flex w-full flex-col px-6">
-          <div className="flex flex-col justify-between">
-            <h2 className="mb-6 text-signoz_vanilla-100">Identify problem traces</h2>
-            <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-              See the top 5 slowest traces for each step transition and view all traces with errors
-              separately. Each trace shows its transition duration, making it easy to spot outliers.
-              Click any trace ID to jump to the full trace visualization for detailed debugging.
-            </p>
-          </div>
-        </div>
-      </GridLayout>
-    </div>
+      }
+      right={IDENTIFY_PROBLEM_TRACES_PANEL}
+    />
   )
 }
 
 const AnalyzeRequestFlowsAcrossMultipleTraceIds: React.FC = () => {
   return (
     <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">
-            Analyze request flows across multiple trace ids
-          </h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            A single trace shows one request. Trace funnels aggregate thousands of traces with the
-            same request flow to reveal system-wide issues that individual trace inspection misses.
-          </p>
-          <Button
-            variant="secondary"
-            rounded="full"
-            className="flex w-fit items-center gap-2"
-            asChild
-          >
-            <TrackingLink
-              href="/docs/trace-funnels/overview/"
-              clickType="Secondary CTA"
-              clickName="Trace Funnels Analyze Request Docs Button"
-              clickLocation="Trace Funnels Analyze Section"
-              clickText="Read Documentation"
-            >
-              Read Documentation
-              <ArrowRight size={14} />
-            </TrackingLink>
-          </Button>
-        </div>
-
+      <FeatureShowcase {...ANALYZE_REQUEST_FLOWS_SHOWCASE} imageClassName="mb-0">
         <div className="mb-8 flex w-full gap-8">
-          <Image
-            src="/img/trace-funnels/analyze-request-flows-across-multiple-trace-ids-1.png"
-            alt="Analyze request flows across multiple trace ids"
-            width={10000}
-            height={10000}
-            className="w-1/2"
-          />
-          <Image
-            src="/img/trace-funnels/analyze-request-flows-across-multiple-trace-ids-2.png"
-            alt="Analyze request flows across multiple trace ids"
-            width={10000}
-            height={10000}
-            className="w-1/2"
-          />
+          {ANALYZE_REQUEST_FLOWS_IMAGES.map((image) => (
+            <Image
+              key={image.src}
+              src={image.src}
+              alt={image.alt}
+              width={10000}
+              height={10000}
+              className="w-1/2"
+            />
+          ))}
         </div>
-      </div>
+      </FeatureShowcase>
       <HeroCards
         cards={ANALYZE_REQUEST_FLOW_CARDS}
         layoutVariant={'no-border'}
@@ -186,67 +113,20 @@ const AnalyzeRequestFlowsAcrossMultipleTraceIds: React.FC = () => {
 }
 
 const SeeDropOffsBetweenSteps: React.FC = () => {
-  return (
-    <>
-      <div className="border-t-1 border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6">
-        <div className="mb-8 max-w-4xl">
-          <h2 className="mb-6 text-signoz_vanilla-100">See drop-offs between steps</h2>
-          <p className="mb-8 leading-relaxed text-signoz_vanilla-400">
-            Each funnel step shows how many traces reached it and what percentage converted from the
-            previous step. View aggregate metrics like average rate, average duration, error count
-            and p99 latency for each transition. Visualize where traces drop off in your sequence
-            and compare performance between different steps to identify bottlenecks.
-          </p>
-        </div>
-
-        <Image
-          src="/img/trace-funnels/see-drop-offs-between-steps.png"
-          alt="See drop-offs between steps"
-          width={10000}
-          height={10000}
-          className="mb-8"
-        />
-      </div>
-    </>
-  )
+  return <FeatureShowcase {...SEE_DROP_OFFS_SHOWCASE} />
 }
 
 const StopLosingUsersBanner: React.FC = () => {
-  const stopLosingUsersButtons = [
-    {
-      text: 'Start your free trial',
-      href: '/teams/',
-      variant: 'default' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Primary CTA',
-        clickName: 'Trace Funnels Banner Start Trial',
-        clickLocation: 'Trace Funnels Bottom Banner',
-        clickText: 'Start your free trial',
-      },
-    },
-    {
-      text: 'Read Documentation',
-      href: '/docs/trace-funnels/overview/',
-      variant: 'secondary' as const,
-      className: 'flex-center',
-      tracking: {
-        clickType: 'Secondary CTA',
-        clickName: 'Trace Funnels Banner Docs',
-        clickLocation: 'Trace Funnels Bottom Banner',
-        clickText: 'Read Documentation',
-      },
-    },
-  ]
-
   return (
-    <div className="border-t-1 flex flex-col items-center justify-center border-dashed border-signoz_slate-400 bg-signoz_ink-500 p-6 py-20">
-      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">
-        Stop Losing Users in Multi- <br />
-        Step Flows
-      </h2>
-      <ButtonGroup buttons={stopLosingUsersButtons} />
-    </div>
+    <CTABanner
+      title={
+        <>
+          Stop Losing Users in Multi- <br />
+          Step Flows
+        </>
+      }
+      buttons={STOP_LOSING_USERS_BUTTONS}
+    />
   )
 }
 
@@ -257,15 +137,21 @@ const TraceFunnels: React.FC = () => {
       <Header />
 
       <SectionLayout variant="bordered" className="!px-0">
+        <Divider className="mt-12" />
         <DefineMultiStepSequences />
+        <Divider />
         <SeeDropOffsBetweenSteps />
+        <Divider className="mt-12" />
         <IdentifyProblemTraces />
+        <Divider />
         <AnalyzeRequestFlowsAcrossMultipleTraceIds />
+        <Divider />
         <StopLosingUsersBanner />
       </SectionLayout>
 
       <UsageBasedPricing show={['traces']} />
       <SigNozStats />
+      <Divider />
       <CustomerStoriesSection
         tracking={{
           clickName: 'Trace Funnels Customer Stories Button',

--- a/components/ProductNav/ProductNav.tsx
+++ b/components/ProductNav/ProductNav.tsx
@@ -1,4 +1,5 @@
-// components/ProductNav/ProductNav.tsx
+'use client'
+
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState, useEffect } from 'react'
@@ -56,7 +57,7 @@ export default function ProductNav() {
   return (
     <div className="fixed left-0 right-0 top-[56px] z-10">
       <header className="header-bg mx-auto box-border h-[56px] w-full border-b border-signoz_slate-500 text-signoz_vanilla-100 backdrop-blur-[20px] dark:text-signoz_vanilla-100">
-        <div className="mx-auto h-fit max-w-8xl overflow-x-auto md:px-8">
+        <div className="mx-auto h-fit max-w-8xl overflow-x-auto">
           <nav
             className="mb-0 flex h-[55px] gap-3 pl-0 text-center text-sm font-medium text-signoz_vanilla-400 sm:gap-6"
             aria-label="Product Navigation"

--- a/components/QuickStartCloud/index.tsx
+++ b/components/QuickStartCloud/index.tsx
@@ -7,7 +7,7 @@ export default function QuickStartCloud() {
   const sectionName = 'Quick Start Cloud Section'
 
   return (
-    <div className="mx-auto mb-12 mt-16 w-full max-w-7xl bg-[url('/img/background_blur/Frame_2185.webp')] bg-[length:100%_auto] bg-[center_top] bg-no-repeat py-8 sm:bg-[length:55%] sm:bg-[center_top_-2rem] sm:py-12 md:py-16">
+    <div className="mx-auto w-full bg-[url('/img/background_blur/Frame_2185.webp')] bg-[length:100%_auto] bg-[center_top] bg-no-repeat py-8 sm:bg-[length:55%] sm:bg-[center_top_-2rem] sm:py-12 md:py-16">
       <div className="bg-blur-ellipse-206">
         <div className="flex flex-col items-center gap-2 px-4 text-center sm:px-0">
           <h2 className="text-4xl font-bold text-signoz_vanilla-100 md:text-5xl">

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -71,7 +71,7 @@ export default function TopNav() {
     <div className="fixed left-0 right-0 z-[50]">
       <header className="header-bg relative z-10 mx-auto box-border flex h-[56px] w-full items-center border-b border-signoz_slate-500 text-signoz_vanilla-100 backdrop-blur-[20px] dark:text-signoz_vanilla-100">
         <nav
-          className="mx-auto flex w-full max-w-8xl justify-between text-signoz_vanilla-100 dark:text-signoz_vanilla-100 md:px-8"
+          className="mx-auto flex w-full max-w-8xl justify-between text-signoz_vanilla-100 dark:text-signoz_vanilla-100"
           aria-label="Global"
         >
           <div className="flex justify-start gap-x-6">

--- a/components/trusted-by/index.tsx
+++ b/components/trusted-by/index.tsx
@@ -36,7 +36,7 @@ export const TrustedByTeams = ({ page, className }: { page?: string; className?:
   return (
     <section
       className={cn(
-        'm-0 mx-auto grid w-full justify-items-stretch border !border-b-0 border-dashed border-signoz_slate-400 py-6 md:w-[80vw]',
+        'm-0 mx-auto grid w-full justify-items-stretch border !border-b-0 border-dashed border-signoz_slate-400 py-6',
         className
       )}
     >

--- a/components/why-select-signoz/index.tsx
+++ b/components/why-select-signoz/index.tsx
@@ -18,7 +18,7 @@ const WhySelectSignoz = ({
   return (
     <div
       className={cn(
-        'section-container mx-auto w-full border !border-b-0 border-dashed border-signoz_slate-400 !px-0 md:w-[80vw]',
+        'section-container mx-auto w-full border !border-b-0 border-dashed border-signoz_slate-400 !px-0',
         className
       )}
     >

--- a/shared/components/molecules/FeaturePages/CTABanner/CTABanner.types.ts
+++ b/shared/components/molecules/FeaturePages/CTABanner/CTABanner.types.ts
@@ -1,0 +1,7 @@
+import { ButtonGroupButton } from '../ButtonGroup/ButtonGroup.types'
+
+export interface CTABannerProps {
+  title: React.ReactNode
+  buttons: ButtonGroupButton[]
+  className?: string
+}

--- a/shared/components/molecules/FeaturePages/CTABanner/CTABanner.view.tsx
+++ b/shared/components/molecules/FeaturePages/CTABanner/CTABanner.view.tsx
@@ -1,0 +1,19 @@
+import ButtonGroup from '../ButtonGroup'
+import { cn } from 'app/lib/utils'
+import { CTABannerProps } from './CTABanner.types'
+
+const CTABanner: React.FC<CTABannerProps> = ({ title, buttons, className }) => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center bg-signoz_ink-500 p-6 py-20',
+        className
+      )}
+    >
+      <h2 className="mb-6 text-center text-4xl text-signoz_vanilla-100">{title}</h2>
+      <ButtonGroup buttons={buttons} />
+    </div>
+  )
+}
+
+export default CTABanner

--- a/shared/components/molecules/FeaturePages/CTABanner/index.tsx
+++ b/shared/components/molecules/FeaturePages/CTABanner/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './CTABanner.view'
+export type { CTABannerProps } from './CTABanner.types'

--- a/shared/components/molecules/FeaturePages/CustomerStoriesSection/CustomerStoriesSection.view.tsx
+++ b/shared/components/molecules/FeaturePages/CustomerStoriesSection/CustomerStoriesSection.view.tsx
@@ -12,8 +12,8 @@ const CustomerStoriesSection: React.FC<CustomerStoriesSectionProps> = ({
   showFeaturedCaseStudy = true,
 }) => {
   const sectionClassName = showOverlay
-    ? 'relative mx-auto max-w-8xl overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 bg-blur-ellipse-388 md:w-[80vw]'
-    : 'relative mx-auto max-w-8xl overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:w-[80vw]'
+    ? 'relative mx-auto max-w-8xl overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 bg-blur-ellipse-388'
+    : 'relative mx-auto max-w-8xl overflow-hidden border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400'
 
   return (
     <>

--- a/shared/components/molecules/FeaturePages/Divider/Divider.types.ts
+++ b/shared/components/molecules/FeaturePages/Divider/Divider.types.ts
@@ -1,0 +1,5 @@
+export interface DividerProps {
+  orientation?: 'horizontal' | 'vertical'
+  variant?: 'dashed' | 'solid'
+  className?: string
+}

--- a/shared/components/molecules/FeaturePages/Divider/Divider.view.tsx
+++ b/shared/components/molecules/FeaturePages/Divider/Divider.view.tsx
@@ -1,0 +1,21 @@
+import { cn } from 'app/lib/utils'
+import { DividerProps } from './Divider.types'
+
+const Divider: React.FC<DividerProps> = ({
+  orientation = 'horizontal',
+  variant = 'dashed',
+  className,
+}) => {
+  return (
+    <div
+      className={cn(
+        'border-signoz_slate-400',
+        variant === 'dashed' ? 'border-dashed' : 'border-solid',
+        orientation === 'horizontal' ? 'w-full border-t' : 'h-full border-l',
+        className
+      )}
+    />
+  )
+}
+
+export default Divider

--- a/shared/components/molecules/FeaturePages/Divider/Divider.view.tsx
+++ b/shared/components/molecules/FeaturePages/Divider/Divider.view.tsx
@@ -8,6 +8,7 @@ const Divider: React.FC<DividerProps> = ({
 }) => {
   return (
     <div
+      role="separator"
       className={cn(
         'border-signoz_slate-400',
         variant === 'dashed' ? 'border-dashed' : 'border-solid',

--- a/shared/components/molecules/FeaturePages/Divider/index.tsx
+++ b/shared/components/molecules/FeaturePages/Divider/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './Divider.view'
+export type { DividerProps } from './Divider.types'

--- a/shared/components/molecules/FeaturePages/FeatureButton/FeatureButton.types.ts
+++ b/shared/components/molecules/FeaturePages/FeatureButton/FeatureButton.types.ts
@@ -1,0 +1,10 @@
+export interface FeatureButtonConfig {
+  text: string
+  href: string
+  tracking?: {
+    clickType: string
+    clickName?: string
+    clickLocation?: string
+    clickText?: string
+  }
+}

--- a/shared/components/molecules/FeaturePages/FeatureButton/FeatureButton.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureButton/FeatureButton.view.tsx
@@ -1,0 +1,35 @@
+import { ArrowRight } from 'lucide-react'
+import Button from '@/components/ui/Button'
+import TrackingLink from '@/components/TrackingLink'
+import { FeatureButtonConfig } from './FeatureButton.types'
+
+const FeatureButton: React.FC<{ button: FeatureButtonConfig; className?: string }> = ({
+  button,
+  className = 'flex w-fit items-center gap-2',
+}) => {
+  if (button.tracking) {
+    return (
+      <Button variant="secondary" rounded="full" className={className} asChild>
+        <TrackingLink
+          href={button.href}
+          clickType={button.tracking.clickType}
+          clickName={button.tracking.clickName || `${button.text} Button`}
+          clickLocation={button.tracking.clickLocation || 'Feature Page'}
+          clickText={button.tracking.clickText || button.text}
+        >
+          {button.text}
+          <ArrowRight size={14} />
+        </TrackingLink>
+      </Button>
+    )
+  }
+
+  return (
+    <Button variant="secondary" rounded="full" className={className} to={button.href}>
+      {button.text}
+      <ArrowRight size={14} />
+    </Button>
+  )
+}
+
+export default FeatureButton

--- a/shared/components/molecules/FeaturePages/FeatureButton/index.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureButton/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './FeatureButton.view'
+export type { FeatureButtonConfig } from './FeatureButton.types'

--- a/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.types.ts
+++ b/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.types.ts
@@ -2,6 +2,5 @@ export interface FeatureCardProps {
   icon: React.ReactNode
   title: string | React.ReactNode
   description: string | React.ReactNode
-  variant?: 'default' | 'combined'
   className?: string
 }

--- a/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.view.tsx
@@ -1,8 +1,9 @@
 import { FeatureCardProps } from './FeatureCard.types'
+import { cn } from 'app/lib/utils'
 
 const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description, className = '' }) => {
   return (
-    <div className={`bg-transparent p-0 ${className}`}>
+    <div className={cn('bg-transparent p-0', className)}>
       <div className="p-8">
         <div className="grid grid-cols-1 gap-8">
           <div className="">{icon}</div>

--- a/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureCard/FeatureCard.view.tsx
@@ -1,19 +1,8 @@
 import { FeatureCardProps } from './FeatureCard.types'
 
-const FeatureCard: React.FC<FeatureCardProps> = ({
-  icon,
-  title,
-  description,
-  variant = 'default',
-  className = '',
-}) => {
-  const borderClass =
-    variant === 'combined'
-      ? 'border-none'
-      : 'border-r max-md:border-l border-signoz_slate-400 border-dashed last:border-r-0'
-
+const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description, className = '' }) => {
   return (
-    <div className={`p-0 ${borderClass} bg-transparent ${className}`}>
+    <div className={`bg-transparent p-0 ${className}`}>
       <div className="p-8">
         <div className="grid grid-cols-1 gap-8">
           <div className="">{icon}</div>

--- a/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeaturePageHeader/FeaturePageHeader.view.tsx
@@ -37,12 +37,12 @@ const FeaturePageHeader: React.FC<FeaturePageHeaderProps> = ({
     )
 
   return (
-    <header className={cn('relative !mx-auto max-w-8xl md:!w-[80vw]', className)}>
+    <header className={cn('relative !mx-auto max-w-8xl', className)}>
       <div className="absolute bottom-0 left-[12px] right-[12px] top-0 z-[0] border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 md:left-[24px] md:right-[24px]" />
 
       <div
         className={cn(
-          'relative !mx-auto flex max-w-8xl flex-col border !border-b-0 border-dashed border-signoz_slate-400 px-6 pb-4 pt-12 md:!w-[80vw] md:px-8 md:pt-[4rem]',
+          'relative !mx-auto flex max-w-8xl flex-col border !border-b-0 border-dashed border-signoz_slate-400 px-6 pb-4 pt-12 md:px-8 md:pt-[4rem]',
           isLeft ? 'items-start text-left' : 'items-center text-center'
         )}
       >
@@ -67,7 +67,7 @@ const FeaturePageHeader: React.FC<FeaturePageHeaderProps> = ({
 
       <div
         className={cn(
-          'relative z-[1] !mx-auto flex max-w-8xl flex-col gap-4 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 px-6 pb-12 pt-4 md:!w-[80vw] md:px-8',
+          'relative z-[1] !mx-auto flex max-w-8xl flex-col gap-4 border !border-b-0 !border-t-0 border-dashed border-signoz_slate-400 px-6 pb-12 pt-4 md:px-8',
           isLeft ? 'items-start' : 'items-center'
         )}
       >

--- a/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.types.ts
+++ b/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.types.ts
@@ -1,4 +1,5 @@
 export interface FeaturePageLayoutProps {
   children: React.ReactNode
   showProductNav?: boolean
+  fullWidth?: boolean
 }

--- a/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.view.tsx
@@ -6,7 +6,7 @@ const FeaturePageLayout: React.FC<FeaturePageLayoutProps> = ({
   showProductNav = true,
 }) => {
   return (
-    <main className="!mt-[-10px] mb-auto">
+    <main className="relative mx-auto !mt-[-10px] mb-auto max-w-8xl">
       {showProductNav && <ProductNav />}
 
       <div className="relative bg-signoz_ink-500">

--- a/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeaturePageLayout/FeaturePageLayout.view.tsx
@@ -1,12 +1,14 @@
 import ProductNav from '@/components/ProductNav/ProductNav'
+import { cn } from 'app/lib/utils'
 import { FeaturePageLayoutProps } from './FeaturePageLayout.types'
 
 const FeaturePageLayout: React.FC<FeaturePageLayoutProps> = ({
   children,
   showProductNav = true,
+  fullWidth = false,
 }) => {
   return (
-    <main className="relative mx-auto !mt-[-10px] mb-auto max-w-8xl">
+    <main className={cn('relative mx-auto !mt-[-10px] mb-auto', !fullWidth && 'max-w-8xl')}>
       {showProductNav && <ProductNav />}
 
       <div className="relative bg-signoz_ink-500">

--- a/shared/components/molecules/FeaturePages/FeatureShowcase/FeatureShowcase.types.ts
+++ b/shared/components/molecules/FeaturePages/FeatureShowcase/FeatureShowcase.types.ts
@@ -1,0 +1,14 @@
+import { FeatureButtonConfig } from '../FeatureButton/FeatureButton.types'
+
+export interface FeatureShowcaseProps {
+  title?: React.ReactNode
+  description?: React.ReactNode
+  image?: string
+  imageAlt?: string
+  imageElement?: React.ReactNode
+  button?: FeatureButtonConfig
+  children?: React.ReactNode
+  contentClassName?: string
+  imageClassName?: string
+  className?: string
+}

--- a/shared/components/molecules/FeaturePages/FeatureShowcase/FeatureShowcase.view.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureShowcase/FeatureShowcase.view.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image'
+import { cn } from 'app/lib/utils'
+import FeatureButton from '../FeatureButton'
+import { FeatureShowcaseProps } from './FeatureShowcase.types'
+
+const FeatureShowcase: React.FC<FeatureShowcaseProps> = ({
+  title,
+  description,
+  image,
+  imageAlt = '',
+  imageElement,
+  button,
+  children,
+  contentClassName,
+  imageClassName,
+  className,
+}) => {
+  const hasContent = title || description || button
+
+  return (
+    <div className={cn('bg-signoz_ink-500 p-6', className)}>
+      {hasContent && (
+        <div className={cn('mb-8 max-w-4xl', contentClassName)}>
+          {title && <h2 className="mb-6 text-signoz_vanilla-100">{title}</h2>}
+          {description && (
+            <div className="mb-8 leading-relaxed text-signoz_vanilla-400">{description}</div>
+          )}
+          {button && <FeatureButton button={button} />}
+        </div>
+      )}
+
+      {children}
+
+      {imageElement
+        ? imageElement
+        : image && (
+            <Image
+              src={image}
+              alt={imageAlt}
+              width={1440}
+              height={810}
+              sizes="(max-width: 768px) 100vw, 80vw"
+              className={cn('mb-8', imageClassName)}
+            />
+          )}
+    </div>
+  )
+}
+
+export default FeatureShowcase

--- a/shared/components/molecules/FeaturePages/FeatureShowcase/index.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureShowcase/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './FeatureShowcase.view'
+export type { FeatureShowcaseProps } from './FeatureShowcase.types'

--- a/shared/components/molecules/FeaturePages/HeroCards/HeroCards.view.tsx
+++ b/shared/components/molecules/FeaturePages/HeroCards/HeroCards.view.tsx
@@ -1,6 +1,7 @@
 import SectionLayout from '../SectionLayout'
 import GridLayout from '../GridLayout'
 import FeatureCard from '../FeatureCard'
+import Divider from '../Divider'
 import { SectionLayoutProps } from '../SectionLayout'
 
 const HeroCards: React.FC<{
@@ -24,13 +25,12 @@ const HeroCards: React.FC<{
     <SectionLayout variant={layoutVariant} className={`p-0 max-md:mt-8 ${className}`}>
       <GridLayout cols={cols}>
         {cards.map((card, index) => (
-          <FeatureCard
-            key={index}
-            icon={card.icon}
-            title={card.title}
-            description={card.description}
-            variant={variant}
-          />
+          <div key={index} className="relative">
+            <FeatureCard icon={card.icon} title={card.title} description={card.description} />
+            {variant !== 'combined' && index < cards.length - 1 && (index + 1) % cols !== 0 && (
+              <Divider orientation="vertical" className="absolute right-0 top-0 hidden md:block" />
+            )}
+          </div>
         ))}
       </GridLayout>
     </SectionLayout>

--- a/shared/components/molecules/FeaturePages/IconGrid/IconGrid.types.ts
+++ b/shared/components/molecules/FeaturePages/IconGrid/IconGrid.types.ts
@@ -1,6 +1,7 @@
+import { StaticImageData } from 'next/image'
+
 export interface IconGridProps {
-  icons: Array<{ src: string | React.ReactNode; alt: string }>
+  icons: Array<{ src: string | StaticImageData | React.ReactNode; alt: string }>
   title: string
   className?: string
 }
-  

--- a/shared/components/molecules/FeaturePages/IconGrid/IconGrid.view.tsx
+++ b/shared/components/molecules/FeaturePages/IconGrid/IconGrid.view.tsx
@@ -1,17 +1,21 @@
-import Image from "next/image"
-import { IconGridProps } from "./IconGrid.types"
+import Image, { StaticImageData } from 'next/image'
+import { IconGridProps } from './IconGrid.types'
+
+function isImageSrc(src: unknown): src is string | StaticImageData {
+  return typeof src === 'string' || (typeof src === 'object' && src !== null && 'src' in src)
+}
 
 const IconGrid: React.FC<IconGridProps> = ({ icons, title, className = '' }) => {
   return (
     <div className={className}>
       <h3 className="mb-4 text-xs font-medium uppercase text-signoz_vanilla-400">{title}</h3>
-      <div className="flex justify-start items-center gap-4">
+      <div className="flex items-center justify-start gap-4">
         {icons.map((icon, index) => (
           <div key={index} className="flex items-center">
-            {typeof icon.src === 'string' ? (
+            {isImageSrc(icon.src) ? (
               <Image src={icon.src} alt={icon.alt} className="h-8" width={32} height={32} />
             ) : (
-              icon.src
+              (icon.src as React.ReactNode)
             )}
           </div>
         ))}

--- a/shared/components/molecules/FeaturePages/IconTitleDescriptionCard/IconTitleDescriptionCard.view.tsx
+++ b/shared/components/molecules/FeaturePages/IconTitleDescriptionCard/IconTitleDescriptionCard.view.tsx
@@ -23,7 +23,7 @@ const IconTitleDescriptionCard: React.FC<IconTitleDescriptionCardProps> = ({
 
   return (
     <div
-      className={`relative flex w-full flex-col items-start ${styles.gap} border border-dashed border-signoz_slate-400/50 px-8 py-6 ${className}`}
+      className={`relative flex h-full w-full flex-col items-start ${styles.gap} px-8 py-6 ${className}`}
     >
       <div className="flex items-center gap-1 text-xs font-medium uppercase tracking-[0.05rem] text-signoz_vanilla-400">
         {icon && (

--- a/shared/components/molecules/FeaturePages/IconTitleDescriptionCard/IconTitleDescriptionCardGrid.view.tsx
+++ b/shared/components/molecules/FeaturePages/IconTitleDescriptionCard/IconTitleDescriptionCardGrid.view.tsx
@@ -1,6 +1,7 @@
 import IconTitleDescriptionCard from './IconTitleDescriptionCard.view'
 import { IconTitleDescriptionCardGridProps } from './IconTitleDescriptionCardGrid.types'
 import { cn } from 'app/lib/utils'
+import Divider from '../Divider'
 
 const IconTitleDescriptionCardGrid: React.FC<IconTitleDescriptionCardGridProps> = ({
   cards,
@@ -9,17 +10,30 @@ const IconTitleDescriptionCardGrid: React.FC<IconTitleDescriptionCardGridProps> 
 }) => {
   return (
     <div className={cn('grid grid-cols-1 md:grid-cols-2', className)}>
-      {cards.map((card, index) => (
-        <IconTitleDescriptionCard
-          key={index}
-          icon={card.icon}
-          iconText={card.iconText || ''}
-          title={card.title}
-          description={card.description}
-          className={card.className}
-          variant={variant}
-        />
-      ))}
+      {cards.map((card, index) => {
+        const isLast = index === cards.length - 1
+        const lastDesktopRowStart = Math.floor((cards.length - 1) / 2) * 2
+        const isLastDesktopRow = index >= lastDesktopRowStart
+        const isLeftDesktopColumn = index % 2 === 0
+
+        return (
+          <div key={index} className="relative h-full">
+            <IconTitleDescriptionCard
+              icon={card.icon}
+              iconText={card.iconText || ''}
+              title={card.title}
+              description={card.description}
+              className={card.className}
+              variant={variant}
+            />
+            {!isLast && <Divider className="absolute bottom-0 left-0 md:hidden" />}
+            {!isLastDesktopRow && <Divider className="absolute bottom-0 left-0 hidden md:block" />}
+            {isLeftDesktopColumn && index + 1 < cards.length && (
+              <Divider orientation="vertical" className="absolute right-0 top-0 hidden md:block" />
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
@@ -1,4 +1,5 @@
 import { SectionLayoutProps } from './SectionLayout.types'
+import { cn } from 'app/lib/utils'
 
 const SectionLayout: React.FC<SectionLayoutProps> = ({
   children,
@@ -9,15 +10,15 @@ const SectionLayout: React.FC<SectionLayoutProps> = ({
   const getVariantClasses = () => {
     switch (variant) {
       case 'full-width':
-        return '!mx-auto md:!w-[80vw]'
+        return '!mx-auto'
       case 'bordered':
-        return '!mx-auto border border-dashed !border-b-0 !border-t-0 border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto border border-dashed !border-b-0 !border-t-0 border-signoz_slate-400'
       case 'no-border':
-        return '!mx-auto !w-[90vw] border !border-b-0 !border-t-0 border-none border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw]'
       case 'border-x':
-        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-signoz_slate-400'
       default:
-        return '!mx-auto border border-dashed !border-b-0 border-signoz_slate-400 md:!w-[80vw]'
+        return '!mx-auto border border-dashed !border-b-0 border-signoz_slate-400'
     }
   }
 
@@ -25,7 +26,7 @@ const SectionLayout: React.FC<SectionLayoutProps> = ({
 
   return (
     <div
-      className={`section-container ${getVariantClasses()} ${backgroundClass} ${className} max-w-8xl`}
+      className={cn('w-full px-4', getVariantClasses(), backgroundClass, className, 'max-w-8xl')}
     >
       {children}
     </div>

--- a/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
+++ b/shared/components/molecules/FeaturePages/SectionLayout/SectionLayout.view.tsx
@@ -16,9 +16,9 @@ const SectionLayout: React.FC<SectionLayoutProps> = ({
       case 'no-border':
         return '!mx-auto !w-[90vw]'
       case 'border-x':
-        return '!mx-auto !w-[90vw] border border-dashed border-b-1 border-t-1 border-signoz_slate-400'
+        return '!mx-auto !w-[90vw] border border-dashed border-signoz_slate-400'
       default:
-        return '!mx-auto border border-dashed !border-b-0 border-signoz_slate-400'
+        return '!mx-auto border border-dashed !border-b-0 !border-t-0 border-signoz_slate-400'
     }
   }
 

--- a/shared/components/molecules/FeaturePages/SignozStats/SignozStats.view.tsx
+++ b/shared/components/molecules/FeaturePages/SignozStats/SignozStats.view.tsx
@@ -64,8 +64,8 @@ const SigNozStats = () => {
   ]
 
   return (
-    <SectionLayout variant="bordered" className="flex flex-col !px-0 sm:flex-row">
-      <div className="!border-b-1 flex-1 border !border-l-0 !border-r-0 border-dashed border-signoz_slate-400">
+    <SectionLayout variant="bordered" className="flex flex-col !px-0 md:flex-row">
+      <div className="flex-1 border-b border-dashed border-signoz_slate-400 md:border-b-0">
         <p className="pl-12 pt-10 text-left text-4xl font-bold !leading-[3.5rem] text-signoz_vanilla-100 sm:text-4xl">
           Developers <br />
           Love
@@ -74,8 +74,8 @@ const SigNozStats = () => {
         </p>
       </div>
 
-      <div className="flex flex-[2_2_0%] flex-col">
-        <div className="border-b border-l border-t border-dashed border-signoz_slate-400 bg-transparent p-0">
+      <div className="flex min-w-0 flex-[2_2_0%] flex-col">
+        <div className="border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
           <div className="p-10 md:p-6">
             <h2 className="text-2xl font-bold text-signoz_vanilla-100">
               Your data stays where you want
@@ -89,7 +89,7 @@ const SigNozStats = () => {
               ))}
             </div>
           </div>
-          <div className="[&>div]:!border-r-1 grid grid-cols-1 text-left sm:grid-cols-2 [&>div]:border-l-0 [&>div]:border-signoz_slate-400">
+          <div className="[&>div]:!border-r-1 grid grid-cols-1 text-left md:grid-cols-2 [&>div]:border-l-0 [&>div]:border-signoz_slate-400">
             {STATS_LIST.map((stat, index) => (
               <StatsCard
                 logo={stat.logo}
@@ -100,8 +100,11 @@ const SigNozStats = () => {
               />
             ))}
           </div>
-          <div className="border-t border-dashed border-signoz_slate-400 py-6 sm:py-6 sm:pl-10">
-            <ButtonGroup buttons={communityButtons} className="flex-col gap-3 sm:flex-row" />
+          <div className="border-t border-dashed border-signoz_slate-400 py-6 md:pl-10">
+            <ButtonGroup
+              buttons={communityButtons}
+              className="flex-col flex-wrap gap-3 sm:flex-row"
+            />
           </div>
         </div>
       </div>

--- a/shared/components/molecules/FeaturePages/SignozStats/SignozStats.view.tsx
+++ b/shared/components/molecules/FeaturePages/SignozStats/SignozStats.view.tsx
@@ -89,7 +89,7 @@ const SigNozStats = () => {
               ))}
             </div>
           </div>
-          <div className="[&>div]:!border-r-1 grid grid-cols-1 text-left md:grid-cols-2 [&>div]:border-l-0 [&>div]:border-signoz_slate-400">
+          <div className="grid grid-cols-1 text-left md:grid-cols-2 [&>div]:!border-r [&>div]:border-l-0 [&>div]:border-signoz_slate-400">
             {STATS_LIST.map((stat, index) => (
               <StatsCard
                 logo={stat.logo}

--- a/shared/components/molecules/FeaturePages/SplitSection/SplitSection.types.ts
+++ b/shared/components/molecules/FeaturePages/SplitSection/SplitSection.types.ts
@@ -1,0 +1,20 @@
+import { FeatureButtonConfig } from '../FeatureButton/FeatureButton.types'
+
+export interface SplitSectionPanel {
+  title: React.ReactNode
+  description: React.ReactNode
+  image?: string
+  imageAlt?: string
+  imageElement?: React.ReactNode
+  className?: string
+  contentClassName?: string
+  imageClassName?: string
+  button?: FeatureButtonConfig
+}
+
+export interface SplitSectionProps {
+  left: SplitSectionPanel | React.ReactNode
+  right: SplitSectionPanel | React.ReactNode
+  withVerticalDivider?: boolean
+  className?: string
+}

--- a/shared/components/molecules/FeaturePages/SplitSection/SplitSection.view.tsx
+++ b/shared/components/molecules/FeaturePages/SplitSection/SplitSection.view.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import Image from 'next/image'
+import GridLayout from '../GridLayout'
+import Divider from '../Divider'
+import FeatureButton from '../FeatureButton'
+import { cn } from 'app/lib/utils'
+import { SplitSectionPanel, SplitSectionProps } from './SplitSection.types'
+
+function isPanelConfig(value: SplitSectionPanel | React.ReactNode): value is SplitSectionPanel {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !React.isValidElement(value) &&
+    'title' in value &&
+    'description' in value
+  )
+}
+
+const PanelContent: React.FC<{ panel: SplitSectionPanel }> = ({ panel }) => {
+  return (
+    <div className={cn('flex h-full w-full flex-col px-6', panel.className)}>
+      <div className={cn('flex flex-col justify-between', panel.contentClassName)}>
+        <h2 className="mb-6 text-signoz_vanilla-100">{panel.title}</h2>
+        {panel.description && (
+          <div className="mb-8 leading-relaxed text-signoz_vanilla-400">{panel.description}</div>
+        )}
+      </div>
+
+      {panel.button && (
+        <FeatureButton button={panel.button} className="mb-8 flex w-fit items-center gap-2" />
+      )}
+
+      {panel.imageElement
+        ? panel.imageElement
+        : panel.image && (
+            <Image
+              src={panel.image}
+              alt={panel.imageAlt || ''}
+              width={1440}
+              height={810}
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className={panel.imageClassName}
+            />
+          )}
+    </div>
+  )
+}
+
+const SplitSection: React.FC<SplitSectionProps> = ({
+  left,
+  right,
+  withVerticalDivider = false,
+  className,
+}) => {
+  const leftContent = isPanelConfig(left) ? <PanelContent panel={left} /> : left
+  const rightContent = isPanelConfig(right) ? <PanelContent panel={right} /> : right
+
+  if (withVerticalDivider) {
+    return (
+      <div className={cn('bg-signoz_ink-500', className)}>
+        <GridLayout variant="split" className="!gap-y-0">
+          <div className="relative flex h-full w-full flex-col">
+            {leftContent}
+            <Divider orientation="vertical" className="absolute right-0 top-0 hidden lg:block" />
+          </div>
+          <div className="flex h-full w-full flex-col">{rightContent}</div>
+        </GridLayout>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('bg-signoz_ink-500', className)}>
+      <GridLayout variant="split">
+        <div className="flex h-full w-full flex-col">{leftContent}</div>
+        <div className="flex h-full w-full flex-col">{rightContent}</div>
+      </GridLayout>
+    </div>
+  )
+}
+
+export default SplitSection

--- a/shared/components/molecules/FeaturePages/SplitSection/index.tsx
+++ b/shared/components/molecules/FeaturePages/SplitSection/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './SplitSection.view'
+export type { SplitSectionProps, SplitSectionPanel } from './SplitSection.types'

--- a/shared/components/molecules/FeaturePages/UsageBasedPricing/UsageBasedPricing.view.tsx
+++ b/shared/components/molecules/FeaturePages/UsageBasedPricing/UsageBasedPricing.view.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import { ArrowRight } from 'lucide-react'
 import { Section } from 'app/(site)/pricing/pricingv1/components/PricingCalculator'
+import Divider from '../Divider'
 
 const UsageBasedPricing: React.FC<{
   show: Section[]
@@ -27,7 +28,7 @@ const UsageBasedPricing: React.FC<{
           </p>
         </div>
         <div className="flex-[2_2_0%]">
-          <div className="border-b border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
+          <div className="border-l border-dashed border-signoz_slate-400 bg-transparent p-0">
             <div className="flex flex-col gap-2 px-10 py-10">
               <div className="text-2xl font-semibold text-signoz_vanilla-100">{sectionTitle}</div>
               <p className="text-base font-normal text-signoz_vanilla-400">{sectionDescription}</p>

--- a/shared/components/molecules/FeaturePages/constants.ts
+++ b/shared/components/molecules/FeaturePages/constants.ts
@@ -1,0 +1,1 @@
+export const BUTTON_CLASS_NAME = 'flex items-center justify-center gap-1 h-full w-full'


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> The components used in feature pages had repeated overrides in multiple places and introduced double borders - refactored the components, and used dividers correctly and fixed max-width issues on pages


#### Screenshots / Screen Recordings (if applicable)

| Page | Before | After |
|------|--------|-------|
| Agent Native Observability | <img width="1916" height="5028" alt="agent-native-observability-before" src="https://github.com/user-attachments/assets/069b3f13-9ee8-4c5d-9ae8-67855df96c7d" /> | <img width="1916" height="5018" alt="agent-native-observability-after" src="https://github.com/user-attachments/assets/40f98a55-111e-40ab-97a7-f377ad62287c" /> |
| Alerts Management | <img width="1916" height="8649" alt="alerts-management-before" src="https://github.com/user-attachments/assets/353b1fa8-bcd0-4671-8cad-9ce54806b1fa" /> | <img width="1916" height="8688" alt="alerts-management-after" src="https://github.com/user-attachments/assets/34f09a2d-7b2d-48b4-887a-0c8f09d9edfc" /> |
| ClickStack Alternative | <img width="1916" height="9543" alt="clickstack-alternative-before" src="https://github.com/user-attachments/assets/4ca460a3-c29f-409e-affe-0ff207131a14" /> | <img width="1916" height="9544" alt="clickstack-alternative-after" src="https://github.com/user-attachments/assets/d8af065c-3ada-4ade-bae4-431b5c0b2206" /> |
| Cloudwatch Alternative | <img width="1916" height="8413" alt="cloudwatch-alternative-before" src="https://github.com/user-attachments/assets/5f084dfb-021d-4a7b-8153-79e7c6baddcb" /> | <img width="1916" height="8371" alt="cloudwatch-alternative-after" src="https://github.com/user-attachments/assets/6055e8ef-7851-4996-8ac6-66c7375a692e" /> |
| Datadog Migration Tool | <img width="1916" height="6791" alt="datadog-migration-tool-before" src="https://github.com/user-attachments/assets/366781f8-6cc5-4d3a-aabc-2cc41326b159" /> | <img width="1916" height="6750" alt="datadog-migration-tool-after" src="https://github.com/user-attachments/assets/53631551-0b7f-436d-bc55-2a9922ed7319" /> |
| Distributed Tracing | <img width="1916" height="7278" alt="distributed-tracing-before" src="https://github.com/user-attachments/assets/a7b510ea-b857-48a9-8671-d5532f29de34" /> | <img width="1916" height="7403" alt="distributed-tracing-after" src="https://github.com/user-attachments/assets/78a5f4fd-2f7a-4dbb-811a-758c78072ecc" /> |
| External APIs | <img width="1916" height="7218" alt="external-apis-before" src="https://github.com/user-attachments/assets/76f74a7d-84fd-4bb8-adb9-b98be8332bab" /> | <img width="1916" height="7186" alt="external-apis-after" src="https://github.com/user-attachments/assets/83f9f458-d036-470e-83eb-9e14149fec6c" /> |
| LLM Observability | <img width="1916" height="7537" alt="llm-observability-before" src="https://github.com/user-attachments/assets/895615c8-1805-44dc-ba07-9cd55839dd51" /> | <img width="1916" height="7534" alt="llm-observability-after" src="https://github.com/user-attachments/assets/d159e332-9efa-440e-8394-d97ad7c021de" /> 
| Log Management |
<img width="1916" height="6538" alt="log-management-before" src="https://github.com/user-attachments/assets/b784c29e-0ab7-48b1-98cd-36f6da918bfd" /> | <img width="1916" height="6522" alt="log-management-after" src="https://github.com/user-attachments/assets/32b21c23-fe4c-4f53-88cd-21f51a4342a5" /> 
| Pricing | <img width="1916" height="15171" alt="pricing-before" src="https://github.com/user-attachments/assets/537c7fb4-be04-4183-a3d6-7f0bcf4ea5b3" /> | <img width="1916" height="15050" alt="pricing-after" src="https://github.com/user-attachments/assets/a3e8c60b-c74e-4b49-a40b-ee08d29778a1" /> |
| Trace Funnels | <img width="1916" height="7619" alt="trace-funnels-before" src="https://github.com/user-attachments/assets/00d94cdc-b41e-4353-9b02-c62d9ab6972d" /> | <img width="1916" height="7624" alt="trace-funnels-after" src="https://github.com/user-attachments/assets/8e2d14a3-e6d2-4899-b413-efa03936919a" /> |


#### Issues closed by this PR
> Closes https://github.com/SigNoz/growth-pod/issues/880

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Feature pages
- Potential regressions: UX regressions on Feature pages
- Rollback plan: Revert the PR

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered


---
