### PR TITLE
feat: migrate docs listicles to CMS

### DIFF
--- a/.github/workflows/sync-content-cms.yml
+++ b/.github/workflows/sync-content-cms.yml
@@ -71,6 +71,7 @@ jobs:
           files: |
             data/**/*.mdx
             data/**/*.md
+            constants/listicles/*.json
           json: true
           escape_json: false
           write_output_files: true

--- a/.github/workflows/sync-content-cms.yml
+++ b/.github/workflows/sync-content-cms.yml
@@ -12,6 +12,7 @@ on:
       - 'data/**/*.mdx'
       - 'data/**/*.md'
       - 'data-assets/**'
+      - 'constants/listicles/*.json'
   push:
     branches:
       - main  # Configurable: Change to your production branch
@@ -20,6 +21,7 @@ on:
       - 'data/**/*.mdx'
       - 'data/**/*.md'
       - 'data-assets/**'
+      - 'constants/listicles/*.json'
 
 env:
   # Configurable: Array of folders to sync to CMS

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -33,8 +33,8 @@ else
   echo 'husky (pre-commit): skipping stale URL check (no relevant changes staged)'
 fi
 
-# Check CMS-synced content assets
-if printf '%s\n' "$STAGED_FILES" | grep -E '^data/(faqs|case-study|opentelemetry|comparisons|guides|blog)/.*\.mdx?$' >/dev/null; then
+# Check CMS-synced content assets (MDX content and listicle JSON configs)
+if printf '%s\n' "$STAGED_FILES" | grep -E '^(data/(faqs|case-study|opentelemetry|comparisons|guides|blog)/.*\.mdx?|constants/listicles/.*\.json)$' >/dev/null; then
   echo 'husky (pre-commit): checking CMS content assets'
   node scripts/check-cms-assets.js
 else

