### PR TITLE
bugfix: plans entityName special handling causing Tab reset

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -35,18 +35,16 @@ const Tabs = ({ children, entityName }: { children: React.ReactNode; entityName?
   const firstChild = validChildren[0]
   const defaultActiveTab = defaultChild?.props.value ?? firstChild?.props.value ?? null
 
-  const urlKey = entityName && entityName !== 'plans' ? entityName : null
+  const urlKey = entityName || null
 
   const resolveActiveTab = useCallback((): string | null => {
-    if (entityName === 'plans') return defaultActiveTab
-
     if (urlKey) {
       const urlValue = searchParams.get(urlKey)
       if (urlValue && tabValuesSet.has(urlValue)) return urlValue
     }
 
     return defaultActiveTab
-  }, [urlKey, searchParams, tabValuesSet, defaultActiveTab, entityName])
+  }, [urlKey, searchParams, tabValuesSet, defaultActiveTab])
 
   const [localActiveTab, setLocalActiveTab] = useState(resolveActiveTab)
 

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -73,7 +73,7 @@ const Tabs = ({ children, entityName }: { children: React.ReactNode; entityName?
           if (!isValidElement(child)) return null
           const { value, label } = child.props
 
-          if (hideSelfHostTab && value === 'self-host') return null
+          if (hideSelfHostTab && value.startsWith('self-host')) return null
           return (
             <button
               key={value}
@@ -92,7 +92,10 @@ const Tabs = ({ children, entityName }: { children: React.ReactNode; entityName?
       </div>
       <div className="mt-4">
         {childrenArray.map((child) => {
-          if (!isValidElement(child) || (hideSelfHostTab && child.props.value === 'self-host')) {
+          if (
+            !isValidElement(child) ||
+            (hideSelfHostTab && child.props.value.startsWith('self-host'))
+          ) {
             return null
           }
 

--- a/components/__tests__/Tabs.test.tsx
+++ b/components/__tests__/Tabs.test.tsx
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import Tabs from '../Tabs'
+
+const TabItem = ({
+  value,
+  label,
+  children,
+}: {
+  value: string
+  label: string
+  default?: boolean
+  children?: React.ReactNode
+}) => (
+  <div value={value} label={label} data-tab-value={value}>
+    {children}
+  </div>
+)
+
+const mockPathname = vi.fn(() => '/docs/install/')
+const mockReplace = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useRouter: () => ({ replace: mockReplace }),
+}))
+
+const mockSearchParams = vi.fn(() => new URLSearchParams())
+vi.mock('@/hooks/useSearchParamsState', () => ({
+  useSearchParamsState: () => mockSearchParams(),
+}))
+
+beforeEach(() => {
+  mockPathname.mockReturnValue('/docs/install/')
+  mockReplace.mockClear()
+  mockSearchParams.mockReturnValue(new URLSearchParams())
+})
+
+const getTabButtons = () => screen.queryAllByRole('button')
+const getTabButton = (name: string) => screen.queryByRole('button', { name })
+const getTabPanels = () =>
+  document.querySelectorAll<HTMLDivElement>('[data-tabs-root] > .mt-4 > [data-tab-value]')
+
+describe('Tabs basic rendering', () => {
+  it('renders all tab buttons', () => {
+    render(
+      <Tabs>
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted')).toBeTruthy()
+  })
+
+  it('shows the default tab content', () => {
+    render(
+      <Tabs>
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    const panels = getTabPanels()
+    const cloudPanel = Array.from(panels).find((p) => p.getAttribute('data-tab-value') === 'cloud')
+    const selfHostPanel = Array.from(panels).find(
+      (p) => p.getAttribute('data-tab-value') === 'self-host'
+    )
+
+    expect(cloudPanel).not.toHaveAttribute('hidden')
+    expect(selfHostPanel).toHaveAttribute('hidden')
+  })
+
+  it('switches content on tab click', () => {
+    render(
+      <Tabs>
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    fireEvent.click(getTabButton('Self-Hosted')!)
+
+    const panels = getTabPanels()
+    const cloudPanel = Array.from(panels).find((p) => p.getAttribute('data-tab-value') === 'cloud')
+    const selfHostPanel = Array.from(panels).find(
+      (p) => p.getAttribute('data-tab-value') === 'self-host'
+    )
+
+    expect(cloudPanel).toHaveAttribute('hidden')
+    expect(selfHostPanel).not.toHaveAttribute('hidden')
+  })
+})
+
+describe('onboarding hides self-host tabs when entityName="plans"', () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue('/docs-onboarding/install/')
+  })
+
+  it('hides tab with value="self-host"', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted')).toBeNull()
+    expect(screen.queryByText('Self-hosted content')).toBeNull()
+  })
+
+  it('hides tab with value="self-hosted"', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-hosted" label="SigNoz Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('SigNoz Cloud')).toBeTruthy()
+    expect(getTabButton('SigNoz Self-Hosted')).toBeNull()
+    expect(screen.queryByText('Self-hosted content')).toBeNull()
+  })
+
+  it('hides tab with value="self-host-deployment"', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host-deployment" label="Self-Hosted Deployment">
+          Deployment content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted Deployment')).toBeNull()
+    expect(screen.queryByText('Deployment content')).toBeNull()
+  })
+
+  it('hides tab with value="self-host-daemonset"', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host-daemonset" label="Self-Hosted DaemonSet">
+          Daemonset content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted DaemonSet')).toBeNull()
+    expect(screen.queryByText('Daemonset content')).toBeNull()
+  })
+
+  it('hides all self-host variants and keeps only cloud tabs', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="signoz-cloud" label="SigNoz Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Host">
+          SH content
+        </TabItem>
+        <TabItem value="self-hosted" label="Self-Hosted">
+          SH2 content
+        </TabItem>
+        <TabItem value="self-host-deployment" label="Self-Host Deploy">
+          SH3 content
+        </TabItem>
+      </Tabs>
+    )
+
+    const buttons = getTabButtons()
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toHaveTextContent('SigNoz Cloud')
+  })
+
+  it('does NOT hide self-host tabs when entityName is not "plans"', () => {
+    render(
+      <Tabs entityName="environment">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted')).toBeTruthy()
+  })
+
+  it('does NOT hide self-host tabs when entityName is undefined', () => {
+    render(
+      <Tabs>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+        <TabItem value="cloud" label="Cloud">
+          Cloud content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Self-Hosted')).toBeTruthy()
+    expect(getTabButton('Cloud')).toBeTruthy()
+  })
+})
+
+describe('non-onboarding routes show all tabs', () => {
+  it('shows self-host tabs on /docs/ routes', () => {
+    mockPathname.mockReturnValue('/docs/install/')
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    expect(getTabButton('Cloud')).toBeTruthy()
+    expect(getTabButton('Self-Hosted')).toBeTruthy()
+  })
+})
+
+describe('plans tabs sync to URL', () => {
+  it('calls router.replace with plans param on tab click', () => {
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    fireEvent.click(getTabButton('Self-Hosted')!)
+
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('plans=self-host'), {
+      scroll: false,
+    })
+  })
+
+  it('restores tab from URL search params', () => {
+    mockSearchParams.mockReturnValue(new URLSearchParams('plans=self-host'))
+
+    render(
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          Self-hosted content
+        </TabItem>
+      </Tabs>
+    )
+
+    const panels = getTabPanels()
+    const selfHostPanel = Array.from(panels).find(
+      (p) => p.getAttribute('data-tab-value') === 'self-host'
+    )
+    expect(selfHostPanel).not.toHaveAttribute('hidden')
+  })
+})

