### PR TITLE
docs: change page title to Logs Explorer

### DIFF
--- a/data/docs/userguide/logs_query_builder.mdx
+++ b/data/docs/userguide/logs_query_builder.mdx
@@ -1,6 +1,6 @@
 ---
 date: 2026-05-20
-title: Live Tail Logs in SigNoz
+title: Logs Explorer
 meta_title: "Logs Explorer: Query, Search & Analyze Logs Efficiently"
 id: logs_query_builder
 description: Explore logs with SigNoz Logs Explorer. Query, search and analyze logs efficiently using powerful log explorer queries and real-time insights.


### PR DESCRIPTION
## Summary

Changes the page title of the [Logs Explorer user guide](https://signoz.io/docs/userguide/logs_query_builder/) from **"Live Tail Logs in SigNoz"** to **"Logs Explorer"**.

The page content already describes the Logs Explorer interface, so the new title better reflects what the page is about.

## Changes

- `data/docs/userguide/logs_query_builder.mdx` — update frontmatter `title`

## Verification

- `yarn check:docs-metadata` ✅
- `yarn test:docs-metadata` ✅ (30 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)