### PR TITLE
(blog) fix relative link in windows-logs blog

### DIFF
--- a/data/guides/windows-logs.mdx
+++ b/data/guides/windows-logs.mdx
@@ -15,7 +15,7 @@ related_articles:
   - '/guides/apache-log'
 ---
 
-When a Windows machine crashes, refuses to start a service, drops a network connection, or shows signs of suspicious activity, the [Windows Event Log](/docs/logs-management/send-logs/windows-events-log/) is one of the first places to check. It records activity from the operating system, applications, drivers, services, and security controls, which can be viewed in Windows Event Viewer for troubleshooting issues.
+When a Windows machine crashes, refuses to start a service, drops a network connection, or shows signs of suspicious activity, the [Windows Event Log](https://signoz.io/docs/logs-management/send-logs/windows-events-log/) is one of the first places to check. It records activity from the operating system, applications, drivers, services, and security controls, which can be viewed in Windows Event Viewer for troubleshooting issues.
 
 This guide explains what the Windows Event Log is, which log categories matter most, where Windows log files are stored, and how to use Event Viewer to access logs, apply filters, and create Custom Views to narrow down the events you actually need.
 

--- a/data/guides/windows-logs.mdx
+++ b/data/guides/windows-logs.mdx
@@ -1,7 +1,8 @@
 ---
 title: "Windows Event Logs: How to View, Filter, and Troubleshoot Logs"
 meta_title: "Windows Event Logs: View, Filter & Troubleshoot"
-date: 2026-06-11
+published_date: 2024-07-03
+updated_date: 2026-06-11
 tags: [Windows, Logging]
 authors: [saurabh_patil]
 description: "Learn how to check Windows Event Logs, use Event Viewer, find log file locations, filter events, and troubleshoot Windows issues."


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Fixes the relative link in the windows-logs blog that might cause crawlers to fail.
