### PR TITLE
fix(docs): add missing HTTPXClientInstrumentor import in Grok monitoring metrics config

### DIFF
--- a/data/docs/grok-monitoring.mdx
+++ b/data/docs/grok-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 title: xAI Grok Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor xAI Grok using OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Grok LLM applications with real-time dashboards.
 doc_type: howto
@@ -182,6 +182,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A reader reported a "code sample error" in the [Grok monitoring docs](https://signoz.io/docs/grok-monitoring/). In the **Manual Instrumentation → Metrics Configuration** block, the final line calls `HTTPXClientInstrumentor().instrument()` but the block never imports `HTTPXClientInstrumentor`. Because that block is presented as a self-contained step (it re-declares all of its own imports), copy-pasting it fails immediately with:

```
NameError: name 'HTTPXClientInstrumentor' is not defined
```

The fix adds the one missing import so the runnable block matches the separate "Import Modules for Metrics" snippet, which already lists it. This is the minimal, correct change — no behavior or other samples need to change.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

N/A — docs code-sample fix.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A — reported via reader feedback.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?
> Regression, faulty assumption, edge case, refactor, etc.

The metrics configuration code block lists its own imports but omits `from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor`, while still calling `HTTPXClientInstrumentor().instrument()` at the end. The import exists only in the earlier standalone "Import Modules for Metrics" snippet, so anyone copying the config block in isolation hits a `NameError`.

#### Fix Strategy
> How does this PR address the root cause?

Add the missing `from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor` import to the metrics configuration block so it is self-contained and runnable as shown.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (docs content fix)
- Manual verification: `yarn check:docs-metadata` ✅ and `yarn check:doc-redirects` ✅; pre-commit hooks passed. Reviewed the imports against the block's usage to confirm every called name is now imported.
- Edge cases covered: Confirmed the other code samples (pip installs, auto-instrumentation command, traces config, both `main.py` examples) already have matching imports and need no change.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Single docs page (`data/docs/grok-monitoring.mdx`); one added import line plus a `date` frontmatter bump.
- Potential regressions: None — additive import in a documentation code sample.
- Rollback plan: Revert this PR.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a missing `HTTPXClientInstrumentor` import in the Grok monitoring manual-instrumentation metrics example so the code sample runs as-is. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- The doc's `date` frontmatter was bumped from `2026-06-11` to `2026-06-29` only because `check:docs-metadata` rejects edits to docs with a stale `date`. If `date` should reflect original publish date rather than last edit, let me know and I'll adjust.

---
