### PR TITLE
chore: upgrade clickhouse version to 25.12.5

### DIFF
--- a/data/docs/install/azure-container-apps.mdx
+++ b/data/docs/install/azure-container-apps.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-27
+date: 2026-06-25
 tags : [Self-Host]
 title: Deploying to Azure Container Apps
 description: Learn how to install SigNoz on Azure Container Apps
@@ -521,7 +521,7 @@ properties:
             volumeName: shared-binary-volume
     containers:
       - name: clickhouse
-        image: docker.io/clickhouse/clickhouse-server:25.5.6
+        image: docker.io/clickhouse/clickhouse-server:25.12.5
         env:
           - name: CLICKHOUSE_SKIP_USER_SETUP
             value: "1"

--- a/data/docs/install/ecs.mdx
+++ b/data/docs/install/ecs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-25
 tags : [Self-Host]
 title: Deploying to ECS
 description: Learn how to install SigNoz on ECS
@@ -310,7 +310,7 @@ Each section below shows one `containerDefinition` snippet. Replace all `<…>` 
 ```json
 {
   "name": "init-clickhouse",
-  "image": "clickhouse/clickhouse-server:25.5.6",
+  "image": "clickhouse/clickhouse-server:25.12.5",
   "cpu": 256,
   "memory": 256,
   "memoryReservation": 256,
@@ -377,7 +377,7 @@ Each section below shows one `containerDefinition` snippet. Replace all `<…>` 
 ```json
 {
   "name": "clickhouse",
-  "image": "clickhouse/clickhouse-server:25.5.6",
+  "image": "clickhouse/clickhouse-server:25.12.5",
   "cpu": 1024,
   "memory": 512,
   "memoryReservation": 512,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Update clickhouse version since collector v0.145+ requires atleast clickhouse v25.12.5 to support the table settings migration added in https://github.com/SigNoz/signoz-otel-collector/pull/833