### PR TITLE
docs: add Dashboards V2 API reference and V2 detail page guide

### DIFF
--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -2118,6 +2118,8 @@ const docsSideNav = [
         route: '/docs/userguide/manage-dashboards',
         items: [
           { type: 'doc', route: '/docs/userguide/manage-dashboards', label: 'Manage Dashboards' },
+          { type: 'doc', route: '/docs/dashboards/dashboards-v2', label: 'Dashboards V2' },
+          { type: 'doc', route: '/docs/dashboards/dashboards-v2-api', label: 'Dashboards V2 API' },
           {
             label: 'Panel Types',
             type: 'category',

--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,0 +1,129 @@
+---
+date: 2026-06-09
+id: dashboards-v2-api
+title: Dashboards V2 API Reference
+description: Reference for the SigNoz Dashboards V2 API payload, including the panel envelope, query envelope, and the validated query kind enum.
+doc_type: reference
+---
+
+The Dashboards V2 API uses a strict, enum-validated JSON schema for panels and their underlying queries. This page documents the panel envelope, the query envelope, and the allowed values for the `kind` field on each.
+
+<Admonition type="warning">
+  **Breaking change:** The V2 API renamed the query `kind` values to lowercase snake_case and now strictly validates them as an enum. Requests that send the previous PascalCase strings (for example `TimeSeriesQuery`, `LogQuery`) or any value outside the allowed set are rejected with a validation error. See [Migrate existing payloads](#migrate-existing-payloads) below.
+</Admonition>
+
+## Panel envelope
+
+A V2 dashboard panel is wrapped in an envelope with a `kind` discriminator and a `spec` body.
+
+| Field | Type | Description |
+|---|---|---|
+| `kind` | string (enum) | Must be `"Panel"`. Any other value is rejected. |
+| `spec` | object | Panel specification — title, description, layout, visualization options, and the composite query that produces panel data. |
+
+Example panel envelope:
+
+```json
+{
+  "kind": "Panel",
+  "spec": {
+    "title": "Request rate",
+    "query": {
+      "queries": [
+        {
+          "kind": "time_series",
+          "spec": { /* query spec */ }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Query envelope
+
+Every query inside a panel's composite query is wrapped in an envelope with a `kind` discriminator and a `spec` body. The API rejects any `kind` value not in the allowed set below.
+
+| Field | Type | Description |
+|---|---|---|
+| `kind` | string (enum) | One of `time_series`, `raw`, `scalar`, `raw_stream`, `trace`. |
+| `spec` | object | Query specification — its shape depends on `kind`. |
+
+### `kind` values
+
+| Value | Use it for |
+|---|---|
+| `time_series` | Time series queries that drive line, bar, area, and other time-bucketed visualizations. |
+| `raw` | Raw row queries that return individual records (for example, logs in a List panel). |
+| `scalar` | Single-value queries that return one aggregated number (for example, a Value panel). |
+| `raw_stream` | Streaming raw queries (live tail / continuous result). |
+| `trace` | Trace queries used by trace-aware panels. |
+
+<Admonition type="info">
+  The `kind` field is validated as a strict enum. Sending an unrecognized value — including the previous PascalCase names — returns a validation error. Always send the lowercase snake_case form shown above.
+</Admonition>
+
+## Migrate existing payloads
+
+If you have dashboard JSON, automation, or templates that were written against the previous V2 schema, update each query `kind` value before posting it back to the V2 API.
+
+| Previous value | New value |
+|---|---|
+| `TimeSeriesQuery` | `time_series` |
+| `LogQuery` | `raw` |
+
+Where to apply the migration:
+
+- Dashboard JSON exports kept under version control (for example, in a Git repository or Terraform module).
+- Scripts or CI jobs that create or update dashboards through the V2 API.
+- Any third-party tool that emits Dashboards V2 payloads.
+
+After updating, re-import or re-apply the dashboard JSON. The API will reject the request if any query envelope still uses a legacy value.
+
+## Sample panel payload
+
+A minimal panel envelope with a single time-series query:
+
+```json
+{
+  "kind": "Panel",
+  "spec": {
+    "title": "p95 latency",
+    "description": "p95 of HTTP server latency by service",
+    "query": {
+      "queries": [
+        {
+          "kind": "time_series",
+          "spec": {
+            "name": "A",
+            "signal": "metrics",
+            "stepInterval": 60,
+            "aggregations": [
+              { "expression": "p95(duration_ms)" }
+            ],
+            "groupBy": [
+              { "name": "service.name" }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Validation errors
+
+When a payload fails enum validation, the API returns an HTTP 400 with a message identifying the offending field and value. Common causes:
+
+- Sending `TimeSeriesQuery` or `LogQuery` instead of `time_series` or `raw`.
+- Sending a misspelled or capitalized variant of an allowed value (for example, `Time_Series` or `TIME_SERIES`).
+- Using a panel envelope `kind` other than `"Panel"`.
+
+Fix the value in the payload and resubmit.
+
+## Related
+
+- [Manage dashboards](https://signoz.io/docs/userguide/manage-dashboards/) — Create and edit dashboards in the SigNoz UI.
+- [Terraform provider for SigNoz](https://signoz.io/docs/dashboards/terraform-provider-signoz/) — Manage dashboards as code.
+- [Import a dashboard](https://signoz.io/docs/dashboards/import-dashboard/) — Import dashboard JSON through the UI.

--- a/data/docs/dashboards/dashboards-v2.mdx
+++ b/data/docs/dashboards/dashboards-v2.mdx
@@ -1,0 +1,125 @@
+---
+date: 2026-06-09
+id: dashboards-v2
+title: Dashboards V2 — Detail Page Guide
+description: Learn how to use the V2 dashboard detail page in SigNoz — inline title editing, Configure drawer, collapsible sections, and the redesigned options menu.
+doc_type: howto
+---
+
+The V2 dashboard detail page redesigns how you edit, organize, and share a single dashboard. This guide covers the header toolbar, the options menu, the right-side Configure drawer, and the new section and empty-state behaviors.
+
+<Admonition type="info">
+  **Preview:** The V2 detail page is being rolled out incrementally. If your dashboard still uses the previous layout, see [Manage dashboards](https://signoz.io/docs/userguide/manage-dashboards/) instead. Screenshots and step-by-step UI references on this page will be refreshed as V2 becomes generally available.
+</Admonition>
+
+## Dashboard header
+
+The header at the top of every V2 dashboard collects all dashboard-level controls in one toolbar.
+
+- **Breadcrumb bar** — Shows `Dashboard / <title>`. Selecting the **Dashboard** link returns to the dashboards list and restores the filters and sort you had applied before opening the dashboard.
+- **Dashboard title** — Click the title to edit it in place. Press **Enter** or click the check icon to save; press **Escape** or click the X icon to cancel. Inline editing requires edit permission on the dashboard.
+- **Lock indicator** — A lock icon appears next to the title when the dashboard is locked. Unlock the dashboard from the [options menu](#options-menu) to resume editing.
+- **Time-range picker** — Selects the time range applied to every panel on the dashboard.
+- **Configure** — Opens the right-side [Configure drawer](#configure-drawer). Visible only when the dashboard is unlocked and you have edit permission.
+- **Add Panel** — Adds a new panel to the dashboard. Visible only when the dashboard is unlocked and you have edit permission.
+- **Options menu** — The three-dots button on the right. See [Options menu](#options-menu) below.
+
+## Options menu
+
+The three-dots menu in the header groups dashboard actions into three sections.
+
+### Edit
+
+- **Rename** — Opens the inline title editor (same flow as clicking the title).
+- **Lock / Unlock Dashboard** — Toggles the locked state. Available to the dashboard author and to admins. Disabled for dashboards created by an integration. On success a confirmation toast is shown; on failure an error dialog is shown.
+- **Full Screen** — Opens the dashboard in a chromeless full-screen view for wall displays and presentations.
+
+### Export
+
+- **Export JSON** — Downloads the full dashboard definition as a `.json` file.
+- **Copy as JSON** — Copies the dashboard JSON to the clipboard.
+
+### Danger
+
+- **Delete Dashboard** — Opens a confirmation dialog with explicit **Cancel** and **Delete** buttons. The dashboard is removed only after you confirm.
+
+## Configure drawer
+
+Selecting **Configure** in the header opens the **Dashboard Configuration** drawer on the right. The drawer is the primary way to edit dashboard settings in V2 and replaces the previous configuration modal.
+
+The drawer has three tabs:
+
+- **General** — Dashboard metadata and cross-panel sync settings.
+- **Variables** — Template variables. (Coming soon — see [Variables](#variables-tab).)
+- **Publish** — Public sharing. (Coming soon — see [Publish](#publish-tab).)
+
+### General tab
+
+The General tab has two groups of settings.
+
+**Dashboard metadata**
+
+| Field | Description |
+|---|---|
+| Name | Dashboard name. Has an icon picker next to it for the dashboard's display icon. |
+| Description | Free-text description shown on the dashboard list and at the top of the dashboard. |
+| Tags | One or more tags used to filter dashboards in the list. |
+
+**Cross-Panel Sync**
+
+The Cross-Panel Sync section is rendered inside the General tab. It controls how hovering one chart highlights the same point in time on every other chart in the dashboard.
+
+1. **Sync Mode** — Choose how panels respond to a hover:
+   - **No Sync** — Panels behave independently.
+   - **Crosshair** — A vertical time-marker appears on every other panel at the hovered timestamp.
+   - **Tooltip** — Same as Crosshair, plus matching tooltips appear on related panels.
+2. **Synced Tooltip Series** — Appears only when Sync Mode is set to **Tooltip**:
+   - **All** — Shows the full tooltip with every series on the receiving panels.
+   - **Filtered** — Shows only the series that match the hovered series based on shared group-by dimensions.
+
+For the matching rules and visual behavior, see [Cross-Panel Sync](https://signoz.io/docs/dashboards/interactivity/#cross-panel-sync) in the interactivity guide.
+
+### Unsaved changes footer
+
+Editing any field on the General tab pins a footer to the bottom of the drawer. The footer shows how many fields are currently dirty and offers two actions:
+
+- **Discard** — Reverts all unsaved changes in the drawer.
+- **Save** — Persists the changes to the dashboard.
+
+The footer is hidden when no fields are dirty.
+
+### Variables tab
+
+The Variables tab is present in the drawer as a placeholder. It currently shows the message "V2 dashboard variables coming next." For now, edit dashboard variables using the [previous variables workflow](https://signoz.io/docs/userguide/manage-variables/).
+
+### Publish tab
+
+The Publish tab is present in the drawer as a placeholder. It currently shows the message "V2 public dashboard publishing coming next." For now, manage public sharing using the [previous public sharing workflow](https://signoz.io/docs/dashboards/public-sharing/).
+
+## Sections and layout
+
+V2 dashboards organize panels into **sections**. Each section has its own header and can be collapsed independently.
+
+- **Collapse / expand** — Each section header has a chevron that toggles the section open and closed. Collapsed sections hide their panels but remain in the dashboard layout.
+- **Template-variable badge** — A badge appears on a section header when the section is configured to repeat using a template variable.
+- **Inline add (empty section)** — When an unlocked section has no panels and the dashboard is in edit mode, a dashed **New Panel** button appears inside the section body. Selecting it opens the same panel creation flow as the header **Add Panel** button.
+
+## Empty dashboard welcome screen
+
+A dashboard with no panels at all shows a **Welcome to your new dashboard** screen instead of an empty grid. The welcome screen has a primary **New Panel** call-to-action that opens the panel creation flow.
+
+## Permissions
+
+The following V2 controls depend on dashboard permissions:
+
+- Inline title editing, **Configure**, **Add Panel**, and the inline section add button are visible only when the dashboard is unlocked **and** the user has edit permission.
+- **Lock / Unlock Dashboard** is available to the dashboard author and to admins. It is disabled for integration-created dashboards.
+- **Delete Dashboard** is available to users with delete permission and always prompts for confirmation.
+
+## Related
+
+- [Manage dashboards](https://signoz.io/docs/userguide/manage-dashboards/) — Create, edit, and remove dashboards.
+- [Interactivity](https://signoz.io/docs/dashboards/interactivity/) — Cross-panel sync matching rules and other interactive features.
+- [Dashboards V2 API reference](https://signoz.io/docs/dashboards/dashboards-v2-api/) — Panel and query envelope reference for the V2 API.
+- [Public sharing](https://signoz.io/docs/dashboards/public-sharing/) — Current public sharing workflow.
+- [Variables](https://signoz.io/docs/userguide/manage-variables/) — Current variables workflow.


### PR DESCRIPTION
## Summary

- New **Dashboards V2 API reference** at `/docs/dashboards/dashboards-v2-api/` documents the panel envelope (`kind: \"Panel\"`), the query envelope, and the validated `kind` enum (`time_series`, `raw`, `scalar`, `raw_stream`, `trace`). Includes a migration callout for users with existing dashboard JSON or automation that uses the previous PascalCase values (`TimeSeriesQuery` -> `time_series`, `LogQuery` -> `raw`).
- New **Dashboards V2 detail page guide** at `/docs/dashboards/dashboards-v2/` drafts the V2 UI surface: header toolbar (breadcrumb, inline title editing, lock indicator, time-range picker, Configure, Add Panel), the grouped options menu (Edit / Export / Danger), the right-side Configure drawer (General tab with name/description/tags/icon and Cross-Panel Sync, unsaved-changes footer, Variables and Publish placeholders), collapsible sections, the empty-section inline add button, and the empty-dashboard welcome screen. Page is explicitly marked as a preview pending the V2 routing feature gate.
- Updates `constants/docsSideNav.ts` to surface both new pages under **Dashboards -> Working with Dashboards**.
- Frontmatter `date` set to `2026-06-09` on all new files.

## Status by track

- **Track 1 (live)** — PR #11559 introduced the V2 API breaking change. The new API reference is publish-ready.
- **Track 2 (pending)** — PRs #11543 and #11581 added the V2 detail page UI, but the entire surface is excluded from the production build (`tsconfig` exclude on `DashboardPageV2/**`) and is not user-accessible yet. The detail page guide is drafted now and should be reviewed; screenshots will be captured and added when the feature gate opens. This PR is intentionally a draft for that reason.

## Open items carried over from the deliverable

These are unresolved and may need follow-up before this PR can move out of draft:

- Whether dashboards saved with the old PascalCase `kind` values are auto-migrated or fail on read/edit.
- Whether the `distribution` value is a valid query kind (present in backend allowed list, absent from OpenAPI enum).
- Which PR lifts the `DashboardPageV2` tsconfig exclusion and the expected ship date.
- Whether V2 fully replaces V1 or rolls out gradually.

Source PRs: #11543, #11559, #11581

Auto-generated by docs-sync pipeline