### PR TITLE
docs: update cancel subscription FAQ for new fallback dialog

### DIFF
--- a/data/docs/faqs/general.mdx
+++ b/data/docs/faqs/general.mdx
@@ -49,14 +49,8 @@ You can ingest data from across your environments and tag your telemetry with th
 
 ### Q. How Do I cancel my subscription ?
 
-A. SigNoz Cloud subscriptions are cancelled by emailing the support team. Open **Settings → Billing**, click **Cancel subscription**, type `cancel` in the confirmation field, and click **Cancel subscription** to confirm. SigNoz then tries to open your default mail client with a pre-filled message to [cloud-support@signoz.io](mailto:cloud-support@signoz.io).
-
-If your browser has no default mail client configured, the dialog stays open on a fallback screen with the support email address and two actions:
-
-- **Copy email template** — copies the pre-filled cancellation request to your clipboard so you can paste it into any mail client or webmail. The button briefly shows **Copied!** as confirmation.
-- **Reopen email client** — retries the `mailto:` link without restarting the flow.
-
-Send the email from any account you have access to. If you cannot send email at all, reach out via the chatbox at the bottom right corner of your SigNoz Cloud interface instead.
+A. SigNoz Cloud subscriptions are cancelled by emailing the support team. Open **Settings → Billing**, click **Cancel subscription**, type `cancel` in the confirmation field, and click **Cancel subscription** to confirm. 
+You can also reach out via the chatbox at the bottom right corner of your SigNoz Cloud interface instead.
 
 ### Q. What happens when my SigNoz Cloud trial expires?
 

--- a/data/docs/faqs/general.mdx
+++ b/data/docs/faqs/general.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-23
+date: 2026-06-09
 title: General FAQs
 
 id: general-faqs
@@ -49,7 +49,14 @@ You can ingest data from across your environments and tag your telemetry with th
 
 ### Q. How Do I cancel my subscription ?
 
-A. Reach out to us on chatbox at the bottom right corner of your SigNoz Cloud interface.
+A. SigNoz Cloud subscriptions are cancelled by emailing the support team. Open **Settings → Billing**, click **Cancel subscription**, type `cancel` in the confirmation field, and click **Cancel subscription** to confirm. SigNoz then tries to open your default mail client with a pre-filled message to [cloud-support@signoz.io](mailto:cloud-support@signoz.io).
+
+If your browser has no default mail client configured, the dialog stays open on a fallback screen with the support email address and two actions:
+
+- **Copy email template** — copies the pre-filled cancellation request to your clipboard so you can paste it into any mail client or webmail. The button briefly shows **Copied!** as confirmation.
+- **Reopen email client** — retries the `mailto:` link without restarting the flow.
+
+Send the email from any account you have access to. If you cannot send email at all, reach out via the chatbox at the bottom right corner of your SigNoz Cloud interface instead.
 
 ### Q. What happens when my SigNoz Cloud trial expires?
 


### PR DESCRIPTION
## Summary
- Update the **How do I cancel my subscription?** entry in `data/docs/faqs/general.mdx` to describe the self-service Settings → Billing flow.
- Document the new fallback dialog (introduced in SigNoz #11622) for users whose browser has no default mail client: **Copy email template**, **Reopen email client**, and the **Copied!** button confirmation state.
- Bumped the `date` frontmatter field to `2026-06-09`.

No new pages or screenshots — the existing FAQ had no screenshots of the prior dialog and the fallback UI is self-explanatory.

Source PRs: SigNoz/signoz#11622

Auto-generated by docs-sync pipeline