### PR TITLE
docs: update install docs for Foundry-only self-hosting

### DIFF
--- a/constants/docsSideNav.ts
+++ b/constants/docsSideNav.ts
@@ -91,6 +91,11 @@ const docsSideNav = [
                 route: '/docs/install/docker-selinux',
               },
               {
+                type: 'doc',
+                label: 'Migrate to Foundry',
+                route: '/docs/install/migrate-to-foundry',
+              },
+              {
                 type: 'category',
                 isExpanded: false,
                 label: 'Troubleshooting',

--- a/constants/listicles/self-host-installation.json
+++ b/constants/listicles/self-host-installation.json
@@ -18,12 +18,6 @@
           "icon": "/img/icons/listicle/si-docker.svg"
         },
         {
-          "name": "Swarm",
-          "href": "/docs/install/docker-swarm",
-          "clickName": "Install Docker Swarm",
-          "icon": "/img/icons/listicle/si-docker.svg"
-        },
-        {
           "name": "SELinux",
           "href": "/docs/install/docker-selinux",
           "clickName": "Install Docker SELinux",

--- a/data/docs/install.mdx
+++ b/data/docs/install.mdx
@@ -1,8 +1,9 @@
 ---
-date: 2024-10-17
+date: 2026-06-24
 id: Get Started
 title: Get Started with SigNoz
 description: Welcome to SigNoz! Send data from your application and infrastructure and get visibility into application performance within minutes.
+doc_type: howto
 ---
 To get started with SigNoz, follow the instructions in the sections below. SigNoz cloud is the fastest way to get started with SigNoz. [Sign up](https://signoz.io/teams/) now and get 30-day free access to all features.
 
@@ -15,7 +16,7 @@ To get started with SigNoz, follow the instructions in the sections below. SigNo
 
 <DocCard
     title="📄️ Self Host SigNoz"
-    description="Docker, Docker Swarm, Kubernetes"
+    description="Docker with Foundry, Kubernetes, and more"
     href="/docs/install/self-host/"
 />
 

--- a/data/docs/install/docker-selinux.mdx
+++ b/data/docs/install/docker-selinux.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-05-06
+date: 2026-06-24
 title: Docker SELinux
 tags : [Self-Host]
 description:  Learn how to install SigNoz on SeLinux systems with Docker. Follow our detailed, step-by-step guide to set up SigNoz on macOS or Linux. Ensure smooth installation and start monitoring your applications effectively.
@@ -59,9 +59,7 @@ These are the some of the services for which you need to add labels in the docke
 
 ## Install SigNoz 
 
-Please Follow the docs for installing Signoz in docker or docker swarm
-- [Docker Swarm](/docs/install/docker-swarm/)
-- [Docker Compose](/docs/install/docker/)
+Follow the [Docker installation guide](/docs/install/docker/) to install SigNoz with Foundry.
 
 ## Related Topics
 

--- a/data/docs/install/docker-swarm.mdx
+++ b/data/docs/install/docker-swarm.mdx
@@ -1,130 +1,28 @@
 ---
-date: 2026-03-26
-title: Docker Swarm
+date: 2026-06-24
+title: Docker Swarm Installation Discontinued - Use Foundry
 tags : [Self-Host]
-description: Learn how to install SigNoz on Docker Swarm
+description: Docker Swarm is no longer a supported SigNoz deployment target. Learn what changed and how to install or migrate self-hosted SigNoz with Foundry instead.
 id: docker-swarm
 slug: /install/docker-swarm
+doc_type: howto
 ---
 
 <HostingDecision />
 
-This section provides information on installing SigNoz on Docker Swarm.
-
-<KeyPointCallout title="Deploy with Foundry" defaultCollapsed={false}>
-<a href="https://github.com/SigNoz/foundry" target="_blank" rel="noopener noreferrer nofollow">Foundry</a> can deploy SigNoz on Docker Swarm for you using <a href="https://github.com/SigNoz/foundry/tree/main/docs/examples/docker/swarm" target="_blank" rel="noopener noreferrer nofollow">Docker Swarm casting</a> (a configuration file). You install the dependencies, and Foundry handles everything else, from generating the Compose file and configs to deploying the stack.
-</KeyPointCallout>
-
-## Prerequisites
-
-{/* <!-- Double-check if this list is comprehensive about memory, disk space, etc. --> */}
-{/* <!-- This section should focus on SigNoz, hence we could assume that Docker Swarm is already installed, similar to the Docker Standalone or Kubernetes sections. Not sure why we show to initialize a swarm or add more nodes here.  --> */}
-
-- A Linux or macOS machine. Microsoft Windows is not officially supported.
-- [Docker Engine](https://docs.docker.com/get-docker/). A minimum of 4GB of memory
-must be allocated to each Docker node.
-- [Docker Compose](https://docs.docker.com/compose/install/)
-- [Git client](https://desktop.github.com/)
-
-## Install SigNoz on Docker Swarm
-
-<Admonition type="info">
-Please use non-root user (mainly for Git repository cloning), otherwise you may end up seeing file system permissions errors after the installation.
+<Admonition type="warning" title="Docker Swarm is no longer supported">
+SigNoz no longer supports Docker Swarm as a deployment target. The bundled Docker Swarm Compose files (including the high-availability variants) have been removed from the SigNoz repository, and there is no Foundry-based Docker Swarm replacement at this time. The legacy `install.sh` script and Docker Swarm instructions on this page no longer work.
 </Admonition>
-    
-1. <CloneRepo />
 
-2. _(Optional)_ If you don't have a swarm cluster in place, you can create one by entering the following command:
-    ```bash
-    docker swarm init
-    ```
+## What to do instead
 
-    The output should look similar as shown below:
-    ```output
-    Swarm initialized: current node (6muco3j7jjuo6k4rbiq8yr8fw) is now a manager.
+Self-hosted SigNoz now installs and runs through [Foundry](https://github.com/SigNoz/foundry), an open-source CLI that provisions and manages your observability stack from a single declarative config.
 
-    To add a worker to this swarm, run the following command:
-
-    docker swarm join --token SWMTKN-1-6ak6diq1lbrwemx17up9c1ph039h64z0dxksjxv647qnqrd290-4tt6q22dd462p4lf2n6bqbnt4 192.168.65.3:2377
-
-    To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
-    ```
-
-3. _(Optional)_ You can use the `docker swarm join` command to add more nodes to the swarm.
-    Note that the node you added in the previous step is the manager. For details, see the
-    [Docker Swarm Join](https://docs.docker.com/engine/reference/commandline/swarm_join/)
-    page of the Docker documentation.
-
-4. Deploy SigNoz by entering the `docker stack deploy` command and specifying the following:
-    - `-d` to deploy the stack in detached mode
-    - `--prune` to remove services that are no longer referenced by the stack
-    - `-c` and the path to the Swarm Compose file (`docker-compose.yaml`)
-    - The name of the stack (`signoz`)
-
-    ```bash
-    cd deploy/docker-swarm
-    docker stack deploy -d --prune -c docker-compose.yaml signoz
-    ```
-
-    The output should look similar to the following:
-
-    ```output
-    Creating network signoz-net
-    Creating service signoz_query-service
-    Creating service signoz_frontend
-    Creating service signoz_otel-collector
-    Creating service signoz_signoz-telemetrystore-migrator
-    Creating service signoz_init-clickhouse
-    Creating service signoz_zookeeper-1
-    Creating service signoz_clickhouse
-    Creating service signoz_alertmanager
-    ```
-
-## Verify the Installation
-
-1. Using the `docker stack services` command, monitor the SigNoz deployment process.
-    Wait until all SigNoz services and replicas are created:
-
-    ```bash
-    docker stack services signoz
-    ```
-
-    You should see the following output:
-
-    ```output
-    ID             NAME                     MODE         REPLICAS   IMAGE                                        PORTS                  
-    loqa6qbq7lk3   signoz_clickhouse        replicated   1/1        clickhouse/clickhouse-server:24.1.2-alpine
-    zqoee9ij9xh0   signoz_init-clickhouse   replicated   0/1        clickhouse/clickhouse-server:24.1.2-alpine   
-    9awvkhh1feov   signoz_otel-collector    replicated   3/3        signoz/signoz-otel-collector:0.111.24        *:4317-4318->4317-4318/tcp
-    eu5fbg0v1bps   signoz_signoz            replicated   1/1        signoz/signoz:0.113.0                         *:80->8080/tcp                  
-    fcp7uk67tkks   signoz_signoz-telemetrystore-migrator   replicated   0/1        signoz/signoz-otel-collector:0.144.1
-    nw6xukg1gkf7   signoz_zookeeper-1       replicated   1/1        signoz/zookeeper:3.7.1
-    ```
-
-<RetentionInfo />
-
-
-
-## Scale Up SigNoz Cluster
-
-SigNoz uses the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) to ingest data.
-By default, the instructions in the [Install SigNoz on Docker Swarm](/docs/install/docker-swarm/) document create
-three replicas, and each replica can handle 50K spans per second. To handle an increased load, perform the following steps:
-
-1. Open the `deploy/docker-swarm/docker-compose.yaml` file in a plain-text editor.
-
-2. In the `services.otel-collector.deploy.replicas` field, enter the number of replicas you wish to create. The following example creates four replicas:
-
-  ![Open Telemetry Collector - Create four replicas](/img/scale-up-otel.webp)
-
-3. Update the `signoz` stack by entering the following command:
-
-  ```bash
-  docker stack deploy --prune -d -c docker-compose.yaml signoz
-  ```
-
+- **New installs:** follow the [Docker installation guide](https://signoz.io/docs/install/docker/) to deploy SigNoz with Foundry.
+- **Existing Docker Swarm or Docker Compose users:** follow the [migration guide](https://signoz.io/docs/install/migrate-to-foundry/) to move to Foundry while preserving your existing telemetry data.
+- **Kubernetes users:** see the [Kubernetes installation guide](https://signoz.io/docs/install/kubernetes/) for multi-node, highly available deployments.
 
 ## Next Steps
-- [Collect Telemetry from your Docker Clusters](/docs/opentelemetry-collection-agents/docker/install/)
-- [Instrument Your Application](/docs/instrumentation/overview/)
-- [Tutorials](/docs/install/)
+- [Install SigNoz on Docker with Foundry](https://signoz.io/docs/install/docker/)
+- [Migrate to Foundry](https://signoz.io/docs/install/migrate-to-foundry/)
+- [Instrument Your Application](https://signoz.io/docs/instrumentation/overview/)

--- a/data/docs/install/docker.mdx
+++ b/data/docs/install/docker.mdx
@@ -1,8 +1,8 @@
 ---
-date: 2026-06-11
-title: Docker Standalone
+date: 2026-06-24
+title: Install SigNoz on Docker with Foundry - Self-Host
 tags : [Self-Hosted Community]
-description: Learn how to install SigNoz on Docker. Step-by-step self-host guide for macOS and Linux, from setup to verifying the installation in the SigNoz UI.
+description: Install self-hosted SigNoz on Docker with Foundry. Step-by-step guide to deploy, verify, and migrate existing Docker Compose setups to Foundry.
 id: docker-standalone
 slug: /install/docker
 doc_type: howto
@@ -10,20 +10,20 @@ doc_type: howto
 
 <HostingDecision />
 
-This guide explains how to install SigNoz on Docker using Docker Compose. It runs all the components SigNoz requires on a single machine, making it the quickest way to get started with SigNoz.
+This guide explains how to install SigNoz on Docker using <a href="https://github.com/SigNoz/foundry" target="_blank" rel="noopener noreferrer nofollow">Foundry</a>. It runs all the components SigNoz requires on a single machine, making it the quickest way to get started with SigNoz.
+
+<Admonition type="info" title="Already running SigNoz with Docker Compose?">
+SigNoz no longer ships the legacy `install.sh` script or bundled Docker Compose files — Foundry is now the only supported way to install and run self-hosted SigNoz. If you already run SigNoz via Docker Compose, follow the [migration guide](https://signoz.io/docs/install/migrate-to-foundry/) to move to Foundry while preserving your existing telemetry data.
+</Admonition>
 
 ## Prerequisites
 
 - A Linux or macOS machine. Microsoft Windows is not officially supported.
 - <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener noreferrer nofollow">Docker Engine</a> 20.10+ (or Docker Desktop) with the <a href="https://docs.docker.com/compose/install/" target="_blank" rel="noopener noreferrer nofollow">Docker Compose</a> v2 plugin.
 - At least 4GB of memory allocated to Docker.
-- <a href="https://git-scm.com/downloads" target="_blank" rel="noopener noreferrer nofollow">Git</a> (manual method only).
 - Open ports: `8080` (SigNoz UI), `4317` and `4318` (OTLP ingestion), and `8000` if you enable the MCP server.
 
 ## Install SigNoz
-
-<Tabs entityName="setup">
-<TabItem value="foundry" label="Foundry" default>
 
 <Admonition type="info" title="What is Foundry?" defaultCollapsed={true}>
 Foundry is an open-source CLI that runs your self-hosted observability stack as code. One declarative config provisions the infrastructure, installs the SigNoz backend, and sets up OpenTelemetry collection on bare metal, containers, or Kubernetes. Learn more about <a href="https://github.com/SigNoz/foundry" target="_blank" rel="noopener noreferrer nofollow">Foundry</a>.
@@ -184,76 +184,6 @@ docker compose -f pours/deployment/compose.yaml logs -f signoz-signoz-0
 Increase the memory allocated to Docker — SigNoz needs at least 4GB.
 
 </details>
-
-</TabItem>
-<TabItem value="manual" label="Manual">
-
-### Step 1: Clone the SigNoz repository
-
-<CloneRepo />
-
-### Step 2: Start the containers
-
-To install SigNoz, enter the `docker compose up` command, specifying the following:
-
-- `-d` to run containers in the background
-- `--remove-orphans` to remove orphaned containers
-
-```bash
-cd docker
-docker compose up -d --remove-orphans
-```
-
-### Step 3: Verify the installation
-
-Check that the containers are running:
-
-```bash
-docker ps
-```
-
-The output should look similar to the following:
-
-```output
-CONTAINER ID   IMAGE                                   COMMAND                  CREATED              STATUS                        PORTS                                                             NAMES
-e9baf4553644   signoz/signoz:v0.128.0                  "./signoz server"        About a minute ago   Up 36 seconds (healthy)       0.0.0.0:8080->8080/tcp, [::]:8080->8080/tcp                       signoz
-4f2ecd9efd3c   signoz/signoz-otel-collector:v0.144.5   "/bin/sh -c '/signoz…"   About a minute ago   Up 36 seconds                 0.0.0.0:4317-4318->4317-4318/tcp, [::]:4317-4318->4317-4318/tcp   signoz-otel-collector
-8743f2bfe97f   clickhouse/clickhouse-server:25.5.6     "/entrypoint.sh"         About a minute ago   Up About a minute (healthy)   8123/tcp, 9000/tcp, 9009/tcp                                      signoz-clickhouse
-a1055af51110   signoz/zookeeper:3.7.1                  "/opt/bitnami/script…"   About a minute ago   Up About a minute (healthy)   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp                            signoz-zookeeper-1
-```
-
-Once all containers are running, point your browser to `http://<IP-ADDRESS>:8080/` to access the SigNoz UI — `http://localhost:8080/` when SigNoz runs on your local machine.
-
-### Install a specific version of SigNoz
-
-To install a specific version, check out its release tag after cloning the repository (Step 1), then start the containers as in Step 2. For example, to install SigNoz version `v0.128.0`:
-
-```bash
-git checkout v0.128.0
-```
-
-<details>
-
-<ToggleHeading>
-## Troubleshooting
-</ToggleHeading>
-
-### A container is unhealthy or the UI does not load
-
-Check the component's logs from the `deploy/docker` directory:
-
-```bash
-docker compose logs -f signoz
-```
-
-### Containers keep restarting
-
-Increase the memory allocated to Docker — SigNoz needs at least 4GB.
-
-</details>
-
-</TabItem>
-</Tabs>
 
 <RetentionInfo />
 

--- a/data/docs/install/migrate-to-foundry.mdx
+++ b/data/docs/install/migrate-to-foundry.mdx
@@ -1,0 +1,166 @@
+---
+date: 2026-06-24
+title: Migrate SigNoz from Docker Compose to Foundry Guide
+tags: [Self-Host]
+description: Migrate an existing self-hosted SigNoz Docker Compose deployment to Foundry without losing telemetry. Covers volume reuse, casting.yaml, cutover, and rollback.
+id: migrate-to-foundry
+slug: /install/migrate-to-foundry
+doc_type: howto
+---
+
+<HostingDecision />
+
+This guide walks you through migrating an existing self-hosted SigNoz deployment running on Docker Compose to [Foundry](https://signoz.io/docs/install/docker/). The legacy `install.sh` script and the bundled Docker Compose files are deprecated and are no longer distributed by SigNoz, so Foundry is now the supported way to run and upgrade self-hosted SigNoz.
+
+<Admonition type="info" title="Setting up SigNoz for the first time?">
+You don't need this guide. Follow the [Docker installation guide](https://signoz.io/docs/install/docker/) instead — it installs SigNoz with Foundry from scratch.
+</Admonition>
+
+## Overview
+
+The migration reuses your existing Docker volumes so you keep all your telemetry history. You generate a Foundry configuration (`casting.yaml`) that mirrors your legacy Compose setup, bring the old stack down without deleting volumes, then let Foundry recreate the containers against those same volumes.
+
+Two `foundryctl` commands do the work:
+
+- **`forge`** — generates the deployment manifests from your `casting.yaml`. It does not touch running containers, so it is safe to re-run while you iterate.
+- **`cast`** — applies the generated manifests: it creates and starts the containers and pulls new images.
+
+To stay up to date on new installation platforms and patterns, see <a href="https://github.com/SigNoz/foundry" target="_blank" rel="noopener noreferrer nofollow">Foundry</a>.
+
+## Prerequisites
+
+- An existing self-hosted SigNoz deployment running on Docker Compose.
+- Foundry installed:
+
+  ```bash
+  curl -fsSL https://signoz.io/foundry.sh | bash
+  ```
+
+  For manual install (Windows PowerShell, air-gapped, etc.), see the <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">Foundry getting-started guide</a>.
+
+<Admonition type="warning" title="Back up before you start">
+Before proceeding, back up both:
+
+- **Your Docker volumes** — these hold your data.
+- **Your existing `docker-compose.yaml` and any config it references** — keep a copy somewhere safe. The Compose manifests are no longer distributed by SigNoz, so this backup is your only way to roll back to your previous setup.
+</Admonition>
+
+## Migration steps
+
+1. **Note your existing volume names.** Record the volume names your current deployment uses for the following components:
+
+   - ClickHouse
+   - SigNoz
+   - ZooKeeper
+
+   If you used the Docker Compose file SigNoz previously provided, the volumes are `signoz-clickhouse`, `signoz-sqlite`, and `signoz-zookeeper-1`.
+
+2. **Generate your `casting.yaml`.** Based on internal testing, the following casting generates manifests that mimic the legacy Docker Compose setup. Compare it against your backed-up `docker-compose.yaml`, then run `foundryctl forge -f casting.yaml`.
+
+   Foundry's <a href="https://github.com/SigNoz/foundry/tree/main/docs/examples/docker/compose" target="_blank" rel="noopener noreferrer nofollow">Docker Compose example</a> is a useful reference.
+
+   <Admonition type="warning">
+   If your deployment had more than one shard or replica, adjust the manifest volumes accordingly.
+   </Admonition>
+
+   <Admonition type="info">
+   The `replica` and `shard` macros below are placeholders. Replace them with the values from your existing ClickHouse configuration (check the `macros` section of your current ClickHouse config, for example `config.xml` or `metrika.xml`), otherwise the generated manifests will not match your existing data.
+   </Admonition>
+
+   ```yaml
+   apiVersion: v1alpha1
+   kind: Installation
+   metadata:
+     name: signoz
+   spec:
+     deployment:
+       flavor: compose
+       mode: docker
+     metastore:
+       kind: sqlite
+     telemetrykeeper:
+       kind: zookeeper
+     telemetrystore:
+       spec:
+         config:
+           data:
+             config-0-0.yaml: |
+               macros:
+                 replica: "example01-01-1" # replace with your existing ClickHouse replica macro
+                 shard: "01"               # replace with your existing ClickHouse shard macro
+     patches:
+       - target: "deployment/compose.yaml"
+         operations:
+           - op: replace
+             path: /volumes/signoz-telemetrykeeper-0-data/name
+             value: signoz-zookeeper-1
+           - op: replace
+             path: /volumes/signoz-telemetrystore-0-0-data/name
+             value: signoz-clickhouse
+           - op: replace
+             path: /volumes/signoz-metastore-sqlite-0-data/name
+             value: signoz-sqlite
+           - op: add
+             path: /services/signoz-telemetrykeeper-zookeeper-0/user
+             value: root
+   ```
+
+   The `patches` block remaps Foundry's generated volume names to your existing volume names (from step 1) so the new containers attach to your current data.
+
+   <Admonition type="info">
+   The `user: root` patch on the ZooKeeper service lets the container read and write the data in your reused ZooKeeper volume, which the legacy Compose setup created with `root`-owned files. Without it, ZooKeeper may fail to start with permission errors.
+   </Admonition>
+
+   If you had custom configuration for features like SMTP or additional ingestion processors and receivers, include those in your casting file using <a href="https://github.com/SigNoz/foundry/blob/main/docs/concepts/patches.md" target="_blank" rel="noopener noreferrer nofollow">patches</a>, <a href="https://github.com/SigNoz/foundry/blob/main/docs/concepts/moldings.md#custom-config-files" target="_blank" rel="noopener noreferrer nofollow">custom configuration files</a>, or <a href="https://github.com/SigNoz/foundry/blob/main/docs/reference/casting-file.md#molding-spec" target="_blank" rel="noopener noreferrer nofollow">environment variables</a>, based on your previous configuration.
+
+3. **Review your manifests.** Before proceeding, check the generated manifests in `pours/deployment`:
+
+   - Validate that the container images match what your deployment had. Foundry uses `latest` on generation by default.
+   - If your SigNoz version was older than `latest`, check the [upgrade path](https://signoz.io/docs/operate/upgrade/) first.
+   - Confirm the produced manifests match your older configuration. Pay extra attention to `compose.yaml`, as it is the main entry point for your new deployment.
+   - The ClickHouse configuration files are now in YAML — validate that your custom settings are present.
+
+4. **Bring the legacy stack down.** Run `docker compose down`.
+
+   <Admonition type="warning">
+   Do **not** include `--volumes` (or `-v`). That would wipe the volumes you need to reuse and cause data loss.
+   </Admonition>
+
+   <Admonition type="info">
+   This step causes downtime, so plan accordingly.
+   </Admonition>
+
+5. **Confirm the old containers are stopped.** Run `docker ps -a` and verify the SigNoz containers are down. Multiple containers cannot bind the same volume.
+
+6. **Recreate the stack with Foundry.** Run:
+
+   ```bash
+   foundryctl cast -f casting.yaml
+   ```
+
+   This recreates the containers based on your spec and downloads new container images. When `cast` runs, the migration container executes its migrations.
+
+## Verify the migration
+
+- The SigNoz containers are up and running.
+- Log in to the SigNoz UI at `http://localhost:8080` and confirm your historical data is present.
+- Confirm ingestion is working — the ingesters receive data on `localhost:4317` (gRPC) and `localhost:4318` (HTTP).
+- Review the logs from both ClickHouse and ZooKeeper; no errors should be present.
+
+## Roll back
+
+Because step 4 brought the legacy stack down without `-v`, your original volumes are untouched and still hold your data. To roll back:
+
+1. Stop and remove the containers Foundry created — `docker compose down`, again without `-v`.
+2. Confirm the containers are gone with `docker ps -a` so nothing else is bound to the volumes.
+3. Reapply your original Docker Compose file — `docker compose up -d`. It reattaches to the existing volumes and restores your prior state.
+
+## Troubleshooting
+
+If you run into issues during migration, reach out to the community on <a href="https://signoz.io/slack" target="_blank" rel="noopener noreferrer nofollow">Slack</a>.
+
+## Next steps
+
+- [Install SigNoz on Docker with Foundry](https://signoz.io/docs/install/docker/)
+- [Upgrade SigNoz](https://signoz.io/docs/operate/upgrade/)
+- <a href="https://github.com/SigNoz/foundry" target="_blank" rel="noopener noreferrer nofollow">Foundry on GitHub</a>

--- a/data/docs/install/self-host.mdx
+++ b/data/docs/install/self-host.mdx
@@ -1,9 +1,10 @@
 ---
-date: 2026-06-10
+date: 2026-06-24
 tags : [Self-Host]
-title: Install Self-Hosted SigNoz
-description: Choose a self-hosted SigNoz installation method including Docker Standalone, Docker Swarm, and Kubernetes with Helm.
+title: Install Self-Hosted SigNoz - Docker & Kubernetes Guide
+description: Choose a self-hosted SigNoz installation method, including Docker with Foundry and Kubernetes with Helm, and get up and running in minutes.
 id: self-host
+doc_type: howto
 ---
 
 This documentation provides different ways to install Self-Hosted SigNoz.


### PR DESCRIPTION
## Summary

SigNoz has removed its legacy Docker-based install method — `install.sh` now only prints a deprecation notice, and all bundled Docker Compose files (Docker standalone, Docker Swarm, and HA variants) have been deleted. These docs updates remove the now-broken workflows and point users to Foundry (PR #11811).

### Changes
- **`/docs/install/docker/`** — removed the broken "Manual" tab (cloned the repo and ran `docker compose up` against the now-deleted compose file); unwrapped the single Foundry path; added a migration notice for existing Docker Compose users; dropped the obsolete Git prerequisite.
- **`/docs/install/docker-swarm/`** — replaced the broken Swarm instructions with a deprecation notice (Swarm is discontinued with no Foundry replacement); removed the forbidden `KeyPointCallout`; pointed users to Foundry and the migration guide.
- **`/docs/install/migrate-to-foundry/`** (new) — first-class migration guide surfacing the in-repo `MIGRATION.md`: volume reuse, `casting.yaml` generation, cutover, rollback, and verification.
- **`/docs/install/self-host/`** — refreshed overview title/description (Foundry + Kubernetes); removed the Docker Swarm card from the self-host install listicle.
- **`/docs/install.mdx` (Get Started)** — updated the self-host card description (no longer lists Docker Swarm).
- **`/docs/install/docker-selinux/`** — removed the dead Docker Swarm link; pointed install to the Foundry Docker guide.
- **Sidebar** — added "Migrate to Foundry" under Install on Docker.
- Updated frontmatter `date` to 2026-06-24 on all edited files.

### Notes
- No product UI screenshots: this change is entirely in the install/onboarding flow, not the product UI.
- `tests/component-items-sync.test.js` cannot run in this environment (missing `typescript` dev dependency); the edited listicle JSON is valid and parses.

Source PRs: #11811

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)