### PR TITLE
[codex] Update trace field docs

### DIFF
--- a/data/docs/ai/use-cases/dashboard-creation-natural-language.mdx
+++ b/data/docs/ai/use-cases/dashboard-creation-natural-language.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-27
 title: Dashboard Creation from Natural Language
 meta_title: Create Dashboards with Natural Language
 description: Build SigNoz dashboards faster by describing the visualizations you need in plain English — AI assistants handle the rest via the MCP server.
@@ -36,7 +36,7 @@ Your assistant will first verify the service exists and is actively sending tele
 Three panels configured (all scoped to service.name = 'recommendation' over last 24h):
 
 1. P99 Latency (top-left)
-   - Metric: p99(durationNano) on traces
+   - Metric: p99(duration_nano) on traces
    - Visualization: Time series
 
 2. Error Rate (%) (top-right)

--- a/data/docs/ai/use-cases/incident-specific-dashboard.mdx
+++ b/data/docs/ai/use-cases/incident-specific-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-27
 title: Incident Specific Dashboard Spin-Up
 meta_title: Incident Dashboard Spin-Up with AI
 description: Instantly generate focused SigNoz dashboards for active incidents with relevant metrics and traces using AI and the MCP server.
@@ -54,7 +54,7 @@ Section 1: Golden Signals vs 7-day Baseline
 
 Section 2: Top Errors & Failing Traces
 - Table of failing operations grouped by span name
-- List of recent error traces with traceID and status messages for one-click drill-down
+- List of recent error traces with `trace_id` and status messages for one-click drill-down
 
 Section 3: Dependency Health
 - Error rate % for each dependency: payment, cart, product-catalog, currency, shipping, email

--- a/data/docs/ai/use-cases/postmortem-evidence-pack.mdx
+++ b/data/docs/ai/use-cases/postmortem-evidence-pack.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-06-27
 title: Postmortem Evidence Pack
 meta_title: Postmortem Evidence Pack - AI Incident Report
 description: Compile alerts, logs, trace anomalies, and metric changes into a clean postmortem evidence timeline using AI and SigNoz MCP in minutes.
@@ -98,7 +98,7 @@ Other sporadic errors (low volume):
 Trace ID: 76fd879f63426af304263cd3ebc30648
 Time: 2026-04-23 15:52:54 UTC
 Duration: 2.08s
-Status: hasError=true
+Status: has_error=true
 
 Call chain:
 load-generator → frontend-proxy → frontend → checkout (PlaceOrder)
@@ -122,7 +122,7 @@ Same pattern matches traces:
 - d943417a… (15:39:19)
 - b43e327f… (15:36:49)
 