--- a/app/(site)/api/revalidate/route.ts
+++ b/app/(site)/api/revalidate/route.ts
@@ -80,6 +80,7 @@ export async function POST(request: NextRequest) {
       revalidateTag('comparisons-list')
       revalidateTag('guides-list')
       revalidateTag('blogs-list')
+      revalidateTag('listicles-list')
 
       results.push({
         path: '/',
@@ -172,6 +173,7 @@ export async function GET(request: NextRequest) {
       revalidateTag('comparisons-list')
       revalidateTag('guides-list')
       revalidateTag('blogs-list')
+      revalidateTag('listicles-list')
 
       results.push({
         path: '/',

--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -11,7 +11,7 @@ import Chatbase from '@/components/Chatbase'
 import JsonLdScript from '@/components/JsonLdScript'
 import { buildBreadcrumbSchema, getDocsBreadcrumbs } from '@/utils/breadcrumbSchema'
 
-export const dynamicParams = false
+export const dynamicParams = true
 export const revalidate = 86400 // 1 day - see CMS_REVALIDATE_INTERVAL
 
 export async function generateMetadata(props: {

--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -12,6 +12,7 @@ import JsonLdScript from '@/components/JsonLdScript'
 import { buildBreadcrumbSchema, getDocsBreadcrumbs } from '@/utils/breadcrumbSchema'
 
 export const dynamicParams = false
+export const revalidate = 86400 // 1 day - see CMS_REVALIDATE_INTERVAL
 
 export async function generateMetadata(props: {
   params: Promise<{ slug: string[] }>

--- a/components/Listicle/Listicle.tsx
+++ b/components/Listicle/Listicle.tsx
@@ -1,8 +1,5 @@
-import {
-  getListicleConfig,
-  getListicleItems,
-  getListicleSectionItems,
-} from '@/constants/listicles/utils'
+import { getListicleItems, getListicleSectionItems } from '@/constants/listicles/utils'
+import { getRuntimeListicleConfig } from '@/utils/listicleRepository'
 import type { ListicleConfig } from './types'
 import ListicleCardGrid from './ListicleCardGrid'
 import SearchableListicleClient from './SearchableListicleClient'
@@ -88,8 +85,8 @@ function SectionedPattern({
   )
 }
 
-export default function Listicle({ name, defaultSection }: ListicleProps) {
-  const config = getListicleConfig(name)
+export default async function Listicle({ name, defaultSection }: ListicleProps) {
+  const config = await getRuntimeListicleConfig(name)
   if (!config) {
     return <div className="py-4 text-red-500">Unknown listicle: &ldquo;{name}&rdquo;</div>
   }

--- a/components/Listicle/types.ts
+++ b/components/Listicle/types.ts
@@ -4,7 +4,7 @@ export interface ListicleItem {
   name: string
   href: string
   clickName?: string
-  icon?: IconSpec
+  icon: IconSpec
 }
 
 export interface SubsectionConfig {

--- a/contributing/site-code.md
+++ b/contributing/site-code.md
@@ -43,7 +43,7 @@ Each listicle is fully self-contained in a single JSON file — items, icons, ma
 | Registry     | `constants/listicles/registry.ts`  | Maps `name` string to config; `index.ts` re-exports                             |
 | Utilities    | `constants/listicles/utils.ts`     | Shared traversal for rendered UI and agent markdown                             |
 | Component    | `components/Listicle/Listicle.tsx` | Generic renderer for flat, sectioned, and searchable patterns                   |
-| Icons        | `public/img/icons/listicle/*.svg`  | Generated SVGs (brand icons); existing assets elsewhere are referenced directly |
+| Icons        | `data-assets/img/icons/listicle/*.svg` | Generated SVGs (brand icons); existing assets elsewhere are referenced directly |
 | MDX usage    | `data/docs/**/*.mdx`               | `<Listicle name="..." />` with optional `defaultSection`                        |
 | Agent stubs  | `utils/docs/agentMarkdownStubs.ts` | Markdown fallback — auto-extracts items from JSON configs                       |
 

--- a/scripts/check-cms-assets.js
+++ b/scripts/check-cms-assets.js
@@ -83,20 +83,13 @@ function extractAssetPaths(content, frontmatter) {
   return Array.from(paths)
 }
 
-function getStagedMigratedFiles() {
+function getStagedFiles() {
   const output = execSync('git diff --cached --name-only --diff-filter=ACM', { encoding: 'utf8' })
-  return output
-    .trim()
-    .split('\n')
-    .filter((f) => f && MIGRATED_PATTERN.test(f))
-}
-
-function getStagedListicleFiles() {
-  const output = execSync('git diff --cached --name-only --diff-filter=ACM', { encoding: 'utf8' })
-  return output
-    .trim()
-    .split('\n')
-    .filter((f) => f && LISTICLE_PATTERN.test(f))
+  const files = output.trim().split('\n').filter(Boolean)
+  return {
+    migrated: files.filter((f) => MIGRATED_PATTERN.test(f)),
+    listicles: files.filter((f) => LISTICLE_PATTERN.test(f)),
+  }
 }
 
 function collectListicleIconPaths(config) {
@@ -138,8 +131,7 @@ function isUsedOutsideMigratedContent(assetPath) {
 }
 
 function main() {
-  const stagedFiles = getStagedMigratedFiles()
-  const stagedListicles = getStagedListicleFiles()
+  const { migrated: stagedFiles, listicles: stagedListicles } = getStagedFiles()
   if (stagedFiles.length === 0 && stagedListicles.length === 0) return
 
   const totalCount = stagedFiles.length + stagedListicles.length

--- a/scripts/check-cms-assets.js
+++ b/scripts/check-cms-assets.js
@@ -15,6 +15,7 @@ const matter = require('gray-matter')
 const SYNC_FOLDERS = ['faqs', 'case-study', 'opentelemetry', 'comparisons', 'guides', 'blog']
 
 const MIGRATED_PATTERN = new RegExp(`^data/(${SYNC_FOLDERS.join('|')})/.*\\.mdx?$`)
+const LISTICLE_PATTERN = /^constants\/listicles\/.*\.json$/
 
 function stripFencedCodeBlocks(content) {
   let out = content.replace(/^[ \t]*```[^\n]*\n[\s\S]*?^[ \t]*```/gm, '\n')
@@ -90,6 +91,32 @@ function getStagedMigratedFiles() {
     .filter((f) => f && MIGRATED_PATTERN.test(f))
 }
 
+function getStagedListicleFiles() {
+  const output = execSync('git diff --cached --name-only --diff-filter=ACM', { encoding: 'utf8' })
+  return output
+    .trim()
+    .split('\n')
+    .filter((f) => f && LISTICLE_PATTERN.test(f))
+}
+
+function collectListicleIconPaths(config) {
+  const paths = new Set()
+  function collect(items) {
+    ;(items || []).forEach((item) => {
+      if (typeof item.icon === 'string' && !item.icon.startsWith('http')) {
+        paths.add(item.icon)
+      }
+    })
+  }
+  collect(config.items)
+  ;(config.staticSections || []).forEach((s) => collect(s.items))
+  ;(config.sections || []).forEach((s) => {
+    collect(s.items)
+    ;(s.subsections || []).forEach((ss) => collect(ss.items))
+  })
+  return Array.from(paths)
+}
+
 function readStagedFile(filePath) {
   return execSync(`git show ":${filePath}"`, { encoding: 'utf8' })
 }
@@ -104,7 +131,7 @@ function isUsedOutsideMigratedContent(assetPath) {
     ).trim()
 
     const files = result.split('\n').filter(Boolean)
-    return files.some((f) => !MIGRATED_PATTERN.test(f))
+    return files.some((f) => !MIGRATED_PATTERN.test(f) && !LISTICLE_PATTERN.test(f))
   } catch {
     return false
   }
@@ -112,9 +139,11 @@ function isUsedOutsideMigratedContent(assetPath) {
 
 function main() {
   const stagedFiles = getStagedMigratedFiles()
-  if (stagedFiles.length === 0) return
+  const stagedListicles = getStagedListicleFiles()
+  if (stagedFiles.length === 0 && stagedListicles.length === 0) return
 
-  console.log(`\nChecking assets for ${stagedFiles.length} CMS-synced file(s)...\n`)
+  const totalCount = stagedFiles.length + stagedListicles.length
+  console.log(`\nChecking assets for ${totalCount} CMS-synced file(s)...\n`)
 
   const allAssets = new Map()
 
@@ -123,6 +152,21 @@ function main() {
       const raw = readStagedFile(file)
       const { data: frontmatter, content: body } = matter(raw)
       const assets = extractAssetPaths(body, frontmatter)
+
+      for (const asset of assets) {
+        if (!allAssets.has(asset)) allAssets.set(asset, new Set())
+        allAssets.get(asset).add(file)
+      }
+    } catch (err) {
+      console.warn(`  Warning: could not parse ${file}: ${err.message}`)
+    }
+  }
+
+  for (const file of stagedListicles) {
+    try {
+      const raw = readStagedFile(file)
+      const config = JSON.parse(raw)
+      const assets = collectListicleIconPaths(config)
 
       for (const asset of assets) {
         if (!allAssets.has(asset)) allAssets.set(asset, new Set())

--- a/scripts/revalidate-after-cms-sync.js
+++ b/scripts/revalidate-after-cms-sync.js
@@ -142,6 +142,63 @@ function findListiclesForAssets(assetPaths) {
   return keys
 }
 
+const DOCS_DIR = 'data/docs'
+
+/**
+ * Converts a docs MDX file path to its URL route.
+ * e.g. data/docs/instrumentation.mdx -> /docs/instrumentation/
+ *      data/docs/cloud.mdx -> /docs/cloud/
+ *      data/docs/install/kubernetes.mdx -> /docs/install/kubernetes/
+ */
+function docsFileToRoute(filePath) {
+  const rel = filePath.replace(/^data\/docs\//, '').replace(/\.(mdx?|md)$/, '')
+  return `/docs/${rel}/`
+}
+
+/**
+ * Scans data/docs/ MDX files for <Listicle name="KEY" /> usage and builds
+ * a map of listicle key -> doc routes that embed it.
+ */
+function buildListicleKeyToDocPaths(keys) {
+  const keySet = new Set(keys)
+  if (keySet.size === 0) return new Map()
+
+  const pattern = /<Listicle\s+name=["']([^"']+)["']/g
+  const map = new Map()
+
+  function scanDir(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        scanDir(full)
+      } else if (/\.mdx?$/.test(entry.name)) {
+        const content = fs.readFileSync(full, 'utf8')
+        let match
+        while ((match = pattern.exec(content)) !== null) {
+          const key = match[1]
+          if (keySet.has(key)) {
+            if (!map.has(key)) map.set(key, [])
+            map.get(key).push(docsFileToRoute(full))
+          }
+        }
+        pattern.lastIndex = 0
+      }
+    }
+  }
+
+  if (fs.existsSync(DOCS_DIR)) scanDir(DOCS_DIR)
+  return map
+}
+
+function getDocPathsForListicleKeys(keys) {
+  const map = buildListicleKeyToDocPaths(keys)
+  const paths = []
+  for (const docPaths of map.values()) {
+    paths.push(...docPaths)
+  }
+  return uniqueStrings(paths)
+}
+
 function uniqueStrings(arr) {
   return [...new Set(arr.filter(Boolean))]
 }
@@ -192,9 +249,14 @@ function buildPayload() {
     affectedListicleKeys.forEach((key) => extraTags.push(`listicle-${key}`))
   }
 
+  const listicleDocPaths = hasListicleChanges
+    ? getDocPathsForListicleKeys(affectedListicleKeys)
+    : []
+  const allPaths = uniqueStrings([...cmsUrls, ...listicleDocPaths])
+
   return {
     mode: 'selective',
-    paths: cmsUrls,
+    paths: allPaths,
     tags: uniqueStrings(extraTags),
   }
 }

--- a/scripts/revalidate-after-cms-sync.js
+++ b/scripts/revalidate-after-cms-sync.js
@@ -45,6 +45,8 @@ const FOLDER_TO_URL_PREFIX = {
   blog: 'blog',
 }
 
+const LISTICLE_CONFIG_DIR = 'constants/listicles'
+
 function getFolderName(filePath) {
   const parts = filePath.split('/')
   if (parts[0] === 'data' && parts.length > 1) {
@@ -77,6 +79,69 @@ function filePathToCmsUrl(filePath) {
   return `/${prefix}${pathField}`
 }
 
+function filePathToListicleKey(filePath) {
+  const match = filePath.match(/^constants\/listicles\/([^/]+)\.json$/)
+  return match ? match[1] : null
+}
+
+function changedAssetFileToListicleAssetPath(filePath) {
+  if (filePath.startsWith('data-assets/')) {
+    return `/${filePath.replace(/^data-assets\//, '')}`
+  }
+
+  return null
+}
+
+function collectListicleItems(config) {
+  const items = []
+
+  if (config.items) items.push(...config.items)
+  if (config.staticSections) {
+    config.staticSections.forEach((section) => items.push(...(section.items || [])))
+  }
+  if (config.sections) {
+    config.sections.forEach((section) => {
+      if (section.items) items.push(...section.items)
+      if (section.subsections) {
+        section.subsections.forEach((subsection) => items.push(...(subsection.items || [])))
+      }
+    })
+  }
+
+  return items
+}
+
+function listicleReferencesAsset(config, assetPath) {
+  return collectListicleItems(config).some((item) => item.icon === assetPath)
+}
+
+function findListiclesForAssets(assetPaths) {
+  if (!fs.existsSync(LISTICLE_CONFIG_DIR) || assetPaths.length === 0) {
+    return []
+  }
+
+  const assetSet = new Set(assetPaths)
+  const keys = []
+
+  for (const file of fs
+    .readdirSync(LISTICLE_CONFIG_DIR)
+    .filter((entry) => entry.endsWith('.json'))) {
+    const filePath = `${LISTICLE_CONFIG_DIR}/${file}`
+    try {
+      const config = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      if ([...assetSet].some((assetPath) => listicleReferencesAsset(config, assetPath))) {
+        keys.push(file.replace(/\.json$/, ''))
+      }
+    } catch (error) {
+      console.warn(
+        `⚠️ Could not inspect ${filePath} for listicle asset revalidation: ${error.message}`
+      )
+    }
+  }
+
+  return keys
+}
+
 function uniqueStrings(arr) {
   return [...new Set(arr.filter(Boolean))]
 }
@@ -84,9 +149,16 @@ function uniqueStrings(arr) {
 function buildPayload() {
   const allContentFiles = [...CHANGED_FILES, ...DELETED_FILES]
   const cmsUrls = uniqueStrings(allContentFiles.map(filePathToCmsUrl))
+  const listicleKeys = uniqueStrings(allContentFiles.map(filePathToListicleKey))
+  const changedListicleAssetPaths = uniqueStrings(
+    CHANGED_ASSETS.map(changedAssetFileToListicleAssetPath)
+  )
+  const listicleAssetKeys = findListiclesForAssets(changedListicleAssetPaths)
+  const affectedListicleKeys = uniqueStrings([...listicleKeys, ...listicleAssetKeys])
 
   const hasAssetChanges = CHANGED_ASSETS.length > 0
   const hasCmsPaths = cmsUrls.length > 0
+  const hasListicleChanges = affectedListicleKeys.length > 0
 
   if (cmsUrls.length > BULK_THRESHOLD) {
     console.log(
@@ -95,12 +167,12 @@ function buildPayload() {
     return { mode: 'all', reason: 'bulk' }
   }
 
-  if (!hasCmsPaths && hasAssetChanges) {
+  if (!hasCmsPaths && !hasListicleChanges && hasAssetChanges) {
     console.log('📣 Asset-only change: using full revalidation (cannot map to page paths).')
     return { mode: 'all', reason: 'assets-only' }
   }
 
-  if (!hasCmsPaths) {
+  if (!hasCmsPaths && !hasListicleChanges) {
     console.log('⏭️ No CMS-backed content paths in this sync; skipping revalidation.')
     return { mode: 'skip', reason: 'no-cms-paths' }
   }
@@ -114,6 +186,10 @@ function buildPayload() {
   }
   if (cmsUrls.some((u) => u.startsWith('/blog/'))) {
     extraTags.push('blogs-list')
+  }
+  if (hasListicleChanges) {
+    extraTags.push('listicles-list')
+    affectedListicleKeys.forEach((key) => extraTags.push(`listicle-${key}`))
   }
 
   return {

--- a/scripts/sync-content-to-strapi.js
+++ b/scripts/sync-content-to-strapi.js
@@ -39,7 +39,6 @@ const S3_REGION = process.env.S3_REGION
 const CDN_URL = process.env.CDN_URL
 const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID
 const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY
-
 const s3Client = new S3Client({
   region: S3_REGION,
   credentials: {
@@ -47,6 +46,9 @@ const s3Client = new S3Client({
     secretAccessKey: AWS_SECRET_ACCESS_KEY,
   },
 })
+
+const LISTICLE_CONFIG_DIR = 'constants/listicles'
+const LISTICLE_ENDPOINT = 'listicles'
 
 // URL prefix to Strapi endpoint/content_type mapping for related_articles component
 const RELATED_ARTICLE_TYPE_MAP = {
@@ -287,6 +289,14 @@ function getFolderName(filePath) {
   return null
 }
 
+function isListicleConfigFile(filePath) {
+  return new RegExp(`^${LISTICLE_CONFIG_DIR}/[^/]+\\.json$`).test(filePath)
+}
+
+function getListicleKeyFromPath(filePath) {
+  return path.basename(filePath, '.json')
+}
+
 // Helper: Generate path field from file path
 function generatePathField(filePath, folderName) {
   const parts = filePath.split('/')
@@ -310,6 +320,135 @@ function parseMDXFile(filePath) {
   } catch (error) {
     throw new Error(`Failed to parse file ${filePath}: ${error.message}`)
   }
+}
+
+function parseListicleConfig(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    throw new Error(`Failed to parse listicle config ${filePath}: ${error.message}`)
+  }
+}
+
+function assertNonEmptyString(value, fieldName) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${fieldName} should be a non-empty string`)
+  }
+}
+
+function assertValidHref(href, fieldName) {
+  assertNonEmptyString(href, fieldName)
+  if (!href.startsWith('/') && !href.startsWith('https://')) {
+    throw new Error(`${fieldName} should start with / or https://`)
+  }
+}
+
+function assertValidIcon(icon, fieldName) {
+  if (typeof icon === 'string') {
+    assertNonEmptyString(icon, fieldName)
+    return
+  }
+
+  if (!icon || typeof icon !== 'object') {
+    throw new Error(`${fieldName} should be a string path or badge object`)
+  }
+
+  assertNonEmptyString(icon.badge, `${fieldName}.badge`)
+  assertNonEmptyString(icon.color, `${fieldName}.color`)
+}
+
+function assertValidListicleItems(items, fieldName) {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error(`${fieldName} should be a non-empty array`)
+  }
+
+  items.forEach((item, index) => {
+    assertNonEmptyString(item.name, `${fieldName}[${index}].name`)
+    assertValidHref(item.href, `${fieldName}[${index}].href`)
+    assertValidIcon(item.icon, `${fieldName}[${index}].icon`)
+    if (item.clickName !== undefined) {
+      assertNonEmptyString(item.clickName, `${fieldName}[${index}].clickName`)
+    }
+  })
+}
+
+function validateListicleConfig(config, key) {
+  if (!config || typeof config !== 'object') {
+    throw new Error(`${key}.json should contain an object`)
+  }
+
+  if (config.id !== key) {
+    throw new Error(`${key}.json id should match filename`)
+  }
+
+  if (!['flat', 'sectioned', 'searchable'].includes(config.pattern)) {
+    throw new Error(`${key}.pattern should be flat, sectioned, or searchable`)
+  }
+
+  assertNonEmptyString(config.markdownTitle, `${key}.markdownTitle`)
+  assertNonEmptyString(config.sectionName, `${key}.sectionName`)
+
+  if (config.pattern === 'sectioned') {
+    if (!Array.isArray(config.sections) || config.sections.length === 0) {
+      throw new Error(`${key}.sections should be a non-empty array`)
+    }
+
+    config.sections.forEach((section, index) => {
+      assertNonEmptyString(section.id, `${key}.sections[${index}].id`)
+      assertNonEmptyString(section.label, `${key}.sections[${index}].label`)
+      assertNonEmptyString(section.title, `${key}.sections[${index}].title`)
+      assertNonEmptyString(section.sectionName, `${key}.sections[${index}].sectionName`)
+
+      if (section.items) {
+        assertValidListicleItems(section.items, `${key}.sections[${index}].items`)
+      }
+
+      if (section.subsections) {
+        if (!Array.isArray(section.subsections) || section.subsections.length === 0) {
+          throw new Error(`${key}.sections[${index}].subsections should be a non-empty array`)
+        }
+
+        section.subsections.forEach((subsection, subsectionIndex) => {
+          assertNonEmptyString(
+            subsection.id,
+            `${key}.sections[${index}].subsections[${subsectionIndex}].id`
+          )
+          assertNonEmptyString(
+            subsection.title,
+            `${key}.sections[${index}].subsections[${subsectionIndex}].title`
+          )
+          assertNonEmptyString(
+            subsection.sectionName,
+            `${key}.sections[${index}].subsections[${subsectionIndex}].sectionName`
+          )
+          assertValidListicleItems(
+            subsection.items,
+            `${key}.sections[${index}].subsections[${subsectionIndex}].items`
+          )
+        })
+      }
+
+      if (!section.items && !section.subsections) {
+        throw new Error(`${key}.sections[${index}] should have items or subsections`)
+      }
+    })
+    return
+  }
+
+  if (config.staticSections) {
+    if (config.pattern !== 'flat') {
+      throw new Error(`${key}.staticSections should only be used with flat listicles`)
+    }
+
+    config.staticSections.forEach((section, index) => {
+      assertNonEmptyString(section.title, `${key}.staticSections[${index}].title`)
+      assertNonEmptyString(section.sectionName, `${key}.staticSections[${index}].sectionName`)
+      assertValidListicleItems(section.items, `${key}.staticSections[${index}].items`)
+    })
+    return
+  }
+
+  assertValidListicleItems(config.items, `${key}.items`)
 }
 
 /**
@@ -480,6 +619,204 @@ function replaceAssetPaths(content, frontmatter, assets) {
   })
 
   return { content: newContent, frontmatter: newFrontmatter }
+}
+
+function isRemoteUrl(value) {
+  return typeof value === 'string' && /^https?:\/\//.test(value)
+}
+
+function toCdnAssetUrl(assetPath, cdnUrl = CDN_URL) {
+  if (isRemoteUrl(assetPath)) return assetPath
+  const cleanPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath
+  return `${cdnUrl}/${cleanPath}`
+}
+
+function collectListicleItems(config) {
+  const items = []
+
+  if (config.items) items.push(...config.items)
+  if (config.staticSections) {
+    config.staticSections.forEach((section) => items.push(...(section.items || [])))
+  }
+  if (config.sections) {
+    config.sections.forEach((section) => {
+      if (section.items) items.push(...section.items)
+      if (section.subsections) {
+        section.subsections.forEach((subsection) => items.push(...(subsection.items || [])))
+      }
+    })
+  }
+
+  return items
+}
+
+function extractListicleAssetPaths(config) {
+  const paths = new Set()
+
+  collectListicleItems(config).forEach((item) => {
+    if (typeof item.icon === 'string' && !isRemoteUrl(item.icon)) {
+      paths.add(item.icon)
+    }
+  })
+
+  return Array.from(paths)
+}
+
+function resolveListicleAssetLocalPath(assetPath) {
+  const cleanPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath
+  const localPath = path.join('data-assets', cleanPath)
+  return fs.existsSync(localPath) ? localPath : null
+}
+
+async function checkListicleCDN(assetPath) {
+  const url = toCdnAssetUrl(assetPath)
+  try {
+    await axios.head(url)
+    return true
+  } catch (error) {
+    if (error.response && error.response.status === 404) {
+      return false
+    }
+
+    console.warn(`    ⚠️ Error checking listicle CDN for ${url}: ${error.message}`)
+    return false
+  }
+}
+
+async function uploadListicleAsset(assetPath, force = false) {
+  const cleanPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath
+  const localPath = resolveListicleAssetLocalPath(assetPath)
+  const s3Key = `web/${cleanPath}`
+  const onCDN = await checkListicleCDN(assetPath)
+
+  if (!localPath && !onCDN) {
+    throw new Error(
+      `❌ Listicle asset sync failed: "${assetPath}" does not exist in 'data-assets' and was not found on the CDN.`
+    )
+  }
+
+  if (!localPath || (onCDN && !force)) {
+    return
+  }
+
+  try {
+    const fileContent = fs.readFileSync(localPath)
+    const contentType = mime.lookup(localPath) || 'application/octet-stream'
+
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: S3_BUCKET_NAME,
+        Key: s3Key,
+        Body: fileContent,
+        ContentType: contentType,
+      })
+    )
+  } catch (error) {
+    throw new Error(`Failed to upload listicle asset ${s3Key} to S3: ${error.message}`)
+  }
+}
+
+function mapListicleItemToStrapi(item) {
+  const data = {
+    name: item.name,
+    href: item.href,
+  }
+
+  if (item.clickName) {
+    data.click_name = item.clickName
+  }
+
+  if (typeof item.icon === 'string') {
+    data.icon_path = toCdnAssetUrl(item.icon)
+  } else if (item.icon) {
+    data.icon_badge = item.icon.badge
+    data.icon_color = item.icon.color
+  }
+
+  return data
+}
+
+function mapListicleSubsectionToStrapi(subsection) {
+  return {
+    section_id: subsection.id,
+    title: subsection.title,
+    section_name: subsection.sectionName,
+    grid_cols: subsection.gridCols,
+    items: (subsection.items || []).map(mapListicleItemToStrapi),
+  }
+}
+
+function mapListicleSectionToStrapi(section) {
+  return {
+    section_id: section.id,
+    label: section.label,
+    title: section.title,
+    section_name: section.sectionName,
+    grid_cols: section.gridCols,
+    items: (section.items || []).map(mapListicleItemToStrapi),
+    subsections: (section.subsections || []).map(mapListicleSubsectionToStrapi),
+  }
+}
+
+function mapListicleStaticSectionToStrapi(section) {
+  return {
+    title: section.title,
+    section_name: section.sectionName,
+    grid_cols: section.gridCols,
+    items: (section.items || []).map(mapListicleItemToStrapi),
+  }
+}
+
+function mapListicleConfigToStrapi(config) {
+  return {
+    key: config.id,
+    pattern: config.pattern,
+    markdown_title: config.markdownTitle,
+    section_name: config.sectionName,
+    title: config.title,
+    description: config.description,
+    grid_cols: config.gridCols,
+    view_all_href: config.viewAllHref,
+    view_all_text: config.viewAllText,
+    search_placeholder: config.searchPlaceholder,
+    wrapper_title: config.wrapperTitle,
+    items: (config.items || []).map(mapListicleItemToStrapi),
+    sections: (config.sections || []).map(mapListicleSectionToStrapi),
+    static_sections: (config.staticSections || []).map(mapListicleStaticSectionToStrapi),
+  }
+}
+
+function changedAssetFileToListicleAssetPath(filePath) {
+  if (filePath.startsWith('data-assets/')) {
+    return `/${filePath.replace(/^data-assets\//, '')}`
+  }
+
+  return null
+}
+
+function loadListicleConfigsReferencingAssets(assetPaths) {
+  const referencedByKey = new Map()
+  if (!fs.existsSync(LISTICLE_CONFIG_DIR) || assetPaths.length === 0) {
+    return referencedByKey
+  }
+
+  const assetSet = new Set(assetPaths)
+  const files = fs.readdirSync(LISTICLE_CONFIG_DIR).filter((file) => file.endsWith('.json'))
+
+  files.forEach((file) => {
+    const filePath = path.join(LISTICLE_CONFIG_DIR, file)
+    const key = getListicleKeyFromPath(filePath)
+    const config = parseListicleConfig(filePath)
+    const referencedAssets = extractListicleAssetPaths(config).filter((assetPath) =>
+      assetSet.has(assetPath)
+    )
+
+    if (referencedAssets.length > 0) {
+      referencedByKey.set(key, referencedAssets)
+    }
+  })
+
+  return referencedByKey
 }
 
 // Helper: Fetch all entities from Strapi endpoint
@@ -979,6 +1316,109 @@ async function deleteEntry(folderName, documentId) {
   }
 }
 
+async function findListicleByKey(key) {
+  try {
+    const response = await axios.get(`${CMS_API_URL}/api/${LISTICLE_ENDPOINT}`, {
+      params: {
+        filters: { key: { $eq: key } },
+        pagination: { limit: 1 },
+      },
+      headers: {
+        Authorization: `Bearer ${CMS_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (response.data.data && response.data.data.length > 0) {
+      return response.data.data[0]
+    }
+
+    return null
+  } catch (error) {
+    console.error(`  ❌ Error in findListicleByKey:`, error.message)
+    if (error.response) {
+      console.error(`  Response:`, JSON.stringify(error.response.data, null, 2))
+    }
+    throw new Error(`Failed to find listicle by key: ${error.message}`)
+  }
+}
+
+async function createListicleEntry(data) {
+  try {
+    const response = await axios.post(
+      `${CMS_API_URL}/api/${LISTICLE_ENDPOINT}`,
+      { data },
+      {
+        headers: {
+          Authorization: `Bearer ${CMS_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+
+    return response.data
+  } catch (error) {
+    const errorMsg = error.response?.data?.error?.message || error.message
+    const errorDetails = error.response?.data?.error?.details || {}
+    console.error(`  ❌ Listicle create failed: ${errorMsg}`)
+    if (Object.keys(errorDetails).length > 0) {
+      console.error(`  Error details:`, JSON.stringify(errorDetails, null, 2))
+    }
+    if (error.response) {
+      console.error(`  Response:`, JSON.stringify(error.response.data, null, 2))
+    }
+    throw error
+  }
+}
+
+async function updateListicleEntry(documentId, data) {
+  try {
+    const response = await axios.put(
+      `${CMS_API_URL}/api/${LISTICLE_ENDPOINT}/${documentId}`,
+      { data },
+      {
+        headers: {
+          Authorization: `Bearer ${CMS_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+
+    return response.data
+  } catch (error) {
+    const errorMsg = error.response?.data?.error?.message || error.message
+    const errorDetails = error.response?.data?.error?.details || {}
+    console.error(`  ❌ Listicle update failed: ${errorMsg}`)
+    if (Object.keys(errorDetails).length > 0) {
+      console.error(`  Error details:`, JSON.stringify(errorDetails, null, 2))
+    }
+    if (error.response) {
+      console.error(`  Response:`, JSON.stringify(error.response.data, null, 2))
+    }
+    throw error
+  }
+}
+
+async function deleteListicleEntry(documentId) {
+  try {
+    const response = await axios.delete(`${CMS_API_URL}/api/${LISTICLE_ENDPOINT}/${documentId}`, {
+      headers: {
+        Authorization: `Bearer ${CMS_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    return response.data
+  } catch (error) {
+    const errorMsg = error.response?.data?.error?.message || error.message
+    console.error(`  ❌ Listicle delete failed: ${errorMsg}`)
+    if (error.response) {
+      console.error(`  Response:`, JSON.stringify(error.response.data, null, 2))
+    }
+    throw new Error(`Failed to delete listicle: ${errorMsg}`)
+  }
+}
+
 // Helper: Detect operation type
 function detectOperationType(filePath, isDeletedFile = false) {
   if (isDeletedFile) {
@@ -1005,6 +1445,7 @@ async function syncToStrapi() {
     skipped: [],
     errors: [],
     relationWarnings: [], // Track unmatched relations
+    listicleAssets: [],
   }
 
   // Combine changed and deleted files with a flag to indicate deletion
@@ -1023,6 +1464,38 @@ async function syncToStrapi() {
     console.log(`\n📄 Processing: ${filePath}${isDeleted ? ' (deleted)' : ''}`)
 
     try {
+      if (isListicleConfigFile(filePath)) {
+        const key = getListicleKeyFromPath(filePath)
+        const operationType = detectOperationType(filePath, isDeleted)
+
+        if (operationType === 'delete') {
+          pendingOperations.push({
+            type: 'delete_listicle',
+            key,
+            filePath,
+          })
+          continue
+        }
+
+        const config = parseListicleConfig(filePath)
+        validateListicleConfig(config, key)
+
+        const assetPaths = extractListicleAssetPaths(config)
+        for (const assetPath of assetPaths) {
+          const localPath = resolveListicleAssetLocalPath(assetPath)
+          const force = localPath ? CHANGED_ASSETS.includes(localPath) : false
+          await uploadListicleAsset(assetPath, force)
+        }
+
+        pendingOperations.push({
+          type: 'upsert_listicle',
+          key,
+          filePath,
+          config,
+        })
+        continue
+      }
+
       const folderName = getFolderName(filePath)
 
       if (!folderName || !SYNC_FOLDERS.includes(folderName)) {
@@ -1076,6 +1549,28 @@ async function syncToStrapi() {
     } catch (error) {
       console.error(`❌ Error processing ${filePath}: ${error.message}`)
       results.errors.push({ file: filePath, error: error.message })
+    }
+  }
+
+  const changedListicleAssetPaths = CHANGED_ASSETS.map(changedAssetFileToListicleAssetPath).filter(
+    Boolean
+  )
+  const listicleRefsByKey = loadListicleConfigsReferencingAssets(changedListicleAssetPaths)
+
+  for (const [key, assetPaths] of listicleRefsByKey) {
+    const hasPendingListicleConfig = pendingOperations.some(
+      (op) => op.key === key && (op.type === 'upsert_listicle' || op.type === 'delete_listicle')
+    )
+    if (hasPendingListicleConfig) continue
+
+    for (const assetPath of assetPaths) {
+      try {
+        await uploadListicleAsset(assetPath, true)
+        results.listicleAssets.push({ key, asset: assetPath })
+      } catch (error) {
+        console.error(`❌ Error syncing listicle asset ${assetPath}: ${error.message}`)
+        results.errors.push({ file: assetPath, error: error.message })
+      }
     }
   }
 
@@ -1139,7 +1634,39 @@ async function syncToStrapi() {
     console.log(`\n📄 Syncing: ${filePath} (${type})`)
 
     try {
-      if (type === 'delete') {
+      if (type === 'delete_listicle') {
+        const { key } = op
+        console.log(`🗑️ Deleting listicle from CMS: ${key}`)
+        const existingEntry = await findListicleByKey(key)
+
+        if (existingEntry) {
+          await deleteListicleEntry(existingEntry.documentId)
+          console.log(`✅ Deleted listicle successfully`)
+          results.deleted.push({ file: filePath, key })
+        } else {
+          console.log(`⚠️ Listicle not found in CMS, skipping deletion`)
+          results.skipped.push(filePath)
+        }
+      } else if (type === 'upsert_listicle') {
+        const { key, config } = op
+        const strapiData = mapListicleConfigToStrapi(config)
+        const existingEntry = await findListicleByKey(key)
+
+        if (existingEntry) {
+          console.log(`🔄 Updating listicle in CMS: ${key}`)
+          if (!existingEntry.documentId) {
+            throw new Error(`Listicle found but has no documentId`)
+          }
+          await updateListicleEntry(existingEntry.documentId, strapiData)
+          console.log(`✅ Updated listicle successfully`)
+          results.updated.push({ file: filePath, key })
+        } else {
+          console.log(`➕ Creating listicle in CMS: ${key}`)
+          await createListicleEntry(strapiData)
+          console.log(`✅ Created listicle successfully`)
+          results.created.push({ file: filePath, key })
+        }
+      } else if (type === 'delete') {
         console.log(`🗑️ Deleting from CMS: ${pathField}`)
         const existingEntry = await findEntryByPath(folderName, pathField)
 

--- a/scripts/update-pr-comment.js
+++ b/scripts/update-pr-comment.js
@@ -56,7 +56,8 @@ module.exports = async ({ github, context, core }) => {
         body += `| Operation | Route |\n`
         body += `|-----------|-------|\n`
         allProcessed.forEach((item) => {
-          body += `| ${item.operation} | \`${item.path}\` |\n`
+          const route = item.key ? `listicle:${item.key}` : item.path
+          body += `| ${item.operation} | \`${route}\` |\n`
         })
         body += `\n</details>\n\n`
       }

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -11,6 +11,7 @@ const SKIP_IF_ONLY_CHANGES_IN = [
   'data/guides',
   'data/blog',
   'data-assets',
+  'constants/listicles',
   '.agents',
   '.claude',
   '.github',

--- a/tests/component-items-sync.test.js
+++ b/tests/component-items-sync.test.js
@@ -231,6 +231,23 @@ test('all listicle items have valid name, href, and icon', () => {
   }
 })
 
+test('all listicle string icon paths exist in data-assets/', () => {
+  for (const { name, config } of loadAllListicleConfigs()) {
+    const items = collectItems(config)
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (typeof item.icon === 'string') {
+        const cleanPath = item.icon.startsWith('/') ? item.icon.slice(1) : item.icon
+        const dataAssetsPath = join(__dirname, '..', 'data-assets', cleanPath)
+        assert.ok(
+          require('fs').existsSync(dataAssetsPath),
+          `${name} item "${item.name}" icon "${item.icon}" missing from data-assets/`
+        )
+      }
+    }
+  }
+})
+
 test('no duplicate hrefs within each listicle section', () => {
   for (const { name, config } of loadAllListicleConfigs()) {
     for (const section of getListicleSectionItems(config)) {

--- a/tests/component-items-sync.test.js
+++ b/tests/component-items-sync.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 const { loadTsModule } = require('./helpers/loadTsModule')
-const { readdirSync, readFileSync } = require('fs')
+const { readdirSync, readFileSync, existsSync } = require('fs')
 const { join } = require('path')
 
 const { getListicleSectionItems } = loadTsModule('constants/listicles/utils.ts')
@@ -240,7 +240,7 @@ test('all listicle string icon paths exist in data-assets/', () => {
         const cleanPath = item.icon.startsWith('/') ? item.icon.slice(1) : item.icon
         const dataAssetsPath = join(__dirname, '..', 'data-assets', cleanPath)
         assert.ok(
-          require('fs').existsSync(dataAssetsPath),
+          existsSync(dataAssetsPath),
           `${name} item "${item.name}" icon "${item.icon}" missing from data-assets/`
         )
       }

--- a/tests/listicle-cms-transform.test.js
+++ b/tests/listicle-cms-transform.test.js
@@ -1,0 +1,143 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { transformCmsListicle } = loadTsModule('utils/listicleCms.ts')
+
+test('transformCmsListicle maps flat listicles', () => {
+  const config = transformCmsListicle({
+    key: 'apm-quick-start',
+    pattern: 'flat',
+    markdown_title: 'APM Quick Start',
+    section_name: 'APM',
+    grid_cols: 'grid-cols-2',
+    view_all_href: '/docs/apm',
+    view_all_text: 'View all APM docs',
+    items: [
+      {
+        name: 'Python',
+        href: '/docs/python',
+        click_name: 'Python Link',
+        icon_path: 'https://cdn.example.com/img/icons/listicle/si-python.svg',
+      },
+    ],
+  })
+
+  assert.deepEqual(config, {
+    id: 'apm-quick-start',
+    pattern: 'flat',
+    markdownTitle: 'APM Quick Start',
+    sectionName: 'APM',
+    gridCols: 'grid-cols-2',
+    viewAllHref: '/docs/apm',
+    viewAllText: 'View all APM docs',
+    items: [
+      {
+        name: 'Python',
+        href: '/docs/python',
+        clickName: 'Python Link',
+        icon: 'https://cdn.example.com/img/icons/listicle/si-python.svg',
+      },
+    ],
+  })
+})
+
+test('transformCmsListicle maps sectioned listicles with subsections and badge icons', () => {
+  const config = transformCmsListicle({
+    key: 'metrics-quick-start',
+    pattern: 'sectioned',
+    markdown_title: 'Metrics Quick Start',
+    section_name: 'Metrics',
+    sections: [
+      {
+        section_id: 'databases',
+        label: 'Databases',
+        title: 'Databases',
+        section_name: 'Database Metrics',
+        grid_cols: 'grid-cols-3',
+        subsections: [
+          {
+            section_id: 'sql',
+            title: 'SQL',
+            section_name: 'SQL Metrics',
+            items: [
+              {
+                name: 'PostgreSQL',
+                href: '/docs/postgres',
+                icon_badge: 'PG',
+                icon_color: '#336791',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  assert.deepEqual(config.sections, [
+    {
+      id: 'databases',
+      label: 'Databases',
+      title: 'Databases',
+      sectionName: 'Database Metrics',
+      gridCols: 'grid-cols-3',
+      subsections: [
+        {
+          id: 'sql',
+          title: 'SQL',
+          sectionName: 'SQL Metrics',
+          items: [
+            {
+              name: 'PostgreSQL',
+              href: '/docs/postgres',
+              icon: {
+                badge: 'PG',
+                color: '#336791',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ])
+})
+
+test('transformCmsListicle maps searchable and static-section fields', () => {
+  const config = transformCmsListicle({
+    key: 'java-instrumentation',
+    pattern: 'searchable',
+    markdown_title: 'Java Instrumentation',
+    section_name: 'Java',
+    search_placeholder: 'Search Java integrations',
+    wrapper_title: 'Choose your framework',
+    static_sections: [
+      {
+        title: 'Frameworks',
+        section_name: 'Frameworks',
+        items: [
+          {
+            name: 'Spring Boot',
+            href: '/docs/spring',
+            icon_path: '/img/icons/listicle/si-springboot.svg',
+          },
+        ],
+      },
+    ],
+  })
+
+  assert.equal(config.searchPlaceholder, 'Search Java integrations')
+  assert.equal(config.wrapperTitle, 'Choose your framework')
+  assert.deepEqual(config.staticSections, [
+    {
+      title: 'Frameworks',
+      sectionName: 'Frameworks',
+      items: [
+        {
+          name: 'Spring Boot',
+          href: '/docs/spring',
+          icon: '/img/icons/listicle/si-springboot.svg',
+        },
+      ],
+    },
+  ])
+})

--- a/utils/listicleCms.ts
+++ b/utils/listicleCms.ts
@@ -77,18 +77,28 @@ function transformIcon(item: CmsListicleItem): IconSpec | undefined {
     }
   }
 
+  if (item.icon_badge || item.icon_color) {
+    console.warn(
+      `Listicle item "${item.name}": partial badge icon (badge=${item.icon_badge}, color=${item.icon_color}) — both required`
+    )
+  }
+
   return undefined
 }
 
 function transformItem(item: CmsListicleItem): ListicleItem {
+  const icon = transformIcon(item)
+  if (!icon) {
+    console.warn(`Listicle item "${item.name}": missing icon data from CMS`)
+  }
+
   const transformed: ListicleItem = {
     name: item.name,
     href: item.href,
+    icon: icon ?? '',
   }
 
   setOptionalString(transformed, 'clickName', item.click_name)
-  const icon = transformIcon(item)
-  if (icon) transformed.icon = icon
 
   return transformed
 }

--- a/utils/listicleCms.ts
+++ b/utils/listicleCms.ts
@@ -1,0 +1,171 @@
+import type {
+  IconSpec,
+  ListicleConfig,
+  ListicleItem,
+  SectionConfig,
+  SubsectionConfig,
+} from '@/components/Listicle/types'
+
+export type CmsListicleItem = {
+  name: string
+  href: string
+  click_name?: string | null
+  icon_path?: string | null
+  icon_badge?: string | null
+  icon_color?: string | null
+}
+
+export type CmsListicleSubsection = {
+  section_id: string
+  title: string
+  section_name: string
+  grid_cols?: string | null
+  items?: CmsListicleItem[] | null
+}
+
+export type CmsListicleSection = {
+  section_id: string
+  label: string
+  title: string
+  section_name: string
+  grid_cols?: string | null
+  items?: CmsListicleItem[] | null
+  subsections?: CmsListicleSubsection[] | null
+}
+
+export type CmsListicleStaticSection = {
+  title: string
+  section_name: string
+  grid_cols?: string | null
+  items?: CmsListicleItem[] | null
+}
+
+export type CmsListicle = {
+  key: string
+  pattern: ListicleConfig['pattern']
+  markdown_title: string
+  section_name: string
+  title?: string | null
+  description?: string | null
+  grid_cols?: string | null
+  view_all_href?: string | null
+  view_all_text?: string | null
+  search_placeholder?: string | null
+  wrapper_title?: string | null
+  items?: CmsListicleItem[] | null
+  sections?: CmsListicleSection[] | null
+  static_sections?: CmsListicleStaticSection[] | null
+}
+
+function optionalString(value?: string | null): string | undefined {
+  return value || undefined
+}
+
+function setOptionalString(target: object, key: string, value?: string | null) {
+  const normalized = optionalString(value)
+  if (normalized) {
+    ;(target as Record<string, string>)[key] = normalized
+  }
+}
+
+function transformIcon(item: CmsListicleItem): IconSpec | undefined {
+  if (item.icon_path) return item.icon_path
+  if (item.icon_badge && item.icon_color) {
+    return {
+      badge: item.icon_badge,
+      color: item.icon_color,
+    }
+  }
+
+  return undefined
+}
+
+function transformItem(item: CmsListicleItem): ListicleItem {
+  const transformed: ListicleItem = {
+    name: item.name,
+    href: item.href,
+  }
+
+  setOptionalString(transformed, 'clickName', item.click_name)
+  const icon = transformIcon(item)
+  if (icon) transformed.icon = icon
+
+  return transformed
+}
+
+function transformSubsection(subsection: CmsListicleSubsection): SubsectionConfig {
+  const transformed: SubsectionConfig = {
+    id: subsection.section_id,
+    title: subsection.title,
+    sectionName: subsection.section_name,
+    items: (subsection.items || []).map(transformItem),
+  }
+
+  setOptionalString(transformed, 'gridCols', subsection.grid_cols)
+
+  return transformed
+}
+
+function transformSection(section: CmsListicleSection): SectionConfig {
+  const transformed: SectionConfig = {
+    id: section.section_id,
+    label: section.label,
+    title: section.title,
+    sectionName: section.section_name,
+  }
+
+  setOptionalString(transformed, 'gridCols', section.grid_cols)
+
+  if (section.items && section.items.length > 0) {
+    transformed.items = section.items.map(transformItem)
+  }
+
+  if (section.subsections && section.subsections.length > 0) {
+    transformed.subsections = section.subsections.map(transformSubsection)
+  }
+
+  return transformed
+}
+
+function transformStaticSection(section: CmsListicleStaticSection) {
+  const transformed = {
+    title: section.title,
+    sectionName: section.section_name,
+    items: (section.items || []).map(transformItem),
+  }
+
+  setOptionalString(transformed, 'gridCols', section.grid_cols)
+
+  return transformed
+}
+
+export function transformCmsListicle(listicle: CmsListicle): ListicleConfig {
+  const config: ListicleConfig = {
+    id: listicle.key,
+    pattern: listicle.pattern,
+    markdownTitle: listicle.markdown_title,
+    sectionName: listicle.section_name,
+  }
+
+  setOptionalString(config, 'title', listicle.title)
+  setOptionalString(config, 'description', listicle.description)
+  setOptionalString(config, 'gridCols', listicle.grid_cols)
+  setOptionalString(config, 'viewAllHref', listicle.view_all_href)
+  setOptionalString(config, 'viewAllText', listicle.view_all_text)
+  setOptionalString(config, 'searchPlaceholder', listicle.search_placeholder)
+  setOptionalString(config, 'wrapperTitle', listicle.wrapper_title)
+
+  if (listicle.items && listicle.items.length > 0) {
+    config.items = listicle.items.map(transformItem)
+  }
+
+  if (listicle.sections && listicle.sections.length > 0) {
+    config.sections = listicle.sections.map(transformSection)
+  }
+
+  if (listicle.static_sections && listicle.static_sections.length > 0) {
+    config.staticSections = listicle.static_sections.map(transformStaticSection)
+  }
+
+  return config
+}

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -107,11 +107,24 @@ export async function getRuntimeListicleConfig(name: string) {
   try {
     console.log(`[listicle:${name}] → trying unstable_cache CMS fetch`)
     const result = await getCachedCmsListicle(name)
-    console.log(`[listicle:${name}] → CMS success, got config: ${result ? 'yes' : 'null'}`)
+    console.log(
+      `[listicle:${name}] → unstable_cache CMS success, got config: ${result ? 'yes' : 'null'}`
+    )
     return result
   } catch (err) {
-    console.log(`[listicle:${name}] → unstable_cache failed:`, (err as Error).message)
-    console.log(`[listicle:${name}] → falling back to local config`)
-    return getLocalListicleConfig(name)
+    console.log(`[listicle:${name}] → unstable_cache failed: ${(err as Error).message}`)
+
+    try {
+      console.log(`[listicle:${name}] → trying direct CMS fetch (no unstable_cache)`)
+      const result = await fetchCmsListicle(name)
+      console.log(
+        `[listicle:${name}] → direct CMS fetch success, got config: ${result ? 'yes' : 'null'}`
+      )
+      return result
+    } catch (directErr) {
+      console.log(`[listicle:${name}] → direct CMS fetch failed: ${(directErr as Error).message}`)
+      console.log(`[listicle:${name}] → falling back to local config`)
+      return getLocalListicleConfig(name)
+    }
   }
 }

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -20,6 +20,7 @@ function isLocalListicleOverlayEnabled() {
 }
 
 async function fetchCmsListicle(key: string) {
+  console.log(`[listicle:${key}] fetchCmsListicle called — API_URL: ${API_URL}`)
   if (!API_URL) {
     throw new Error('NEXT_PUBLIC_SIGNOZ_CMS_API_URL is not configured')
   }
@@ -91,13 +92,26 @@ function getCachedCmsListicle(key: string) {
 }
 
 export async function getRuntimeListicleConfig(name: string) {
+  const env = {
+    dev: isLocalListicleOverlayEnabled(),
+    cms: hasCMSConfig(),
+    nodeEnv: process.env.NODE_ENV,
+  }
+  console.log(`[listicle:${name}] start — env:`, JSON.stringify(env))
+
   if (isLocalListicleOverlayEnabled() || !hasCMSConfig()) {
+    console.log(`[listicle:${name}] → local (dev overlay or no CMS config)`)
     return getLocalListicleConfig(name)
   }
 
   try {
-    return await getCachedCmsListicle(name)
-  } catch {
+    console.log(`[listicle:${name}] → trying unstable_cache CMS fetch`)
+    const result = await getCachedCmsListicle(name)
+    console.log(`[listicle:${name}] → CMS success, got config: ${result ? 'yes' : 'null'}`)
+    return result
+  } catch (err) {
+    console.log(`[listicle:${name}] → unstable_cache failed:`, (err as Error).message)
+    console.log(`[listicle:${name}] → falling back to local config`)
     return getLocalListicleConfig(name)
   }
 }

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -97,8 +97,18 @@ export async function getRuntimeListicleConfig(name: string) {
 
   try {
     return await getCachedCmsListicle(name)
-  } catch (error) {
-    console.error(`Failed to fetch listicle "${name}" from CMS:`, error)
-    return null
+  } catch (cacheError) {
+    console.warn(`Cached listicle fetch failed for "${name}", retrying without cache:`, cacheError)
+
+    try {
+      return await fetchCmsListicle(name)
+    } catch (directError) {
+      console.warn(
+        `Direct CMS fetch also failed for "${name}", falling back to local config:`,
+        directError
+      )
+
+      return getLocalListicleConfig(name)
+    }
   }
 }

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -1,0 +1,106 @@
+import { unstable_cache } from 'next/cache'
+import qs from 'qs'
+
+import { getListicleConfig as getLocalListicleConfig } from '@/constants/listicles/utils'
+import { CMS_REVALIDATE_INTERVAL } from '@/constants/cache'
+import { transformCmsListicle, type CmsListicle } from './listicleCms'
+
+const API_URL = process.env.NEXT_PUBLIC_SIGNOZ_CMS_API_URL
+
+type ListicleApiResponse = {
+  data: CmsListicle[]
+}
+
+function hasCMSConfig() {
+  return Boolean(API_URL)
+}
+
+function isLocalListicleOverlayEnabled() {
+  return process.env.NODE_ENV === 'development'
+}
+
+async function fetchCmsListicle(key: string) {
+  if (!API_URL) {
+    throw new Error('NEXT_PUBLIC_SIGNOZ_CMS_API_URL is not configured')
+  }
+
+  const query = qs.stringify(
+    {
+      filters: {
+        key: {
+          $eq: key,
+        },
+      },
+      populate: {
+        items: '*',
+        sections: {
+          populate: {
+            items: '*',
+            subsections: {
+              populate: {
+                items: '*',
+              },
+            },
+          },
+        },
+        static_sections: {
+          populate: {
+            items: '*',
+          },
+        },
+      },
+      pagination: {
+        page: 1,
+        pageSize: 1,
+      },
+    },
+    {
+      encode: false,
+      addQueryPrefix: true,
+      arrayFormat: 'repeat',
+    }
+  )
+
+  const response = await fetch(`${API_URL}/api/listicles${query}`, {
+    cache: 'force-cache',
+    next: {
+      tags: ['listicles-list', `listicle-${key}`],
+    },
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const errorMessage = await response.text()
+    throw new Error(`Failed to fetch listicle "${key}": ${response.status} ${errorMessage}`)
+  }
+
+  const data = (await response.json()) as ListicleApiResponse
+  const listicle = data.data?.[0]
+  return listicle ? transformCmsListicle(listicle) : null
+}
+
+function getCachedCmsListicle(key: string) {
+  const cachedFn = unstable_cache(() => fetchCmsListicle(key), [`cached-listicle-${key}`], {
+    tags: ['listicles-list', `listicle-${key}`],
+    revalidate: CMS_REVALIDATE_INTERVAL,
+  })
+
+  return cachedFn()
+}
+
+export async function getRuntimeListicleConfig(name: string) {
+  const localConfig = getLocalListicleConfig(name)
+
+  if (isLocalListicleOverlayEnabled() || !hasCMSConfig()) {
+    return localConfig
+  }
+
+  try {
+    return (await getCachedCmsListicle(name)) || localConfig
+  } catch (error) {
+    console.warn(`Failed to fetch listicle "${name}" from CMS; using local fallback:`, error)
+    return localConfig
+  }
+}

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -19,13 +19,8 @@ function isLocalListicleOverlayEnabled() {
   return process.env.NODE_ENV === 'development'
 }
 
-async function fetchCmsListicle(key: string) {
-  console.log(`[listicle:${key}] fetchCmsListicle called — API_URL: ${API_URL}`)
-  if (!API_URL) {
-    throw new Error('NEXT_PUBLIC_SIGNOZ_CMS_API_URL is not configured')
-  }
-
-  const query = qs.stringify(
+function buildListicleQuery(key: string) {
+  return qs.stringify(
     {
       filters: {
         key: {
@@ -61,8 +56,19 @@ async function fetchCmsListicle(key: string) {
       arrayFormat: 'repeat',
     }
   )
+}
 
-  const response = await fetch(`${API_URL}/api/listicles${query}`, {
+function parseListicleResponse(data: ListicleApiResponse) {
+  const listicle = data.data?.[0]
+  return listicle ? transformCmsListicle(listicle) : null
+}
+
+async function fetchCmsListicle(key: string) {
+  if (!API_URL) {
+    throw new Error('NEXT_PUBLIC_SIGNOZ_CMS_API_URL is not configured')
+  }
+
+  const response = await fetch(`${API_URL}/api/listicles${buildListicleQuery(key)}`, {
     cache: 'force-cache',
     next: {
       tags: ['listicles-list', `listicle-${key}`],
@@ -77,9 +83,26 @@ async function fetchCmsListicle(key: string) {
     throw new Error(`Failed to fetch listicle "${key}": ${response.status} ${errorMessage}`)
   }
 
-  const data = (await response.json()) as ListicleApiResponse
-  const listicle = data.data?.[0]
-  return listicle ? transformCmsListicle(listicle) : null
+  return parseListicleResponse((await response.json()) as ListicleApiResponse)
+}
+
+async function fetchCmsListiclePlain(key: string) {
+  if (!API_URL) {
+    throw new Error('NEXT_PUBLIC_SIGNOZ_CMS_API_URL is not configured')
+  }
+
+  const response = await fetch(`${API_URL}/api/listicles${buildListicleQuery(key)}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const errorMessage = await response.text()
+    throw new Error(`Failed to fetch listicle "${key}": ${response.status} ${errorMessage}`)
+  }
+
+  return parseListicleResponse((await response.json()) as ListicleApiResponse)
 }
 
 function getCachedCmsListicle(key: string) {
@@ -92,37 +115,25 @@ function getCachedCmsListicle(key: string) {
 }
 
 export async function getRuntimeListicleConfig(name: string) {
-  const env = {
-    dev: isLocalListicleOverlayEnabled(),
-    cms: hasCMSConfig(),
-    nodeEnv: process.env.NODE_ENV,
-  }
-  console.log(`[listicle:${name}] start — env:`, JSON.stringify(env))
-
   if (isLocalListicleOverlayEnabled() || !hasCMSConfig()) {
     console.log(`[listicle:${name}] → local (dev overlay or no CMS config)`)
     return getLocalListicleConfig(name)
   }
 
   try {
-    console.log(`[listicle:${name}] → trying unstable_cache CMS fetch`)
+    console.log(`[listicle:${name}] → trying unstable_cache`)
     const result = await getCachedCmsListicle(name)
-    console.log(
-      `[listicle:${name}] → unstable_cache CMS success, got config: ${result ? 'yes' : 'null'}`
-    )
+    console.log(`[listicle:${name}] → unstable_cache success: ${result ? 'yes' : 'null'}`)
     return result
   } catch (err) {
     console.log(`[listicle:${name}] → unstable_cache failed: ${(err as Error).message}`)
-
     try {
-      console.log(`[listicle:${name}] → trying direct CMS fetch (no unstable_cache)`)
-      const result = await fetchCmsListicle(name)
-      console.log(
-        `[listicle:${name}] → direct CMS fetch success, got config: ${result ? 'yes' : 'null'}`
-      )
+      console.log(`[listicle:${name}] → trying plain fetch`)
+      const result = await fetchCmsListiclePlain(name)
+      console.log(`[listicle:${name}] → plain fetch success: ${result ? 'yes' : 'null'}`)
       return result
     } catch (directErr) {
-      console.log(`[listicle:${name}] → direct CMS fetch failed: ${(directErr as Error).message}`)
+      console.log(`[listicle:${name}] → plain fetch failed: ${(directErr as Error).message}`)
       console.log(`[listicle:${name}] → falling back to local config`)
       return getLocalListicleConfig(name)
     }

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -91,16 +91,14 @@ function getCachedCmsListicle(key: string) {
 }
 
 export async function getRuntimeListicleConfig(name: string) {
-  const localConfig = getLocalListicleConfig(name)
-
   if (isLocalListicleOverlayEnabled() || !hasCMSConfig()) {
-    return localConfig
+    return getLocalListicleConfig(name)
   }
 
   try {
-    return (await getCachedCmsListicle(name)) || localConfig
+    return await getCachedCmsListicle(name)
   } catch (error) {
-    console.warn(`Failed to fetch listicle "${name}" from CMS; using local fallback:`, error)
-    return localConfig
+    console.error(`Failed to fetch listicle "${name}" from CMS:`, error)
+    return null
   }
 }

--- a/utils/listicleRepository.ts
+++ b/utils/listicleRepository.ts
@@ -97,18 +97,7 @@ export async function getRuntimeListicleConfig(name: string) {
 
   try {
     return await getCachedCmsListicle(name)
-  } catch (cacheError) {
-    console.warn(`Cached listicle fetch failed for "${name}", retrying without cache:`, cacheError)
-
-    try {
-      return await fetchCmsListicle(name)
-    } catch (directError) {
-      console.warn(
-        `Direct CMS fetch also failed for "${name}", falling back to local config:`,
-        directError
-      )
-
-      return getLocalListicleConfig(name)
-    }
+  } catch {
+    return getLocalListicleConfig(name)
   }
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Listicle components (the icon-grid cards used across 28 docs pages) are currently hardcoded in `constants/listicles/*.json`. This PR migrates them to the Strapi CMS sync pipeline so listicle content can be updated without a full site rebuild - matching how blog, comparisons, guides, and other content types already work. Precursor to full content migration for docs.

#### Screenshots / Screen Recordings (if applicable)

TBA

All pages render identically to production.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `tests/component-items-sync.test.js` - 6 tests covering JSON parsing, schema validation, item validation, icon asset existence in `data-assets/`, and duplicate href detection
  - `tests/listicle-cms-transform.test.js` - CMS transform round-trip tests
- Manual verification:
  - Visual comparison of 7 preview pages vs production (all listicle patterns: flat, sectioned, searchable)
  - Tab switching and search filtering verified on preview
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Docs pages that render `<Listicle>` components (28 pages). No impact on blog, comparisons, guides, or other content types.
- Potential regressions: If Strapi CMS is down or returns invalid data, the listicle component renders an error message. CMS is the sole source of truth in production (matches content repository pattern).
- Rollback plan: Revert PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
Stacks before https://github.com/SigNoz/signoz.io/pull/3504 
