### PR TITLE
docs: document SSO base path support in setup guides

### DIFF
--- a/data/docs/manage/administrator-guide/configuration/serving-on-external-url.mdx
+++ b/data/docs/manage/administrator-guide/configuration/serving-on-external-url.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-30
+date: 2026-06-09
 id: serving-on-external-url
 title: Serving SigNoz on an External URL
 description: Learn how to serve SigNoz on a custom external URL or base path so it can run behind a reverse proxy alongside other services on the same domain.
@@ -40,6 +40,16 @@ After restarting SigNoz with the updated configuration:
 ```bash
 curl -i https://example.com/api/v1/health
 ```
+
+## SSO callback URLs
+
+SSO callback URLs (OIDC, SAML, and Google OAuth) and the failed-login redirect automatically inherit the base path you set in `SIGNOZ_GLOBAL_EXTERNAL__URL` — no manual adjustment is required. For example, with `SIGNOZ_GLOBAL_EXTERNAL__URL=https://example.com/signoz`, SigNoz advertises:
+
+- OIDC: `https://example.com/signoz/api/v1/complete/oidc`
+- SAML (ACS URL): `https://example.com/signoz/api/v1/complete/saml`
+- Google OAuth: `https://example.com/signoz/api/v1/complete/google`
+
+Register these prefixed URLs with your Identity Provider when setting up SSO. See the [SSO setup guides](https://signoz.io/docs/manage/administrator-guide/sso/overview/) for provider-specific steps.
 
 <details>
 <ToggleHeading>

--- a/data/docs/manage/administrator-guide/sso/user-guides/oidc-keycloak.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/oidc-keycloak.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-23
+date: 2026-06-09
 id: oidc-keycloak
 
 title: Setting Up SSO OIDC With Keycloak
@@ -53,6 +53,10 @@ Before you begin, ensure you have:
    - Set **Valid redirect URIs** to `<your-instance-url>/api/v1/complete/oidc`
    - Set **Web origins** to `<your-instance-url>`
 8. Click **Save**
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the callback URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/oidc` with Keycloak. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ### Step 3: Note the Client Secret
 

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-awsso.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-awsso.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-10-21
+date: 2026-06-09
 id: saml-awsso
 
 title: SAML Authentication with AWS SSO
@@ -37,6 +37,10 @@ In the SAML application configuration:
 2. **ACS URL**: Enter your SigNoz instance URL with the redirect path `/api/v1/complete/saml` appended to it (e.g., `https://signoz.example.com/api/v1/complete/saml`)
 
 3. **Application SAML Audience**: Enter your SigNoz instance host:port (e.g., `signoz.example.com` if your SigNoz instance URL is `https://signoz.example.com`)
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the ACS URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/saml` with AWS Identity Center. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ![AWS SSO SAML Application Configuration 1](/img/docs/sso/awsso-01.png)
 

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-jumpcloud.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-jumpcloud.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-10-21
+date: 2026-06-09
 id: saml-jumpcloud
 
 title: SAML Authentication with JumpCloud
@@ -38,6 +38,9 @@ In the SAML application configuration:
 
 2. **ACS URL**: Enter your SigNoz instance URL with the redirect path `/api/v1/complete/saml` appended to it (e.g., `https://signoz.example.com/api/v1/complete/saml`)
 
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the ACS URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/saml` with JumpCloud. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ![JumpCloud SAML Application Configuration 1](/img/docs/sso/jumpcloud-01.png)
 

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-keycloak.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-keycloak.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-22
+date: 2026-06-09
 id: saml-keycloak
 
 title: Setting Up SSO SAML 2.0 With Keycloak
@@ -61,6 +61,10 @@ Before you begin, ensure you have:
 4. Click **Save**
 
 ![KeyCloak SAML Endpoint Configuration](/img/docs/saml-keycloak/client-settings-advanced-idp-acs.webp)
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the ACS URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/saml` with Keycloak. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ### Step 4: Set Up SAML Mappers
 1. Go to the **Client scopes** tab of your SAML client

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-microsoft-entra.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-microsoft-entra.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-10-21
+date: 2026-06-09
 id: saml-microsoft-entra
 
 title: SAML Authentication with Microsoft Entra ID
@@ -33,6 +33,10 @@ Before starting, ensure you have:
 2. **Entity Identifier (Entity ID)**: Enter your SigNoz instance host:port (e.g., `signoz.example.com` if your SigNoz instance URL is `https://signoz.example.com`)
 3. **Reply URL (Assertion Consumer Service URL)**:  Enter your SigNoz instance URL with the redirect path `/api/v1/complete/saml` appended to it (e.g., `https://signoz.example.com/api/v1/complete/saml`)
 4. **Sign on URL**: Enter your SigNoz instance URL (e.g., `https://signoz.example.com`)
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the Reply URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/saml` with Microsoft Entra ID. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ### Step 3: Export Metadata
 
@@ -103,5 +107,5 @@ Now you'll configure SigNoz to accept authentication from Microsoft Entra ID:
 
 **Common issues and solutions:**
 
-- **"Authentication failed" error**: Check that the redirect URI exactly matches `https://${SIGNOZ_BASEURL}/api/v1/complete/saml` in Microsoft Entra ID
+- **"Authentication failed" error**: Check that the redirect URI exactly matches `<your-instance-url>/api/v1/complete/saml` in Microsoft Entra ID. If you serve SigNoz under a base path, the URL must include that prefix (e.g., `https://example.com/signoz/api/v1/complete/saml`)
 - **Locked out?**: If you're unable to login because of faulty setup, use password authentication by appending `?password=Y` to your login URL: `<your-instance-url>/login?password=Y`

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-okta.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-okta.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-10-21
+date: 2026-06-09
 id: saml-okta
 
 title: SAML Authentication with Okta
@@ -37,6 +37,10 @@ Before starting, ensure you have:
    - **Single Sign-on URL**: `<your-instance-url>/api/v1/complete/saml`
    - **Audience URI (SP Entity ID)**: `<your-instance-url>`
 4. Click **Save** to create the application integration
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the Single Sign-on URL automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/saml` with Okta. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 <figure data-zoomable align="center">
   <img src="/img/docs/okta-sso-saml-integration.gif" alt="Okta SSO SAML Integration" />

--- a/data/docs/manage/administrator-guide/sso/user-guides/sso-google.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/sso-google.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-22
+date: 2026-06-09
 id: sso-google
 description: Set up Google Workspace SSO authentication with SigNoz, including group-based access control and role mapping.
 title: Single Sign-on Authentication With Google Workspace
@@ -32,9 +32,14 @@ Before starting, ensure you have:
 3. Click **Create credentials → OAuth client ID → Web application**
 4. Add an **Authorized redirect URI**:
    ```
-   https://${SIGNOZ_BASEURL}/api/v1/complete/google
+   <your-instance-url>/api/v1/complete/google
    ```
+   Replace `<your-instance-url>` with your SigNoz URL (e.g., `https://signoz.example.com/api/v1/complete/google`).
 5. Click **Create** and note the **Client ID** and **Client Secret**. You'll paste these into SigNoz shortly
+
+<Admonition type="info">
+If your self-hosted SigNoz is served under a base path (for example `https://example.com/signoz`), the redirect URI automatically inherits that prefix — register `https://example.com/signoz/api/v1/complete/google` with Google. See [Serving SigNoz on an External URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) for details.
+</Admonition>
 
 ### Step 2: Configure SigNoz for Google Authentication
 
@@ -173,7 +178,7 @@ Group-based role mapping requires **Fetch Groups** to be enabled (see [Step 5](#
 
 **Common issues and solutions:**
 
-- **"Authentication failed" error**: Check that the redirect URI exactly matches `https://${SIGNOZ_BASEURL}/api/v1/complete/google` in Google Cloud
+- **"Authentication failed" error**: Check that the redirect URI exactly matches `<your-instance-url>/api/v1/complete/google` in Google Cloud. If you serve SigNoz under a base path, the URI must include that prefix (e.g., `https://example.com/signoz/api/v1/complete/google`)
 - **Stuck in a login loop**: Ensure **Enforce SSO** is enabled **and** the user's email domain matches the configured authenticated domain
 - **Groups not being fetched**: Verify that the service account has Domain-Wide Delegation enabled, the `admin.directory.group.readonly` scope is authorized in Google Workspace Admin, and the Admin SDK API is enabled in Google Cloud
 - **"Insufficient permissions" error for groups**: Check that the admin email in **Domain to Admin Email** has permissions to list groups in Google Workspace. The admin must have at least the Groups Reader role


### PR DESCRIPTION
## Summary
- Added a note in each SSO setup guide (OIDC Keycloak, SAML Keycloak/Okta/Microsoft Entra/AWS SSO/JumpCloud, Google Workspace) clarifying that callback/ACS/redirect URLs automatically inherit the base path set via `SIGNOZ_GLOBAL_EXTERNAL__URL`, with example prefixed URLs and a cross-link to the external URL guide.
- Added a new "SSO callback URLs" section to `serving-on-external-url.mdx` listing the prefixed OIDC, SAML, and Google OAuth callback URLs.
- Replaced legacy `https://${SIGNOZ_BASEURL}/...` example URLs in Google and Microsoft Entra guides with the standard `<your-instance-url>/...` placeholder and added base-path guidance in their troubleshooting bullets.
- Updated frontmatter `date` to `2026-06-09` on every edited file.

Source PRs: #11588

Auto-generated by docs-sync pipeline