-All with identical statusMessage and similar 1.7–2.8s durations.
+All with identical status_message and similar 1.7–2.8s durations.
 ```
 
 </details>

--- a/data/docs/alerts-management/trace-based-alerts.mdx
+++ b/data/docs/alerts-management/trace-based-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: 2026-06-27
 title: Trace based alerts
 description: Create trace-based alerts in SigNoz using the Traces Query Builder to monitor span attributes, latency, and error rates.
 doc_type: reference
@@ -23,7 +23,7 @@ to perform operations on your Traces to define conditions based on traces data. 
 
 - **Aggregate Attribute**: Select how the trace data should be aggregated. You can use functions like `count()`, `p90(duration_nano)`, `avg(duration_nano)`, etc.
 
-- **Group By**: Group trace data by different span/trace attributes, like `serviceName`, `status`, or other custom attributes.
+- **Group By**: Group trace data by different span/trace attributes, like `service.name`, `status_code`, or other custom attributes.
 
 - **[Legend Format](https://signoz.io/docs/userguide/query-builder-v5/#legend-format)**: An optional field to define the format for the legend in the visual representation of the alert.
 
@@ -191,7 +191,7 @@ Using the `external_http_url` attribute we filter for a specific external API en
 />
 
 <Admonition type="info">
-Remember to select y-axis unit as nanoseconds as our aggregate key is durationNano.
+Remember to select y-axis unit as nanoseconds as our aggregate key is `duration_nano`.
 </Admonition>
 <br></br>
 #### Step 2: Set alert conditions

--- a/data/docs/apm-and-distributed-tracing/application-details.mdx
+++ b/data/docs/apm-and-distributed-tracing/application-details.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-12
+date: 2026-06-27
 title: Application Details
 description: Explore application-level metrics in SigNoz including latency percentiles, error rates, operations per second, key operations, and Apdex scores.
 doc_type: reference
@@ -39,7 +39,7 @@ Application Performance Index (<a href="https://www.apdex.org/" rel="noopener no
 **Key Operations** <br></br>
 Lists the top operations for your service with P50, P95, P99 latency, number of calls, and error rate. Click any operation to drill into its traces.
 
-The **Entry Point Spans** toggle filters the Key Operations table to show only spans where the `serviceName` changes — i.e., the first span when a request enters this service from any upstream service. Switching it on hides internal downstream spans and gives you a concise, high-level view of how external traffic is behaving.
+The **Entry Point Spans** toggle filters the Key Operations table to show only spans where the `service.name` resource attribute changes — i.e., the first span when a request enters this service from any upstream service. Switching it on hides internal downstream spans and gives you a concise, high-level view of how external traffic is behaving.
 
 <Figure
   src="/img/docs/apm-and-distributed-tracing/key-operations-entrypoint-spans.webp"

--- a/data/docs/apm-and-distributed-tracing/querying-traces.mdx
+++ b/data/docs/apm-and-distributed-tracing/querying-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-25
+date: 2026-06-27
 title: Querying Traces
 description: Query traces in SigNoz using the Query Builder in Trace Explorer and Dashboards, with ClickHouse SQL available in Dashboards.
 doc_type: reference
@@ -19,7 +19,7 @@ Use the **Filter** field to narrow down spans using attributes. Supported operat
 |---|---|---|
 | Exact match | `=` | `service.name = 'frontend'` |
 | Exclude | `!=` | `service.name != 'redis'` |
-| One of several | `IN` | `httpMethod IN ('GET', 'POST')` |
+| One of several | `IN` | `http_method IN ('GET', 'POST')` |
 | Substring | `LIKE` | `name LIKE '%payment%'` |
 | Field exists | `EXISTS` | `db.system EXISTS` |
 

--- a/data/docs/dashboards/dashboard-templates/db-calls-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/db-calls-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-06-27
 
 title: DB Calls Monitoring Dashboard
 description: Monitor comprehensive database operations including transaction rates, top DB statements, error rates, and slowest database calls for performance optimization.
@@ -45,10 +45,10 @@ This dashboard tracks essential database metrics to help you:
 - **DB Error Rate**: Shows database error percentage over time
 
 ### Top Operations
-- **Top DB Statements Table**: Shows database statements with dbName, db.statement, total calls, average duration, and rate
+- **Top DB Statements Table**: Shows database statements with `db_name`, `db.statement`, total calls, average duration, and rate
 
 ### Slowest DB Calls
-- **Slowest DB Calls Table**: Shows slowest database operations with timestamp, serviceName, name, durationNano, db.statement, and dbOperation
+- **Slowest DB Calls Table**: Shows slowest database operations with timestamp, `service.name`, name, `duration_nano`, `db.statement`, and `db_operation`
 
 ## Dashboard Variables
 
@@ -57,6 +57,6 @@ This dashboard includes pre-configured variables for filtering:
 - **service.name**: Filter by specific service names making database calls
 ## Related Dashboards
 
-- [APM Metrics](/docs/dashboards/dashboard-templates/apm-metrics/)
-- [SigNoz Ingestion Analysis](/docs/dashboards/dashboard-templates/signoz-ingestion-analysis/)
-- [Key Operations](/docs/dashboards/dashboard-templates/key-operations/)
+- [APM Metrics](https://signoz.io/docs/dashboards/dashboard-templates/apm-metrics/)
+- [SigNoz Ingestion Analysis](https://signoz.io/docs/dashboards/dashboard-templates/signoz-ingestion-analysis/)
+- [Key Operations](https://signoz.io/docs/dashboards/dashboard-templates/key-operations/)

--- a/data/docs/dashboards/dashboard-templates/hermes-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/hermes-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-27
 title: Hermes Agent Dashboard
 description: Monitor Hermes coding agent sessions, LLM API calls and token usage, tool-call activity, latency, and errors using OTel traces for complete AI agent observability.
 doc_type: explanation
@@ -47,7 +47,7 @@ This dashboard tracks critical performance metrics for your Hermes coding agent 
 - **LLM API Calls**: Count of spans where `llm.model_name` exists, representing individual chat completion calls made to the model provider.
 - **Tool Calls**: Count of `tool.*` spans, showing the total number of tool invocations across all agent turns.
 - **Total Tokens**: Sum of `gen_ai.usage.total_tokens` across all spans, giving the aggregate token consumption for the selected range.
-- **Error Spans**: Count of spans where `hasError = true`, with a red threshold triggered by any non-zero value for immediate attention.
+- **Error Spans**: Count of spans where `has_error = true`, with a red threshold triggered by any non-zero value for immediate attention.
 
 ### LLM & Model Metrics
 
@@ -77,6 +77,6 @@ This dashboard tracks critical performance metrics for your Hermes coding agent 
 
 ### Error Monitoring
 
-- **Errors Over Time**: Time series of `hasError = true` spans grouped by span name, letting you see which operations are failing and when failure spikes occur.
+- **Errors Over Time**: Time series of `has_error = true` spans grouped by span name, letting you see which operations are failing and when failure spikes occur.
 - **Error Count by Operation**: Table of error counts per operation name sorted descending, identifying the most-failing span types at a glance.
 - **Recent Error Spans**: List of the 25 most recent errored spans sorted by timestamp, showing the span name, status message, `hermes.tool.outcome`, and duration — use this to drill into individual failures and find root causes.

--- a/data/docs/dashboards/using-variables-in-queries.mdx
+++ b/data/docs/dashboards/using-variables-in-queries.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-06-27
 title: Using Variables in Queries
 description: Use dashboard variables in Query Builder, ClickHouse SQL, and PromQL queries in SigNoz.
 doc_type: howto
@@ -33,7 +33,7 @@ Reference variables with `$` prefix in your SQL:
 SELECT
     toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS interval,
     attributes_string['http.method'] AS method,
-    toFloat64(avg(durationNano)) AS value
+    toFloat64(avg(duration_nano)) AS value
 FROM
     signoz_traces.distributed_signoz_index_v3
 WHERE

--- a/data/docs/instrumentation/javascript/nodejs-manual-instrumentation.mdx
+++ b/data/docs/instrumentation/javascript/nodejs-manual-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-27
 title: How to add manual instrumentation in Node.js
 description: Learn how to add manual instrumentation in Node.js with OpenTelemetry. Create custom spans for checkout flows, payments, and business-critical code paths.
 tags: [SigNoz Cloud, Self-Host]
@@ -182,7 +182,7 @@ tracer.startActiveSpan('process-result', { links: [{ context: linkContext }] }, 
 1. Trigger code paths that create manual spans.
 2. In SigNoz **Traces**, filter by `service.name` or span name.
 3. Open a trace and check attributes, events, and error status.
-4. Use `hasError = true` to find spans with recorded exceptions.
+4. Use `has_error = true` to find spans with recorded exceptions.
 
 <details>
 <ToggleHeading>

--- a/data/docs/instrumentation/python/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/python/manual-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-06-27
 title: How to add manual instrumentation in Python
 description: Learn how to add manual instrumentation in Python using OpenTelemetry. Create custom spans, set attributes, and capture business logic for deeper observability.
 
@@ -162,7 +162,7 @@ with tracer.start_as_current_span("span-2", links=[link_from_span_1]):
 1. Trigger the code paths that emit manual spans.
 2. In SigNoz **Traces**, filter by `service.name` or your span name.
 3. Open a trace and verify attributes, events, and error status.
-4. Filter traces with `hasError in [true]` in the Trace Explorer to confirm failures show up with recorded exceptions.
+4. Filter traces with `has_error = true` in the Trace Explorer to confirm failures show up with recorded exceptions.
 
 <details>
 <ToggleHeading>

--- a/data/docs/traces-management/trace-api/aggregate-traces.mdx
+++ b/data/docs/traces-management/trace-api/aggregate-traces.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2024-06-06
+date: 2026-06-27
 title: Aggregate Traces
 description: Perform aggregation operations on trace data using the SigNoz Trace API, with examples for counting and grouping by span attributes.
+doc_type: reference
 
 ---
 
@@ -9,14 +10,14 @@ This section demonstrates how to perform aggregation operations on trace data us
 
 ## Aggregation Example
 
-This example is useful for scenarios where you need to count occurrences of specific values (e.g., customer) and group them by another attribute (e.g., serviceName).
+This example is useful for scenarios where you need to count occurrences of specific values (e.g., customer) and group them by another attribute (e.g., service.name).
 
 ### Query Description
 
-- **Objective**: Count customer values and group them by serviceName
+- **Objective**: Count customer values and group them by service.name
 - **Attributes**:
   - **aggregateAttribute**: `customer`
-  - **groupBy**: `serviceName`
+  - **groupBy**: `service.name`
 
 ### Sample Payload
 
@@ -43,7 +44,8 @@ This is the JSON payload for the example query.
                     ],
                     "groupBy": [
                         {
-                            "name": "serviceName",
+                            "name": "service.name",
+                            "fieldContext": "resource"
                         }
                     ],
                     "order": [

--- a/data/docs/traces-management/trace-api/payload-model.mdx
+++ b/data/docs/traces-management/trace-api/payload-model.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2024-06-06
+date: 2026-06-27
 title: Trace API Payload Model
 description: Detailed reference for the SigNoz Trace API JSON payload structure, including compositeQuery, builder queries, filters, and ClickHouse query fields.
+doc_type: reference
 
 ---
 
@@ -90,7 +91,7 @@ A `selectField` consists of:
 |---|---|
 |name | Name of the field |
 |fieldDataType | Data type of the field (e.g., string, int64, float64, bool) |
-|fieldContext | Type of the field, i.e., attribute/resource. |
+|fieldContext | Type of the field, i.e., attribute/resource/span. |
 
 ### GroupBy Key
 
@@ -100,7 +101,7 @@ The `groupByKey` includes:
 |---|---|
 |name | Name of the field |
 |fieldDataType | Data type of the field (e.g., string, int64, float64, bool) |
-|fieldContext | Type of the field, i.e., attribute/resource |
+|fieldContext | Type of the field, i.e., attribute/resource/span |
 
 ### Order By
 
@@ -123,7 +124,7 @@ A `having` consists of:
 
 ### For builderQuery with table requestType
 
-This sample payload contains the different fields that we looked at above. It queries the SigNoz Trace API and illustrates how to count errors and group them by `serviceName` where `hasError` is `true`.
+This sample payload contains the different fields that we looked at above. It queries the SigNoz Trace API and illustrates how to count errors and group them by `service.name` where `has_error` is `true`.
 
 ```json
 {
@@ -146,11 +147,12 @@ This sample payload contains the different fields that we looked at above. It qu
                         }
                     ],
                     "filter": {
-                        "expression": "hasError = true"
+                        "expression": "has_error = true"
                     },
                     "groupBy": [
                         {
-                            "name": "serviceName",
+                            "name": "service.name",
+                            "fieldContext": "resource"
                         }
                     ],
                     "order": [
@@ -184,7 +186,7 @@ This sample payload contains the different fields that we looked at above. It qu
                 "type": "clickhouse_sql",
                 "spec": {
                     "name": "A",
-                    "query": "SELECT resource_string_service$$name AS `service.name`, toFloat64(avg(durationNano)) AS value FROM signoz_traces.distributed_signoz_index_v3 WHERE timestamp BETWEEN $start_datetime AND $end_datetime AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp GROUP BY (`service.name`) order by (`service.name`) ASC;",
+                    "query": "SELECT resource_string_service$$name AS `service.name`, toFloat64(avg(duration_nano)) AS value FROM signoz_traces.distributed_signoz_index_v3 WHERE timestamp BETWEEN $start_datetime AND $end_datetime AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp GROUP BY (`service.name`) order by (`service.name`) ASC;",
                     "disabled": false
                 }
             }

