### PR TITLE
docs: update metrics query error handling documentation

### DIFF
--- a/data/docs/metrics-management/query-range-api.mdx
+++ b/data/docs/metrics-management/query-range-api.mdx
@@ -1,8 +1,8 @@
 ---
-date: 2026-05-06
+date: 2026-06-18
 title: Metrics API
 id: metrics-query-api
-description: API reference for querying SigNoz metrics.
+description: API reference for querying SigNoz metrics, including the response warnings array for missing metrics and group-by attributes.
 doc_type: reference
 ---
 
@@ -174,3 +174,49 @@ Use two queries and a formula (`A/B`) to calculate error rate:
   }
 }
 ```
+
+## Response Warnings
+
+A query can succeed (HTTP `200`) and still report non-fatal issues through a `warning` object in the response. Querying a metric that has never been ingested, or grouping by an attribute that does not exist on a metric, no longer fails the request — the query returns an empty result for that series along with a warning explaining why.
+
+<Admonition type="warning">
+Querying a metric that has never been received **does not** return a not-found (HTTP `404`) error. To detect misnamed or missing metrics programmatically, inspect the `warnings` array in the response rather than relying on the HTTP status code.
+</Admonition>
+
+Warnings appear under `data.warning.warnings`, where each entry is an object with a `message` field:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "type": "time_series",
+    "data": { "results": [] },
+    "meta": {},
+    "warning": {
+      "warnings": [
+        {
+          "message": "metric http.server.duration has never been received. Check the metric name and instrumentation"
+        }
+      ]
+    }
+  }
+}
+```
+
+The `warning` object is omitted entirely when a query has no warnings.
+
+### Warning Messages
+
+| Scenario | Message format |
+|---|---|
+| A single referenced metric has never been received | `metric <metric-name> has never been received. Check the metric name and instrumentation` |
+| Multiple referenced metrics have never been received | `the following metrics have never been received. Check the metric names and instrumentation: <metric-1>, <metric-2>` |
+| A group-by attribute does not exist on the metric | `` key `<attribute-name>` not found on metric <metric-name> `` |
+| A single metric exists but has no data in the query time range | `no data found for the metric <metric-name> in the query time range` |
+| Multiple metrics exist but have no data in the query time range | `no data found for the following metrics in the query time range: <metric-1>, <metric-2>` |
+
+A single query can return more than one warning at once — for example, when it references several non-existent metrics, the response includes one entry per metric.
+
+### Group-by Attribute Fallback
+
+When a group-by field is applied to a metric but that attribute does not exist on it, the query still completes. The missing attribute is treated as a string-type fallback (it produces empty values rather than failing the query), and a `` key `<attribute-name>` not found on metric <metric-name> `` warning is added so you can correct the attribute name.

--- a/data/docs/metrics-management/querying-metrics.mdx
+++ b/data/docs/metrics-management/querying-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-18
 id: querying-metrics
 title: Querying Metrics
 description: Query metrics in SigNoz using the Query Builder in Metrics Explorer and Dashboards, with ClickHouse SQL and PromQL available in Dashboards.
@@ -14,6 +14,10 @@ The Query Builder is the primary way to query metrics. It is available in both M
 ### Selecting a Metric
 
 Choose the metric you want to query from the **Metric** dropdown. You can search by name to find the right metric.
