### PR TITLE
fix: docs onboarding redirect

### DIFF
--- a/app/docs-onboarding/[...slug]/page.tsx
+++ b/app/docs-onboarding/[...slug]/page.tsx
@@ -4,7 +4,8 @@ import siteMetadata from '@/data/siteMetadata'
 
 // Inlined as literal because Next 15's segment-config static analyzer doesn't
 // follow re-exports. Keep in sync with ../../(site)/docs/(main-docs)/[...slug]/page.tsx
-export const dynamicParams = false
+export const revalidate = 86400
+export const dynamicParams = true
 
 export { default, generateStaticParams } from '../../(site)/docs/(main-docs)/[...slug]/page'
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> PR #3516 (commit `5bfcdee89`, "feat: docs migration base") migrated docs from Contentlayer to a CMS-based approach. The main docs page at `app/(site)/docs/(main-docs)/[...slug]/page.tsx` was updated — `dynamicParams` changed from `false` to `true` and `generateStaticParams` now returns `[]` (pages resolved on-demand at runtime with ISR).
>
> **The onboarding page at `app/docs-onboarding/[...slug]/page.tsx` was NOT updated in that commit.** It still had `dynamicParams = false` but re-exports `generateStaticParams` from the main docs page (which now returns `[]`). The combination of `dynamicParams = false` + zero static params meant **every `/docs-onboarding/*` slug returned 404**.
>
> The file's own comment says "Keep in sync with `../../(site)/docs/(main-docs)/[...slug]/page.tsx`" — but it was not kept in sync.

#### Screenshots / Screen Recordings (if applicable)
> N/A — routing fix, no visual changes.

#### Issues closed by this PR
> Fixes docs-onboarding 404s introduced by PR #3516.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> PR #3516 changed the main docs page to use `dynamicParams = true` with `generateStaticParams` returning `[]` (on-demand ISR). The docs-onboarding page re-exports `generateStaticParams` from the main docs page but was not updated — it kept `dynamicParams = false`. With zero static params and dynamic params disabled, Next.js 404s every slug.

#### Fix Strategy
> Sync the onboarding page's segment config with the main docs page:
> - `dynamicParams = false` → `dynamicParams = true`
> - Add `revalidate = 86400` (24h ISR, matching main docs page)
>
> Both values are inlined (not re-exported) because Next 15's static analyzer doesn't follow re-exports — this is already documented in the file's existing comment.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: None required — no new logic, purely a config sync.
- Manual verification:
  - `/docs-onboarding/install/` should render (was 404 before)
  - `/docs-onboarding/introduction/` should still render (no regression — separate explicit route)
  - `/docs-onboarding/nonexistent-slug/` should 404 (invalid slug handling via `notFound()` in the Page component)
- Edge cases covered:
  - Invalid slugs still 404 correctly: the `Page` component calls `fetchDocBySlug(slug)` and returns `notFound()` if the doc doesn't exist.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Minimal — single file, two config lines changed. Only affects `/docs-onboarding/*` routes.
- Potential regressions: None. The onboarding layout already has `robots: { index: false, follow: false }`, middleware and redirect config are unaffected.
- Rollback plan: Revert the single commit.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Single-line change in `app/docs-onboarding/[...slug]/page.tsx`:

```diff
-export const dynamicParams = false
+export const revalidate = 86400
+export const dynamicParams = true
```

No other files need changes — `introduction/page.tsx`, `layout.tsx`, `middleware.ts`, `next.config.js`, and `components/Link.tsx` are all unaffected.

---
