### PR TITLE
chore: avoid docs md static generation

### DIFF
--- a/app/(site)/api/docs-markdown/[[...slug]]/route.ts
+++ b/app/(site)/api/docs-markdown/[[...slug]]/route.ts
@@ -1,22 +1,14 @@
 import { NextResponse } from 'next/server'
 import { renderDocMarkdownForAgents } from '@/utils/docs/renderDocMarkdownForAgents'
 import { resolveDocsMarkdownSlug } from '@/utils/docs/markdownRouting'
-import { fetchAllDocsForPage, fetchDocBySlug } from '@/utils/cachedData'
+import { fetchDocBySlug } from '@/utils/cachedData'
 
 export const runtime = 'nodejs'
 
 const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
 
 export async function generateStaticParams() {
-  const docs = await fetchAllDocsForPage()
-
-  return [
-    { slug: [] },
-    ...docs
-      .filter((doc) => typeof doc.slug === 'string')
-      .filter((doc) => doc.slug !== 'introduction')
-      .map((doc) => ({ slug: doc.slug.split('/') })),
-  ]
+  return []
 }
 
 const notFoundResponse = () =>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Switches the `/api/docs-markdown/` route from full static prerendering to on-demand ISR by returning `[]` from `generateStaticParams()`. This reduces build time and build output size - pages are generated on first request and cached via ISR (`s-maxage=3600, stale-while-revalidate=86400`) instead of being prerendered at build time.

#### Screenshots / Screen Recordings (if applicable)

<details>
<summary>Content comparison results (21 pages tested via byte-level curl + md5 diff)</summary>

| Page | Before (production) | After (preview) | Verdict |
|------|-------------------|----------------|---------|
| `/ (introduction)` | 6366B / `e8c5f5f7` | 6360B / `95bd12de` | **Identical (CDN domain only)** |
| `instrumentation/javascript/opentelemetry-nodejs` | 19139B / `171ab2e0` | 19139B / `171ab2e0` | **Identical** |
| `cloud/quickstart` | 5189B / `b840eb4f` | 5187B / `dbe5fdd2` | **Identical (CDN domain only)** |
| `install/docker` | 8097B / `9c77dcca` | 8097B / `9c77dcca` | **Identical** |
| `install/kubernetes` | 1179B / `fef63445` | 1179B / `fef63445` | **Identical** |
| `instrumentation/opentelemetry-python` | 27003B / `cbb14467` | 27003B / `cbb14467` | **Identical** |
| `alerts-management/metrics-based-alerts` | 16177B / `59519f48` | 16163B / `3f71989a` | **Identical (CDN domain only)** |
| `architecture` | 3243B / `ddf239a6` | 3242B / `28c4786f` | **Identical (CDN domain only)** |
| `instrumentation/java/opentelemetry-java` | 17200B / `31b9c30c` | 17200B / `31b9c30c` | **Identical** |
| `manage/administrator-guide/sso/user-guides/saml-okta` | 5231B / `ed40d60c` | 5229B / `af723633` | **Identical (CDN domain only)** |
| `aws-monitoring/lambda/lambda-traces` | 15180B / `0d566fff` | 15179B / `1e3ca188` | **Identical (CDN domain only)** |
| `dashboards/panel-types/timeseries` | 3030B / `44dbeacf` | 3028B / `1a69050d` | **Identical (CDN domain only)** |
| `instrumentation/opentelemetry-golang` | 34573B / `3efe244c` | 34571B / `5fabbd47` | **Identical (CDN domain only)** |
| `instrumentation/opentelemetry-dotnet` | 15429B / `d8d0c56c` | 15429B / `d8d0c56c` | **Identical** |
| `migration/migrate-from-datadog-to-signoz` | 5145B / `f8fc9fa3` | 5145B / `f8fc9fa3` | **Identical** |
| `logs-management/send-logs/python-logs` | 14345B / `aa9c4954` | 14343B / `74310d95` | **Identical (CDN domain only)** |
| `frontend-monitoring/sending-logs-with-opentelemetry` | 17900B / `5228b24a` | 17897B / `0d466f1a` | **Identical (CDN domain only)** |
| `mobile-monitoring` | 1187B / `64256e9c` | 1187B / `64256e9c` | **Identical** |
| `logs-pipelines/guides/grok-parser` | 9763B / `01d55c4c` | 9749B / `4bff3216` | **Identical (CDN domain only)** |
| `what-is-signoz` | 7414B / `69adb70f` | 7409B / `ca4ee3c7` | **Identical (CDN domain only)** |
| `overview/core-concepts/overview` | 421B / `ca0e88f4` | 421B / `ca0e88f4` | **Identical** |

Pages cover: Tabs/TabItem, Admonition, Figure, DocCard, code blocks (bash/yaml/js/ts/dockerfile/powershell), tables, deeply nested slugs, image-heavy pages, and simple text pages.

Where byte sizes or hashes differ, normalizing the CDN domain (`d3nu8xzr1i9u95.cloudfront.net` → `dxxw629vre1qa.cloudfront.net`) produces identical output — this is an environment-level config difference, not a code regression.

</details>

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A (existing checks pass: `docs-metadata`, `doc-redirects`, `stale-urls`, `lint`, `build`)
- Manual verification: 21 pages tested across all major MDX component types (Tabs, Admonition, Figure, DocCard, code blocks, tables, deeply nested slugs, image-heavy pages). All returned identical markdown - the only diffs were CDN domain differences (environment config, not code).

---

### ⚠️ Risk & Impact Assessment
> Minimal risk. The route handler logic is unchanged - only the build-time prerendering is removed.

- Blast radius: `/api/docs-markdown/` route only.
- Potential regressions: None detected.
- Rollback plan: Revert the PR.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The change is a single-file, 2-line edit:
1. Removed `fetchAllDocsForPage` import (no longer needed)
2. `generateStaticParams()` returns `[]` instead of mapping all docs at build time

---
