### PR TITLE
docs: add YouTube walkthroughs and cross-links to LLM observability docs

### DIFF
--- a/data/blog/opentelemetry-vercel-ai-sdk.mdx
+++ b/data/blog/opentelemetry-vercel-ai-sdk.mdx
@@ -39,7 +39,7 @@ The Vercel AI SDK makes it easy to build LLM-powered apps with support for provi
 
 To demonstrate how monitoring works in practice, we’ve built a simple product support chatbot using the Vercel AI SDK. The app allows users to ask questions about a product, choose from suggested starter prompts, and give feedback on the chatbot’s responses. A thumbs-up triggers the bot to suggest helpful follow-up questions to deepen the conversation. If the user gives a thumbs-down, the LLM regenerates a new response in an attempt to better address the query. 
 
-The chatbot leverages streaming and LLM calls under the hood—making it a great candidate for observability. By instrumenting this app with OpenTelemetry and analyzing it in SigNoz, we can gain visibility into response times, error patterns, and user interactions. You can check out the github repository for the code [here](https://github.com/SigNoz/vercel-ai-sdk-opentelemetry-example).
+The chatbot leverages streaming and LLM calls under the hood—making it a great candidate for observability. By instrumenting this app with OpenTelemetry and analyzing it in SigNoz, we can gain visibility into response times, error patterns, and user interactions. You can check out the code in the [example chatbot GitHub repository](https://github.com/SigNoz/vercel-ai-sdk-opentelemetry-example).
 
 <figure data-zoomable align='center'>
     <img src="/img/blog/2025/08/combined-chatbot-image.webp" alt="Chatbot App Image"/>
@@ -64,7 +64,9 @@ Once you’ve cloned the example or set up your own Next.js project, follow the 
 
 ## Instrument your Next.js application
 
-Check out detailed instructions on how to set up OpenTelemetry instrumentation in your Nextjs applications and view your application traces in SigNoz over [here](https://signoz.io/docs/instrumentation/javascript/opentelemetry-nextjs/).
+Check out our [OpenTelemetry Next.js instrumentation guide](https://signoz.io/docs/instrumentation/javascript/opentelemetry-nextjs/) for detailed instructions on how to set up OpenTelemetry instrumentation in your Next.js applications and view your application traces in SigNoz.
+
+This blog covers the essential steps to get started. For the complete reference guide, including self-hosted SigNoz setup, custom tracers, and dashboard import, see our [Vercel AI SDK observability documentation](/docs/vercel-ai-sdk-observability/).
 
 ### Prerequisites
 
@@ -152,7 +154,7 @@ The Vercel AI SDK uses [OpenTelemetry](https://signoz.io/opentelemetry/) to co
 
 ### Enabling Telemetry
 
-Check out more detailed information about Vercel AI SDK’s telemetry options visit [here](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#telemetry).
+Check out the [Vercel AI SDK telemetry options documentation](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#telemetry) for more detailed information.
 
 You can then use the `experimental_telemetry` option to enable telemetry on specific function calls while the feature is experimental:
 
@@ -207,7 +209,7 @@ const result = await generateText({
 });
 ```
 
-Your Vercel AI SDK commands should now automatically emit traces, spans, and events. You can find more details on the types of spans and events generated [here](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#collected-data).
+Your Vercel AI SDK commands should now automatically emit traces, spans, and events. You can find more details on the [types of spans and events generated](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#collected-data) in the Vercel AI SDK telemetry reference.
 
 Finally, you should be able to view this data in Signoz Cloud under the traces tab:
 

--- a/data/blog/opentelemetry-vercel-ai-sdk.mdx
+++ b/data/blog/opentelemetry-vercel-ai-sdk.mdx
@@ -66,7 +66,7 @@ Once you’ve cloned the example or set up your own Next.js project, follow the 
 
 Check out our [OpenTelemetry Next.js instrumentation guide](https://signoz.io/docs/instrumentation/javascript/opentelemetry-nextjs/) for detailed instructions on how to set up OpenTelemetry instrumentation in your Next.js applications and view your application traces in SigNoz.
 
-This blog covers the essential steps to get started. For the complete reference guide, including self-hosted SigNoz setup, custom tracers, and dashboard import, see our [Vercel AI SDK observability documentation](/docs/vercel-ai-sdk-observability/).
+This blog covers the essential steps to get started. For the complete reference guide, including self-hosted SigNoz setup, custom tracers, and dashboard import, see our [Vercel AI SDK observability documentation](https://signoz.io/docs/vercel-ai-sdk-observability/).
 
 ### Prerequisites
 

--- a/data/docs/agno-monitoring.mdx
+++ b/data/docs/agno-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: agno-monitoring-with-opentelemetry
 
 title: Agno Monitoring and Observability with OpenTelemetry
@@ -12,6 +12,8 @@ doc_type: howto
 This guide walks you through setting up monitoring and observability for Agno using [OpenTelemetry](https://opentelemetry.io/) and exporting logs, traces, and metrics to SigNoz. With this integration, you can observe the performance of various models, capture request/response details, and track system-level metrics in SigNoz, giving you real-time visibility into latency, error rates, and usage trends for your Agno applications.
 
 Instrumenting Agno in your AI applications with telemetry ensures full observability across your agent workflows, making it easier to debug issues, optimize performance, and understand user interactions. By leveraging SigNoz, you can analyze correlated traces, logs, and metrics in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="i0yFYA6Tiw8" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/anthropic-monitoring.mdx
+++ b/data/docs/anthropic-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-21
+date: 2026-06-09
 id: anthropic-monitoring-with-opentelemetry
 
 title: Anthropic Monitoring & Observability with OpenTelemetry
@@ -12,6 +12,8 @@ doc_type: howto
 Anthropic monitoring gives you production-level visibility into your Claude API applications, tracking token usage, request latency, error rates, and costs across every model call. This guide shows you how to instrument Anthropic Claude with <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and export traces, logs, and metrics to SigNoz, so you can observe model performance and debug issues in real time.
 
 With this setup, SigNoz gives you correlated traces, logs, and metrics in unified dashboards, making it straightforward to identify slow Claude API responses, detect rate limit errors, track per-request token consumption, and configure alerts before issues affect your users.
+
+<YouTube id="RePHjtdnVZs" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/claude-agent-monitoring.mdx
+++ b/data/docs/claude-agent-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: claude-agent-monitoring-with-opentelemetry
 
 title: Claude Agent SDK Monitoring & Observability with OpenTelemetry
@@ -12,6 +12,8 @@ doc_type: howto
 This guide walks you through setting up monitoring and observability for Claude Agent SDK using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting logs, traces, and metrics to SigNoz. With this integration, you can observe the performance of various models, capture request/response details, and track system-level metrics in SigNoz, giving you real-time visibility into latency, error rates, and usage trends for your Claude Code SDK applications.
 
 Instrumenting Claude Agent SDK in your AI applications with telemetry ensures full observability across your agent workflows, making it easier to debug issues, optimize performance, and understand user interactions. By leveraging SigNoz, you can analyze correlated traces, logs, and metrics in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="hm9AiZVYz30" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-19
+date: 2026-06-09
 id: claude-code-monitoring-with-opentelemetry
 
 title: Claude Code Monitoring & Observability with OpenTelemetry
@@ -19,6 +19,8 @@ Claude Code monitoring with OpenTelemetry gives you full visibility into how Cla
 - **Errors & retries** — detect API failures and retry exhaustion before they snowball
 
 Once set up, all of this flows into SigNoz dashboards where you can correlate logs and metrics, set alerts, and analyze trends over time.
+
+<YouTube id="Od0xbRuFryw" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/codex-monitoring.mdx
+++ b/data/docs/codex-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: codex-monitoring-with-opentelemetry
 title: OpenAI Codex Observability & Monitoring with OpenTelemetry
 description: Learn how to monitor OpenAI Codex usage with OpenTelemetry and SigNoz. Track coding assistant traces, logs, and performance metrics.
@@ -11,6 +11,8 @@ doc_type: howto
 [OpenAI Codex](https://developers.openai.com/codex/) is an AI-powered coding assistant designed to help developers write, understand, and debug code through natural language interactions. It translates natural language into code and can work across multiple programming languages.
 
 This guide walks you through setting up observability and monitoring for OpenAI Codex using [OpenTelemetry](https://opentelemetry.io/) and exporting traces and logs to SigNoz. With this integration, you can observe and track various metrics for your Codex AI coding assistant usage.
+
+<YouTube id="SK2WhKrnlFg" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/huggingface-observability.mdx
+++ b/data/docs/huggingface-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: huggingface-observability-with-opentelemetry
 title: Hugging Face Observability & Monitoring with OpenTelemetry
 description: Setup Hugging Face observability with OpenTelemetry and SigNoz. Monitor model inference, track traces, and analyze LLM usage with unified dashboards.
@@ -11,6 +11,8 @@ doc_type: howto
 This guide walks you through setting up observability and monitoring for Hugging Face using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces, logs, and metrics to SigNoz. With this integration, you can observe and track various metrics for your Hugging Face applications and LLM usage.
 
 Monitoring Hugging Face in your AI applications with telemetry ensures full observability across your AI and LLM workflows. By leveraging SigNoz, you can analyze correlated traces, logs, and metrics in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="UDUJITRJiOg" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/langchain-observability.mdx
+++ b/data/docs/langchain-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-26
+date: 2026-06-09
 id: langchain-observability-with-opentelemetry
 
 title: LangChain & LangGraph Observability with OpenTelemetry
@@ -16,6 +16,8 @@ With full LangChain and LangGraph observability in SigNoz, you can trace every u
 To get started, check out our example LangChain trip planner agent with OpenTelemetry-based observability/monitoring (via OpenInference). View the <a href="https://github.com/SigNoz/langchain-monitoring-demo" target="_blank" rel="noopener noreferrer nofollow">LangChain trip planner agent repository</a>.
 
 You can also check out our <a href="https://github.com/SigNoz/signoz-mcp-demo" target="_blank" rel="noopener noreferrer nofollow">LangChain SigNoz MCP agent repository</a>.
+
+<YouTube id="BsnWgcoIsbQ" mute={false} />
 
 ## Prerequisites
 
@@ -231,3 +233,11 @@ When you click on a trace ID in SigNoz, you'll see a detailed view of the trace,
 You can instrument your LangChain/LangGraph applications in JavaScript using the <a href="https://www.npmjs.com/package/@arizeai/openinference-instrumentation-langchain" target="_blank" rel="noopener noreferrer nofollow">OpenInference LangChain Instrumentor</a> package.
 
 For detailed guidance on instrumenting JavaScript applications with OpenTelemetry and connecting them to SigNoz, see the [SigNoz OpenTelemetry JavaScript instrumentation docs](https://signoz.io/docs/instrumentation/javascript/opentelemetry-nodejs/).
+
+Additional resources:
+- Watch the <a href="https://youtu.be/yQezobnHzeg" target="_blank" rel="noopener noreferrer nofollow">LangGraph observability walkthrough</a>
+- Watch the <a href="https://youtu.be/fS9TN558UQY" target="_blank" rel="noopener noreferrer nofollow">LangChain agent monitoring walkthrough</a>
+- Read [LangChain Observability with OpenTelemetry](https://signoz.io/blog/langchain-observability-with-opentelemetry/)
+- Read [Monitoring a LangChain Agent that uses the SigNoz MCP](https://signoz.io/blog/monitoring-langchain-agent-querying-signoz-mcp-server/)
+- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
+- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)

--- a/data/docs/llamaindex-observability.mdx
+++ b/data/docs/llamaindex-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: llamaindex-observability-with-opentelemetry
 
 title: LlamaIndex Observability & Monitoring with OpenTelemetry
@@ -13,6 +13,8 @@ This guide walks you through enabling observability and monitoring for your Pyth
 Instrumenting your RAG workflows with telemetry enables full observability across the retrieval and generation pipeline. This is especially valuable when building production-grade developer-facing tools, where insight into model behavior, latency bottlenecks, and retrieval accuracy is essential. With SigNoz, you can trace each user question end-to-end, from prompt to response, and continuously improve performance and reliability.
 
 To get started, check out our example LlamaIndex RAG Q&A bot, complete with OpenTelemetry-based monitoring (via OpenInference). View the full repository [here](https://github.com/SigNoz/llamaindex-rag-opentelemetry-demo).
+
+<YouTube id="HN_naacui5E" mute={false} />
 
 ## Prerequisites
 
@@ -199,3 +201,9 @@ When you click on a trace ID in SigNoz, you'll see a detailed view of the trace,
     <i>Detailed traces view of your LlamaIndex Application</i>
   </figcaption>
 </figure>
+
+## Additional Resources
+
+- Read [Observing LlamaIndex Apps with OpenTelemetry + SigNoz](https://signoz.io/blog/opentelemetry-llamaindex/)
+- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
+- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)

--- a/data/docs/mistral-observability.mdx
+++ b/data/docs/mistral-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: mistral-observability-with-opentelemetry
 title: Mistral AI Observability & Monitoring with OpenTelemetry
 description: Setup Mistral AI observability with OpenTelemetry and SigNoz. Monitor LLM performance, track traces, logs, and metrics in unified dashboards.
@@ -11,6 +11,8 @@ doc_type: howto
 This guide walks you through setting up observability and monitoring for Mistral using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces, logs, and metrics to SigNoz. With this integration, you can observe and track various metrics for your Mistral applications and LLM usage.
 
 Monitoring Mistral in your AI applications with telemetry ensures full observability across your AI and LLM workflows. By leveraging SigNoz, you can analyze correlated traces, logs, and metrics in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="NFDN1Q2mdyk" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/n8n-monitoring.mdx
+++ b/data/docs/n8n-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: n8n-monitoring-with-opentelemetry
 title: n8n Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor n8n Cloud workflows with OpenTelemetry and SigNoz. Track execution traces, set up alerts, and debug workflow issues.
@@ -11,6 +11,8 @@ doc_type: howto
 This guide walks you through setting up monitoring and observability for n8n Cloud using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces to SigNoz. With this integration, you can observe and track various metrics for your n8n workflow executions.
 
 Monitoring n8n cloud workflows with telemetry ensures full observability across your executions. By leveraging SigNoz, you can analyze traces in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="U23O8zL34Ho" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/openclaw-observability.mdx
+++ b/data/docs/openclaw-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-26
+date: 2026-06-09
 id: openclaw-observability-with-opentelemetry
 title: OpenClaw Observability & Monitoring with OpenTelemetry
 description: Set up OpenClaw observability and monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics from LLM applications to optimize performance.
@@ -11,6 +11,8 @@ doc_type: howto
 OpenClaw observability gives you real-time visibility into your LLM applications and AI workflows by collecting traces, logs, and metrics using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a>. This guide shows you how to instrument OpenClaw and send telemetry data to SigNoz, so you can monitor performance, debug issues, and optimize your AI workflows.
 
 With full OpenClaw observability in SigNoz, you can correlate traces, logs, and metrics in a single dashboard, set up alerts for error rates or high latency, and analyze LLM usage patterns over time to continuously improve reliability and efficiency.
+
+<YouTube id="2DS1Y-h6GdE" mute={false} />
 
 ## Prerequisites
 
@@ -251,6 +253,7 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 </details>
 
 Additional resources:
+- Read [Monitoring OpenClaw with OpenTelemetry](https://signoz.io/blog/monitoring-openclaw-with-opentelemetry/)
 - Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
 - Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
 - Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)

--- a/data/docs/openrouter-observability.mdx
+++ b/data/docs/openrouter-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-06-09
 id: openrouter-monitoring-with-opentelemetry
 title: OpenRouter Observability & Monitoring with OpenTelemetry
 description: Set up OpenRouter observability and monitoring with OpenTelemetry and SigNoz. Track traces, monitor LLM API routing, and analyze usage across models.
@@ -11,6 +11,8 @@ doc_type: howto
 OpenRouter observability gives you full visibility into your LLM API routing across multiple models. This guide walks you through setting up OpenRouter monitoring using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces to SigNoz, so you can track requests, latency, and usage across your OpenRouter applications.
 
 With full OpenRouter observability in SigNoz, you can correlate traces across your AI and LLM workflows, configure alerts on latency and errors, and gain actionable insights to continuously improve reliability and responsiveness. SigNoz brings your OpenRouter telemetry into unified dashboards so you can monitor every model request in one place.
+
+<YouTube id="M0dAUjQ42rI" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/qwen-observability.mdx
+++ b/data/docs/qwen-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-09
 id: qwen-observability-with-opentelemetry
 title: Qwen Observability & Monitoring with OpenTelemetry
 description: Setup Qwen observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Qwen LLM applications with unified dashboards.
@@ -11,6 +11,8 @@ doc_type: howto
 This guide walks you through setting up observability and monitoring for Qwen using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces, logs, and metrics to SigNoz. With this integration, you can observe and track various metrics for your Qwen applications and LLM usage.
 
 Monitoring Qwen in your AI applications with telemetry ensures full observability across your AI and LLM workflows. By leveraging SigNoz, you can analyze correlated traces, logs, and metrics in unified dashboards, configure alerts, and gain actionable insights to continuously improve reliability, responsiveness, and user experience.
+
+<YouTube id="-oRm8Ws_0Fc" mute={false} />
 
 ## Prerequisites
 

--- a/data/docs/vercel-ai-sdk-observability.mdx
+++ b/data/docs/vercel-ai-sdk-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-28
+date: 2026-06-09
 id: vercel-ai-sdk-observability-with-opentelemetry
 title: Vercel AI SDK Observability & Monitoring with OpenTelemetry
 description: Set up Vercel AI SDK observability with OpenTelemetry and SigNoz. Monitor AI function calls, trace requests end-to-end in your Next.js app.
@@ -13,6 +13,8 @@ Vercel AI SDK observability gives you visibility into AI function calls, request
 With full Vercel AI SDK observability in SigNoz, you can trace AI interactions end-to-end, debug latency, set alerts on degraded performance, and improve the reliability of your AI features. This is especially valuable for production-grade Vercel observability where visibility into model behavior and user interactions is critical.
 
 Explore the <a href="https://github.com/SigNoz/vercel-ai-sdk-opentelemetry-example" target="_blank" rel="noopener noreferrer nofollow">SigNoz Vercel AI SDK example chatbot</a>, which includes observability and monitoring via OpenTelemetry.
+
+<YouTube id="AMeLYQe59j8" mute={false} />
 
 ## Prerequisites
 
@@ -202,3 +204,9 @@ The [Vercel AI SDK Observability Dashboard](https://signoz.io/docs/dashboards/da
     <i>Vercel AI SDK Dashboard</i>
   </figcaption>
 </figure>
+
+## Additional Resources
+
+- Read [Observing Vercel AI SDK with OpenTelemetry + SigNoz](https://signoz.io/blog/opentelemetry-vercel-ai-sdk/)
+- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
+- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Improves discoverability and engagement on the LLM observability docs by embedding product walkthrough videos and adding cross-links between docs and related SigNoz blogs.

- Embedded YouTube walkthrough videos (via the `<YouTube>` MDX component) in the Qwen, n8n, Mistral, Agno, OpenClaw, Claude Agent SDK, Claude Code, Hugging Face, OpenRouter, Codex, and Anthropic monitoring docs.
- Added two YouTube walkthrough links to the LangChain doc's Additional Resources section.
- Added/extended **Additional Resources** sections on the LangChain, LlamaIndex, Vercel AI SDK, and OpenClaw docs, linking the corresponding SigNoz blogs.
- Added a docs reference in the Vercel AI SDK blog and replaced all generic `here` link anchors with descriptive, SEO-optimal anchor text.
- Bumped the `date` frontmatter on the touched docs to satisfy docs-metadata validation.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

N/A — content-only docs/blog changes (embedded videos + internal links).

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
- [x] 📝 Docs / Content

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: None required (content-only change).
- Manual verification: Pre-commit hooks passed — docs redirects, docs-metadata validation (14 files ✅), stale-URL check, and CMS asset check.
- Edge cases covered: Used the `<YouTube>` MDX component and external-link anchor form (`rel="noopener noreferrer nofollow"`) per docs link conventions; verified no `here` anchors remain in the Vercel blog.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Limited to 14 LLM observability docs + 1 blog post; no code or rendering changes.
- Potential regressions: None expected — additive content and internal links only.
- Rollback plan: Revert the commit.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS |
| Change Type | Maintenance (Docs) |
| Description | Added walkthrough videos and blog cross-links to LLM observability docs |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- Video embeds use the existing `<YouTube id="..." mute={false} />` MDX component, consistent with other docs.
- Blog/doc cross-links use absolute `/docs/...` paths; external (YouTube/third-party) links use the `<a ... rel="noopener noreferrer nofollow">` anchor form.
- `date` frontmatter was bumped to today on touched docs to pass the docs-metadata pre-commit check.

---