--- a/components/__tests__/Tabs.test.tsx
+++ b/components/__tests__/Tabs.test.tsx
@@ -295,3 +295,66 @@ describe('plans tabs sync to URL', () => {
     expect(selfHostPanel).not.toHaveAttribute('hidden')
   })
 })
+
+describe('nested tabs do not reset parent plans tab', () => {
+  it('parent stays on self-host after nested tab click triggers remount', () => {
+    const NestedTabs = () => (
+      <Tabs entityName="plans">
+        <TabItem value="cloud" label="Cloud" default>
+          Cloud content
+        </TabItem>
+        <TabItem value="self-host" label="Self-Hosted">
+          <Tabs entityName="client">
+            <TabItem value="npm" label="npm" default>
+              npm content
+            </TabItem>
+            <TabItem value="yarn" label="yarn">
+              yarn content
+            </TabItem>
+          </Tabs>
+        </TabItem>
+      </Tabs>
+    )
+
+    // Render with plans=self-host already in URL (user previously clicked Self-Hosted)
+    mockSearchParams.mockReturnValue(new URLSearchParams('plans=self-host'))
+    const { unmount } = render(<NestedTabs />)
+
+    // Click "yarn" in the nested tabs
+    fireEvent.click(screen.getByRole('button', { name: 'yarn' }))
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('plans=self-host'), {
+      scroll: false,
+    })
+    expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('client=yarn'), {
+      scroll: false,
+    })
+
+    // Simulate URL state after nested tab click
+    mockSearchParams.mockReturnValue(new URLSearchParams('plans=self-host&client=yarn'))
+
+    // Simulate Next.js remount triggered by router.replace
+    unmount()
+    render(<NestedTabs />)
+
+    // Verify parent is still on Self-Hosted
+    const parentRoot = document.querySelectorAll('[data-tabs-root]')[0]
+    const parentPanels = parentRoot.querySelectorAll(':scope > .mt-4 > [data-tab-value]')
+    const cloudPanel = Array.from(parentPanels).find(
+      (p) => p.getAttribute('data-tab-value') === 'cloud'
+    )
+    const selfHostPanel = Array.from(parentPanels).find(
+      (p) => p.getAttribute('data-tab-value') === 'self-host'
+    )
+
+    expect(cloudPanel).toHaveAttribute('hidden')
+    expect(selfHostPanel).not.toHaveAttribute('hidden')
+
+    // Verify nested tab also restored to yarn
+    const nestedRoot = document.querySelectorAll('[data-tabs-root]')[1]
+    const nestedPanels = nestedRoot.querySelectorAll(':scope > .mt-4 > [data-tab-value]')
+    const yarnPanel = Array.from(nestedPanels).find(
+      (p) => p.getAttribute('data-tab-value') === 'yarn'
+    )
+    expect(yarnPanel).not.toHaveAttribute('hidden')
+  })
+})

