### PR TITLE
docs: add Azure AKS and Container Apps one-click integration pages

### DIFF
--- a/components/Azure/AzureOneClickListicle.tsx
+++ b/components/Azure/AzureOneClickListicle.tsx
@@ -5,10 +5,10 @@ import IconCardGrid from '../Card/IconCardGrid'
 import { AZURE_ONE_CLICK_ITEMS } from '@/constants/componentItems'
 
 const ICON_MAP: Record<string, React.ReactNode> = {
-  '/docs/integrations/azure/cdn-frontdoor': (
+  '/docs/integrations/azure/aks': (
     <img
-      src="/img/icons/azure-cdn-frontdoor-icon.svg"
-      alt="Azure CDN FrontDoor"
+      src="/img/icons/kubernetes-icon.svg"
+      alt="Azure Kubernetes Service (AKS)"
       className="h-7 w-7"
     />
   ),
@@ -18,6 +18,16 @@ const ICON_MAP: Record<string, React.ReactNode> = {
       alt="Azure Blob Storage"
       className="h-7 w-7"
     />
+  ),
+  '/docs/integrations/azure/cdn-frontdoor': (
+    <img
+      src="/img/icons/azure-cdn-frontdoor-icon.svg"
+      alt="Azure CDN FrontDoor"
+      className="h-7 w-7"
+    />
+  ),
+  '/docs/integrations/azure/container-apps': (
+    <img src="/img/icons/azure-icon.svg" alt="Azure Container Apps" className="h-7 w-7" />
   ),
 }
 

--- a/constants/componentItems/azureOneClick.ts
+++ b/constants/componentItems/azureOneClick.ts
@@ -2,13 +2,23 @@ import type { ComponentItem } from './types'
 
 export const AZURE_ONE_CLICK_ITEMS = [
   {
-    name: 'CDN FrontDoor',
-    href: '/docs/integrations/azure/cdn-frontdoor',
-    clickName: 'CDN FrontDoor Integration Link',
+    name: 'AKS',
+    href: '/docs/integrations/azure/aks',
+    clickName: 'AKS Integration Link',
   },
   {
     name: 'Blob Storage',
     href: '/docs/integrations/azure/blob-storage',
     clickName: 'Blob Storage Integration Link',
+  },
+  {
+    name: 'CDN FrontDoor',
+    href: '/docs/integrations/azure/cdn-frontdoor',
+    clickName: 'CDN FrontDoor Integration Link',
+  },
+  {
+    name: 'Container Apps',
+    href: '/docs/integrations/azure/container-apps',
+    clickName: 'Container Apps Integration Link',
   },
 ] satisfies ComponentItem[]

--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -3671,6 +3671,11 @@ const docsSideNav = [
         items: [
           {
             type: 'doc',
+            route: '/docs/integrations/azure/aks',
+            label: 'AKS',
+          },
+          {
+            type: 'doc',
             route: '/docs/integrations/azure/blob-storage',
             label: 'Blob Storage',
           },
@@ -3678,6 +3683,11 @@ const docsSideNav = [
             type: 'doc',
             route: '/docs/integrations/azure/cdn-frontdoor',
             label: 'CDN FrontDoor',
+          },
+          {
+            type: 'doc',
+            route: '/docs/integrations/azure/container-apps',
+            label: 'Container Apps',
           },
         ],
       },

--- a/data/docs/integrations/azure/aks.mdx
+++ b/data/docs/integrations/azure/aks.mdx
@@ -1,0 +1,145 @@
+---
+date: 2026-06-09
+id: aks
+title: Azure Kubernetes Service (AKS) Integration
+description: Monitor Azure Kubernetes Service (AKS) clusters with SigNoz. Collect API Server, ETCD, node, and pod metrics plus diagnostic logs via One-Click Azure Integration.
+doc_type: howto
+tags: [SigNoz Cloud]
+---
+
+import GetHelp from '@/components/shared/get-help.md'
+
+The Azure Kubernetes Service (AKS) integration collects metrics and diagnostic logs from your AKS clusters. Once enabled, the SigNoz agent discovers AKS clusters in your monitored resource groups and configures telemetry collection.
+
+<Admonition type="info">
+This integration supports AKS clusters of resource type `Microsoft.ContainerService/managedClusters` only. Other AKS variants are not collected.
+</Admonition>
+
+## Getting started
+
+Connect your Azure subscription first. See [Azure One-Click Integrations](https://signoz.io/docs/integrations/azure/one-click-azure-integrations/) for setup instructions.
+
+Once connected:
+
+1. In SigNoz, navigate to **Integrations** > **Microsoft Azure**.
+2. Select **Azure Kubernetes Service (AKS)** from the left panel.
+3. Toggle **Log Collection** and **Metric Collection** on.
+
+The agent deploys the necessary Event Hubs and diagnostic settings in the background. Data starts flowing within a few minutes. Navigate to **Dashboards** and open the **Azure Kubernetes Service (AKS) Overview** dashboard to confirm metrics are appearing.
+
+Logs are collected via the `allLogs` category group for AKS resources — no additional Azure-side log configuration is required.
+
+## What's collected
+
+<details>
+<summary>Logs</summary>
+
+| Name | Path | Type |
+|------|------|------|
+| Resource ID | `resources.azure.resource.id` | string |
+
+</details>
+
+<details>
+<summary>Metrics — API Server</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_apiserver_current_inflight_requests_average` | Count | Gauge |
+| `azure_apiserver_current_inflight_requests_total` | Count | Gauge |
+| `azure_apiserver_cpu_usage_percentage_average` | Percent | Gauge |
+| `azure_apiserver_cpu_usage_percentage_maximum` | Percent | Gauge |
+| `azure_apiserver_memory_usage_percentage_average` | Percent | Gauge |
+| `azure_apiserver_memory_usage_percentage_maximum` | Percent | Gauge |
+
+</details>
+
+<details>
+<summary>Metrics — ETCD</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_etcd_cpu_usage_percentage_average` | Percent | Gauge |
+| `azure_etcd_cpu_usage_percentage_maximum` | Percent | Gauge |
+| `azure_etcd_database_usage_percentage_average` | Percent | Gauge |
+| `azure_etcd_database_usage_percentage_maximum` | Percent | Gauge |
+| `azure_etcd_memory_usage_percentage_average` | Percent | Gauge |
+| `azure_etcd_memory_usage_percentage_maximum` | Percent | Gauge |
+
+</details>
+
+<details>
+<summary>Metrics — Nodes</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_node_cpu_usage_millicores_average` | Count | Gauge |
+| `azure_node_cpu_usage_millicores_maximum` | Count | Gauge |
+| `azure_node_cpu_usage_percentage_average` | Percent | Gauge |
+| `azure_node_cpu_usage_percentage_maximum` | Percent | Gauge |
+| `azure_node_disk_usage_bytes_average` | Bytes | Gauge |
+| `azure_node_disk_usage_bytes_maximum` | Bytes | Gauge |
+| `azure_node_disk_usage_percentage_average` | Percent | Gauge |
+| `azure_node_disk_usage_percentage_maximum` | Percent | Gauge |
+| `azure_node_memory_rss_bytes_average` | Bytes | Gauge |
+| `azure_node_memory_rss_bytes_maximum` | Bytes | Gauge |
+| `azure_node_memory_rss_percentage_average` | Percent | Gauge |
+| `azure_node_memory_rss_percentage_maximum` | Percent | Gauge |
+| `azure_node_memory_working_set_bytes_average` | Bytes | Gauge |
+| `azure_node_memory_working_set_bytes_maximum` | Bytes | Gauge |
+| `azure_node_memory_working_set_percentage_average` | Percent | Gauge |
+| `azure_node_memory_working_set_percentage_maximum` | Percent | Gauge |
+| `azure_node_network_in_bytes_average` | Bytes | Gauge |
+| `azure_node_network_in_bytes_maximum` | Bytes | Gauge |
+| `azure_node_network_out_bytes_average` | Bytes | Gauge |
+| `azure_node_network_out_bytes_maximum` | Bytes | Gauge |
+| `azure_kube_node_status_allocatable_cpu_cores_average` | Count | Gauge |
+| `azure_kube_node_status_allocatable_cpu_cores_total` | Count | Gauge |
+| `azure_kube_node_status_allocatable_memory_bytes_average` | Bytes | Gauge |
+| `azure_kube_node_status_allocatable_memory_bytes_total` | Bytes | Gauge |
+| `azure_kube_node_status_condition_average` | Count | Gauge |
+| `azure_kube_node_status_condition_total` | Count | Gauge |
+
+</details>
+
+<details>
+<summary>Metrics — Pods</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_kube_pod_status_phase_average` | Count | Gauge |
+| `azure_kube_pod_status_phase_total` | Count | Gauge |
+| `azure_kube_pod_status_ready_average` | Count | Gauge |
+| `azure_kube_pod_status_ready_total` | Count | Gauge |
+
+</details>
+
+## Dashboards
+
+The integration includes a pre-built **Azure Kubernetes Service (AKS) Overview** dashboard with five collapsible sections containing 13 panels in total:
+
+- **API Server** — CPU and memory usage percentage
+- **ETCD** — CPU, memory, and database usage percentage
+- **Nodes Overview** — allocatable CPU cores, allocatable memory, and node status conditions
+- **Enhanced Nodes Overview** — CPU usage, memory working set, disk used, and network in/out bytes
+- **Pods** — pod status by phase
+
+Pre-built dashboards are locked and cannot be edited. To customize, use **Export JSON** from the dashboard menu and import it as a new dashboard.
+
+### Filtering by subscription and cluster
+
+The dashboard exposes two variables you can use to scope all panels:
+
+- **`azuremonitor.subscription_id`** — Azure subscription ID
+- **`name`** — AKS cluster name
+
+Select a subscription and cluster from the dropdowns at the top of the dashboard to filter every panel to that cluster.
+
+## Next steps
+
+- [Create alerts](https://signoz.io/docs/alerts/) on API Server availability, pod readiness, or node resource saturation
+- [Build custom dashboards](https://signoz.io/docs/userguide/manage-dashboards/) to correlate AKS metrics with application traces
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/integrations/azure/container-apps.mdx
+++ b/data/docs/integrations/azure/container-apps.mdx
@@ -1,0 +1,136 @@
+---
+date: 2026-06-09
+id: container-apps
+title: Azure Container Apps Integration
+description: Monitor Azure Container Apps with SigNoz. Collect CPU, memory, replica, and network metrics plus console and system logs via One-Click Azure Integration.
+doc_type: howto
+tags: [SigNoz Cloud]
+---
+
+import GetHelp from '@/components/shared/get-help.md'
+
+The Azure Container Apps integration collects metrics and diagnostic logs from your Container Apps. Once enabled, the SigNoz agent discovers Container App resources in your monitored resource groups and configures telemetry collection.
+
+## Prerequisites
+
+- Connect your Azure subscription first. See [Azure One-Click Integrations](https://signoz.io/docs/integrations/azure/one-click-azure-integrations/) for setup instructions.
+- For log collection: the **Container App Environment** must have **Azure Monitor** selected as the logging option. Without this, the `ContainerAppConsoleLogs` and `ContainerAppSystemLogs` diagnostic categories are unavailable and no logs will appear in SigNoz.
+
+<Admonition type="warning">
+Log collection requires **Azure Monitor** as the logging destination on the Container App Environment. Set this in the Azure Portal under your Container App Environment > **Logging options** before enabling Log Collection in SigNoz.
+</Admonition>
+
+## Getting started
+
+Once connected:
+
+1. In SigNoz, navigate to **Integrations** > **Microsoft Azure**.
+2. Select **Container App** from the left panel.
+3. Toggle **Log Collection** and **Metric Collection** on.
+
+The agent deploys the necessary Event Hubs and diagnostic settings in the background. Data starts flowing within a few minutes. Navigate to **Dashboards** and open the **Azure Container App Overview** dashboard to confirm metrics are appearing.
+
+## What's collected
+
+This integration ingests logs from the `ContainerAppConsoleLogs` and `ContainerAppSystemLogs` diagnostic categories only. Other Container App log categories are not collected.
+
+<details>
+<summary>Logs</summary>
+
+| Name | Path | Type |
+|------|------|------|
+| Resource ID | `resources.azure.resource.id` | string |
+
+</details>
+
+<details>
+<summary>Metrics — CPU and memory</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_cpupercentage_average` | Percent | Gauge |
+| `azure_cpupercentage_maximum` | Percent | Gauge |
+| `azure_cpupercentage_minimum` | Percent | Gauge |
+| `azure_cpupercentage_total` | Percent | Gauge |
+| `azure_memorypercentage_average` | Percent | Gauge |
+| `azure_memorypercentage_maximum` | Percent | Gauge |
+| `azure_memorypercentage_minimum` | Percent | Gauge |
+| `azure_memorypercentage_total` | Percent | Gauge |
+| `azure_usagenanocores_average` | Count | Gauge |
+| `azure_usagenanocores_maximum` | Count | Gauge |
+| `azure_usagenanocores_minimum` | Count | Gauge |
+| `azure_usagenanocores_total` | Count | Gauge |
+| `azure_workingsetbytes_average` | Bytes | Gauge |
+| `azure_workingsetbytes_maximum` | Bytes | Gauge |
+| `azure_workingsetbytes_minimum` | Bytes | Gauge |
+| `azure_workingsetbytes_total` | Bytes | Gauge |
+
+</details>
+
+<details>
+<summary>Metrics — Network</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_rxbytes_average` | Bytes | Gauge |
+| `azure_rxbytes_maximum` | Bytes | Gauge |
+| `azure_rxbytes_minimum` | Bytes | Gauge |
+| `azure_rxbytes_total` | Bytes | Gauge |
+| `azure_txbytes_average` | Bytes | Gauge |
+| `azure_txbytes_maximum` | Bytes | Gauge |
+| `azure_txbytes_minimum` | Bytes | Gauge |
+| `azure_txbytes_total` | Bytes | Gauge |
+
+</details>
+
+<details>
+<summary>Metrics — Replicas and quota</summary>
+
+| Metric name | Unit | Type |
+|-------------|------|------|
+| `azure_replicas_average` | Count | Gauge |
+| `azure_replicas_maximum` | Count | Gauge |
+| `azure_replicas_minimum` | Count | Gauge |
+| `azure_replicas_total` | Count | Gauge |
+| `azure_restartcount_average` | Count | Gauge |
+| `azure_restartcount_maximum` | Count | Gauge |
+| `azure_restartcount_minimum` | Count | Gauge |
+| `azure_restartcount_total` | Count | Gauge |
+| `azure_coresquotaused_maximum` | Count | Gauge |
+| `azure_coresquotaused_minimum` | Count | Gauge |
+| `azure_totalcoresquotaused_average` | Count | Gauge |
+| `azure_totalcoresquotaused_maximum` | Count | Gauge |
+| `azure_totalcoresquotaused_minimum` | Count | Gauge |
+
+</details>
+
+## Dashboards
+
+The integration includes a pre-built **Azure Container App Overview** dashboard with six panels:
+
+- CPU Usage Percentage
+- Memory Percentage
+- Replica Count
+- Total Replica Restart Count
+- Network In Bytes
+- Network Out Bytes
+
+Pre-built dashboards are locked and cannot be edited. To customize, use **Export JSON** from the dashboard menu and import it as a new dashboard.
+
+### Filtering by subscription and container app
+
+The dashboard exposes two variables you can use to scope all panels:
+
+- **`azuremonitor.subscription_id`** — Azure subscription ID
+- **`name`** — container app name
+
+Select a subscription and container app from the dropdowns at the top of the dashboard to filter every panel to that container app.
+
+## Next steps
+
+- [Create alerts](https://signoz.io/docs/alerts/) on CPU/memory saturation, replica restarts, or quota exhaustion
+- [Build custom dashboards](https://signoz.io/docs/userguide/manage-dashboards/) to correlate Container App metrics with application traces
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/integrations/azure/one-click-azure-integrations.mdx
+++ b/data/docs/integrations/azure/one-click-azure-integrations.mdx
@@ -1,8 +1,8 @@
 ---
-date: 2026-05-06
+date: 2026-06-09
 id: one-click-azure-integrations
 title: Azure One-Click Integrations
-description: Monitor Azure CDN FrontDoor and Blob Storage with SigNoz One-Click Azure Integration. Connect your Azure subscription and SigNoz deploys the monitoring infrastructure for you.
+description: Monitor Azure services with SigNoz One-Click Azure Integration. Connect your Azure subscription and SigNoz deploys the monitoring infrastructure for you.
 doc_type: howto
 tags: [SigNoz Cloud]
 ---
@@ -202,7 +202,7 @@ Remove-AzSubscriptionDeploymentStack `
 
 ## Limitations
 
-- **Two Azure services are currently supported**: Azure CDN FrontDoor and Azure Blob Storage. More services will be added in future releases.
+- **Supported Azure services**: see the [Supported integrations](#supported-integrations) list above. More services are added in ongoing releases.
 - **Large deployments may hit ARM template size limits**: If you have a large number of resources across many regions and resource groups, the deployment may fail. Add only the resource groups you actively want to monitor. Support for larger deployments will be addressed in a future release.
 - **Deployment region is set at connection time and cannot be changed**: To change the region, disconnect and reconnect the account.
 


### PR DESCRIPTION
## Summary

- Added `data/docs/integrations/azure/aks.mdx` — Azure Kubernetes Service (AKS) one-click integration with the full metric inventory (API Server, ETCD, Nodes, Pods), `allLogs` log behavior, and the AKS Overview dashboard variables (`azuremonitor.subscription_id`, `name`).
- Added `data/docs/integrations/azure/container-apps.mdx` — Container Apps one-click integration with the full 36-metric inventory, the Azure Monitor logging-option prerequisite called out in an `Admonition`, the two supported log categories (`ContainerAppConsoleLogs`, `ContainerAppSystemLogs`), and the Container App Overview dashboard variables.
- Updated `constants/componentItems/azureOneClick.ts` to surface both new pages in the `<AzureOneClickListicle />` (sorted alphabetically: AKS, Blob Storage, CDN FrontDoor, Container Apps).
- Updated `components/Azure/AzureOneClickListicle.tsx` icon map for the two new entries.
- Updated `constants/docsSideNav.ts` to add both pages to the Azure One-Click Integrations sidebar group.
- Updated `data/docs/integrations/azure/one-click-azure-integrations.mdx` description and Limitations section: removed the stale "Two Azure services are currently supported" line so the page no longer contradicts the listicle.
- All edited and new files use `date: 2026-06-09`.

## Notes / open items for the docs author before marking ready

- **Screenshots not captured.** The `agent-browser` automation couldn't sign in to the SigNoz demo (`SIGNOZ_DEMO_EMAIL` / `SIGNOZ_DEMO_PASSWORD` env vars were not set in the runner). Both new pages currently have no `Figure` blocks. A docs author should follow the screenshot capture plan from the deliverable (integration catalog tile, integration detail page, dashboard with/without variable filters) and add `Figure` components under `public/img/docs/integrations/azure/`.
- The Container Apps icon currently reuses the generic `azure-icon.svg`. Replace with a dedicated Container Apps icon if available.
- Open deliverable questions are unresolved and not invented in the docs: metric descriptions (left blank in the product), whether `allLogs` automatically picks up future Azure log categories, and any Azure-side IAM/diagnostic-settings prerequisites beyond what's already covered in `one-click-azure-integrations.mdx`.

## Source PRs

- SigNoz/signoz#11615 — AKS (merged 2026-06-09)
- SigNoz/signoz#11580 — Container Apps (merged 2026-06-09)

Auto-generated by docs-sync pipeline (BATCH_ID: batch_20260609_120920)