### PR TITLE
docs: recommend delta temporality by default in application metrics docs

### DIFF
--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-24
+date: 2026-06-11
 title: Understanding Metrics Billing and Reducing Costs
 id: reducing-metrics-costs
 description: Learn how metrics billing works based on cardinality and discover strategies to reduce costs effectively.
@@ -40,27 +40,47 @@ Use a templated approach:
 Histogram metrics are particularly costly because:
 
 1. **Bucket configuration** - Each bucket distribution creates a separate series. Optimize your bucket configuration based on your workload's latency patterns.
-2. **Cumulative nature** - With cumulative histogram metrics, values continue to be sent even when there's no recent activity, especially problematic when combined with high-cardinality attributes like method names containing IDs.
+2. **Cumulative nature** - With cumulative histogram metrics, values continue to be sent even when there's no recent activity, especially problematic when combined with high-cardinality attributes like method names containing IDs. Switching to delta temporality avoids this — see [Use Delta Temporality](#1-use-delta-temporality).
 
 ## Cost Reduction Strategies
 
-### 1. Remove or Template High-Cardinality Attributes
+### 1. Use Delta Temporality
+
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default: on every export interval, the SDK re-sends the running total for every active series — even when nothing has changed since the last export. With **delta** temporality, synchronous instruments (Counter, Histogram) that record no measurements during an export interval export no data points at all for that interval, so idle series don't add billable samples.
+
+We recommend setting delta temporality in your application's SDK using the standard environment variable:
+
+```bash
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
+```
+
+This environment variable is supported by the OpenTelemetry SDKs for Java, Python, Go, JavaScript/Node.js, .NET, and Ruby. Some SDKs (such as Rust) configure temporality in code instead — see the [application metrics guides](https://signoz.io/docs/metrics-management/send-metrics/#applications) for language-specific instructions.
+
+<Admonition type="info">
+The savings apply to synchronous instruments only. Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality.
+</Admonition>
+
+<Admonition type="warning">
+Deriving deltas at the OpenTelemetry Collector with the <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/cumulativetodeltaprocessor/README.md" target="_blank" rel="noopener noreferrer nofollow">cumulativetodelta processor</a> does **not** reduce costs. The SDK still exports the cumulative value on every interval even when nothing changed, and the processor converts each of those points into a zero-value delta point — which is still ingested and billed. To get the savings, set delta temporality in the SDK itself.
+</Admonition>
+
+### 2. Remove or Template High-Cardinality Attributes
 
 Replace unique IDs with templated values to reduce the number of unique time series being created.
 
-### 2. Optimize Histogram Buckets
+### 3. Optimize Histogram Buckets
 
 Reduce the number of buckets while maintaining meaningful data. See [Configure Custom Buckets](https://signoz.io/docs/metrics-management/configure-custom-buckets/) for more details.
 
-### 3. Implement Sampling
+### 4. Implement Sampling
 
 Reduce the volume of metrics sent from your application. This directly reduces the number of data points ingested.
 
-### 4. Review Attribute Necessity
+### 5. Review Attribute Necessity
 
 Ensure all identifying attributes are essential for your monitoring needs. Remove any attributes that don't provide actionable insights.
 
-### 5. Aggregate or Drop Metrics
+### 6. Aggregate or Drop Metrics
 
 Consider using the following techniques:
 

--- a/data/docs/metrics-management/send-metrics/applications/golang.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/golang.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 id: golang
 title: Send Metrics from Go application
 description: Learn how to instrument your Go application with OpenTelemetry to send metrics to SigNoz
@@ -37,6 +37,7 @@ Set the following environment variables to configure the OpenTelemetry exporter:
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://ingest.<region>.signoz.cloud:443/v1/metrics"
 export OTEL_EXPORTER_OTLP_METRICS_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 export OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
@@ -56,6 +57,8 @@ env:
   value: 'signoz-ingestion-key=<your-ingestion-key>'
 - name: OTEL_RESOURCE_ATTRIBUTES
   value: 'service.name=<service-name>'
+- name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  value: 'delta'
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
@@ -69,6 +72,7 @@ Verify these values:
 $env:OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "https://ingest.<region>.signoz.cloud:443/v1/metrics"
 $env:OTEL_EXPORTER_OTLP_METRICS_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
 $env:OTEL_RESOURCE_ATTRIBUTES = "service.name=<service-name>"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
@@ -86,6 +90,7 @@ Add environment variables to your Dockerfile:
 ENV OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://ingest.<region>.signoz.cloud:443/v1/metrics"
 ENV OTEL_EXPORTER_OTLP_METRICS_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 ENV OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>"
+ENV OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 
 CMD ["./main"]
 ```
@@ -95,6 +100,7 @@ Or pass them at runtime using `docker run`:
 docker run -e OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://ingest.<region>.signoz.cloud:443/v1/metrics" \
     -e OTEL_EXPORTER_OTLP_METRICS_HEADERS="signoz-ingestion-key=<your-ingestion-key>" \
     -e OTEL_RESOURCE_ATTRIBUTES="service.name=<service-name>" \
+    -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
     your-image:latest
 ```
 
@@ -104,6 +110,12 @@ Verify these values:
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`)
 </TabItem>
 </Tabs>
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
+</KeyPointCallout>
 
 ### Step 2. Install OpenTelemetry packages
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-aspnetcore.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-aspnetcore.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-16
+date: 2026-06-11
 id: opentelemetry-aspnetcore
 title: Send Metrics from ASP.NET Core using OpenTelemetry
 description: Instrument your ASP.NET Core application with OpenTelemetry NuGet packages and send HTTP, Kestrel, and runtime metrics to SigNoz.
@@ -79,6 +79,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ```
 
 </TabItem>
@@ -90,6 +91,7 @@ $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://ingest.<region>.signoz.cloud:443"
 $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
 $env:OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
 $env:OTEL_RESOURCE_ATTRIBUTES = "deployment.environment=production"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 ```
 
 </TabItem>
@@ -102,6 +104,7 @@ docker run \
   -e OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>" \
   -e OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf" \
   -e OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production" \
+  -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
   your-image:latest
 ```
 
@@ -120,6 +123,8 @@ env:
     value: "http/protobuf"
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "deployment.environment=production"
+  - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+    value: "delta"
 ```
 
 </TabItem>
@@ -130,6 +135,13 @@ Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
 - `<your-ingestion-key>`: Your [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
 - `OTEL_RESOURCE_ATTRIBUTES`: Sets `deployment.environment` on all telemetry — the [ASP.NET Core Metrics dashboard](https://signoz.io/docs/dashboards/dashboard-templates/aspnet-metrics/) uses this to filter by environment
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
+
+<Admonition type="info" title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
+</Admonition>
 
 ### Step 4. Validate
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-dotnet.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-dotnet.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 id: opentelemetry-dotnet
 title: Send Metrics from .NET Application using OpenTelemetry
 description: Send custom and runtime metrics from your .NET application to SigNoz using OpenTelemetry automatic instrumentation.
@@ -47,6 +47,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_METRIC_EXPORT_INTERVAL="60000"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 export OTEL_TRACES_EXPORTER="none"
 export OTEL_LOGS_EXPORTER="none"
 export OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES="MyApp.Metrics"
@@ -61,6 +62,12 @@ Verify these values:
 The automatic instrumentation generates traces for HTTP requests by default. Since traces and logs export is enabled by default, these would be sent to SigNoz even though this guide only covers metrics.
 
 Setting `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `none` disables them while keeping metrics working. If you want traces or logs later, change them to `otlp` or remove these variables.
+</KeyPointCallout>
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
 </KeyPointCallout>
 
 ### Step 3. Add custom metrics to your application
@@ -136,6 +143,8 @@ env:
   value: 'otlp'
 - name: OTEL_METRIC_EXPORT_INTERVAL
   value: '60000'
+- name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  value: 'delta'
 - name: OTEL_TRACES_EXPORTER
   value: 'none'
 - name: OTEL_LOGS_EXPORTER
@@ -172,6 +181,7 @@ $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
 $env:OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf"
 $env:OTEL_METRICS_EXPORTER = "otlp"
 $env:OTEL_METRIC_EXPORT_INTERVAL = "60000"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 $env:OTEL_TRACES_EXPORTER = "none"
 $env:OTEL_LOGS_EXPORTER = "none"
 $env:OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES = "MyApp.Metrics"
@@ -217,6 +227,7 @@ ENV OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 ENV OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 ENV OTEL_METRICS_EXPORTER="otlp"
 ENV OTEL_METRIC_EXPORT_INTERVAL="60000"
+ENV OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ENV OTEL_TRACES_EXPORTER="none"
 ENV OTEL_LOGS_EXPORTER="none"
 ENV OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES="MyApp.Metrics"
@@ -247,6 +258,7 @@ docker run -p 8080:8080 \
   -e OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf" \
   -e OTEL_METRICS_EXPORTER="otlp" \
   -e OTEL_METRIC_EXPORT_INTERVAL="60000" \
+  -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
   -e OTEL_TRACES_EXPORTER="none" \
   -e OTEL_LOGS_EXPORTER="none" \
   -e OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES="MyApp.Metrics" \

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-java.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-26
+date: 2026-06-11
 id: opentelemetry-java
 title: Send Metrics from Java Application using OpenTelemetry
 description: Send custom and JVM runtime metrics from your Java application to SigNoz using the OpenTelemetry Java agent.
@@ -50,6 +50,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 export OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_METRIC_EXPORT_INTERVAL="60000"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 export OTEL_TRACES_EXPORTER="none"
 export OTEL_LOGS_EXPORTER="none"
 ```
@@ -63,6 +64,12 @@ Replace the following:
 The Java agent auto-instruments web frameworks like Spring Boot, JAX-RS, and Servlet containers, generating traces for every HTTP request. Since traces and logs export is enabled by default, these would be sent to SigNoz even though this guide only covers metrics.
 
 For applications handling many requests, this can generate significant data volume and costs. Setting `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `none` disables them while keeping metrics working. If you want traces or logs later, change them to `otlp` or remove these variables.
+</KeyPointCallout>
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
 </KeyPointCallout>
 
 ### Step 3. Add OpenTelemetry API dependency
@@ -157,6 +164,8 @@ env:
   value: 'otlp'
 - name: OTEL_METRIC_EXPORT_INTERVAL
   value: '60000'
+- name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  value: 'delta'
 - name: OTEL_TRACES_EXPORTER
   value: 'none'
 - name: OTEL_LOGS_EXPORTER
@@ -186,6 +195,7 @@ $env:OTEL_EXPORTER_OTLP_ENDPOINT = "https://ingest.<region>.signoz.cloud:443"
 $env:OTEL_EXPORTER_OTLP_HEADERS = "signoz-ingestion-key=<your-ingestion-key>"
 $env:OTEL_METRICS_EXPORTER = "otlp"
 $env:OTEL_METRIC_EXPORT_INTERVAL = "60000"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 $env:OTEL_TRACES_EXPORTER = "none"
 $env:OTEL_LOGS_EXPORTER = "none"
 ```
@@ -220,6 +230,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443"
 ENV OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>"
 ENV OTEL_METRICS_EXPORTER="otlp"
 ENV OTEL_METRIC_EXPORT_INTERVAL="60000"
+ENV OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ENV OTEL_TRACES_EXPORTER="none"
 ENV OTEL_LOGS_EXPORTER="none"
 
@@ -248,6 +259,7 @@ docker run -p 8080:8080 \
   -e OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<key>" \
   -e OTEL_METRICS_EXPORTER="otlp" \
   -e OTEL_METRIC_EXPORT_INTERVAL="60000" \
+  -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
   -e OTEL_TRACES_EXPORTER="none" \
   -e OTEL_LOGS_EXPORTER="none" \
   my-java-app

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-11
+date: 2026-06-11
 id: opentelemetry-nodejs
 title: Send Metrics from Node.js application
 description: Learn how to send metrics from Node.js applications (Express, Fastify, Koa, NestJS, Runtime) to SigNoz using OpenTelemetry
@@ -43,6 +43,7 @@ export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="none"
 export OTEL_LOGS_EXPORTER="none"
 export OTEL_METRIC_EXPORT_INTERVAL="60000"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
 ```
 Verify these values:
@@ -50,6 +51,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `OTEL_METRIC_EXPORT_INTERVAL`: How often to export metrics in milliseconds (default: 60000 for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -74,6 +76,8 @@ env:
   value: 'none'
 - name: OTEL_METRIC_EXPORT_INTERVAL
   value: '60000'
+- name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  value: 'delta'
 - name: NODE_OPTIONS
   value: '--require @opentelemetry/auto-instrumentations-node/register'
 ```
@@ -82,6 +86,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `OTEL_METRIC_EXPORT_INTERVAL`: How often to export metrics in milliseconds (default: 60000 for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -96,6 +101,7 @@ $env:OTEL_METRICS_EXPORTER = "otlp"
 $env:OTEL_TRACES_EXPORTER = "none"
 $env:OTEL_LOGS_EXPORTER = "none"
 $env:OTEL_METRIC_EXPORT_INTERVAL = "60000"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 $env:NODE_OPTIONS = "--require @opentelemetry/auto-instrumentations-node/register"
 ```
 Verify these values:
@@ -103,6 +109,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service.
 - `OTEL_METRIC_EXPORT_INTERVAL`: How often to export metrics in milliseconds (default: 60000 for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -121,6 +128,7 @@ ENV OTEL_METRICS_EXPORTER="otlp"
 ENV OTEL_TRACES_EXPORTER="none"
 ENV OTEL_LOGS_EXPORTER="none"
 ENV OTEL_METRIC_EXPORT_INTERVAL="60000"
+ENV OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ENV NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
 
 CMD ["node", "app.js"]
@@ -136,6 +144,7 @@ docker run -e OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:
     -e OTEL_TRACES_EXPORTER="none" \
     -e OTEL_LOGS_EXPORTER="none" \
     -e OTEL_METRIC_EXPORT_INTERVAL="60000" \
+    -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
     -e NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register" \
     your-image:latest
 ```
@@ -145,6 +154,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `OTEL_METRIC_EXPORT_INTERVAL`: How often to export metrics in milliseconds (default: 60000 for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 </Tabs>
@@ -155,6 +165,12 @@ The auto-instrumentation package (`@opentelemetry/auto-instrumentations-node`) i
 Since OpenTelemetry Node.js enables traces and logs export by default, these would be sent to SigNoz even though this guide only covers metrics. For apps handling many requests, this can generate significant volume and costs.
 
 Setting `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` to `none` disables traces and logs while keeping metrics working as expected. If you want traces or logs later, you can change them to `otlp` or remove these variables altogether.
+</KeyPointCallout>
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
 </KeyPointCallout>
 
 ### Step 2. Install OpenTelemetry packages

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-python.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-08
+date: 2026-06-11
 id: opentelemetry-python
 title: Send Metrics from Python application
 description: Learn how to send metrics from Python applications (Flask, Django, FastAPI, Celery, Runtime) to SigNoz using OpenTelemetry
@@ -43,12 +43,14 @@ export OTEL_SERVICE_NAME="<service-name>"
 export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="none"
 export OTEL_METRIC_EXPORT_INTERVAL="60000"
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `<export-interval>`: How often to export metrics in milliseconds (default: `60000` for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -71,12 +73,15 @@ env:
   value: 'none'
 - name: OTEL_METRIC_EXPORT_INTERVAL
   value: '60000'
+- name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  value: 'delta'
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `<export-interval>`: How often to export metrics in milliseconds (default: `60000` for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -90,12 +95,14 @@ $env:OTEL_SERVICE_NAME = "<service-name>"
 $env:OTEL_METRICS_EXPORTER = "otlp"
 $env:OTEL_TRACES_EXPORTER = "none"
 $env:OTEL_METRIC_EXPORT_INTERVAL = "60000"
+$env:OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta"
 ```
 Verify these values:
 - `<region>`: Your [SigNoz Cloud region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint).
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service.
 - `<export-interval>`: How often to export metrics in milliseconds (default: `60000` for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 
@@ -113,6 +120,7 @@ ENV OTEL_SERVICE_NAME="<service-name>"
 ENV OTEL_METRICS_EXPORTER="otlp"
 ENV OTEL_TRACES_EXPORTER="none"
 ENV OTEL_METRIC_EXPORT_INTERVAL="60000"
+ENV OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 
 CMD ["opentelemetry-instrument", "python", "app.py"]
 ```
@@ -126,6 +134,7 @@ docker run -e OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:
     -e OTEL_METRICS_EXPORTER="otlp" \
     -e OTEL_TRACES_EXPORTER="none" \
     -e OTEL_METRIC_EXPORT_INTERVAL="60000" \
+    -e OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta" \
     your-image:latest
 ```
 
@@ -134,6 +143,7 @@ Verify these values:
 - `<your-ingestion-key>`: Your SigNoz [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 - `<service-name>`: A descriptive name for your service (e.g., `payment-service`).
 - `<export-interval>`: How often to export metrics in milliseconds (default: `60000` for 60 seconds).
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: Set to `delta` to reduce metric costs. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 </TabItem>
 </Tabs>
@@ -144,6 +154,12 @@ The bootstrap command (Step 3) installs instrumentations for all detected librar
 Since `opentelemetry-distro` enables traces by default, these traces would be sent to SigNoz even though this guide only covers metrics. For apps handling many requests, this can generate significant trace volume and costs.
 
 Setting `OTEL_TRACES_EXPORTER` to `none` disables traces while keeping metrics working as expected. If you want traces later, you can change it to `otlp` or remove this variable altogether. See the [Python traces instrumentation guide](https://signoz.io/docs/instrumentation/opentelemetry-python/) for more details.
+</KeyPointCallout>
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed="true">
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` set to `delta`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
 </KeyPointCallout>
 
 ### Step 2. Install OpenTelemetry packages

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-ruby.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-ruby.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-05
+date: 2026-06-11
 id: opentelemetry-ruby
 title: Send Metrics from Ruby Application Using OpenTelemetry
 description: Learn how to send metrics from Ruby applications (Rails, Sinatra, Sidekiq) to SigNoz using OpenTelemetry
@@ -151,6 +151,10 @@ This guide installs only metrics packages (`opentelemetry-exporter-otlp-metrics`
 `OTEL_LOGS_EXPORTER` is also set to `none` as an explicit metrics-only guard. With the current gems and SDK behavior in this setup, logs are not exported.
 
 Keeping both `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` set to `none` avoids trace exporter warnings and keeps configuration intent clear. If you add traces/logs instrumentation and exporters later, you can set them to `otlp` or remove the env variables altogether.
+</KeyPointCallout>
+
+<KeyPointCallout title="Metric temporality" defaultCollapsed={true}>
+The Ruby Metrics SDK currently exports metrics with **delta** temporality (cumulative temporality is not yet implemented), so no extra configuration is needed. Delta is also what we recommend for cost efficiency: synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
 </KeyPointCallout>
 
 ### Step 2. Install OpenTelemetry packages

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-rust.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-rust.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-23
+date: 2026-06-11
 id: opentelemetry-rust
 title: Send Metrics from Rust Application Using OpenTelemetry
 description: Learn how to instrument your Rust application with OpenTelemetry to send metrics to SigNoz
@@ -148,7 +148,7 @@ Create a helper function to configure the OpenTelemetry Meter Provider. This pro
 use opentelemetry::global;
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider, Temporality};
 use opentelemetry_sdk::Resource;
 use std::time::Duration;
 
@@ -182,12 +182,13 @@ fn init_meter_provider() -> Result<SdkMeterProvider, Box<dyn std::error::Error +
         })
         .unwrap_or_default();
 
-    // Build the OTLP HTTP exporter
+    // Build the OTLP HTTP exporter with delta temporality
     let exporter = MetricExporter::builder()
         .with_http()
         .with_endpoint(&endpoint)
         .with_headers(headers.into_iter().collect())
         .with_timeout(Duration::from_secs(10))
+        .with_temporality(Temporality::Delta)
         .build()?;
 
     // Create resource with service name
@@ -211,6 +212,12 @@ fn init_meter_provider() -> Result<SdkMeterProvider, Box<dyn std::error::Error +
     Ok(meter_provider)
 }
 ```
+
+<KeyPointCallout title="Why delta temporality?" defaultCollapsed={true}>
+OpenTelemetry SDKs export metrics with **cumulative** temporality by default, which re-sends the running total of every active series on each export interval — even when nothing has changed. With `.with_temporality(Temporality::Delta)`, synchronous instruments (like Counters and Histograms) that record nothing during an export interval send no data points for that interval, reducing the number of billable samples.
+
+The Rust SDK does not support the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable, so temporality is set on the exporter builder as shown above. Observable (asynchronous) instruments emit a data point on every collection cycle regardless of temporality. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for details.
+</KeyPointCallout>
 
 ### Step 4. Instrument your application
 

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-11
 title: Metric Types and Aggregation
 description: Learn about the different metric types (Counter, Gauge, Histogram, Exponential Histogram) supported by SigNoz and how temporal and spatial aggregation works for each type.
 id: types-and-aggregation
@@ -45,6 +45,10 @@ A table representing the different types of metrics and their temporality suppor
 | Exponential Histogram | No | Yes |
 
 The Gauge metric type does not have a temporality, as it represents a single value at a point in time.
+
+<Admonition type="tip">
+We recommend exporting metrics with **delta** temporality. It reduces ingestion costs because synchronous instruments that record nothing during an export interval send no data points for that interval (with cumulative, every active series is re-sent on each interval), and it is required for exponential histograms in SigNoz. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for how to configure it.
+</Admonition>
 
 ## Aggregation
 


### PR DESCRIPTION
## Why

From a recent customer conversation (#customer-conversations): a customer evaluating delta temporality for cost optimization asked whether zero-value delta samples are emitted (and billed) when a metric has no activity between export intervals. Key takeaways from @srikanthccv's answer:

- **SDK-level delta temporality** (`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`): synchronous instruments that record nothing in an export interval emit **no datapoint at all** — that's where the cost savings come from. (Async/observable instruments emit a point every collection cycle either way.)
- **Collector-derived deltas** (`cumulativetodelta` processor): **no savings** — the SDK keeps exporting the cumulative value every interval, and the processor converts each of those into a zero-value delta point that is still ingested and billed.

Decision: actively encourage users to send delta temporality by default across application metrics docs.

## What changed

**`metrics-management/reducing-costs.mdx`**
- Added **"Use Delta Temporality"** as cost reduction strategy #1 (existing strategies renumbered 2–6), explaining the sync-instrument savings, the async-instrument caveat, and a warning that the `cumulativetodelta` processor does not reduce costs
- Cross-linked from the cumulative-histogram cost driver bullet

**Application metrics guides** (`send-metrics/applications/*`)
- **Java, Python, Go, Node.js, .NET, ASP.NET Core**: added `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"` to every env block (bash / PowerShell / Dockerfile / `docker run` / k8s manifest), plus a collapsed **"Why delta temporality?"** callout
- **Rust**: the SDK doesn't support the env var, so the example now sets `.with_temporality(Temporality::Delta)` on the `MetricExporter` builder (verified against opentelemetry-otlp 0.31 docs), with an explanatory callout
- **Ruby**: informational callout noting the Ruby Metrics SDK already exports delta only (cumulative not yet implemented), which matches the recommendation

**`metrics-management/types-and-aggregation.mdx`**
- Added a tip recommending delta temporality in the Temporality section

## Verification of OTel claims

- Env var support per language verified against the [OTel spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) (Go, Java, JS, Python, Ruby, .NET ✓; Rust ✗)
- Go support double-checked in the [`otlpmetrichttp` package docs](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp); Rust `with_temporality` checked on docs.rs

## Checks

- ✅ `yarn check:docs-metadata` (all 10 files pass)
- ✅ `yarn check:doc-redirects` + `yarn test:doc-redirects`
- ⚠️ `yarn test:docs-metadata` has one pre-existing failure ("should allow date exactly 7 days in the past") — a timezone boundary flake in the test's own synthetic fixture (`toISOString()` is UTC), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes: [#904](https://github.com/SigNoz/growth-pod/issues/904)