--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -152,7 +152,7 @@ When documenting OpenTelemetry Collector changes:
 - Use `Admonition` for notes, warnings, tips, and supplementary or optional material. Do not use `KeyPointCallout`.
 - Use `Tabs` and `TabItem` only when flows materially differ by platform or environment. Always provide an `entityName` prop on `<Tabs>` that matches what the tabs represent:
   - `entityName="environment"` — deployment infrastructure tabs: VM, Kubernetes, Docker, Windows. Only use this when the tabs distinguish between these deployment environments.
-  - `entityName="plans"` — SigNoz Cloud vs Self-Hosted tabs.
+  - `entityName="plans"` — SigNoz Cloud vs Self-Hosted tabs. **Self-Hosted `TabItem` values must start with `self-host`** (e.g., `self-host`, `self-hosted`, `self-host-deployment`). The onboarding iframe hides tabs whose value starts with `self-host` — any other naming (e.g., `selfhosted`, `deployment-selfhosted`) will leak through and show in the in-product onboarding view.
   - For other tab groupings, use a short descriptive name (e.g., `"language"`, `"signal"`, `"setup"`).
 - Prefer numbered steps for procedures and bullets for reference content.
 - Keep headings short and meaningful.

--- a/contributing/docs-review.md
+++ b/contributing/docs-review.md
@@ -60,8 +60,9 @@ Review each changed doc against these checks in order:
 13. Next steps help users complete the broader job.
 14. Links directly help readers complete the current step.
 15. Added or edited links resolve and use canonical production paths.
-16. Discovery surfaces are updated when the new doc should appear in an existing list or overview.
-17. Added or changed images are WebP, at least 1200 px wide, and use the `Figure` component with descriptive alt text.
+16. When `entityName="plans"` tabs are present, every Self-Hosted `TabItem` value starts with `self-host` (e.g., `self-host`, `self-hosted`, `self-host-deployment`). Values that don't match this prefix will leak through and show in the in-product onboarding iframe.
+17. Discovery surfaces are updated when the new doc should appear in an existing list or overview.
+18. Added or changed images are WebP, at least 1200 px wide, and use the `Figure` component with descriptive alt text.
 
 If a check cannot be validated from the PR context, call out the assumption and residual risk.
 

--- a/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/user-guides/k8s-infra-multi-cluster.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/user-guides/k8s-infra-multi-cluster.mdx
@@ -56,7 +56,7 @@ presets:
 </Admonition>
 
   </TabItem>
-  <TabItem value="selfhosted" label="Self-Hosted SigNoz">
+  <TabItem value="self-hosted" label="Self-Hosted SigNoz">
 
 *override-values.yaml*
 

--- a/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
@@ -399,7 +399,7 @@ spec:
 </Admonition>
 
 </TabItem>