+
+<Admonition type="info">
+Querying a metric that has never been received does not fail the query — it returns an empty result along with the warning `metric <metric-name> has never been received. Check the metric name and instrumentation`. If a panel shows no data, check the query warning to confirm the metric name and instrumentation are correct. See the [Metrics API reference](https://signoz.io/docs/metrics-management/query-range-api/#response-warnings) for the full list of warning messages.
+</Admonition>
 
 ### Filtering
 

--- a/data/docs/metrics-management/troubleshooting/faqs.mdx
+++ b/data/docs/metrics-management/troubleshooting/faqs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-18
 id: faqs
 title: Metrics Management FAQs
 description: Frequently asked questions about metrics management and troubleshooting in SigNoz
@@ -37,5 +37,21 @@ When you can't see specific metrics in SigNoz, this is often caused by a tempora
 Maintain consistent temporality in your metrics to avoid these issues and ensure optimal performance through the query builder interface.
 
 For more information about metric temporality, see [Metric Types and Aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/#temporality-of-metrics).
+
+</details>
+
+### Why does my panel say "metric has never been received"?
+
+A query that references a metric name that has never been ingested no longer returns an error — it returns an empty result with the warning `metric <metric-name> has never been received. Check the metric name and instrumentation`. This warning is a diagnostic signal that the metric name is misspelled or that the expected telemetry isn't reaching SigNoz.
+
+<details>
+
+<summary> Show resolution steps </summary>
+
+1. **Verify the metric name** — Compare the name in your query against what your application or collector actually exports. Names are case-sensitive and OpenTelemetry metric names use dots (for example `http.server.duration`).
+2. **Confirm instrumentation is sending data** — Check that the relevant SDK or collector is configured and that the metric is being produced. See [Send Metrics to SigNoz](https://signoz.io/docs/metrics-management/send-metrics/).
+3. **Browse available metrics** — Use the [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/) to find the exact name of a metric that has been received.
+
+For the full list of query warning messages, including the group-by attribute fallback, see the [Metrics API reference](https://signoz.io/docs/metrics-management/query-range-api/#response-warnings).
 
 </details> 

--- a/data/docs/querying/query-performance.mdx
+++ b/data/docs/querying/query-performance.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-18
 id: query-performance
 title: Query Performance & Common Issues
 description: Diagnose slow queries, missing results, and unexpected output — with tips to optimize query and dashboard performance in SigNoz.
@@ -52,7 +52,11 @@ Make sure the selected time range actually includes the data you expect. If you 
 
 Use the [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/) or Logs/Traces Explorer to verify that the metric, service, or attribute you're querying actually has data in the selected time period.
 
-**4. Check for EXISTS vs value filters**
+**4. Check the query warnings for a misnamed metric**
+
+A metrics query that references a metric name that has never been received returns an empty result with a warning instead of an error — the panel simply shows no data. Check the query or panel warning for `metric <metric-name> has never been received. Check the metric name and instrumentation`, which points to a metric-name typo or an instrumentation gap. A group-by attribute that doesn't exist on the metric produces a similar `` key `<attribute-name>` not found on metric <metric-name> `` warning. See the [Metrics API reference](https://signoz.io/docs/metrics-management/query-range-api/#response-warnings) for all warning messages.
+
+**5. Check for EXISTS vs value filters**
 
 If you're filtering on an attribute that may not be present on all spans/logs, use `EXISTS` first to confirm the attribute is present before filtering on its value.
 


### PR DESCRIPTION
## Summary

Querying a metric that has never been ingested (or grouping by a non-existent attribute) no longer returns a not-found error — the query now returns an empty result with a warning in the response. These docs updates reflect that contract change.

- **Metrics API reference** (`query-range-api.mdx`) — added a new **Response Warnings** section documenting the `data.warning.warnings[].message` array, the warning message formats (single/multiple missing metrics, group-by attribute fallback, dormant metrics), the 'multiple warnings per query' behavior, and the group-by string-type fallback. Added an admonition that missing metrics do **not** return HTTP 404.
- **Querying Metrics** (`querying-metrics.mdx`) — added a note that selecting a never-received metric returns an empty result plus a warning.
- **Query Performance & Common Issues** (`query-performance.mdx`) — added a 'no results' troubleshooting step pointing users to the query warning for a misnamed metric or missing group-by attribute.
- **Metrics Management FAQs** (`troubleshooting/faqs.mdx`) — added a FAQ explaining the 'metric has never been received' warning as a diagnostic signal, with resolution steps.
- Updated frontmatter `date` to 2026-06-18 on all edited files.

Notes on open questions from the deliverable:
- No existing docs claimed a 404/not-found error for missing metrics, so no incorrect statements needed removal — the updates are additive.
- The `warnings` array was not previously documented; it is now covered in the Metrics API reference.
- Alerts and dashboard troubleshooting docs did not mention error feedback for invalid metric names, so no edits were required there.
- No browser screenshots: this PR changes only the query response payload (no UI changes), per the deliverable's screenshot plan.

Source PRs: #11754

Auto-generated by docs-sync pipeline