### PR TITLE
docs: update infra monitoring Hosts disk charts

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: overview
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
@@ -80,9 +80,9 @@ Monitor host performance metrics across customizable time periods.
 - **Network Connections**: Active network connection count
 
 ##### Disk Performance
-- **System Disk I/O (Bytes)**: Total bytes read/written to disk
-- **System Disk Operations/s**: Rate of read/write operations
-- **Disk Operations Time**: Average time taken for disk operations
+- **System disk io (bytes transferred)**: Total bytes read/written to disk, broken down by device and direction (e.g., `sda::read`, `sda::write`).
+- **System disk operations/s**: Rate of disk read/write operations per second, broken down by device and direction.
+- **System disk operation time/s**: Rate of disk operation time, broken down by device and direction.
 
 **Time Range Selection:**
 - Choose from preset time ranges (e.g., last hour, last 24 hours)


### PR DESCRIPTION
## Summary
- Update Host detail Metrics tab Disk Performance section in `data/docs/infrastructure-monitoring/overview.mdx` to match the chart titles and behavior from SigNoz/signoz#11599:
  - `System Disk I/O (Bytes)` → `System disk io (bytes transferred)`, now broken down by device and direction (e.g. `sda::read`, `sda::write`).
  - `System Disk Operations/s` description tightened to clarify it now correctly shows operations per second (previously plotted operation time data).
  - `Disk Operations Time` renamed to `System disk operation time/s`, now per-device/direction rate of disk operation time.
- Bump frontmatter `date` to `2026-06-09` on the edited file.

## Out of scope / notes for reviewer
- Deployment, Job, Namespace, and Volume detail views (deliverable items #1–5) are not currently enumerated chart-by-chart in `data/docs/infrastructure-monitoring/**` — there is no existing page section that names the corrected charts, so no rename or description was needed there. If/when those views get dedicated chart listings, they should pick up the new titles (`Memory usage, request, limits`, `Memory Usage`, namespace-scoped pod CPU/memory at 10 series, working inode charts).
- The dashboard template pages `data/docs/dashboards/dashboard-templates/hostmetrics-k8s.mdx` and `hostmetrics-vm.mdx` still list a `Disk Operations Time` panel — left untouched because they describe a separate JSON dashboard template, not the Infra Monitoring Hosts product view that #11599 changed.
- Screenshots were not refreshed: the demo workspace (`https://demo.in.signoz.cloud`) requires SSO and credentials weren't available in this environment. `public/img/docs/infrastructure-monitoring/host-metrics-details.webp` still shows the old single-series `system disk io` legend and the old `Disk operations time` title — flagging for a follow-up refresh.

Source PRs: SigNoz/signoz#11599

Auto-generated by docs-sync pipeline