-  <TabItem value="daemonset-selfhosted" label="Self-Hosted SigNoz">
+  <TabItem value="self-host-daemonset" label="Self-Hosted SigNoz">
 
 ```yaml
 apiVersion: opentelemetry.io/v1beta1
@@ -983,7 +983,7 @@ spec:
   Example: "staging", "production", etc.
 </Admonition>
 </TabItem>
-  <TabItem value="deployment-selfhosted" label="Self-Hosted SigNoz">
+  <TabItem value="self-host-deployment" label="Self-Hosted SigNoz">
 
 ```yaml
 apiVersion: opentelemetry.io/v1beta1


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Selecting "Self-Hosted" on any docs page with Cloud/Self-Hosted tabs, then clicking a nested tab (e.g., a client or install method), resets the parent tab back to "Cloud". The user's nested selection becomes hidden, forcing them to re-click "Self-Hosted" to see it.
>
> This PR removes the special-casing of `entityName="plans"` in the `Tabs` component so that plan tabs sync their state to the URL - just like every other `entityName` already does.

#### Screenshots / Screen Recordings (if applicable)
> Repro page: `/docs/ai/signoz-mcp-server/`
> 1. Click "Self-Hosted" tab
> 2. Click any nested tab inside the Self-Hosted content
> 3. **Before fix:** Parent resets to "Cloud", nested content disappears
> 4. **After fix:** Parent stays on "Self-Hosted", URL shows `?plans=self-hosted&...`

#### Issues closed by this PR
> N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> When the `Tabs` component was built, `entityName="plans"` was intentionally excluded from URL-based state syncing to keep the URL clean - plan tabs were expected to be top-level with no nested tabs underneath, so local React state was sufficient.
>
> Two lines enforced this:
> - **Line 38:** `const urlKey = entityName && entityName !== 'plans' ? entityName : null` - prevented `plans` from getting a URL key
> - **Line 41:** `if (entityName === 'plans') return defaultActiveTab` - forced `plans` to always resolve to the default tab ("Cloud")
>
> This special handling was added to retain legacy functionality for "plans" and this worked fine as long as plan tabs had no nested tabs. But when docs pages started nesting tabs inside the plan tab content (e.g., client tabs, install method tabs inside the "Self-Hosted" panel), the nested tab's `handleTabChange` calls `router.replace()` to update the URL. This triggers a Next.js re-render/remount of the component tree. Since `plans` tabs relied only on local React state (`localActiveTab`), that state was lost on remount, and `resolveActiveTab()` always returned the default ("Cloud") — resetting the parent.
>
> All other `entityName` values survived this correctly because they synced to URL params and could restore their state after remount.

#### Fix Strategy
> Removed the two lines that special-cased `plans`, so it now syncs to URL params like every other `entityName`:
>
> 1. Changed `const urlKey = entityName && entityName !== 'plans' ? entityName : null` → `const urlKey = entityName || null`
> 2. Removed `if (entityName === 'plans') return defaultActiveTab`
>
> Now `plans` tabs write `?plans=cloud` or `?plans=self-hosted` to the URL on click, read their state back from the URL on remount, and survive nested tab interactions. Pages without `?plans=...` in the URL still default to "Cloud" (same behavior as before).

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (UI interaction behavior)
- Manual verification:
  - `/docs/ai/signoz-mcp-server/` — click Self-Hosted → click nested tab → parent stays on Self-Hosted
  - Checked on staging instance to validate docs onboarding behaviour - hides Self host tab
- Edge cases covered:
  - Pages visited without `?plans=` param default to Cloud (same as before)
  - Onboarding pages still hide the Self-Hosted tab as expected (`hideSelfHostTab` logic unchanged)
  - `yarn build` passes - no build errors across all 70+ pages using `entityName="plans"`

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: All ~70 docs pages that use `entityName="plans"` tabs. The only behavioral change is that `?plans=cloud` or `?plans=self-hosted` now appears in the URL - tab selection and defaults are unchanged.
- Potential regressions: URLs now contain the `plans` query param where they previously didn't. This is purely additive - existing bookmarks/links without the param still work and default to Cloud.
- Rollback plan: Revert the PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The fix is two lines in `components/Tabs.tsx`. The `plans` exclusion was originally an intentional simplification (keep URLs clean when plan tabs had no children), but it became a bug once docs started nesting tabs inside plan content. The fix simply removes the special case so `plans` behave identically to every other `entityName`.
