### PR TITLE
(blog) link to OTel LLM within FastAPI blog

### DIFF
--- a/data/blog/opentelemetry-fastapi.mdx
+++ b/data/blog/opentelemetry-fastapi.mdx
@@ -7,7 +7,7 @@ description: Learn how to instrument FastAPI with OpenTelemetry for production-g
 image: /img/blog/2024/02/opentelemetry-fastapi-cover.webp
 keywords: [opentelemetry,opentelemetry python,opentelemetry fastapi,fastapi instrumentation,fastapi monitoring,fastapi observability,python tracing,distributed tracing,signoz]
 related_articles:
-  - '/opentelemetry/python-overview'
+  - '/blog/opentelemetry-llm'
   - '/blog/opentelemetry-flask'
   - '/blog/opentelemetry-tracing'
   - '/blog/opentelemetry-architecture'
@@ -45,6 +45,12 @@ Integrating OpenTelemetry with FastAPI has several benefits:
 
 The key advantage of OpenTelemetry is that it decouples instrumentation from the backend. You instrument once, and can send data to any compatible backend without any vendor lock-in.<br />
 In this guide, we'll use [SigNoz](https://signoz.io/) as the backend for visualizing the telemetry data.
+
+<KeyPointCallout title="Building AI and LLM apps with FastAPI?">
+FastAPI has become one of the most popular web frameworks for building high-throughput AI backends and agentic workflows due to its strong async support and validation guarantees. 
+
+If you are using FastAPI to serve LLMs and build agentic workflows, standard observability isn't enough to handle non-deterministic outputs and track token usage. We have a dedicated guide that walks through instrumenting these specific AI workloads — check out [Observing LLM Applications with OpenTelemetry](https://signoz.io/blog/opentelemetry-llm/).
+</KeyPointCallout>
 
 ## Running a FastAPI Application with OpenTelemetry
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This PR interlinks the OpenTelemetry LLM blog that uses FastAPI for serving agentic workflows and walking user through its implementation details, into the OTel FastAPI blog.

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---
