### PR TITLE
docs: update Kubernetes Volumes table documentation

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-12
 id: overview
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
@@ -277,6 +277,25 @@ The **Logs** tab provides real-time logs from selected Kubernetes pods, helping 
 - Seamless integration with the Logs Explorer feature.
 - The "Explore in Logs Explorer" button opens the full logs interface, keeping time ranges and filters.
 - Highlighted warning and error messages.
+
+### Volumes View: Monitoring Persistent Volume Claims
+
+The **Volumes View** lists the Persistent Volume Claims (PVCs) in your cluster so you can track storage capacity and inode usage for each volume.
+
+#### Table Columns
+
+- **PVC Name**: Name of the Persistent Volume Claim.
+- **Namespace Name**: The namespace where the PVC is used.
+- **Capacity**: Total storage capacity of the volume.
+- **Used**: Amount of storage currently used on the volume.
+- **Available**: Amount of storage available on the volume.
+- **Inodes**: Total number of inodes on the volume.
+- **Inodes Used**: Number of inodes in use on the volume.
+- **Inodes Free**: Number of free inodes on the volume.
+
+<Admonition type="info">
+Inode columns help you catch inode exhaustion, where a volume runs out of inodes and cannot create new files even though free disk space remains. Volume metrics are collected by the `kubeletstats` receiver — see [Kubernetes Metrics](https://signoz.io/docs/infrastructure-monitoring/k8s-metrics/) to make sure the `volume` metric group is enabled.
+</Admonition>
 
 ### Consistent Monitoring Across Views
 


### PR DESCRIPTION
## Summary
- Added a **Volumes View** section to the Infrastructure Monitoring overview (`data/docs/infrastructure-monitoring/overview.mdx`) with a column-by-column reference for the Kubernetes Volumes table: PVC Name, Namespace Name, Capacity, Used, Available, and the three new Inodes, Inodes Used, and Inodes Free columns
- Documented the renamed column labels (Volume Capacity → Capacity, Volume Utilization → Used, Volume Available → Available); no existing docs referenced the old labels for this table, so no other pages needed changes
- Added an admonition explaining inode exhaustion and linking to the Kubernetes Metrics setup doc for enabling the `volume` metric group in the kubeletstats receiver
- Updated frontmatter dates on all edited files

## Notes
- No screenshot was added: the demo environment (demo.in.signoz.cloud) has no PVC volume data even over a 1-week window, so the Volumes table renders an empty state. Existing docs contained no Volumes table screenshots to replace. A screenshot can be added once an environment with PVC data is available.
- Column names were verified against the frontend source of the source PR (`frontend/src/container/InfraMonitoringK8s/Volumes/table.config.tsx`).

Source PRs: SigNoz/signoz#11683

Auto-generated by docs-sync pipeline