### PR TITLE
fix: add missing entityName to all Tabs so tab selection is URL-shareable

### DIFF
--- a/data/blog/opentelemetry-collector-contrib.mdx
+++ b/data/blog/opentelemetry-collector-contrib.mdx
@@ -311,7 +311,7 @@ The recommended way to use OCB is to download the pre-compiled binary for your s
 
 `cd` into the `builder` directory in our example repo and download the binary based on your machine’s OS and architecture:
 
-<Tabs>
+<Tabs entityName="platform">
 <TabItem value="linux-amd64" label="Linux (AMD 64)" default>
 
 ```bash

--- a/data/docs/agno-monitoring.mdx
+++ b/data/docs/agno-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: agno-monitoring-with-opentelemetry
 
 title: Agno Monitoring and Observability with OpenTelemetry
@@ -24,10 +24,10 @@ Instrumenting Agno in your AI applications with telemetry ensures full observabi
 
 ## Monitoring Agno
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: signoz-mcp-server
 title: SigNoz MCP Server
 meta_title: SigNoz MCP Server - AI Assistant Integration Guide
@@ -15,7 +15,7 @@ If you've already set up the MCP server, skip ahead to the [use cases](https://s
 
 ## Connect to SigNoz's MCP server
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="cloud" label="SigNoz Cloud" default>
 
 Connect your AI tool to SigNoz Cloud's hosted MCP server. No installation required — just add the URL and authenticate.
@@ -29,7 +29,7 @@ Make sure you select the correct region that matches your SigNoz Cloud account. 
 
 - `<region>`: Your SigNoz Cloud region. Find your region under **Settings → Ingestion** in SigNoz, or see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint).
 
-<Tabs>
+<Tabs entityName="client">
 <TabItem value="cloud-cursor" label="Cursor" default>
 
 ### Install in one click
@@ -290,7 +290,7 @@ Only **Admin** users can create API keys. Keep your key secure — never commit 
 
 ### Install the MCP server
 
-<Tabs>
+<Tabs entityName="install-method">
 <TabItem value="download" label="Download Binary (Recommended)" default>
 
 Download the latest binary from <a href="https://github.com/SigNoz/signoz-mcp-server/releases" target="_blank" rel="noopener noreferrer nofollow">GitHub Releases</a>:
@@ -362,10 +362,10 @@ The binary is at `./bin/signoz-mcp-server`.
 
 ### Configure your MCP client
 
-<Tabs>
+<Tabs entityName="client">
 <TabItem value="sh-cursor" label="Cursor" default>
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-cursor-stdio" label="Stdio (Recommended)" default>
 
 Add the following to `.cursor/mcp.json` in your project root, or use **Cursor → Settings → Tools & Integrations → + New MCP Server**:
@@ -422,7 +422,7 @@ LOG_LEVEL=info \
 </TabItem>
 <TabItem value="sh-copilot" label="VS Code / GitHub Copilot">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-copilot-stdio" label="Stdio (Recommended)" default>
 
 Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) → **`MCP: Open User Configuration`**, then add:
@@ -475,7 +475,7 @@ Open Copilot Chat in **Agent mode** and confirm you trust the server.
 </TabItem>
 <TabItem value="sh-claude-desktop" label="Claude Desktop">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-claude-stdio" label="Stdio (Recommended)" default>
 
 Go to **Settings → Developer → Edit Config** and add to `claude_desktop_config.json`:
@@ -532,7 +532,7 @@ LOG_LEVEL=info \
 </TabItem>
 <TabItem value="sh-claude-code" label="Claude Code">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-claudecode-stdio" label="Stdio (Recommended)" default>
 
 ```bash
@@ -566,7 +566,7 @@ claude mcp add --scope user --transport http signoz http://localhost:8000/mcp
 </TabItem>
 <TabItem value="sh-codex" label="OpenAI Codex">
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="sh-codex-cli" label="CLI (Recommended)" default>
 
 ```bash
@@ -616,7 +616,7 @@ url = "http://localhost:8000/mcp"
 </TabItem>
 <TabItem value="sh-windsurf" label="Windsurf">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-windsurf-stdio" label="Stdio (Recommended)" default>
 
 Add this configuration to `~/.codeium/windsurf/mcp_config.json`
@@ -663,7 +663,7 @@ Add this configuration to `~/.codeium/windsurf/mcp_config.json`
 </TabItem>
 <TabItem value="sh-gemini" label="Gemini CLI">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-gemini-stdio" label="Stdio (Recommended)" default>
 
 Add to `~/.gemini/settings.json`:
@@ -736,7 +736,7 @@ Open Zed settings (`Cmd+,`) and add:
 </TabItem>
 <TabItem value="sh-antigravity" label="Antigravity">
 
-<Tabs>
+<Tabs entityName="transport">
 <TabItem value="sh-antigravity-stdio" label="Stdio (Recommended)" default>
 
 Add to `mcp_config.json` (open via `...` menu → **MCP Servers** → **Manage MCP Servers** → **View raw config**):

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -362,10 +362,10 @@ The binary is at `./bin/signoz-mcp-server`.
 
 ### Configure your MCP client
 
-<Tabs entityName="client">
+<Tabs entityName="self-host-client">
 <TabItem value="sh-cursor" label="Cursor" default>
 
-<Tabs entityName="transport">
+<Tabs entityName="cursor-transport">
 <TabItem value="sh-cursor-stdio" label="Stdio (Recommended)" default>
 
 Add the following to `.cursor/mcp.json` in your project root, or use **Cursor → Settings → Tools & Integrations → + New MCP Server**:
@@ -422,7 +422,7 @@ LOG_LEVEL=info \
 </TabItem>
 <TabItem value="sh-copilot" label="VS Code / GitHub Copilot">
 
-<Tabs entityName="transport">
+<Tabs entityName="copilot-transport">
 <TabItem value="sh-copilot-stdio" label="Stdio (Recommended)" default>
 
 Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) → **`MCP: Open User Configuration`**, then add:
@@ -475,7 +475,7 @@ Open Copilot Chat in **Agent mode** and confirm you trust the server.
 </TabItem>
 <TabItem value="sh-claude-desktop" label="Claude Desktop">
 
-<Tabs entityName="transport">
+<Tabs entityName="claude-desktop-transport">
 <TabItem value="sh-claude-stdio" label="Stdio (Recommended)" default>
 
 Go to **Settings → Developer → Edit Config** and add to `claude_desktop_config.json`:
@@ -532,7 +532,7 @@ LOG_LEVEL=info \
 </TabItem>
 <TabItem value="sh-claude-code" label="Claude Code">
 
-<Tabs entityName="transport">
+<Tabs entityName="claude-code-transport">
 <TabItem value="sh-claudecode-stdio" label="Stdio (Recommended)" default>
 
 ```bash
@@ -566,7 +566,7 @@ claude mcp add --scope user --transport http signoz http://localhost:8000/mcp
 </TabItem>
 <TabItem value="sh-codex" label="OpenAI Codex">
 
-<Tabs entityName="method">
+<Tabs entityName="codex-method">
 <TabItem value="sh-codex-cli" label="CLI (Recommended)" default>
 
 ```bash
@@ -616,7 +616,7 @@ url = "http://localhost:8000/mcp"
 </TabItem>
 <TabItem value="sh-windsurf" label="Windsurf">
 
-<Tabs entityName="transport">
+<Tabs entityName="windsurf-transport">
 <TabItem value="sh-windsurf-stdio" label="Stdio (Recommended)" default>
 
 Add this configuration to `~/.codeium/windsurf/mcp_config.json`
@@ -663,7 +663,7 @@ Add this configuration to `~/.codeium/windsurf/mcp_config.json`
 </TabItem>
 <TabItem value="sh-gemini" label="Gemini CLI">
 
-<Tabs entityName="transport">
+<Tabs entityName="gemini-transport">
 <TabItem value="sh-gemini-stdio" label="Stdio (Recommended)" default>
 
 Add to `~/.gemini/settings.json`:
@@ -736,7 +736,7 @@ Open Zed settings (`Cmd+,`) and add:
 </TabItem>
 <TabItem value="sh-antigravity" label="Antigravity">
 
-<Tabs entityName="transport">
+<Tabs entityName="antigravity-transport">
 <TabItem value="sh-antigravity-stdio" label="Stdio (Recommended)" default>
 
 Add to `mcp_config.json` (open via `...` menu → **MCP Servers** → **Manage MCP Servers** → **View raw config**):

--- a/data/docs/amazon-bedrock-monitoring.mdx
+++ b/data/docs/amazon-bedrock-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: amazon-bedrock-monitoring-with-opentelemetry
 
 title: Amazon Bedrock Monitoring and Observability with OpenTelemetry
@@ -25,10 +25,10 @@ Instrumenting Amazon Bedrock in your LLM applications with telemetry ensures ful
 
 ## Monitoring Amazon Bedrock
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/anthropic-monitoring.mdx
+++ b/data/docs/anthropic-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: anthropic-monitoring-with-opentelemetry
 
 title: Anthropic Monitoring & Observability with OpenTelemetry
@@ -27,7 +27,7 @@ With this setup, SigNoz gives you correlated traces, logs, and metrics in unifie
 
 ## Monitoring Anthropic
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/autogen-observability.mdx
+++ b/data/docs/autogen-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: autogen-observability-with-opentelemetry
 
 title: AutoGen Observability & Monitoring with OpenTelemetry
@@ -23,10 +23,10 @@ Instrumenting AutoGen in your AI applications with telemetry ensures full observ
 
 For more detailed info on tracing your AutoGen applications click [here](https://microsoft.github.io/autogen/stable//user-guide/core-user-guide/framework/telemetry.html). For logging, click [here](https://microsoft.github.io/autogen/stable//user-guide/core-user-guide/framework/logging.html).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/aws-monitoring/alb.mdx
+++ b/data/docs/aws-monitoring/alb.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: alb
 title: Monitor AWS Application Load Balancer with SigNoz
 meta_title: AWS ALB Monitoring - Track Latency & Errors
@@ -16,7 +16,7 @@ AWS Application Load Balancer (ALB) operates at the application layer (Layer 7) 
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration
@@ -125,7 +125,7 @@ See <a href="https://github.com/prometheus/cloudwatch_exporter/tree/master/examp
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/api-gateway.mdx
+++ b/data/docs/aws-monitoring/api-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: api-gateway
 title: Monitor AWS API Gateway with SigNoz
 meta_title: Monitor AWS API Gateway - Latency & Errors
@@ -16,7 +16,7 @@ Amazon API Gateway is a fully managed service for creating and publishing APIs. 
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration
@@ -123,7 +123,7 @@ See <a href="https://github.com/prometheus/cloudwatch_exporter/tree/master/examp
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/dynamodb.mdx
+++ b/data/docs/aws-monitoring/dynamodb.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: dynamodb
 title: Monitor AWS DynamoDB with SigNoz
 meta_title: Monitor AWS DynamoDB - Capacity & Throttling
@@ -16,7 +16,7 @@ Amazon DynamoDB is a fully managed NoSQL database service. SigNoz helps you moni
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration
@@ -130,7 +130,7 @@ See <a href="https://github.com/prometheus/cloudwatch_exporter/tree/master/examp
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/ec2/ec2-infra-metrics.mdx
+++ b/data/docs/aws-monitoring/ec2/ec2-infra-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: ec2-infra-metrics
 title: Infrastructure Metrics of EC2 Instance
 meta_title: Collect EC2 Infrastructure Metrics - CPU, Memory & Disk
@@ -13,7 +13,7 @@ This documentation guides you through integrating AWS EC2 infrastructure metrics
 The Hostmetrics receiver is designed to collect metrics about the host system from various sources. It supports various scrapers for collecting different metrics, 
 including CPU, disk, load, filesystem, memory, network, paging, and process metrics.
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="manual" label="Manual Setup (Recommended)" default>
 
 ## Manual Setup with OpenTelemetry

--- a/data/docs/aws-monitoring/ecs/ecs-ec2-external.mdx
+++ b/data/docs/aws-monitoring/ecs/ecs-ec2-external.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: ecs-ec2-external
 title: Monitor ECS EC2 and External Launch Types
 meta_title: Monitor ECS EC2 & External Launch Types
@@ -17,7 +17,7 @@ Amazon ECS with EC2 or External launch types runs containers on EC2 instances or
 - SigNoz Cloud account or Self-Hosted SigNoz
 - An ECS cluster with EC2 or External launch type
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="daemon-service" label="Daemon Service (Recommended)" default>
 
 ## Daemon Service Setup

--- a/data/docs/aws-monitoring/eks/eks-ec2-nodes.mdx
+++ b/data/docs/aws-monitoring/eks/eks-ec2-nodes.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: eks-ec2-nodes
 title: Monitor EKS Logs and Metrics using SigNoz
 meta_title: EKS EC2 Nodes Monitoring - Logs & Metrics Setup
@@ -17,7 +17,7 @@ Amazon EKS (Elastic Kubernetes Service) is a managed Kubernetes service that mak
 - SigNoz Cloud account or Self-Hosted SigNoz
 - An EKS cluster running
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="helm-chart" label="K8s-Infra Helm Chart (Recommended)" default>
 
 ## K8s-Infra Helm Chart

--- a/data/docs/aws-monitoring/elasticache.mdx
+++ b/data/docs/aws-monitoring/elasticache.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: elasticache
 title: Monitor AWS ElastiCache with SigNoz
 meta_title: Monitor AWS ElastiCache - Redis & Memcached Performance
@@ -16,7 +16,7 @@ Amazon ElastiCache provides managed Redis and Memcached clusters. SigNoz helps y
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration

--- a/data/docs/aws-monitoring/elb.mdx
+++ b/data/docs/aws-monitoring/elb.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: elb
 title: Monitor AWS ELB (Classic) with SigNoz
 meta_title: Monitor AWS ELB - Metrics & Access Logs
@@ -19,7 +19,7 @@ SigNoz allows you to monitor your AWS Elastic Load Balancers (Classic) by collec
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="logs" label="Logs" default>
 
 ## Log Collection
@@ -631,7 +631,7 @@ See <a href="https://github.com/prometheus/cloudwatch_exporter/tree/master/examp
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/lambda/lambda-metrics.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: lambda-metrics
 title: Monitor AWS Lambda Metrics with SigNoz
 meta_title: AWS Lambda Metrics - Invocations, Errors & Duration
@@ -16,7 +16,7 @@ This documentation provides details on how to collect AWS Lambda metrics (like I
 - AWS account with appropriate permissions to access CloudWatch.
 - SigNoz Cloud account or Self-Hosted SigNoz.
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration
@@ -118,7 +118,7 @@ You can add more Lambda metrics like `DeadLetterErrors`, `DestinationDeliveryFai
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/lambda/lambda-traces.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: lambda-traces
 title: Send your AWS Lambda Traces to SigNoz
 meta_title: AWS Lambda Traces - OpenTelemetry Auto-Instrumentation
