### PR TITLE
fix(docs): add missing HTTPXClientInstrumentor import across 10 LLM monitoring metrics configs

### DIFF
--- a/data/docs/amazon-bedrock-monitoring.mdx
+++ b/data/docs/amazon-bedrock-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: Amazon Bedrock Monitoring and Observability with OpenTelemetry
 description: Setup Amazon Bedrock monitoring using OpenTelemetry and SigNoz. Track model performance, latency, error rates, and usage across foundation models.
@@ -275,6 +275,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/anthropic-monitoring.mdx
+++ b/data/docs/anthropic-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: Anthropic Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Anthropic API calls using OpenTelemetry and SigNoz. Track latency, errors, and usage trends for better AI observability.
@@ -242,6 +242,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/autogen-observability.mdx
+++ b/data/docs/autogen-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: AutoGen Observability & Monitoring with OpenTelemetry
 description: Setup AutoGen observability with OpenTelemetry and SigNoz. Monitor multi-agent workflows, track performance, and debug issues in real time.
@@ -305,6 +305,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/azure-openai-monitoring.mdx
+++ b/data/docs/azure-openai-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: Azure OpenAI Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Azure OpenAI API using OpenTelemetry and SigNoz. Track model latency, error rates, and usage for enterprise AI workloads.
@@ -251,6 +251,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/crewai-observability.mdx
+++ b/data/docs/crewai-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: CrewAI Observability & Monitoring with OpenTelemetry
 description: Set up CrewAI observability with OpenTelemetry and SigNoz for full CrewAI monitoring. Track agent, tool, and model performance with traces, logs, and metrics.
@@ -308,6 +308,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/deepseek-monitoring.mdx
+++ b/data/docs/deepseek-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: DeepSeek Monitoring & Observability with OpenTelemetry
 description: Set up DeepSeek monitoring with OpenTelemetry and SigNoz to track latency, error rates, and token usage for full DeepSeek observability.
@@ -252,6 +252,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/litellm-observability.mdx
+++ b/data/docs/litellm-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: LiteLLM Observability & Monitoring with OpenTelemetry
 description: Configure LiteLLM observability with OpenTelemetry to export traces, logs, and metrics to SigNoz for real-time LiteLLM monitoring of SDK and Proxy.
@@ -241,6 +241,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/livekit-observability.mdx
+++ b/data/docs/livekit-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: LiveKit Observability & Monitoring with OpenTelemetry
 description: Learn how to instrument LiveKit voice agents with OpenTelemetry and export traces, logs, and metrics to SigNoz to monitor latency and errors.
@@ -380,6 +380,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/pydantic-ai-observability.mdx
+++ b/data/docs/pydantic-ai-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 tags: [SigNoz Cloud]
 title: Pydantic AI Observability & Monitoring with OpenTelemetry
 description: Setup Pydantic AI observability with OpenTelemetry and SigNoz. Monitor agent and model performance, track latency, and debug AI workflows.
@@ -250,6 +250,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})

--- a/data/docs/semantic-kernel-observability.mdx
+++ b/data/docs/semantic-kernel-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-06-29
 
 title: Semantic Kernel Observability - Monitor AI Orchestration
 description: Setup Semantic Kernel observability with OpenTelemetry and SigNoz. Monitor AI model performance, traces, and metrics for better debugging.
@@ -279,6 +279,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry import metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 import os
 
 resource = Resource.create({"service.name": "<service-name>"})


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

This is a fan-out of the Grok monitoring fix in #3601. While fixing that page I checked every LLM integration listed on the [LLM Observability overview](https://signoz.io/docs/llm-observability/) and found the **exact same bug** in 10 other docs.

In each doc's **Manual Instrumentation → Metrics Configuration** code block, the final line calls `HTTPXClientInstrumentor().instrument()` but the block never imports `HTTPXClientInstrumentor`. Because that block is presented as a self-contained step (it re-declares all of its own imports), copy-pasting it fails immediately with:

```
NameError: name 'HTTPXClientInstrumentor' is not defined
```

The fix adds the one missing import to each block so the runnable snippet matches the separate "Import Modules for Metrics" snippet, which already lists it. Minimal, additive change — no behavior or other samples are touched.

Affected docs (10):

- `amazon-bedrock-monitoring`
- `anthropic-monitoring`
- `autogen-observability`
- `azure-openai-monitoring`
- `crewai-observability`
- `deepseek-monitoring`
- `litellm-observability`
- `livekit-observability`
- `pydantic-ai-observability`
- `semantic-kernel-observability`

> Note: this PR intentionally does **not** include the Grok page — that fix lives in #3601.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

N/A — docs code-sample fix.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A — found via fan-out from #3601 reader report.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?
> Regression, faulty assumption, edge case, refactor, etc.

The metrics configuration code block in each affected doc lists its own imports but omits `from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor`, while still calling `HTTPXClientInstrumentor().instrument()` at the end. The import exists only in the earlier standalone "Import Modules for Metrics" snippet, so anyone copying the config block in isolation hits a `NameError`. All 10 pages share the same templated block, so they all share the bug.

#### Fix Strategy
> How does this PR address the root cause?

Add the missing `from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor` import to the metrics configuration block of each doc (placed right after the `SystemMetricsInstrumentor` import, matching #3601), so each block is self-contained and runnable as shown.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (docs content fix)
- Manual verification: `yarn check:docs-metadata` ✅ and `yarn check:doc-redirects` / `yarn test:doc-redirects` ✅; pre-commit hooks passed. Programmatically scanned all LLM integration docs to confirm exactly these 10 blocks call `HTTPXClientInstrumentor()` without importing it.
- Edge cases covered: Confirmed the other LLM docs that reference `HTTPXClientInstrumentor` already import it within the same block and need no change. (The one pre-existing `test:docs-metadata` unit-test failure — "should allow date exactly 7 days in the past" — also fails on clean `main` and is unrelated to this change.)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: 10 docs pages under `data/docs/`; one added import line plus a `date` frontmatter bump each.
- Potential regressions: None — additive import in documentation code samples.
- Rollback plan: Revert this PR.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a missing `HTTPXClientInstrumentor` import in the manual-instrumentation metrics example across 10 LLM monitoring docs so the code samples run as-is. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- Companion to #3601 (Grok) — same root cause, different pages. Kept separate per request; this PR does not modify the Grok page.
- Each doc's `date` frontmatter was bumped from `2026-06-11` to `2026-06-29` because `check:docs-metadata` rejects edits to docs with a stale `date`. If `date` should reflect original publish date rather than last edit, let me know and I'll adjust.

---