--- a/data/docs/traces-management/trace-api/search-traces.mdx
+++ b/data/docs/traces-management/trace-api/search-traces.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2024-06-06
+date: 2026-06-27
 title: Search Traces
 description: Search and filter traces using the SigNoz Trace API with examples for querying spans by attributes, methods, error status, and resource attributes.
+doc_type: reference
 
 ---
 This section provides detailed examples of searching traces using the SigNoz Trace API. The example queries demonstrate querying traces with specific attributes and filters.
@@ -15,14 +16,14 @@ This query is useful when identifying all spans with specific characteristics, s
 This query searches for all spans where:
 
 - `deployment_name`= hotrod
-- `httpMethod`= GET
-- `hasError` = true
+- `http_method`= GET
+- `has_error` = true
 
 ### Attributes and Columns
 
 - Resource Attribute: `deployment_name`
-- Tag Attributes + Columns: `httpMethod`, `hasError`
-- Selected Columns: `serviceName`, `httpMethod`, `responseStatusCode`, `httpUrl`
+- Tag Attributes + Columns: `http_method`, `has_error`
+- Selected Columns: `service.name`, `http_method`, `response_status_code`, `http_url`
 
 You can specify the start and end timestamps in Unix format (milliseconds).
 
@@ -44,20 +45,24 @@ This is the JSON payload for the example query.
                     "name": "A",
                     "signal": "traces",
                     "filter": {
-                        "expression": "deployment_name = 'hotrod' AND httpMethod = 'GET' AND hasError = true"
+                        "expression": "deployment_name = 'hotrod' AND http_method = 'GET' AND has_error = true"
                     },
                     "selectFields": [
                         {
-                            "name": "serviceName",
+                            "name": "service.name",
+                            "fieldContext": "resource"
                         },
                         {
-                            "name": "httpMethod",
+                            "name": "http_method",
+                            "fieldContext": "span"
                         },
                         {
-                            "name": "responseStatusCode",
+                            "name": "response_status_code",
+                            "fieldContext": "span"
                         },
                         {
-                            "name": "httpUrl",
+                            "name": "http_url",
+                            "fieldContext": "span"
                         }
                     ],
                     "order": [
@@ -87,19 +92,19 @@ This type of query can be useful to find the initial operation or root spans in 
 This query searches for  root spans with:
 
 - `deployment_name`= hotrod
-- `httpMethod`= GET
+- `http_method`= GET
 
 ### Attributes and Columns
 
 - Resource Attribute: `deployment_name`
-- Tag Attributes + Columns: `httpMethod`
-- Selected Columns: `serviceName`, `httpMethod`, `responseStatusCode`, `some_custom_tag`
+- Tag Attributes + Columns: `http_method`
+- Selected Columns: `service.name`, `http_method`, `response_status_code`, `some_custom_tag`
 
 You can specify the start and end timestamps in Unix format (milliseconds).
 
 <Admonition>
 
-To search for root spans, you need to add `parentSpanID = ''` in the filter expression
+To search for root spans, you need to add `parent_span_id = ''` in the filter expression
 
 </Admonition>
 
@@ -121,20 +126,23 @@ This is the JSON payload for the example query.
                     "name": "A",
                     "signal": "traces",
                     "filter": {
-                        "expression": "deployment_name = 'hotrod' AND httpMethod = 'GET' AND parentSpanID = ''"
+                        "expression": "deployment_name = 'hotrod' AND http_method = 'GET' AND parent_span_id = ''"
                     },
                     "selectFields": [
                         {
-                            "name": "serviceName",
+                            "name": "service.name",
+                            "fieldContext": "resource"
                         },
                         {
-                            "name": "httpMethod",
+                            "name": "http_method",
+                            "fieldContext": "span"
                         },
                         {
-                            "name": "responseStatusCode",
+                            "name": "response_status_code",
+                            "fieldContext": "span"
                         },
                         {
-                            "name": "some_custom_tag",
+                            "name": "some_custom_tag"
                         }
                     ],
                     "order": [

--- a/data/docs/tutorial/writing-clickhouse-queries-in-dashboard.mdx
+++ b/data/docs/tutorial/writing-clickhouse-queries-in-dashboard.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2024-06-06
+date: 2026-06-27
 title: ClickHouse queries for building dashboards and alerts
 description: Example clickhouse queries to run analytics on observability data
+doc_type: reference
 ---
 
 SigNoz gives you the ability to write powerful ClickHouse queries to plot charts. You can run SQL queries supported by ClickHouse to extract immense value out of your distributed tracing data or logs data. 
@@ -19,7 +20,7 @@ Sharing a few examples of some queries which might be helpful in building dashbo
 ```sql
 SELECT toStartOfInterval(timestamp, INTERVAL 1 MINUTE) AS interval, 
 attributes_string['http.method'] AS method,
-toFloat64(avg(durationNano)) AS value 
+toFloat64(avg(duration_nano)) AS value
 FROM signoz_traces.distributed_signoz_index_v3
 WHERE attributes_string['http.method']!=''
 AND timestamp > now() - INTERVAL 30 MINUTE
@@ -49,19 +50,19 @@ FROM
 (
     SELECT
         interval,
-        traceID,
+        trace_id,
         if(startTime1 != 0, if(startTime2 != 0, (toUnixTimestamp64Nano(startTime2) - toUnixTimestamp64Nano(startTime1)) / 1000000, nan), nan) AS time_diff
     FROM
     (
         SELECT
             toStartOfInterval(timestamp, toIntervalMinute(1)) AS interval,
-            traceID,
+            trace_id,
             minIf(timestamp, if(resource_string_service$$name='driver', if(name = '/driver.DriverService/FindNearest', if((resources_string['component']) = 'gRPC', true, false), false), false)) AS startTime1,
             minIf(timestamp, if(resource_string_service$$name='route', if(name = 'HTTP GET /route', true, false), false)) AS startTime2
         FROM signoz_traces.distributed_signoz_index_v3
         WHERE (timestamp BETWEEN {{.start_datetime}} AND {{.end_datetime}}) AND (ts_bucket_start BETWEEN {{.start_timestamp}} - 1800 AND {{.end_timestamp}}) AND (resource_string_service$$name IN ('driver', 'route'))
-        GROUP BY (interval, traceID)
-        ORDER BY (interval, traceID) ASC
+        GROUP BY (interval, trace_id)
+        ORDER BY (interval, trace_id) ASC
     )
 )
 WHERE isNaN(time_diff) = 0
@@ -94,7 +95,7 @@ FROM (
  SELECT timestamp 
  FROM signoz_traces.distributed_signoz_index_v3
  WHERE resource_string_service$$name='frontend' 
- AND durationNano>=50*exp10(6) 
+ AND duration_nano>=50*exp10(6)
  AND timestamp > now() - INTERVAL 1 MINUTE AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - toIntervalMinute(1))) - 1800)
  GROUP BY interval 
  ORDER BY interval ASC;
@@ -187,5 +188,3 @@ The reserved bind variables `{{.start_datetime}}` and `{{.end_datetime}}` would 
 
 
  
-
-

--- a/data/docs/userguide/writing-clickhouse-traces-query.mdx
+++ b/data/docs/userguide/writing-clickhouse-traces-query.mdx
@@ -1,8 +1,9 @@
 ---
-date: 2026-06-26
+date: 2026-06-27
 
 title: Traces Schema - Write ClickHouse Queries & Build Dashboard Panels
 description: Explore the OpenTelemetry traces schema in ClickHouse. Discover how to build custom dashboard panels, analyze span kinds, and calculate latency metrics with advanced queries.
+doc_type: reference
 ---
 
 SigNoz stores all trace data in ClickHouse. When the visual Query Builder does not cover your use case, you can write ClickHouse SQL directly to build custom dashboard panels.
@@ -601,7 +602,7 @@ FROM
 (
     SELECT
         interval,
-        traceID,
+        trace_id,
         if(startTime1 != 0, 
            if(startTime2 != 0, 
               (toUnixTimestamp64Nano(startTime2) - toUnixTimestamp64Nano(startTime1)) / 1000000, 
@@ -611,7 +612,7 @@ FROM
     (
         SELECT
             toStartOfInterval(timestamp, toIntervalMinute(1)) AS interval,
-            traceID,
+            trace_id,
             minIf(timestamp, 
                 resource_string_service$$name = 'driver' 
                 AND name = '/driver.DriverService/FindNearest'
@@ -624,8 +625,8 @@ FROM
         WHERE timestamp BETWEEN $start_datetime AND $end_datetime
             AND ts_bucket_start BETWEEN $start_timestamp - 1800 AND $end_timestamp
             AND resource_string_service$$name IN ('driver', 'route')
-        GROUP BY interval, traceID
-        ORDER BY interval, traceID ASC
+        GROUP BY interval, trace_id
+        ORDER BY interval, trace_id ASC
     )
 )
 WHERE isNaN(time_diff) = 0


### PR DESCRIPTION
## Summary

- Update trace Query Builder and Trace API docs to use canonical snake_case trace fields instead of deprecated camelCase aliases.
- Refresh related ClickHouse v3 examples and dashboard/use-case docs for fields such as `trace_id`, `duration_nano`, `http_method`, `has_error`, `parent_span_id`, and `service.name`.
- Add missing `doc_type` metadata and clean touched internal docs links.

## Motivation

Follow-up to https://github.com/SigNoz/signoz-ai-assistant/issues/361. The backend keeps camelCase aliases for compatibility, but the docs should teach canonical field names so examples stay aligned with the current trace field model.

## Review

Ran a two-agent review before opening the PR:

- Technical field-name review: found one payload-model wording issue for `fieldContext: "span"`; fixed.
- Docs quality review: found the same fieldContext issue plus relative links and missing `doc_type`; fixed.

## Validation

`yarn` was not available globally in this shell, so checks were run with the equivalent `npm run` scripts after installing dependencies via Yarn 1 from the existing `yarn.lock`.

- `npm run check:docs-metadata`
- `npm run test:docs-metadata`
- `npm run check:doc-redirects`
- `npm run test:doc-redirects`
- `npm run check:stale-urls`
- `npm run test:stale-urls`
- pre-commit hook passed during commit, including docs redirects, docs metadata, stale URL fix/check, and CMS asset check