@@ -44,7 +44,7 @@ Next, we will create the Lambda function. The function will make a REST API call
 The URL will get the object details of the objects with ID 3 and 5. 
 
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
 On your machine, create a folder, say `auto-instrument-tracing-lambda`.
@@ -351,7 +351,7 @@ In order to auto-instrument your Lambda function, follow the steps:
 3. In the **Choose a layer** section, select **Specify an ARN** option.
 4. Choose the correct ARN based on the language, ensure you replace the `<region>` with your region (ex. `us-east-1`):
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 ```
 arn:aws:lambda:<region>:184161586896:layer:opentelemetry-python-0_11_0:1
@@ -380,7 +380,7 @@ The latest releases of the layers can be found in the [OpenTelemetry Lambda Laye
 
 6. Add the following environment variables.
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 ```
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
@@ -427,7 +427,7 @@ In order to install the OpenTelemetry Collector Lambda layer, follow these steps
 3. In the **Choose a layer** section, select **Specify an ARN** option.
 4. Choose the correct ARN based on your function architecture, ensure you replace the `<region>` with your region (ex. `us-east-1`):
 
-<Tabs entityName="plans">
+<Tabs entityName="architecture">
 <TabItem value="x86_64" label="x86_64" default>
 ```
 arn:aws:lambda:<region>:184161586896:layer:opentelemetry-collector-amd64-0_12_0:1

--- a/data/docs/aws-monitoring/msk.mdx
+++ b/data/docs/aws-monitoring/msk.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: msk
 title: Monitor Amazon MSK with SigNoz
 meta_title: Monitor AWS MSK Kafka - Broker & Lag
@@ -16,7 +16,7 @@ Amazon Managed Streaming for Apache Kafka (MSK) is a fully managed Kafka service
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration

--- a/data/docs/aws-monitoring/rds.mdx
+++ b/data/docs/aws-monitoring/rds.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: rds
 title: Monitor AWS RDS with SigNoz
 meta_title: Monitor AWS RDS - Database Metrics & Logs
@@ -16,7 +16,7 @@ Amazon RDS provides managed relational database services for PostgreSQL, MySQL, 
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration

--- a/data/docs/aws-monitoring/s3.mdx
+++ b/data/docs/aws-monitoring/s3.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: s3
 title: Monitor Amazon S3 with SigNoz
 meta_title: Monitor AWS S3 - Storage Metrics & Log Sync
@@ -16,7 +16,7 @@ Amazon S3 is object storage for the cloud. SigNoz helps you monitor S3 bucket me
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click-sync" label="S3 Sync (One-Click)" default>
 
 ## S3 Sync (One-Click)
@@ -96,7 +96,7 @@ S3 storage metrics are reported once per day. Enable request metrics in S3 for m
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/sns.mdx
+++ b/data/docs/aws-monitoring/sns.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: sns
 title: Monitor Amazon SNS with SigNoz
 meta_title: Monitor AWS SNS - Messages & Deliveries
@@ -16,7 +16,7 @@ Amazon Simple Notification Service (SNS) is a fully managed pub/sub messaging se
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration
@@ -117,7 +117,7 @@ See <a href="https://github.com/prometheus/cloudwatch_exporter/tree/master/examp
 
 ### Step 2: Download and Run the Exporter
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="jar" label="JAR File" default>
 
 Download the CloudWatch Exporter JAR file using `curl`:

--- a/data/docs/aws-monitoring/sqs.mdx
+++ b/data/docs/aws-monitoring/sqs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: sqs
 title: Monitor Amazon SQS with SigNoz
 meta_title: Monitor AWS SQS - Queue Depth & Latency
@@ -16,7 +16,7 @@ Amazon Simple Queue Service (SQS) is a fully managed message queuing service. Si
 - AWS account with appropriate permissions
 - SigNoz Cloud account or Self-Hosted SigNoz
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="one-click" label="One-Click Integration" default>
 
 ## One-Click Integration

--- a/data/docs/azure-openai-monitoring.mdx
+++ b/data/docs/azure-openai-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: azure-openai-monitoring-with-opentelemetry
 
 title: Azure OpenAI Monitoring & Observability with OpenTelemetry
@@ -28,10 +28,10 @@ Instrumenting Azure OpenAi in your LLM applications with telemetry ensures full 
 
 The Azure OpenAI API uses an API format compatible with OpenAI. By modifying the configuration, you can use the OpenAI SDK or softwares compatible with the OpenAI API to access the Azure OpenAI API. Hence, a similar method to monitor OpenAI APIs can be used for monitoring Azure OpenAI APIs as well. To read more about this, you can read the [Azure OpenAI API Docs](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-key)
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/baseten-monitoring.mdx
+++ b/data/docs/baseten-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: baseten-monitoring
 title: Baseten Monitoring & Observability with OpenTelemetry
 description: Setup Baseten monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Baseten LLM applications and model usage.
@@ -23,7 +23,7 @@ Monitoring Baseten in your AI applications with telemetry ensures full observabi
 
 For more information on getting started with Baseten in your Python environment, refer to the <a href="https://docs.baseten.co/training/getting-started" target="_blank" rel="noopener noreferrer nofollow">Baseten quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/cicd/jenkins/jenkins-tracing.mdx
+++ b/data/docs/cicd/jenkins/jenkins-tracing.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: jenkins-tracing
 
 title: Jenkins Tracing
@@ -20,7 +20,7 @@ To know more about tracing refer [here](https://signoz.io/docs/instrumentation/o
 ### Step 1: Install and Configure Jenkins OpenTelemetry plugin
 * For installing the plugin, please refer to [this documentation](https://plugins.jenkins.io/opentelemetry-agent-metrics/).
 
-<Tabs>
+<Tabs entityName="plans">
 
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 

--- a/data/docs/codex-monitoring.mdx
+++ b/data/docs/codex-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: codex-monitoring-with-opentelemetry
 title: OpenAI Codex Observability & Monitoring with OpenTelemetry
 description: Learn how to monitor OpenAI Codex usage with OpenTelemetry and SigNoz. Track coding assistant traces, logs, and performance metrics.
@@ -28,7 +28,7 @@ This guide walks you through setting up observability and monitoring for OpenAI 
 For more information on getting started with Codex in your environment, refer to the [Codex quickstart guide](https://developers.openai.com/codex/quickstart/).
 
 
-<Tabs>
+<Tabs entityName="interface">
 <TabItem value="IDE" label="IDE extension" default>
 
 Install the Codex extension for your IDE:
@@ -55,7 +55,7 @@ The Codex CLI is supported on macOS, Windows, and Linux.
 
 Install with your preferred package manager:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 Install with npm:

--- a/data/docs/crewai-observability.mdx
+++ b/data/docs/crewai-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-28
+date: 2026-06-11
 id: crewai-observability-with-opentelemetry
 
 title: CrewAI Observability & Monitoring with OpenTelemetry
@@ -25,10 +25,10 @@ With full CrewAI observability in SigNoz, you can correlate traces, logs, and me
 
 ## CrewAI Monitoring with OpenTelemetry
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/deepseek-monitoring.mdx
+++ b/data/docs/deepseek-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-06-11
 id: deepseek-monitoring-with-opentelemetry
 
 title: DeepSeek Monitoring & Observability with OpenTelemetry
@@ -27,10 +27,10 @@ With full DeepSeek monitoring in SigNoz, you can correlate traces, logs, and met
 
 The DeepSeek API uses an API format compatible with OpenAI. By modifying the configuration, you can use the OpenAI SDK or software compatible with the OpenAI API to access the DeepSeek API. Hence, a similar method to monitor OpenAI APIs can be used for monitoring DeepSeek APIs as well. To read more about this, you can read the <a href="https://api-docs.deepseek.com/" target="_blank" rel="noopener noreferrer nofollow">DeepSeek API Docs</a>
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -58,7 +58,7 @@ Install the following dependencies.
 
 The instrumentation file is required to setup the `LoggerProvider` which is used to create custom logs within your application and export them to your collector.
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
   <TabItem value="ts" label="TypeScript" default>
     ```ts:instrumentation.ts
     import {
@@ -367,7 +367,7 @@ receivers:
 
 The `utils` file will contain our utility functions for recording various kinds of logs (`info`, `warning`, `error`).
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
   <TabItem value="ts" label="TypeScript">
     ```ts:utils.ts
     import {
@@ -485,7 +485,7 @@ You can enrich logs with additional metadata like browser type, user ID etc. to 
 
 To do so, you need to write a custom implementation on top of `LogRecordProcessor` which will intercept all your exported logs and attach additional attributes to them.
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
   <TabItem value="ts" label="TypeScript">
     ```ts:custom-processor.ts
     import type { LogRecordProcessor, SdkLogRecord } from '@opentelemetry/sdk-logs';

--- a/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-logs-with-opentelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 
 title: Sending Logs from your frontend using OpenTelemetry
 meta_title: Send Frontend Logs with OpenTelemetry
@@ -160,7 +160,7 @@ receivers:
   Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 </Admonition>
 
-<Tabs groupId="framework-choice">
+<Tabs entityName="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
     In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
 

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 
 title: Sending Metrics from your frontend using OpenTelemetry
 meta_title: Send Frontend Metrics using OpenTelemetry
@@ -174,7 +174,7 @@ receivers:
   Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 </Admonition>
 
-<Tabs groupId="framework-choice">
+<Tabs entityName="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
     In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
 

--- a/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-metrics-with-opentelemetry.mdx
@@ -58,7 +58,7 @@ Install the following dependencies.
 
 The instrumentation file is required to setup the `MeterProvider` which is used to create custom metrics within your application and export them to your collector.
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
   <TabItem value="typescript" label="TypeScript" default>
     ```ts:instrumentation.ts
     import {

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 
 title: Sending Traces from your frontend application using OpenTelemetry
 meta_title: Send Frontend Traces using OpenTelemetry
@@ -24,7 +24,7 @@ Client side traces help you understand how user actions trigger requests, how lo
 
 Install the following dependencies.
 
-<Tabs groupId="traces-dependencies">
+<Tabs entityName="traces-dependencies">
   <TabItem value="npm" label="Npm">
     ```sh
     npm install @opentelemetry/sdk-trace-base
@@ -228,7 +228,7 @@ Going through each of the 3 instrumentations set up:
   Import the instrumentation file at the top level of your application. This ensures that the OpenTelemetry instrumentation is initialized before any other code runs, allowing it to capture telemetry data from the very beginning of your application's execution.
 </Admonition>
 
-<Tabs groupId="framework-choice">
+<Tabs entityName="framework-choice">
   <TabItem value="react" label="React (Vite/CRA)" default>
     In your main entry file (typically `main.tsx` or `index.tsx`), import the instrumentation file at the very top:
 

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -79,7 +79,7 @@ Install the following dependencies.
 
 The instrumentation file is required to setup the `OTLPTraceExporter` and `WebTracerProvider` which are used to capture traces within your application and export them to your collector.
 
-<Tabs entityName="plans">
+<Tabs entityName="language">
   <TabItem value="typescript" label="TypeScript" default>
     ```ts:instrumentation.ts
     import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
@@ -468,8 +468,8 @@ You can enrich traces with additional metadata like browser type, user ID etc. t
 
 To do so, you need to write a custom implementation of `SpanProcessor` which will intercept all your exported spans and attach additional attributes to them.
 
-<Tabs entityName="plans">
-  <TabItem value="ts" label="TypeScript">
+<Tabs entityName="language">
+  <TabItem value="typescript" label="TypeScript">
     ```ts:custom-processor.ts
     import { SpanProcessor } from '@opentelemetry/sdk-trace-web';
     import { UAParser } from 'ua-parser-js';
@@ -527,7 +527,7 @@ To do so, you need to write a custom implementation of `SpanProcessor` which wil
     ```
 
   </TabItem>
-  <TabItem value="js" label="JavaScript" default>
+  <TabItem value="javascript" label="JavaScript" default>
     ```js:custom-processor.js
     import { UAParser } from 'ua-parser-js';
 

--- a/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
+++ b/data/docs/frontend-monitoring/sending-traces-with-opentelemetry.mdx
@@ -24,7 +24,7 @@ Client side traces help you understand how user actions trigger requests, how lo
 
 Install the following dependencies.
 
-<Tabs entityName="traces-dependencies">
+<Tabs entityName="package-manager">
   <TabItem value="npm" label="Npm">
     ```sh
     npm install @opentelemetry/sdk-trace-base

--- a/data/docs/frontend-monitoring/web-vitals-with-metrics.mdx
+++ b/data/docs/frontend-monitoring/web-vitals-with-metrics.mdx
@@ -26,7 +26,7 @@ This documentation provides a step-by-step guide to setting up web vitals monito
 
 ### Step 1: Install dependencies
 
-<Tabs entityName="web-vitals-dependencies">
+<Tabs entityName="package-manager">
   <TabItem value="npm" label="Npm" default>
     ```sh
     npm install web-vitals

--- a/data/docs/frontend-monitoring/web-vitals-with-metrics.mdx
+++ b/data/docs/frontend-monitoring/web-vitals-with-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 title: Web Vitals Monitoring with OpenTelemetry Metrics
 meta_title: Monitor Web Vitals with OpenTelemetry Metrics
 id: opentelemetry-web-vitals-metrics
@@ -26,7 +26,7 @@ This documentation provides a step-by-step guide to setting up web vitals monito
 
 ### Step 1: Install dependencies
 
-<Tabs groupId="web-vitals-dependencies">
+<Tabs entityName="web-vitals-dependencies">
   <TabItem value="npm" label="Npm" default>
     ```sh
     npm install web-vitals

--- a/data/docs/frontend-monitoring/web-vitals-with-traces.mdx
+++ b/data/docs/frontend-monitoring/web-vitals-with-traces.mdx
@@ -26,7 +26,7 @@ This documentation provides a step-by-step guide to setting up web vitals monito
 
 ### Step 1: Install dependencies
 
-<Tabs entityName="web-vitals-dependencies">
+<Tabs entityName="package-manager">
   <TabItem value="npm" label="Npm" default>
     ```sh
     npm install web-vitals

--- a/data/docs/frontend-monitoring/web-vitals-with-traces.mdx
+++ b/data/docs/frontend-monitoring/web-vitals-with-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 title: Web Vitals Monitoring with OpenTelemetry Traces
 meta_title: Monitor Web Vitals with OpenTelemetry Traces
 id: opentelemetry-web-vitals-traces
@@ -26,7 +26,7 @@ This documentation provides a step-by-step guide to setting up web vitals monito
 
 ### Step 1: Install dependencies
 
-<Tabs groupId="web-vitals-dependencies">
+<Tabs entityName="web-vitals-dependencies">
   <TabItem value="npm" label="Npm" default>
     ```sh
     npm install web-vitals

--- a/data/docs/gcp-monitoring/app-engine/metrics.mdx
+++ b/data/docs/gcp-monitoring/app-engine/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: metrics
 
 title: App Engine Metrics
@@ -297,7 +297,7 @@ SigNoz Self-Hosted using Docker
 Note that `googlecloudmonitoring` receiver is supported only from version 0.112.0 and above of opentelemetry-collector. So, ensure you download and use the appropriate release.
 </Admonition>
 
-<Tabs>
+<Tabs entityName="collector-setup">
 <TabItem value="self-hosted-otel" label="Directly send to self-hosted SigNoz">
 
 The self-hosted SigNoz setup also includes the OTel collector in the bundle. Docker will deploy the OTel collector beside SigNoz as a container. The same OTel collector can be used to directly receive any signals, otherwise, if one more OTel Collector is required for a more granular collection, we can add an additional independent OTel collector, see Using Central OTel collector in between tab.

--- a/data/docs/gcp-monitoring/gcp-clb/metrics.mdx
+++ b/data/docs/gcp-monitoring/gcp-clb/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: metrics
 
 title: Cloud Load Balancer Metrics
@@ -175,7 +175,7 @@ Self-hosted SigNoz in Docker
 </figcaption>
 </figure>
 
-<Tabs>
+<Tabs entityName="collector-setup">
 <TabItem value="bundled-otel-collector" label="Using bundled SigNoz self-hosted OTel Collector">
 
 The self-hosted SigNoz setup includes the OTel collector in the bundle. Docker will deploy the OTel collector beside SigNoz as a container. The same OTel collector can be used to receive any signals directly. Otherwise, if one more OTel Collector is required for a more granular collection, we can add an additional independent OTel collector, see Using additional centralized OTel collector tab.

--- a/data/docs/gcp-monitoring/gcp-fns/fns-metrics.mdx
+++ b/data/docs/gcp-monitoring/gcp-fns/fns-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: fns-metrics
 
 title: Cloud Function Metrics
@@ -453,7 +453,7 @@ SigNoz Self-Hosted using Docker.
 Note that `googlecloudmonitoring` receiver is supported only from version 0.112.0 and above of opentelemetry-collector. So, ensure you download and use the appropriate release.
 </Admonition>
 
-<Tabs>
+<Tabs entityName="collector-setup">
 <TabItem value="self-hosted-otel" label="Directly send to self-hosted SigNoz">
 
 The self-hosted SigNoz setup also includes the OTel collector in the bundle. Docker will deploy the OTel collector beside SigNoz as a container. The same OTel collector can be used to directly receive any signals, otherwise, if one more OTel Collector is required for a more granular collection, we can add an additional independent OTel collector, see Using Central OTel collector in between tab.

--- a/data/docs/gcp-monitoring/gcp-fns/logging.mdx
+++ b/data/docs/gcp-monitoring/gcp-fns/logging.mdx
@@ -15,7 +15,7 @@ This documentation provides a detailed walkthrough on how to set up a Google Clo
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 
 
-<Tabs entityName="method">
+<Tabs entityName="cloud-method">
 <TabItem value="cloud-pubsub" label="Using Pub/Sub (Recommended)" default>
 {/* **Here's a quick summary of what we will be doing in this guide**
 
@@ -656,7 +656,7 @@ By following this guide, you should be able to easily send the logs of your Goog
 
 <TabItem value='self-host' label='Self-Host'>
 
-<Tabs entityName="method">
+<Tabs entityName="self-host-method">
 <TabItem value="self-host-pubsub" label="Using Pub/Sub (Recommended)" default>
 
 {/* **Here's a quick summary of what we will be doing in this guide**

--- a/data/docs/gcp-monitoring/gcp-fns/logging.mdx
+++ b/data/docs/gcp-monitoring/gcp-fns/logging.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-01
+date: 2026-06-11
 id: logging
 title: Cloud Functions Logging
 description: Send Google Cloud Functions logs to SigNoz via Pub/Sub and the OpenTelemetry Collector on Compute Engine.
@@ -15,7 +15,7 @@ This documentation provides a detailed walkthrough on how to set up a Google Clo
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="cloud-pubsub" label="Using Pub/Sub (Recommended)" default>
 {/* **Here's a quick summary of what we will be doing in this guide**
 
@@ -656,7 +656,7 @@ By following this guide, you should be able to easily send the logs of your Goog
 
 <TabItem value='self-host' label='Self-Host'>
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="self-host-pubsub" label="Using Pub/Sub (Recommended)" default>
 
 {/* **Here's a quick summary of what we will be doing in this guide**

--- a/data/docs/gcp-monitoring/gke/gke-logging-and-metrics.mdx
+++ b/data/docs/gcp-monitoring/gke/gke-logging-and-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-01
+date: 2026-06-11
 id: gke-logging-and-metrics
 title: GKE Metrics and Logging
 description: Deploy the SigNoz k8s-infra Helm chart on GKE to collect Kubernetes metrics and logs via the OpenTelemetry Collector.
@@ -181,7 +181,7 @@ GKE cluster status
 helm repo add SigNoz https://charts.signoz.io
 ```
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE cluster" default>
 
 **Step 2:** Install the Otel Collector agent in GKE where SigNoz is running in a Self-hosted VM.
@@ -288,7 +288,7 @@ Kubernetes cluster metrics
 
 If you encounter any issues while setting up logging and metrics for your GKE cluster, follow these troubleshooting steps:
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE Cluster" default>
 
 1. Confirm that the necessary Kubernetes resources are created:

--- a/data/docs/gcp-monitoring/gke/gke-logging-and-metrics.mdx
+++ b/data/docs/gcp-monitoring/gke/gke-logging-and-metrics.mdx
@@ -181,7 +181,7 @@ GKE cluster status
 helm repo add SigNoz https://charts.signoz.io
 ```
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE cluster" default>
 
 **Step 2:** Install the Otel Collector agent in GKE where SigNoz is running in a Self-hosted VM.
@@ -288,7 +288,7 @@ Kubernetes cluster metrics
 
 If you encounter any issues while setting up logging and metrics for your GKE cluster, follow these troubleshooting steps:
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE Cluster" default>
 
 1. Confirm that the necessary Kubernetes resources are created:

--- a/data/docs/gcp-monitoring/gke/gke-tracing.mdx
+++ b/data/docs/gcp-monitoring/gke/gke-tracing.mdx
@@ -532,7 +532,7 @@ Check that the nodes in your GKE clusters are in `Ready` state:
 helm repo add SigNoz https://charts.signoz.io
 ```
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE cluster" default>
 
 **Step 2:** Install the OTel Collector agent in GKE where SigNoz is running in GKE cluster
@@ -821,7 +821,7 @@ You can refer to this [GitHub repository](https://github.com/isItObservable/pixi
 
 Use the appropriate export URL in the script. The export url will receive all the traces captured by Pixie.
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE" default>
 
 ```sh
@@ -863,7 +863,7 @@ kubectl run -n signoz my-hello –image=nginx –port=80
 
 To visualize the traces, log into the SigNoz account and navigate to the traces section.
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE" default>
 
 <Figure
@@ -996,7 +996,7 @@ After editing the config map, and once the application restarts, upon performing
 
 If you encounter any issues while setting up logging and metrics for your GKE cluster, follow these troubleshooting steps:
 
-<Tabs entityName="environment">
+<Tabs entityName="signoz-deployment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE Cluster" default>
 
 1. Confirm that the necessary Kubernetes resources are created:

--- a/data/docs/gcp-monitoring/gke/gke-tracing.mdx
+++ b/data/docs/gcp-monitoring/gke/gke-tracing.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 id: gke-tracing
 
 title: Tracing in GKE
@@ -532,7 +532,7 @@ Check that the nodes in your GKE clusters are in `Ready` state:
 helm repo add SigNoz https://charts.signoz.io
 ```
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE cluster" default>
 
 **Step 2:** Install the OTel Collector agent in GKE where SigNoz is running in GKE cluster
@@ -821,7 +821,7 @@ You can refer to this [GitHub repository](https://github.com/isItObservable/pixi
 
 Use the appropriate export URL in the script. The export url will receive all the traces captured by Pixie.
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE" default>
 
 ```sh
@@ -863,7 +863,7 @@ kubectl run -n signoz my-hello –image=nginx –port=80
 
 To visualize the traces, log into the SigNoz account and navigate to the traces section.
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For self-hosted SigNoz in GKE" default>
 
 <Figure
@@ -996,7 +996,7 @@ After editing the config map, and once the application restarts, upon performing
 
 If you encounter any issues while setting up logging and metrics for your GKE cluster, follow these troubleshooting steps:
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="self-hosted-on-gke-cluster" label="For Self-hosted SigNoz in GKE Cluster" default>
 
 1. Confirm that the necessary Kubernetes resources are created:

--- a/data/docs/google-gemini-monitoring.mdx
+++ b/data/docs/google-gemini-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: google-gemini-monitoring-with-opentelemetry
 
 title: Google Gemini Monitoring & Observability with OpenTelemetry
@@ -24,10 +24,10 @@ Instrumenting Gemini in your LLM applications with telemetry ensures full observ
 
 ## Monitoring Google Gemini
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/grok-monitoring.mdx
+++ b/data/docs/grok-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: grok-monitoring-with-opentelemetry
 title: xAI Grok Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor xAI Grok using OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Grok LLM applications with real-time dashboards.
@@ -25,7 +25,7 @@ Monitoring xAI Grok in your AI applications with telemetry ensures full observab
 
 For more information on getting started with Grok in your Python environment, refer to the [Grok Python README](https://github.com/xai-org/xai-sdk-python).
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/groq-observability.mdx
+++ b/data/docs/groq-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: groq-monitoring-with-opentelemetry
 title: Groq Observability & Monitoring with OpenTelemetry
 description: Learn how to set up observability and monitoring for Groq applications using OpenTelemetry. Export traces, logs, and metrics to SigNoz to monitor LLM usage and optimize your AI workflows.
@@ -25,7 +25,7 @@ Monitoring Groq in your AI applications with telemetry ensures full observabilit
 
 For more information on getting started with Groq in your Python environment, refer to the [Groq quickstart guide](https://console.groq.com/docs/quickstart).
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/haystack-monitoring.mdx
+++ b/data/docs/haystack-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: haystack-monitoring-with-opentelemetry
 title: Haystack Observability & Monitoring with OpenTelemetry
 description: Learn how to monitor Haystack AI pipelines using OpenTelemetry and SigNoz. Track RAG workflows, model performance, and latency in real time.
@@ -25,7 +25,7 @@ Monitoring Haystack in your AI applications with telemetry ensures full observab
 
 For more information on getting started with Haystack in your Python environment, refer to the [Haystack quickstart guide](https://haystack.deepset.ai/overview/quick-start).
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/huggingface-observability.mdx
+++ b/data/docs/huggingface-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: huggingface-observability-with-opentelemetry
 title: Hugging Face Observability & Monitoring with OpenTelemetry
 description: Setup Hugging Face observability with OpenTelemetry and SigNoz. Monitor model inference, track traces, and analyze LLM usage with unified dashboards.
@@ -25,7 +25,7 @@ Monitoring Hugging Face in your AI applications with telemetry ensures full obse
 
 For more information on getting started with Hugging Face in your Python environment, refer to the <a href="https://huggingface.co/inference/get-started" target="_blank" rel="noopener noreferrer nofollow">Hugging Face quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/infrastructure-monitoring/hostmetrics.mdx
+++ b/data/docs/infrastructure-monitoring/hostmetrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 title: Collect Host Metrics with OpenTelemetry
 id: opentelemetry-hostmetrics
 description: Learn how to collect host metrics using the OpenTelemetry hostmetrics receiver. Monitor CPU, memory, disk, and network usage and send data to SigNoz for real-time insights.
@@ -167,7 +167,7 @@ service:
 
 After saving the configuration, restart the collector service to apply changes.
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="systemd" label="Systemd" default>
 
 If you are using systemd to manage the collector service:

--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: overview
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
@@ -23,7 +23,7 @@ Both views share common controls for time range, filtering, and navigation so yo
 
 ## Explore infrastructure views
 
-<Tabs>
+<Tabs entityName="environment">
 
 <TabItem value="Host" label="Host Interface" default>
 

--- a/data/docs/ingestion/signoz-cloud/troubleshooting/troubleshooting.mdx
+++ b/data/docs/ingestion/signoz-cloud/troubleshooting/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 title: Ingestion Troubleshooting
 meta_title: Ingestion Troubleshooting Guide for SigNoz Cloud
 description: Diagnose and fix SigNoz Cloud ingestion issues including connection errors, invalid keys, auth failures, and retry behaviour. Covers diagnostic log setup and an issues catalog.
@@ -87,7 +87,7 @@ Seeing these info logs 2-3 times per day is within normal operating parameters a
 
 </details>
 
-<Tabs>
+<Tabs entityName="status-code">
 <TabItem value="400" label="Bad Request" default>
 **Root Cause:**
   - Payload is malformed

--- a/data/docs/inkeep-monitoring.mdx
+++ b/data/docs/inkeep-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-15
+date: 2026-06-11
 id: inkeep-monitoring-with-opentelemetry
 
 title: Inkeep Monitoring & Observability with OpenTelemetry
@@ -76,7 +76,7 @@ See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/ser
 
 ### Step 3: Configure Your Root .env File
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="cloud" label="SigNoz Cloud" default>
 
 ```bash:.env

--- a/data/docs/install/argocd.mdx
+++ b/data/docs/install/argocd.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 id: argocd
 tags : [Self-Host]
 title: Deploying with ArgoCD
@@ -32,7 +32,7 @@ We will be using the SigNoz Helm [chart](https://github.com/SigNoz/charts), whic
 - Zookeeper
 
 ArgoCD allows to install application by using the helm charts through the UI, or in the declarative GitOps way. For detailed instructions on using helm charts with ArgoCD, please refer to the documentation [documentation][4]
-<Tabs>
+<Tabs entityName="method">
 
 <TabItem label="Apply the argo application with kubectl" value="kubectl">
 

--- a/data/docs/install/ecs.mdx
+++ b/data/docs/install/ecs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-26
+date: 2026-06-11
 id: ecs
 tags : [Self-Host]
 title: Deploying to ECS
@@ -188,7 +188,7 @@ Save the JSON below as `sigz-network.json`.
 
 ### 2.2  Create the Stack
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem label="CLI" value="cli">
 
 ```bash
@@ -624,7 +624,7 @@ aws ecs register-task-definition --cli-input-json file://clickhouse-zookeeper.js
 
 ## 7  Create ECS Services
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem label="CLI" value="cli">
 Create one service per component, using the **capacity provider strategy**.
 

--- a/data/docs/install/kubernetes/local.mdx
+++ b/data/docs/install/kubernetes/local.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-04-30
+date: 2026-06-11
 id: local
 tags : [Self-Host]
 title: Deploying to Local Kubernetes
@@ -17,7 +17,7 @@ import K8sNextSteps from '@/components/shared/k8s-next-steps.md'
 
 Choose one of the following options to set up your local Kubernetes cluster:
 
-<Tabs>
+<Tabs entityName="k8s-distro">
 <TabItem label="Minikube" value="minikube">
 
 - Follow the [official Minikube installation guide][1]

--- a/data/docs/install/kubernetes/openshift.mdx
+++ b/data/docs/install/kubernetes/openshift.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-06-17
+date: 2026-06-11
 id: openshift
 tags : [Self-Host]
 title: Deploying to OpenShift
@@ -79,7 +79,7 @@ users:
 
 Apply the SCCs to the OpenShift Cluster:
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem label="oc CLI (Recommended)" value="oc">
 ```bash
 oc apply -f signoz_scc.yaml

--- a/data/docs/instrumentation/java/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/java/manual-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: java-manual-instrumentation
 title: How to add manual instrumentation in Java
 description: Learn how to add manual instrumentation in Java with OpenTelemetry. Create custom spans for business operations, payment flows, and domain-specific tracing.
@@ -14,7 +14,7 @@ Manual instrumentation lets you capture business operations that automatic instr
 - Complete the [Java OpenTelemetry instrumentation guide](https://signoz.io/docs/instrumentation/java/opentelemetry-java/) so your app is already sending traces
 - Add the OpenTelemetry API dependency to your project
 
-<Tabs>
+<Tabs entityName="build-tool">
 <TabItem value="maven" label="Maven" default>
 ```xml
 <dependency>

--- a/data/docs/instrumentation/java/opentelemetry-quarkus.mdx
+++ b/data/docs/instrumentation/java/opentelemetry-quarkus.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: quarkus
 
 title: Quarkus OpenTelemetry Instrumentation Guide
@@ -95,7 +95,7 @@ Set `service.version` to a per-build value, not a static string. SigNoz detects 
 
 ### Step 2. Add the OpenTelemetry extension
 
-<Tabs>
+<Tabs entityName="build-tool">
 <TabItem value="cli" label="Quarkus CLI" default>
 
 ```bash

--- a/data/docs/instrumentation/javascript/nodejs-exclude-http-endpoints.mdx
+++ b/data/docs/instrumentation/javascript/nodejs-exclude-http-endpoints.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: nodejs-exclude-http-endpoints
 title: Filter Noisy HTTP Endpoints in Node.js OpenTelemetry
 description: Learn how to exclude health checks and noisy HTTP endpoints from OpenTelemetry traces in Node.js. Filter unwanted spans for cleaner observability in SigNoz.
@@ -21,7 +21,7 @@ This guide shows you how to filter out these requests by configuring the `HttpIn
 
 The `HttpInstrumentation` class allows you to define an `ignoreIncomingRequestHook`. This hook is a function that receives the request object (`req`). If it returns `true`, the request is ignored and no span is created.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="Using Auto-Instrumentation SDK" default>
 
 <Admonition type="warning">

--- a/data/docs/instrumentation/javascript/nodejs-selective-instrumentation.mdx
+++ b/data/docs/instrumentation/javascript/nodejs-selective-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: nodejs-selective-instrumentation
 title: Node.js Selective Auto-Instrumentation Guide
 description: Learn how to enable or disable specific OpenTelemetry auto-instrumentations in Node.js. Control which libraries generate traces to reduce noise in SigNoz.
@@ -23,7 +23,7 @@ These steps work the same way regardless of deployment. Only your OTLP endpoint 
 
 ## Configure selective instrumentation
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="no-code" label="No Code" default>
 
 No code changes required. Configure using environment variables.

--- a/data/docs/instrumentation/javascript/opentelemetry-nextjs.mdx
+++ b/data/docs/instrumentation/javascript/opentelemetry-nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: nextjs
 
 title: Next.js OpenTelemetry Instrumentation Guide
@@ -82,7 +82,7 @@ export default nextConfig
 
 Create `instrumentation.ts` (or `instrumentation.js`) in your project root or inside `src/` if you use that folder structure. Do not place it inside `app/` or `pages/`.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="typescript" label="TypeScript" default>
 
 ```ts:instrumentation.ts
@@ -316,7 +316,7 @@ export default nextConfig
 
 Create `instrumentation.ts` (or `instrumentation.js`) in your project root or inside `src/` if you use that folder structure. Do not place it inside `app/` or `pages/`.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="typescript" label="TypeScript" default>
 
 ```ts:instrumentation.ts

--- a/data/docs/integrations/mongodb-atlas.mdx
+++ b/data/docs/integrations/mongodb-atlas.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: mongodb-atlas
 description: This documentation guides you through setting up monitoring for MongoDB Atlas—tracking key metrics, collecting logs, and visualising them through an out-of-the-box dashboard.
 title: MongoDB Atlas Metrics and Logs
@@ -22,10 +22,10 @@ Before you begin, ensure you have:
 
 ## Setup
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="metrics" label="Metrics" default>
 
 ### Step 1: Install OpenTelemetry Collector
@@ -267,7 +267,7 @@ Here are sample screenshots of the MongoDB Atlas logs from SigNoz:
 </TabItem>
 <TabItem value='self-host' label='Self-Host'>
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="metrics" label="Metrics" default>
 
 ### Step 1: Install OpenTelemetry Collector

--- a/data/docs/integrations/nomad.mdx
+++ b/data/docs/integrations/nomad.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-24
+date: 2026-06-11
 id: nomad
 
 title: Monitor HashiCorp Nomad with SigNoz
@@ -43,7 +43,7 @@ Once telemetry is enabled, Nomad exposes metrics in Prometheus format from the H
 
 The following Nomad job runs the OpenTelemetry Collector and scrapes Nomad metrics. It then forwards metrics to SigNoz (Cloud or self-hosted). Replace the placeholders with your values.
 
-<Tabs>
+<Tabs entityName="plans">
 
 <TabItem value="cloud" label="SigNoz Cloud">
 ```hcl

--- a/data/docs/integrations/opentelemetry-hasura.mdx
+++ b/data/docs/integrations/opentelemetry-hasura.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: opentelemetry-hasura
 title: OpenTelemetry Hasura Integration Guide
 description: Learn how to configure Hasura's built-in OpenTelemetry support to export traces, metrics, and logs to SigNoz for end-to-end GraphQL observability.
@@ -30,7 +30,7 @@ You can configure OpenTelemetry export for Hasura using either the Console UI or
 2. Click on **OpenTelemetry Exporter**.
 3. Configure your connection based on the type of telemetry you want to export:
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="traces" label="Traces">
 
 - **Endpoint**: `https://ingest.<region>.signoz.cloud:443/v1/traces`
@@ -127,7 +127,7 @@ hasura metadata apply
 
 Hasura exports the following telemetry data to SigNoz:
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="traces" label="Traces" default>
 
 Hasura traces operations across:
@@ -168,7 +168,7 @@ All logs printed to the output stream are exported to SigNoz. Log structure foll
 
 Hasura Data Connectors run as separate services alongside the GraphQL Engine. Each connector handles communication with a specific database. Data connectors only support traces. To visualize the full timeline of a GraphQL request (including the actual database execution), you must also configure OpenTelemetry for your data connectors using environment variables in their respective deployments.
 
-<Tabs>
+<Tabs entityName="connector">
 <TabItem value="graphql" label="GraphQL Data Connectors">
 
 The GraphQL Data Connectors (which power Athena, MariaDB, MySQL, Oracle, Redshift, Snowflake, etc.) are built on top of Quarkus. Set the following environment variables on the connector container:

--- a/data/docs/integrations/opentelemetry-hasura.mdx
+++ b/data/docs/integrations/opentelemetry-hasura.mdx
@@ -127,7 +127,7 @@ hasura metadata apply
 
 Hasura exports the following telemetry data to SigNoz:
 
-<Tabs entityName="signal">
+<Tabs entityName="telemetry">
 <TabItem value="traces" label="Traces" default>
 
 Hasura traces operations across:

--- a/data/docs/integrations/opentelemetry-kong-gateway.mdx
+++ b/data/docs/integrations/opentelemetry-kong-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: opentelemetry-kong-gateway
 title: OpenTelemetry Kong Gateway Integration
 description: Monitor Kong Gateway by exporting OpenTelemetry traces, metrics, and logs natively to SigNoz.
@@ -29,7 +29,7 @@ Kong Gateway provides a native OpenTelemetry plugin to capture proxy latencies, 
 
 Configure the <a href="https://developer.konghq.com/plugins/opentelemetry/" target="_blank" rel="noopener noreferrer nofollow">opentelemetry plugin</a> either via declarative config (<a href="https://github.com/kong/deck" target="_blank" rel="noopener noreferrer nofollow">decK</a>) or via the Kong Ingress Controller in Kubernetes.
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="deck" label="Declarative Config (decK)" default>
 
 ```yaml:kong-state.yaml
@@ -124,7 +124,7 @@ kubectl apply -f kong-plugin-otel.yaml
 
 ## Available Telemetry
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="traces" label="Traces" default>
 
 Kong instruments each proxied request as an OTel span with child spans for each phase:

--- a/data/docs/integrations/sql-server.mdx
+++ b/data/docs/integrations/sql-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: sql-server
 
 title: SQL Server Metrics and Logs
@@ -20,7 +20,7 @@ This documentation explains how to collect SQL Server metrics and logs using Ope
 <Tabs entityName="plans">
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="metrics" label="Metrics" default>
 
 ### Step 1. Setup OTel Collector
@@ -92,7 +92,7 @@ In the `config.yaml` file, under the `service` section, locate the `pipelines` b
 ### Step 4. Run the OTel Collector
 Inside `otelcol-contrib` folder, run the `otelcol-contrib` command.
 
-    <Tabs>
+    <Tabs entityName="os">
     <TabItem value="linux" label="Linux" default>
       ```bash
       ./otelcol-contrib --config config.yaml
@@ -190,7 +190,7 @@ In the `config.yaml` file, under the `service` section, locate the `pipelines` b
 ### Step 4. Run the OTel Collector
 Inside `otelcol-contrib` folder, run the `otelcol-contrib` command.
 
-    <Tabs>
+    <Tabs entityName="os">
     <TabItem value="linux" label="Linux" default>
         ```bash
         ./otelcol-contrib --config config.yaml
@@ -220,7 +220,7 @@ To see the complete list of logs, refer this [link](https://github.com/open-tele
 <TabItem value='self-host' label='Self-Host'>
 
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="metrics" label="Metrics" default>
 
 ### Step 1. Install SigNoz

--- a/data/docs/integrations/supabase.mdx
+++ b/data/docs/integrations/supabase.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-09-02
+date: 2026-06-11
 id: supabase
 
 title: Supabase Metrics Integration
@@ -36,7 +36,7 @@ Before you begin, ensure you have:
 
 Create a file named `supabase-metrics-collection-config.yaml`:
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="cloud" label="SigNoz Cloud" default>
 
 ```yaml

--- a/data/docs/integrations/temporal-cloud-metrics.mdx
+++ b/data/docs/integrations/temporal-cloud-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-06-11
 id: temporal-cloud-metrics
 title: Getting Temporal Cloud Metrics into SigNoz
 description: Collect Temporal Cloud metrics in SigNoz by configuring an OpenTelemetry Collector to scrape the Temporal Cloud OpenMetrics endpoint.
@@ -38,7 +38,7 @@ Replace `<TEMPORAL_API_KEY>` with the key you generated. A successful response r
 
 Choose the setup that matches your environment:
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="vm" label="VM / Binary" default>
 
 Add the `prometheus` receiver and SigNoz `otlp` exporter to your `otel-collector-config.yaml`. If your collector already has other receivers, append the `prometheus` block and add it to the pipeline — do not replace your existing config.

--- a/data/docs/integrations/temporal-golang-opentelemetry.mdx
+++ b/data/docs/integrations/temporal-golang-opentelemetry.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-06-11
 id: temporal-golang-opentelemetry
 title: Instrumenting a Temporal Go application with OpenTelemetry
 description: Instrument a Temporal Go application with OpenTelemetry and send traces, metrics, and logs to SigNoz.
@@ -408,7 +408,7 @@ func Greet(ctx context.Context, name string) (string, error) {
 
 ### Step 7: Deploy and Run
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="vm" label="VM" default>
 
 <KeyPointCallout title="What classifies as VM?" defaultCollapsed={true}>

--- a/data/docs/langchain-observability.mdx
+++ b/data/docs/langchain-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: langchain-observability-with-opentelemetry
 
 title: LangChain & LangGraph Observability with OpenTelemetry
@@ -37,7 +37,7 @@ To capture detailed telemetry from LangChain/LangGraph without modifying your co
 
 Check out the <a href="https://pypi.org/project/openinference-instrumentation-langchain/" target="_blank" rel="noopener noreferrer nofollow">openinference-instrumentation-langchain package on PyPI</a> for detailed setup instructions.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/litellm-observability.mdx
+++ b/data/docs/litellm-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-28
+date: 2026-06-11
 id: litellm-observability-with-opentelemetry
 
 title: LiteLLM Observability & Monitoring with OpenTelemetry
@@ -24,15 +24,15 @@ With full LiteLLM observability in SigNoz, you can correlate traces, logs, and m
 
 LiteLLM can be monitored in two ways: using the **LiteLLM SDK** (directly embedded in your Python application code for programmatic LLM calls) or the **LiteLLM Proxy Server** (a standalone server that acts as a centralized gateway for managing and routing LLM requests across your infrastructure).
 
-<Tabs>
+<Tabs entityName="setup">
 <TabItem value="LiteLLM SDK" label="LiteLLM SDK" default>
 
 For more detailed info on instrumenting your LiteLLM SDK applications, see the <a href="https://docs.litellm.ai/docs/observability/opentelemetry_integration" target="_blank" rel="noopener noreferrer nofollow">LiteLLM OpenTelemetry integration docs</a>.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/livekit-observability.mdx
+++ b/data/docs/livekit-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: livekit-observability-with-opentelemetry
 
 title: LiveKit Observability & Monitoring with OpenTelemetry
@@ -26,12 +26,12 @@ Instrumenting LiveKit in your AI applications with telemetry ensures full observ
 
 For more detailed info on instrumenting your LiveKit applications with OpenTelemetry click <a href="https://docs.livekit.io/agents/observability/data/" target="_blank" rel="noopener noreferrer nofollow">here</a>.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
 Get started with a sample LiveKit starter project by following the <a href="https://docs.livekit.io/agents/start/voice-ai/" target="_blank" rel="noopener noreferrer nofollow">LiveKit Getting Started Docs</a>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/llamaindex-observability.mdx
+++ b/data/docs/llamaindex-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: llamaindex-observability-with-opentelemetry
 
 title: LlamaIndex Observability & Monitoring with OpenTelemetry
@@ -34,7 +34,7 @@ To capture detailed telemetry from LlamaIndex without modifying your core applic
 
 Check out detailed instructions on how to set up OpenInference instrumentation in your LlamaIndex application over [here](https://pypi.org/project/openinference-instrumentation-llama-index/).
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/logs-management/guides/set-resource-attributes-for-logs.mdx
+++ b/data/docs/logs-management/guides/set-resource-attributes-for-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-12
+date: 2026-06-11
 id: set-resource-attributes-for-logs
 title: Guide to add Resource Attributes
 description: Learn how to add resource attributes to your logs to enable better filtering, grouping, and correlation of logs in SigNoz.
@@ -68,7 +68,7 @@ This processor automatically adds resource attributes by detecting information f
 
 You can configure resource attributes directly in your application code using [OpenTelemetry SDKs](https://signoz.io/docs/instrumentation/). This approach gives you fine-grained control over the attributes for each service.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="nodejs" label="Node.js" default>
 
 ```javascript
@@ -243,7 +243,7 @@ These environment variables are automatically picked up by OpenTelemetry SDKs an
 
 ## Using Kubernetes
 
-<Tabs>
+<Tabs entityName="k8s-method">
 <TabItem value="k8s-infra-chart" label="K8s Infra Chart" default>
 
 The [K8s infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/overview/) enables a lot of these resource attributes by default.

--- a/data/docs/logs-management/send-logs/java-logs.mdx
+++ b/data/docs/logs-management/send-logs/java-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 title: Send logs from Java to SigNoz using OpenTelemetry
 id: java-logs
 doc_type: howto
@@ -33,7 +33,7 @@ This guide focuses on **Application-level Collection (OTLP)**.
 
 ## Send logs to SigNoz
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="Auto-Instrumentation (Recommended)" default>
 
 The **OpenTelemetry Java Agent** automatically captures logs from popular logging frameworks like Log4j 2, Logback, and java.util.logging (JUL) and sends them to SigNoz.
@@ -211,7 +211,7 @@ export OTEL_METRICS_EXPORTER="none"
 
 Add the following OpenTelemetry dependencies to your project.
 
-<Tabs>
+<Tabs entityName="build-tool">
 <TabItem value="maven" label="Maven" default>
 
 ```xml
@@ -504,7 +504,7 @@ public class Application {
 
 Build your project and run the application.
 
-<Tabs>
+<Tabs entityName="build-tool">
 <TabItem value="maven" label="Maven" default>
 
 ```bash

--- a/data/docs/logs-management/send-logs/nodejs-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 title: Send logs from Node.js default console logger to SigNoz using OpenTelemetry
 id: opentelemetry-nodejs-logs
 doc_type: howto
@@ -28,10 +28,10 @@ This guide will walk you through instrumenting your Node.js application to send 
 
 Install the required OpenTelemetry packages:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```bash
@@ -65,7 +65,7 @@ npm install --save @opentelemetry/api-logs \
 </TabItem>
 <TabItem value="yarn" label="yarn">
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```bash
@@ -237,7 +237,7 @@ Replace the placeholders:
 
 Create a new file called `logger.js` or `logger.ts` in your project root. This file reads the configuration from the environment variables set in the previous step.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:logger.js
@@ -303,7 +303,7 @@ export default loggerProvider;
 
 Create a new file called `console-instrumentation.js` or `console-instrumentation.ts` in your project root. This file wraps the default console methods to send logs to OpenTelemetry:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:console-instrumentation.js
@@ -518,7 +518,7 @@ console.debug = function (...args: any[]) {
 
 Import the instrumentation at the very top of your main application file (e.g., `index.js` or `index.ts`):
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js
@@ -563,7 +563,7 @@ app.listen(3000, () => {
 
 Run your application:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```bash

--- a/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-pino-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-06-11
 title: Send logs from Node.js Pino logger to SigNoz using OpenTelemetry
 id: nodejs-pino-logs
 doc_type: howto
@@ -22,7 +22,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 ## Send logs to SigNoz
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="No Code Auto-Instrumentation (recommended)" default>
 
 Auto-instrumentation automatically captures:
@@ -34,7 +34,7 @@ Auto-instrumentation automatically captures:
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -219,7 +219,7 @@ export OTEL_METRICS_EXPORTER="none"
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -382,7 +382,7 @@ Replace the placeholders:
 
 Create a file named `logging-instrumentation.js` or `logging-instrumentation.ts` in your project root. This code reads the environment variables and configures the OpenTelemetry SDK.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:logging-instrumentation.js
@@ -480,7 +480,7 @@ Check out the Pino instrumentation options <a href="https://www.npmjs.com/packag
 
 Import the instrumentation at the very top of your main application file (e.g., `index.js` or `index.ts`).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js
@@ -563,7 +563,7 @@ Pino logs created within a tracing span are automatically enriched with span and
 
 You can use `tracer.startActiveSpan` to correlate logs with traces. Here is an example:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js

--- a/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-06-11
 title: Send logs from Node.js Winston logger to SigNoz using OpenTelemetry
 id: nodejs-winston-logs
 doc_type: howto
@@ -22,7 +22,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 ## Send logs to SigNoz
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="No Code Auto-Instrumentation (recommended)" default>
 
 Auto-instrumentation automatically captures:
@@ -34,7 +34,7 @@ Auto-instrumentation automatically captures:
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -222,7 +222,7 @@ export OTEL_METRICS_EXPORTER="none"
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -387,7 +387,7 @@ Replace the placeholders:
 
 Create a file named `logging-instrumentation.js` or `logging-instrumentation.ts` in your project root. This code reads the environment variables and configures the OpenTelemetry SDK.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:logging-instrumentation.js
@@ -487,7 +487,7 @@ Check out the Winston instrumentation options <a href="https://www.npmjs.com/pac
 
 Import the instrumentation at the very top of your main application file (e.g., `index.js` or `index.ts`).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js
@@ -578,7 +578,7 @@ Winston logs created within a tracing span are automatically enriched with span 
 
 You can use `tracer.startActiveSpan` to correlate logs with traces. Here is an example:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js

--- a/data/docs/logs-management/send-logs/opentelemetry-nodejs-bunyan-logs.mdx
+++ b/data/docs/logs-management/send-logs/opentelemetry-nodejs-bunyan-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-06-11
 title: Send logs from Node.js Bunyan logger to SigNoz using OpenTelemetry
 id: opentelemetry-nodejs-bunyan-logs
 doc_type: howto
@@ -22,7 +22,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 ## Send logs to SigNoz
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="No Code Auto-Instrumentation (recommended)" default>
 
 Auto-instrumentation automatically captures:
@@ -34,7 +34,7 @@ Auto-instrumentation automatically captures:
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -222,7 +222,7 @@ export OTEL_METRICS_EXPORTER="none"
 
 Install the required OpenTelemetry dependencies:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 
 ```bash
@@ -386,7 +386,7 @@ Replace the placeholders:
 
 Create a file named `logging-instrumentation.js` or `logging-instrumentation.ts` in your project root. This code reads the configuration from the environment variables set in the previous step.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:logging-instrumentation.js
@@ -484,7 +484,7 @@ Check out the Bunyan instrumentation options <a href="https://www.npmjs.com/pack
 
 Import the instrumentation at the very top of your main application file (e.g., `index.js` or `index.ts`).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js
@@ -573,7 +573,7 @@ Bunyan logs created within a tracing span are automatically enriched with span a
 
 You can use `tracer.startActiveSpan` to correlate logs with traces. Here is an example:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="javascript" label="JavaScript" default>
 
 ```javascript:index.js

--- a/data/docs/logs-management/send-logs/python-logs.mdx
+++ b/data/docs/logs-management/send-logs/python-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-08
+date: 2026-06-11
 title: Send logs from Python to SigNoz using OpenTelemetry
 id: opentelemetry-python-logs
 doc_type: howto
@@ -21,7 +21,7 @@ Tested with <a href="https://docs.python.org/3.11/" target="_blank" rel="noopene
 
 ## Send logs to SigNoz
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="automatic" label="No Code Auto-Instrumentation (recommended)" default>
 
 Auto-instrumentation automatically captures logs from your Python application with trace correlation.

--- a/data/docs/logs-management/send-logs/vector-logs-to-signoz.mdx
+++ b/data/docs/logs-management/send-logs/vector-logs-to-signoz.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-06-11
 title: Send Logs from Vector to SigNoz
 id: vector-logs-to-signoz
 doc_type: howto
@@ -25,7 +25,7 @@ import GetHelp from '@/components/shared/get-help.md'
 
 ## Configure Vector
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="cloud" label="SigNoz Cloud" default>
 
 To send logs from Vector to SigNoz Cloud, you need to use the `http` sink.

--- a/data/docs/mastra-observability.mdx
+++ b/data/docs/mastra-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: mastra-observability-with-opentelemetry
 title: Mastra Observability & Monitoring with OpenTelemetry
 description: Set up Mastra observability with OpenTelemetry and SigNoz. Track traces for Mastra monitoring - model performance, latency, and error rates.
@@ -27,7 +27,7 @@ You can get the full <a href="https://mastra.ai/en/docs/getting-started/installa
 
 Run the following command to start the interactive setup:
 
-<Tabs>
+<Tabs entityName="package-manager">
 <TabItem value="npm" label="npm" default>
 ```bash
 npx create-mastra@latest

--- a/data/docs/messaging-queues/confluent-kafka.mdx
+++ b/data/docs/messaging-queues/confluent-kafka.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 title: Monitor Confluent Kafka
 meta_title: Monitor Confluent Kafka with OpenTelemetry
 description: Learn how to monitor Confluent Kafka (Cloud and Platform) using OpenTelemetry and SigNoz. Set up Confluent, Java OTel agent, producer-consumer apps, and data visualization.
@@ -36,7 +36,7 @@ beyond the open-source version. Organizations can deploy and maintain Confluent 
 infrastructure, giving them complete control over their environment. Since it builds upon Apache Kafka's 
 core capabilities, Confluent Platform supports all Kafka use cases.
 
-<Tabs>
+<Tabs entityName="platform">
 {/* <TabItem value="confluent-cloud" label="Confluent Cloud" default>
 
 ## Prerequisites
@@ -148,7 +148,7 @@ Create a file `config.yaml`. Here, we will setup the OpenTelemetry Collector con
 
 Here are the contents of the `config.yaml` file:
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
 
 ```yaml
@@ -532,7 +532,7 @@ Place the binary in the root of your project directory.
 
 Update you collector config with the follwing:
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="SigNoz Cloud" label="SigNoz Cloud" default>
 
 ```yaml

--- a/data/docs/messaging-queues/kafka.mdx
+++ b/data/docs/messaging-queues/kafka.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 
 title: Monitor Kafka Service
 meta_title: Monitor Self-Hosted Kafka with OpenTelemetry
@@ -106,7 +106,7 @@ This guide follows these primary steps:
 {/* For simplicity, Steps 1, 2, and 3 are assumed to be performed on the same host (VM, laptop, or containerized environment). */}
 
 
-<Tabs>
+<Tabs entityName="environment">
 <TabItem value="Local" label="Local / VM(AWS/GCP/Azure)" default>
 
 
@@ -302,7 +302,7 @@ Place the binary in the root of your project directory.
 
 Update you collector config with the follwing:
 
-<Tabs>
+<Tabs entityName="plans">
 <TabItem value="SigNoz Cloud" label="SigNoz Cloud" default>
 
 ```yaml

--- a/data/docs/messaging-queues/kafka.mdx
+++ b/data/docs/messaging-queues/kafka.mdx
@@ -106,7 +106,7 @@ This guide follows these primary steps:
 {/* For simplicity, Steps 1, 2, and 3 are assumed to be performed on the same host (VM, laptop, or containerized environment). */}
 
 
-<Tabs entityName="environment">
+<Tabs entityName="setup">
 <TabItem value="Local" label="Local / VM(AWS/GCP/Azure)" default>
 
 

--- a/data/docs/metrics-management/send-metrics/applications/golang.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/golang.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 id: golang
 title: Send Metrics from Go application
 description: Learn how to instrument your Go application with OpenTelemetry to send metrics to SigNoz
@@ -240,7 +240,7 @@ func main() {
 
 You can use OpenTelemetry's auto-instrumentation packages and middleware for popular Go libraries to automatically collect metrics, or create custom metrics manually.
 
-<Tabs>
+<Tabs entityName="metric-type">
 <TabItem value="runtime" label="Runtime Metrics" default>
 
 The `runtime` package provides auto-instrumentation for Go runtime metrics such as memory usage, goroutine count, and GC stats.

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-26
+date: 2026-06-11
 id: opentelemetry-java
 title: Send Metrics from Java Application using OpenTelemetry
 description: Send custom and JVM runtime metrics from your Java application to SigNoz using the OpenTelemetry Java agent.
@@ -69,7 +69,7 @@ For applications handling many requests, this can generate significant data volu
 
 Add the OpenTelemetry API to your project. The agent provides the implementation at runtime.
 
-<Tabs>
+<Tabs entityName="build-tool">
 <TabItem value="maven" label="Maven" default>
 
 ```xml:pom.xml

--- a/data/docs/migration/migrate-from-signoz-self-host-to-signoz-cloud.mdx
+++ b/data/docs/migration/migrate-from-signoz-self-host-to-signoz-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-24
+date: 2026-06-11
 id: migrate-from-signoz-self-host-to-signoz-cloud
 title: Migrate from Self-Hosted SigNoz to SigNoz Cloud
 description: Step-by-step guide to migrate your observability setup from self-hosted SigNoz to SigNoz Cloud, including telemetry pipelines, dashboards, alerts, and pipelines.
@@ -43,7 +43,7 @@ This approach ensures zero data loss during the transition.
 
 Choose the tab that matches your current setup:
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="own-collector" label="Using Your Own OTel Collector" default>
 
 If you're using your own OpenTelemetry Collector that forwards data to SigNoz self-hosted, update the exporter configuration.

--- a/data/docs/mistral-observability.mdx
+++ b/data/docs/mistral-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: mistral-observability-with-opentelemetry
 title: Mistral AI Observability & Monitoring with OpenTelemetry
 description: Setup Mistral AI observability with OpenTelemetry and SigNoz. Monitor LLM performance, track traces, logs, and metrics in unified dashboards.
@@ -25,7 +25,7 @@ Monitoring Mistral in your AI applications with telemetry ensures full observabi
 
 For more information on getting started with Mistral in your Python environment, refer to the <a href="https://docs.mistral.ai/getting-started/quickstart" target="_blank" rel="noopener noreferrer nofollow">Mistral quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/ollama-monitoring.mdx
+++ b/data/docs/ollama-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: ollama-monitoring-with-opentelemetry
 title: Ollama Monitoring & Observability with OpenTelemetry
 description: Set up Ollama monitoring and observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for full LLM visibility in real-time.
@@ -24,7 +24,7 @@ With full Ollama monitoring in SigNoz, you can correlate traces, logs, and metri
 
 For more information on getting started with Ollama in your Python environment, refer to the <a href="https://docs.ollama.com/quickstart#python" target="_blank" rel="noopener noreferrer nofollow">Ollama quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/openai-monitoring.mdx
+++ b/data/docs/openai-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-24
+date: 2026-06-11
 id: openai-monitoring
 
 title: OpenAI Monitoring with OpenTelemetry
@@ -16,7 +16,7 @@ OpenAI monitoring with SigNoz gives you visibility into:
 - **Error rates** — detect API failures, rate limit errors, and timeouts before they impact users
 - **Request traces** — follow individual LLM calls through your full application stack
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
 ## Requirements

--- a/data/docs/openrouter-observability.mdx
+++ b/data/docs/openrouter-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: openrouter-monitoring-with-opentelemetry
 title: OpenRouter Observability & Monitoring with OpenTelemetry
 description: Set up OpenRouter observability and monitoring with OpenTelemetry and SigNoz. Track traces, monitor LLM API routing, and analyze usage across models.
@@ -86,7 +86,7 @@ Once configured, your OpenRouter calls are traced and sent to SigNoz.
 
 For more information on getting started with OpenRouter in your environment, refer to the <a href="https://openrouter.ai/docs/quickstart" target="_blank" rel="noopener noreferrer nofollow">OpenRouter quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="Python" label="Python" default>
 
 ```python

--- a/data/docs/opentelemetry-collection-agents/docker-swarm/install.mdx
+++ b/data/docs/opentelemetry-collection-agents/docker-swarm/install.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 title: Docker Swarm Collection Agent - Install
 id: install
 description: Install the OpenTelemetry Collector on your Docker Swarm cluster to collect metrics, logs, and traces and send them to SigNoz.
@@ -127,7 +127,7 @@ With `--mode global`, one collector runs on each Swarm node. Bind mounts (`/var/
 `--hostname '{{.Node.Hostname}}'` sets the container hostname to the Swarm node's hostname. Without this, the `system` resource detector reports the container ID as `host.name` instead of the actual node hostname, making it hard to identify which node data came from in SigNoz.
 </KeyPointCallout>
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="docker-stack" label="Docker Stack" default>
 
 Create a `docker-stack.yaml` file:

--- a/data/docs/opentelemetry-collection-agents/docker/install.mdx
+++ b/data/docs/opentelemetry-collection-agents/docker/install.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 title: Docker Collection Agent - Install
 id: install
 description: Install the OpenTelemetry Collector on your Docker host to collect metrics, logs, and traces and send them to SigNoz.
@@ -118,7 +118,7 @@ Verify the following values:
 
 ## Step 2: Run the Collector
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="docker-compose" label="Docker Compose" default>
 
 Create a `docker-compose.yaml` file:

--- a/data/docs/opentelemetry-collection-agents/ecs/ec2/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/ecs/ec2/configure.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-04
+date: 2026-06-11
 id: overview
 
 title: ECS EC2 Collection Agent - Configure
@@ -52,7 +52,7 @@ We need to add an entrypoint to the application container to set the
 daemon service. Such that the application container can send data to the
 daemon container running in the same host.
 
-<Tabs groupId="launch-type">
+<Tabs entityName="launch-type">
 <TabItem value="ec2" label="EC2" default>
 **Method 1: Updating entrypoint in task definition**
 

--- a/data/docs/opentelemetry-collection-agents/ecs/ec2/install.mdx
+++ b/data/docs/opentelemetry-collection-agents/ecs/ec2/install.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 id: overview
 title: ECS EC2 Collection Agent - Install
 description: View metrics and logs for your ECS infrastructure
@@ -22,7 +22,7 @@ Before starting, verify you have:
 
 The CloudFormation template defines the infrastructure needed for the daemon service, including container specifications, IAM roles, and network settings.
 
-<Tabs groupId="launch-type">
+<Tabs entityName="launch-type">
 <TabItem value="ec2" label="EC2" default>
 
 ```yaml

--- a/data/docs/opentelemetry-collection-agents/ecs/sidecar/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/ecs/sidecar/configure.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-04
+date: 2026-06-11
 id: configure
 
 title: ECS Serverless Collection Agent - Configure
@@ -37,7 +37,7 @@ Add OpenTelemetry instrumentation to your application. See [SigNoz instrumentati
 
 Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in your application container to point to the sidecar.
 
-<Tabs>
+<Tabs entityName="network-mode">
 <TabItem value="bridge" label="Bridge" default>
 
 ```json
@@ -176,7 +176,7 @@ When collecting logs from multiple applications, it is recommended to use `<appl
 
 In your application task definition, you need to use `awsfirelens` log driver to send logs to the sidecar otel-collector container via Fluent Bit log router.
 
-<Tabs>
+<Tabs entityName="network-mode">
 <TabItem value="bridge" label="Bridge" default>
 
 ```json

--- a/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/install-k8s-infra.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/install-k8s-infra.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 title: K8s Infra - Install
 id: install-k8s-infra
 description: Install the k8s-infra OpenTelemetry collection agent to send Kubernetes metrics, logs, and traces to SigNoz.
@@ -22,9 +22,9 @@ helm repo update
 Based on how you are running SigNoz (e.g. SigNoz Cloud, in an independent VM or Kubernetes cluster),
 you have to provide the address to send data from the above receivers.
 
-<Tabs>
+<Tabs entityName="plans">
   <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
-<Tabs groupId="k8s-vendor">
+<Tabs entityName="k8s-vendor">
   <TabItem value="generic" label="Generic" default>
 
     For generic Kubernetes clusters, you can use the following configuration:
@@ -204,7 +204,7 @@ Replace the placeholders with values for your environment:
 
 </TabItem>
 <TabItem value='self-host' label='Self-Host'>
-<Tabs groupId="k8s-vendor">
+<Tabs entityName="k8s-vendor">
   <TabItem value="generic" label="Generic" default>
 
     For generic Kubernetes clusters, you can use the following configuration:

--- a/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/user-guides/k8s-infra-multi-cluster.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/user-guides/k8s-infra-multi-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 title: Monitor Multiple K8S Clusters with k8s-Infra
 
 id: k8s-infra-multi-cluster
@@ -31,7 +31,7 @@ Set this value in `global.clusterName` for each cluster.
 
 Create an overrides file per cluster (for example, `override-values-prod-us1.yaml`).  
 
-<Tabs>
+<Tabs entityName="plans">
   <TabItem value="cloud" label="SigNoz Cloud" default>
 
 _override-values.yaml_

--- a/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 id: configure
 
 title: OpenTelemetry Operator - Configure
@@ -80,7 +80,7 @@ subjects:
 
 ### Collector CR
 
-<Tabs>
+<Tabs entityName="plans">
   <TabItem value="daemonset-cloud" label="SigNoz Cloud">
 
 ```yaml
@@ -801,7 +801,7 @@ subjects:
 
 ### Collector CR
 
-<Tabs>
+<Tabs entityName="plans">
   <TabItem value="deployment-cloud" label="SigNoz Cloud">
 
 ```yaml

--- a/data/docs/opentelemetry-collection-agents/k8s/otel-operator/install.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/otel-operator/install.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-04
+date: 2026-06-11
 id: install
 
 title: OpenTelemetry Operator - Install
@@ -26,7 +26,7 @@ Before installing the OpenTelemetry Operator, ensure you have:
 
 Choose your preferred installation method to deploy the operator:
 
-<Tabs>
+<Tabs entityName="k8s-method">
 <TabItem label="Kubectl - Apply Manifest" value="manifest">
 Deploy the operator directly using the latest release manifest:
 

--- a/data/docs/opentelemetry-collection-agents/k8s/serverless/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/serverless/configure.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-04
+date: 2026-06-11
 title: K8s Serverless (EKS Fargate) - Configure
 id: configure
 description: How to configure the SigNoz OpenTelemetry Collector agent for EKS Fargate (k8s-serverless) workloads.
@@ -58,7 +58,7 @@ AWS validates against following configuration for Fluent Bit:
 For more details, check out the [AWS Managed Fargate Log Router Documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html#fargate-logging-log-router-configuration).
 </Admonition>
 
-<Tabs default='cloudwatch'>
+<Tabs entityName="output">
 
 <TabItem value="cloudwatch" label="cloudwatch">
 
@@ -135,7 +135,7 @@ aws iam attach-role-policy \
 
 Depending on the output you've configured in Fluent Bit, configure the OpenTelemetry Collector to ingest logs accordingly.
 
-<Tabs default="cloudwatch">
+<Tabs entityName="output">
 <TabItem label="CloudWatch" value="cloudwatch">
 
 We will be using the [awscloudwatchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver) to ingest logs from AWS CloudWatch into the OpenTelemetry Collector. If you've opted for a different output in Fluent Bit, such as Kinesis or Firehose, you can use other receivers made available by the OpenTelemetry community.

--- a/data/docs/opentelemetry-collection-agents/vm/install.mdx
+++ b/data/docs/opentelemetry-collection-agents/vm/install.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 title: VM Collection Agent - Install
 id: install
 description: Install the OpenTelemetry Collector binary on your virtual machine to collect telemetry data.
@@ -20,10 +20,10 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 
 ## OpenTelemetry Collector Installation
 
-<Tabs>
+<Tabs entityName="os">
 <TabItem value="linux" label="Linux" default>
 
-<Tabs groupId="linux-method">
+<Tabs entityName="linux-method">
 <TabItem value="deb" label="DEB" default>
 
 The DEB package installs the Collector as a `systemd` service on Debian or Ubuntu. After installation, the default configuration is at `/etc/otelcol-contrib/config.yaml`.
@@ -483,7 +483,7 @@ In SigNoz, navigate to **Infrastructure Monitoring → Hosts** and verify your h
 </TabItem>
 <TabItem value="windows" label="Windows">
 
-<Tabs groupId="windows-method">
+<Tabs entityName="windows-method">
 <TabItem value="msi" label="MSI" default>
 
 The MSI installs the Collector as a Windows service (display name "OpenTelemetry Collector") and registers an Application Event Log source.

--- a/data/docs/operate/migration/upgrade-0-113.mdx
+++ b/data/docs/operate/migration/upgrade-0-113.mdx
@@ -25,7 +25,7 @@ For more details, see [SigNoz/charts#828](https://github.com/SigNoz/charts/issue
 <Tabs entityName="environment">
 <TabItem value="docker" label="Docker" default>
 
-<Tabs entityName="deployment">
+<Tabs entityName="docker-deployment">
 <TabItem value="docker-standalone" label="Standalone" default>
 
 <KeyPointCallout title="Using default Docker Compose files?" defaultCollapsed={false}>
@@ -282,7 +282,7 @@ The container should show status `Exited (0)`.
 </TabItem>
 <TabItem value="docker-swarm" label="Docker Swarm">
 
-<Tabs entityName="deployment">
+<Tabs entityName="swarm-deployment">
 <TabItem value="docker-swarm-standalone" label="Standalone" default>
 
 <KeyPointCallout title="Using default Docker Compose files?" defaultCollapsed={false}>
@@ -617,7 +617,7 @@ The Docker Compose files use environment variables. The CLI flags are available 
 ## Troubleshooting
 </ToggleHeading>
 
-<Tabs entityName="environment">
+<Tabs entityName="troubleshooting-env">
 <TabItem value="docker" label="Docker" default>
 
 ### Migrator container exits with non-zero code

--- a/data/docs/operate/migration/upgrade-0-113.mdx
+++ b/data/docs/operate/migration/upgrade-0-113.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-25
+date: 2026-06-11
 id: upgrade-0-113
 tags: [Self-Host]
 title: Upgrade to v0.113.0
@@ -25,7 +25,7 @@ For more details, see [SigNoz/charts#828](https://github.com/SigNoz/charts/issue
 <Tabs entityName="environment">
 <TabItem value="docker" label="Docker" default>
 
-<Tabs>
+<Tabs entityName="deployment">
 <TabItem value="docker-standalone" label="Standalone" default>
 
 <KeyPointCallout title="Using default Docker Compose files?" defaultCollapsed={false}>
@@ -282,7 +282,7 @@ The container should show status `Exited (0)`.
 </TabItem>
 <TabItem value="docker-swarm" label="Docker Swarm">
 
-<Tabs>
+<Tabs entityName="deployment">
 <TabItem value="docker-swarm-standalone" label="Standalone" default>
 
 <KeyPointCallout title="Using default Docker Compose files?" defaultCollapsed={false}>

--- a/data/docs/operate/migration/upgrade-standard.mdx
+++ b/data/docs/operate/migration/upgrade-standard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 id: upgrade-standard
 tags: [Self-Host]
 title: Standard Upgrade Guide for SigNoz
@@ -101,7 +101,7 @@ To upgrade to a specific version (e.g., v0.6.2):
 
 1. **Update image tags** in your `docker-compose.yaml` for these services:
 
-<Tabs>
+<Tabs entityName="version">
 <TabItem value="v0.113+" label="v0.113 and later" default>
 
    - `signoz`
@@ -178,7 +178,7 @@ The following commands automatically detect your system architecture:
 
 3. **Run database migrations:**
 
-<Tabs>
+<Tabs entityName="version">
 <TabItem value="v0.113+" label="v0.113 and later" default>
 
    Starting with v0.113, migrations are built into `signoz-otel-collector`. The separate `signoz-schema-migrator` binary is no longer needed. See the [v0.113 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-113/) for details.

--- a/data/docs/operate/reset-admin-password.mdx
+++ b/data/docs/operate/reset-admin-password.mdx
@@ -1,15 +1,16 @@
 ---
-date: 2024-06-06
+date: 2026-06-11
 id: reset-admin-password
 tags : [Self-Host]
 title: Reset Admin Password
+description: Reset the root admin password of your self-hosted SigNoz by removing users, organisations, and invites from the SQLite database.
 ---
 
 In case you have forgotten the root admin password, you can reset it by removing all users, organisation and invites from the SQLite database.
 
 Starting from v0.76.0, multiple services (Query Service, Frontend, and Alertmanager) have been merged into a single `signoz` binary/image. Please follow the  steps below based on your SigNoz version.
 
-<Tabs>
+<Tabs entityName="version">
 <TabItem label="Version >= 0.76.0" value=">=0.76.0" default>
 The guide mainly covers the following:
 - Exec into the `signoz` container

--- a/data/docs/pipecat-monitoring.mdx
+++ b/data/docs/pipecat-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: pipecat-monitoring-with-opentelemetry
 
 title: Pipecat Monitoring & Observability with OpenTelemetry
@@ -27,12 +27,12 @@ Instrumenting Pipecat in your AI applications with telemetry ensures full observ
 
 For detailed information on instrumenting Pipecat applications with OpenTelemetry, see the <a href="https://docs.pipecat.ai/server/utilities/opentelemetry#opentelemetry-tracing" target="_blank" rel="noopener noreferrer nofollow">Pipecat OpenTelemetry documentation</a>.
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
 Get started with a sample Pipecat starter project by following the <a href="https://docs.pipecat.ai/getting-started/quickstart" target="_blank" rel="noopener noreferrer nofollow">Pipecat quickstart docs</a>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/pydantic-ai-observability.mdx
+++ b/data/docs/pydantic-ai-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: pydantic-ai-observability-with-opentelemetry
 tags: [SigNoz Cloud]
 title: Pydantic AI Observability & Monitoring with OpenTelemetry
@@ -23,10 +23,10 @@ Instrumenting Pydantic AI in your AI applications with telemetry ensures full ob
 
 For more detailed info on instrumenting your Pydantic AI applications click [here](https://ai.pydantic.dev/logfire/#otel-without-logfire).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/qwen-observability.mdx
+++ b/data/docs/qwen-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-06-11
 id: qwen-observability-with-opentelemetry
 title: Qwen Observability & Monitoring with OpenTelemetry
 description: Setup Qwen observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Qwen LLM applications with unified dashboards.
@@ -25,7 +25,7 @@ Monitoring Qwen in your AI applications with telemetry ensures full observabilit
 
 For more information on getting started with Qwen in your Python environment, refer to the <a href="https://www.alibabacloud.com/help/en/model-studio/first-api-call-to-qwen" target="_blank" rel="noopener noreferrer nofollow">Qwen quickstart guide</a>.
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 

--- a/data/docs/semantic-kernel-observability.mdx
+++ b/data/docs/semantic-kernel-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-11
 id: semantic-kernel-observability-with-opentelemetry
 
 title: Semantic Kernel Observability - Monitor AI Orchestration
@@ -25,10 +25,10 @@ Instrumenting Semantic Kernel in your AI applications with telemetry ensures ful
 For more detailed info on tracing your Semantic Kernel applications click [here](https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-console?tabs=Bash-CreatFile%2CBash-EnvironmentVariable&pivots=programming-language-python).
 For more detailed info on Semantic Kernel telemetry data click [here](https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/?pivots=programming-language-python).
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python" default>
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="No Code" label="No Code(Recommended)" default>
 
 No-code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries.

--- a/data/docs/temporal-observability.mdx
+++ b/data/docs/temporal-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-11
 id: temporal-observability-with-opentelemetry
 tags: [SigNoz Cloud, Self-Host]
 title: Temporal Observability & Monitoring with OpenTelemetry
@@ -22,7 +22,7 @@ With full Temporal observability in SigNoz, you can correlate traces, logs, and 
 
 ## Monitor Temporal Workflows with OpenTelemetry
 
-<Tabs>
+<Tabs entityName="instrumentation">
 <TabItem value="auto-instrumentation" label="Auto-instrumentation (Recommended)" default>
 
 No code auto-instrumentation is recommended for quick setup with minimal code changes. It's ideal when you want to get observability up and running without modifying your application code and are leveraging standard instrumentor libraries. 
@@ -53,7 +53,7 @@ opentelemetry-bootstrap --action=install
 
 Create a `.env` file in your project root and add the following environment variables based on your Temporal deployment:
 
-<Tabs>
+<Tabs entityName="deployment">
 <TabItem value="self-hosted" label="Self Hosted Temporal" default>
 
 ```bash:.env
@@ -338,7 +338,7 @@ HTTPXClientInstrumentor().instrument()
 
 Create a `.env` file in your project root and add the following environment variables based on your Temporal deployment:
 
-<Tabs>
+<Tabs entityName="deployment">
 <TabItem value="self-hosted" label="Self Hosted Temporal" default>
 
 ```bash:.env

--- a/data/docs/userguide/collect_docker_logs.mdx
+++ b/data/docs/userguide/collect_docker_logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-07
+date: 2026-06-11
 title: Collecting Docker Logs
 description: Collect Docker container logs and Docker daemon logs using OpenTelemetry Collector and send them to SigNoz.
 id: collect_docker_logs
@@ -24,7 +24,7 @@ Docker writes container output to JSON log files on the host and daemon events t
 
 ## Setup
 
-<Tabs>
+<Tabs entityName="log-type">
 <TabItem value="container-logs" label="Container Logs" default>
 
 ### Step 1. Update Collector configuration
@@ -34,7 +34,7 @@ Two approaches for collecting container logs, pick one:
 - **<a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md" target="_blank" rel="noopener noreferrer nofollow">filelog</a>**: tails all container log files under a single glob. Simpler setup. Requires only read access to `/var/lib/docker/containers`.
 - **<a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md" target="_blank" rel="noopener noreferrer nofollow">receiver_creator</a> + <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/dockerobserver/README.md" target="_blank" rel="noopener noreferrer nofollow">docker_observer</a>**: spawns one receiver per container by watching the Docker socket. Sets `container.name` and `container.image.name` automatically with no regex.
 
-<Tabs>
+<Tabs entityName="receiver">
 <TabItem value="filelog" label="Using filelog receiver (recommended)" default>
 
 Get your Collector's container ID so you can exclude its own logs:
@@ -222,7 +222,7 @@ What each key part does:
 
 ### Step 2. Start the Collector
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="docker-run" label="Using docker run" default>
 
 ```bash
@@ -320,7 +320,7 @@ Apr 23 12:01:06 myhost dockerd[1234]: time="2025-04-23T12:01:06Z" level=info msg
 
 If the command returns no output or an error, your daemon uses syslog instead. Use the matching tab below.
 
-<Tabs>
+<Tabs entityName="log-source">
 <TabItem value="journald" label="journald" default>
 
 ### Step 1. Add the journald receiver

--- a/data/docs/userguide/collect_kubernetes_pod_logs.mdx
+++ b/data/docs/userguide/collect_kubernetes_pod_logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-06-11
 title: Collecting Kubernetes Pod Logs
 description: Collect Kubernetes pod logs in SigNoz and process them with OpenTelemetry Collector operators.
 id: collect_kubernetes_pod_logs
@@ -69,7 +69,7 @@ To extract specific attributes from certain types of logs, you can use the vario
 
 ### Exclude/Include/Filter Logs Collection
 
-<Tabs>
+<Tabs entityName="method">
 <TabItem value="filter-logs" label="Exclude Logs">
 
 To exclude logs based on namespaces, pods, or containers, you need to modify/create `override-values.yaml` file with the below configuration to customize and 

--- a/data/docs/userguide/drop-metrics.mdx
+++ b/data/docs/userguide/drop-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-19
+date: 2026-06-11
 id: drop-metrics
 doc_type: howto
 
@@ -136,7 +136,7 @@ This environment variable will prevent the SDK from generating any metrics, redu
 
 To disable instruments from specific packages, you can use environment variables depending on your programming language:
 
-<Tabs>
+<Tabs entityName="language">
 <TabItem value="python" label="Python">
 
 ```bash

--- a/data/docs/userguide/vercel-to-signoz.mdx
+++ b/data/docs/userguide/vercel-to-signoz.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-21
+date: 2026-06-11
 title: Stream Telemetry from Vercel to SigNoz
 description: Learn how to stream logs and distributed traces from your Vercel applications to SigNoz Cloud using Vercel Log and OpenTelemetry drains.
 id: vercel-to-signoz
@@ -28,7 +28,7 @@ Most steps are identical. To adapt this guide, update the endpoint and remove th
 
 Create a separate drain for each signal you want to export:
 
-<Tabs>
+<Tabs entityName="signal">
 <TabItem value="logs" label="Logs" default>
 
 ### Step 1: Create a New Log Drain


### PR DESCRIPTION
## Problem

Without an `entityName` prop, `<Tabs>` does not sync the selected tab to the URL query string. When someone shares a docs link (e.g. https://signoz.io/docs/ai/signoz-mcp-server/ with a specific client tab selected), the recipient always lands on the default tab instead of the one being referenced.

`contributing/docs-authoring.md` already mandates `entityName` on every `<Tabs>`, and recently updated docs follow it — but 197 `<Tabs>` instances across 107 docs pages (plus 1 blog post) predate the rule and were missing it.

## Changes

Added `entityName` to all 197 remaining `<Tabs>` instances, classified by what the tabs actually represent (verified against tab values and surrounding content, not just pattern-matched):

| entityName | Used for | Count |
|---|---|---|
| `language` | Python / Java / JavaScript / TypeScript / .NET tabs | 33 |
| `instrumentation` | No Code vs Code, automatic vs manual instrumentation | 31 |
| `method` | CLI vs console, kubectl vs UI, jar vs docker, docker-compose vs docker-run, etc. | 21 |
| `setup` | one-click vs manual (AWS integrations), LiteLLM SDK vs Proxy | 15 |
| `plans` | SigNoz Cloud vs Self-Hosted (per docs-authoring convention) | 14 |
| `environment` | VM / Kubernetes / Docker / Windows, Host vs Kubernetes | 10 |
| `signal` | traces / metrics / logs | 9 |
| `package-manager` | npm / yarn / pnpm / bun / Homebrew | 9 |
| others | `transport`, `client`, `build-tool`, `os`, `version`, `deployment`, `collector-setup`, `k8s-method`, `network-mode`, `launch-type`, `status-code`, … | 55 |

Notable per-file decisions:

- **`data/docs/ai/signoz-mcp-server.mdx`** (the reported page): `plans` for Cloud vs Self-Hosted, `client` for the AI-tool tabs, `transport` for the nested stdio/HTTP tabs, `install-method` for the binary install tabs — so `?client=cloud-cursor` style links now restore the selection.
- **`data/docs/temporal-observability.mdx`**: its `self-hosted|cloud` tabs refer to **Temporal** deployment, not SigNoz plans, so they get `deployment` (keeps URL sync) instead of `plans`.
- Converted 12 Docusaurus-era `groupId="..."` props to `entityName="..."` (groupId is ignored by our Tabs component): `framework-choice`, `launch-type`, `k8s-vendor`, `linux-method`, `windows-method`, `traces-dependencies`, `web-vitals-dependencies`.
- Replaced an unsupported `default='cloudwatch'` prop on `<Tabs>` (k8s serverless configure) with `entityName="output"` — `default` only works on `TabItem`.
- Bumped `date:` frontmatter on all 107 touched docs (required by `check:docs-metadata`) and added the missing `description` on `data/docs/operate/reset-admin-password.mdx`.

Note: `entityName="plans"` intentionally does not write to the URL (existing component behavior in `components/Tabs.tsx`); all other names sync the selected tab to a query param.

## Verification

- Re-scan of `data/docs` + `data/blog`: **0** `<Tabs>` without `entityName` remain
- `yarn check:docs-metadata` ✅, `yarn check:doc-redirects` ✅, `yarn test:doc-redirects` ✅
- `yarn test:docs-metadata` has 1 failing test ("should allow date exactly 7 days in the past") that also fails on clean `main` — pre-existing, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
