### PR TITLE
docs(infra-monitoring): update docs for pod status and pod restart counts

### DIFF
--- a/data/docs/infrastructure-monitoring/kubernetes/clusters.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/clusters.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-clusters
 title: Clusters
 description: Monitor Kubernetes cluster resource allocation in SigNoz — CPU and memory vs allocatable capacity, node readiness, and workload health summaries.
@@ -58,6 +58,12 @@ The **Clusters** view provides a high-level overview of resource allocation and 
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Cluster-wide counts of pods grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - A growing `Pending` backlog cluster-wide indicates scheduling pressure (insufficient CPU/memory across all nodes, taints blocking placement, or namespace ResourceQuotas saturated); persistent `Failed` / `Unknown` warrants drilling into specific workloads.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Cluster-wide counts of pods grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- A rising `CrashLoopBackOff` / `OOMKilled` / `ImagePullBackOff` count cluster-wide points to a bad rollout or an image/registry problem hitting many workloads at once, while climbing `Evicted` counts signal node resource pressure; use it as the cluster-level health rollup, then drill into the offending workloads from their own views.
 
 ## Cluster Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-daemonsets
 title: DaemonSets
 description: Monitor Kubernetes DaemonSet rollout status and resource usage in SigNoz — available vs desired nodes with CPU and memory metrics.
@@ -86,6 +86,12 @@ The **DaemonSets** view shows rollout status and aggregated resource usage. If A
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of the DaemonSet's pods grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - A `Pending` count means one or more of the DaemonSet's pods can't be placed on their target nodes — typically a taint without matching toleration or `requests` larger than the node's available capacity; `Failed` / `Unknown` warrant inspecting `kubectl describe daemonset/<name>` and the affected pods' events.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the DaemonSet's pods grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- Because a DaemonSet runs the same pod fleet-wide, a `CrashLoopBackOff` / `Error` count usually means the agent image or config is broken on every node at once, while `OOMKilled` points to the per-node resource budget being too tight; inspect with `kubectl describe daemonset/<name>` and the affected pods' logs.
 
 ## DaemonSet Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-deployments
 title: Deployments
 description: Monitor Kubernetes deployment availability and resource usage in SigNoz — CPU and memory with request/limit utilization and network activity.
@@ -86,6 +86,12 @@ The **Deployments** view shows aggregated resource usage across all pods in each
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of the Deployment's pods grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - A persistent `Pending` count means the Deployment's pods can't be scheduled (insufficient capacity, taints blocking placement, or a ResourceQuota); `Failed` / `Unknown` spikes warrant inspecting `kubectl describe deployment` and the failing pods' events.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the Deployment's pods grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- Any `CrashLoopBackOff` / `OOMKilled` / `ImagePullBackOff` count is a failing-rollout signal — the new ReplicaSet's pods aren't coming up; read it alongside the **Available** vs **Desired** counts and confirm with `kubectl rollout status deployment/<name>`.
 
 ## Deployment Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-jobs
 title: Jobs
 description: Monitor Kubernetes job status and resource usage in SigNoz — active, successful, and failed pod counts with CPU and memory metrics.
@@ -98,6 +98,12 @@ The **Jobs** view tracks job completion status alongside resource consumption, u
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of the Job's pods grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec. Note this reflects ALL pods the Job has ever created, including replacements for failed retries — so the counts can grow over the Job's lifetime even with `.spec.parallelism = 1`.
 - `Pending` pods mean the scheduler can't place them yet (insufficient capacity or a missing toleration); `Failed` and `Unknown` warrant inspecting `kubectl describe job/<name>` and the pod events.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the Job's pods grouped by their kubectl-style display status within the selected window, including replacements for failed retries. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- `OOMKilled` / `Error` counts are the primary triage signal for a failing Job — the work isn't completing; read them alongside the **Failed** count on the Jobs view and inspect with `kubectl describe job/<name>`.
 
 ## Job Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/namespaces.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/namespaces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-namespaces
 title: Namespaces
 description: Monitor Kubernetes namespace resource usage in SigNoz — aggregated CPU and memory, top pods, network activity, and workload health.
@@ -46,6 +46,12 @@ The **Namespaces** view shows aggregated resource usage per namespace, useful fo
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of pods in this namespace grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - A persistent `Pending` count usually means the namespace is hitting a `ResourceQuota` cap or its pods can't fit on any node (insufficient CPU/memory); `Failed` / `Unknown` spikes warrant drilling into those pods from the detail page.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the pods in this namespace grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- A `CrashLoopBackOff` / `ImagePullBackOff` spike confined to one namespace usually points to a bad deploy or a missing image-pull secret for that tenant, while climbing `Evicted` counts signal the namespace is bumping against its resource limits; drill into the affected workloads from this namespace.
 
 ## Namespace Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/nodes.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/nodes.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-nodes
 title: Nodes
 description: Monitor Kubernetes node CPU, memory, and network performance in SigNoz — usage vs allocatable capacity, top pods by resource, and filesystem utilization.
@@ -64,6 +64,12 @@ The **Nodes** view shows CPU and memory usage alongside allocatable capacity for
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of pods on this node grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - A `Pending` spike on a single node typically means the scheduler can't place pods there (check **CPU Alloc** / **Memory Allocatable** headroom and node taints); `Failed` / `Unknown` spikes warrant drilling into those pods' events and logs from the node detail page.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the pods on this node grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- A cluster of `OOMKilled` / `Evicted` pods on a single node points to memory pressure on that node specifically, while concentrated `CrashLoopBackOff` may indicate a node-local fault (disk, container runtime, networking) rather than an application bug; open the node detail page to inspect events and logs.
 
 ## Node Detail Page
 

--- a/data/docs/infrastructure-monitoring/kubernetes/pods.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/pods.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-pods
 title: Pods
 description: Monitor Kubernetes pod CPU, memory, and network performance in SigNoz — request/limit utilization, per-container breakdowns, and correlated traces and logs.
@@ -61,6 +61,27 @@ The **Pods** view is the default Kubernetes monitoring view. It shows all active
 - This column relies on the OTel metric(s): `k8s.pod.phase`.
 - Latest lifecycle phase for the pod within the selected window — one of `Pending`, `Running`, `Succeeded`, `Failed`, or `Unknown`. Per the Kubernetes Pod-lifecycle docs: `Pending` means containers haven't been set up yet (waiting to be scheduled or downloading images); `Succeeded` and `Failed` are terminal (`Failed` means at least one container exited non-zero or was terminated by the system); `Unknown` "typically occurs due to an error in communicating with the node where the Pod should be running."
 - Use this to spot stuck `Pending` pods (scheduling pressure, image-pull failure, missing toleration) or unexpected `Failed` / `Unknown` pods — open the pod detail page to inspect events and logs for the root cause.
+
+### Pod Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` (all from the k8s_cluster receiver; the latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics)). All three must be flowing for this column to be populated.
+- The kubectl-style display status for the pod — the value `kubectl get pods` prints under STATUS — derived from the latest value of each metric in the selected window via a priority cascade: a container-level reason (`k8s.container.status.reason`) takes precedence, then a pod-level reason (`k8s.pod.status_reason`), then the lifecycle phase (`k8s.pod.phase`). Surfaced statuses are the five phases `Pending` / `Running` / `Succeeded` / `Failed` / `Unknown`; container reasons `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `CreateContainerConfigError`, `ContainerCreating`, `OOMKilled`, `Completed`, `Error`, `ContainerCannotRun`; and pod-level reasons `Evicted`, `NodeAffinity`, `NodeLost`, `Shutdown`, `UnexpectedAdmissionError`.
+- A few statuses that `kubectl` can show are not derivable from these metrics. Note these gaps and why they exist:
+  - `Terminating` is not surfaced, because the metrics emit no pod deletion timestamp.
+  - `Init:*` states are not surfaced, because the k8s_cluster receiver reports only regular containers and not init containers.
+  - `Signal:N` and `ExitCode:N` are not surfaced, because uncoded terminated reasons collapse to `Error`.
+- Use this to triage pods directly from the list without `kubectl` — `CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, and `Evicted` are the pods to investigate first; click the pod name to open its logs and events for the root cause.
+
+### Restarts
+
+- This column relies on the OTel metric(s): `k8s.container.restarts` (from the k8s_cluster receiver; enabled by default).
+- Total container restarts for the pod — the sum across the pod's containers of each container's latest cumulative restart count within the selected window, the same value `kubectl get pods` prints under RESTARTS. It excludes init containers, which the receiver does not report restarts for. OpenTelemetry cautions against reading too much into the exact number:
+
+  > "How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that."
+  >
+  > — <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md#k8scontainerrestarts" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry k8sclusterreceiver documentation</a>
+
+- Treat the value as a signal rather than a precise count: `0` means no restarts in the recent past, anything `> 0` is a pod worth investigating (crash loops, OOM kills, failing liveness probes). Read it alongside the **Pod Status** column to tell a one-off restart from sustained flapping, then open the pod's logs and events to find the cause.
 
 Additional columns available via the Columns selector: **Namespace**, **Node**, **Cluster**.
 

--- a/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: k8s-statefulsets
 title: StatefulSets
 description: Monitor Kubernetes StatefulSet availability and resource usage in SigNoz — available vs desired pods with CPU and memory utilization percentages.
@@ -86,6 +86,12 @@ The **StatefulSets** view shows rollout status and resource utilization. Statefu
 - This column relies on the OTel metric `k8s.pod.phase` from the k8s_cluster receiver, encoded `1` = Pending, `2` = Running, `3` = Succeeded, `4` = Failed, `5` = Unknown.
 - Counts of the StatefulSet's pods grouped by their latest observed lifecycle phase within the selected window, per the Kubernetes pod-lifecycle spec.
 - StatefulSets create pods sequentially with stable ordinal names (`<name>-0`, `<name>-1`, ...) — a single pod stuck in `Pending` blocks all higher-ordinal pods from being created, so a persistent `Pending` count of 1 can mean the entire scale-up is stalled; inspect the affected ordinal with `kubectl describe pod <name>-N`.
+
+### Pod Counts by Status
+
+- This column relies on the OTel metric(s): `k8s.pod.phase`, `k8s.pod.status_reason`, and `k8s.container.status.reason` from the k8s_cluster receiver. The latter two are disabled by default in the upstream receiver but enabled by default in the [k8s-infra chart](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra/#6-cluster-level-metrics); all three must be flowing for this column to be populated.
+- Counts of the StatefulSet's pods grouped by their kubectl-style display status within the selected window. The status is derived exactly as on the Pods view — see [Pod Status](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/#pod-status) for the full priority cascade, the statuses it surfaces, and the statuses it cannot derive.
+- A `CrashLoopBackOff` on an early ordinal blocks the rest of the StatefulSet from rolling out, while `OOMKilled` counts usually mean memory is undersized for the workload's data set; inspect the lowest failing ordinal first with `kubectl describe pod <name>-N`.
 
 ## StatefulSet Detail Page
 

--- a/data/docs/infrastructure-monitoring/user-guides/k8s-metrics.mdx
+++ b/data/docs/infrastructure-monitoring/user-guides/k8s-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 title: Setup Kubernetes Metrics with OpenTelemetry
 description: Configure the OpenTelemetry kubeletstats and k8scluster receivers (plus k8sattributesprocessor) on top of a running Kubernetes Collection Agent to track node, pod, container, and volume metrics in SigNoz.
 doc_type: howto
@@ -236,7 +236,10 @@ These allocations are exposed via the `k8s.node.allocatable_cpu`, `k8s.node.allo
 #### 3. Optional Metrics
 Key optional metrics for enhanced monitoring:
 - `k8s.node.condition`: Detailed node health status
-- `k8s.pod.status_reason`: Root cause analysis for pod states
+- `k8s.pod.status_reason`: Pod-level status reasons (`Evicted`, `NodeLost`, `Shutdown`, ...)
+- `k8s.container.status.reason`: Container-level status reasons (`CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, ...)
+
+`k8s.pod.status_reason` and `k8s.container.status.reason` are disabled by default in the upstream receiver but enabled by default in the [`k8s-infra`](https://signoz.io/docs/opentelemetry-collection-agents/k8s/k8s-infra/install-k8s-infra/) Helm chart — together they drive the kubectl-style **Pod Status** column. Enable them manually only if you run the `k8s_cluster` receiver without the chart (or on a chart version older than the one that ships them on by default).
 
 For a comprehensive list of available metrics, conditions, and resources, refer to the [k8sclusterreceiver documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md).
 
@@ -257,6 +260,8 @@ receivers:
       k8s.node.condition:
         enabled: true
       k8s.pod.status_reason:
+        enabled: true
+      k8s.container.status.reason:
         enabled: true
 ```
 

--- a/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/k8s-infra/configure-k8s-infra.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 title: K8s Infra - Configure
 id: k8s-infra-otel-config
 description: Configure the k8s-infra OpenTelemetry collection agent to send Kubernetes metrics, logs, and traces to SigNoz.
@@ -27,10 +27,11 @@ or OtelAgent service name.
 For OtelAgent service name, the endpoint would be something like
 `my-release-k8s-infra-otel-agent.default.svc:4317`. Replace `my-release` with
 your helm release name and `default` with your namespace.
+
 </Admonition>
 
 To send data from your applications, you must first instrument it with OpenTelemetry.
-You can find instrumentation instructions for your specific language [here][10]. 
+You can find instrumentation instructions for your specific language [here][10].
 
 Once you're done instrumenting your application, add below to your application manifest
 files for applications to start sending data to the otel-collectors running as DaemonSet.
@@ -58,11 +59,12 @@ env:
     value: $(HOST_IP):4317
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: service.name=APPLICATION_NAME,k8s.pod.ip=$(K8S_POD_IP),k8s.pod.uid=$(K8S_POD_UID)
-  ```
-  
+```
+
 <Admonition>
-  - Replace `APPLICATION_NAME` with your application name that you wish to see in SigNoz.
-  - In cases of some SDKs, you would need to include `http://` or `https://` prefix for `OTEL_EXPORTER_OTLP_ENDPOINT`
+  - Replace `APPLICATION_NAME` with your application name that you wish to see in SigNoz. - In cases
+  of some SDKs, you would need to include `http://` or `https://` prefix for
+  `OTEL_EXPORTER_OTLP_ENDPOINT`
 </Admonition>
 
 ### Disable Logs Collection
@@ -95,99 +97,103 @@ otelDeployment:
 ```
 
 ## Essential Presets
+
 SigNoz allows you to use the presets in the k8s-infra Helm chart to easily configure OtelCollector. The following configurations can be set by modifying the `values.yml` in the [k8s-infra Helm chart](https://github.com/signoz/charts/tree/main/charts/k8s-infra/values.yaml).
 
 <Admonition>
-  The `presets` section in the `values.yaml` file allows you to enable or disable specific configurations. To check the available presets, refer to the [k8s-infra Helm chart documentation](https://github.com/SigNoz/charts/blob/main/charts/k8s-infra/README.md#presets-configuration).
+  The `presets` section in the `values.yaml` file allows you to enable or disable specific
+  configurations. To check the available presets, refer to the [k8s-infra Helm chart
+  documentation](https://github.com/SigNoz/charts/blob/main/charts/k8s-infra/README.md#presets-configuration).
 </Admonition>
-### 1. OTLP/HTTP Exporter
-```yaml
-presets:
-  otlphttpExporter:
-    enabled: true  # Must be enabled for data to reach SigNoz
-```
+### 1. OTLP/HTTP Exporter ```yaml presets: otlphttpExporter: enabled: true # Must be enabled for
+data to reach SigNoz ```
 
 **What it does**: Enables sending telemetry data to SigNoz backend over OTLP/HTTP. This is required for SigNoz to receive any data.
 
 ### 2. Host Metrics Collection
+
 ```yaml
 presets:
   hostMetrics:
     enabled: true
-    collectionInterval: 30s  # Adjust based on your monitoring needs
+    collectionInterval: 30s # Adjust based on your monitoring needs
     scrapers:
-      cpu: {}        # Collects CPU usage, time, and utilization metrics
-      load: {}       # Collects system load averages
-      memory: {}     # Collects memory usage metrics
-      disk:          # Collects disk I/O metrics
+      cpu: {} # Collects CPU usage, time, and utilization metrics
+      load: {} # Collects system load averages
+      memory: {} # Collects memory usage metrics
+      disk: # Collects disk I/O metrics
         exclude:
-          devices:   # Regex patterns to exclude specific devices
+          devices: # Regex patterns to exclude specific devices
             - ^ram\d+$
             - ^loop\d+$
             # Add custom device exclusions here
-      filesystem:    # Collects filesystem metrics
+      filesystem: # Collects filesystem metrics
         exclude_fs_types:
           fs_types:
             - tmpfs
             - squashfs
             # Add filesystem types to exclude
-      network:       # Collects network metrics
+      network: # Collects network metrics
         exclude:
           interfaces:
-            - ^veth.*$    # Excludes virtual ethernet devices
-            - ^docker.*$  # Excludes docker interfaces
+            - ^veth.*$ # Excludes virtual ethernet devices
+            - ^docker.*$ # Excludes docker interfaces
             # Add network interfaces to exclude
 ```
 
 **Key points**:
+
 - Adjust `collectionInterval` based on your monitoring granularity needs
 - Customize device exclusions to reduce noise from irrelevant storage devices
 - Configure network interface exclusions to focus on relevant network metrics
 
 ### 3. Container Log Collection
+
 ```yaml
 presets:
   logsCollection:
     enabled: true
-    startAt: beginning      # Options: beginning or end
-    includeFilePath: true   # Adds file path as metadata
-    includeFileName: false  # Adds file name as metadata
-    
+    startAt: beginning # Options: beginning or end
+    includeFilePath: true # Adds file path as metadata
+    includeFileName: false # Adds file name as metadata
+
     # Exclusion configuration
     blacklist:
       enabled: true
-      signozLogs: true     # Excludes SigNoz's own logs
+      signozLogs: true # Excludes SigNoz's own logs
       namespaces:
-        - kube-system      # Add namespaces to exclude
+        - kube-system # Add namespaces to exclude
       pods:
-        - hotrod          # Add pod names to exclude
+        - hotrod # Add pod names to exclude
         - locust
-      containers: []       # Add container names to exclude
-    
+      containers: [] # Add container names to exclude
+
     # Inclusion configuration (overrides blacklist if enabled)
     whitelist:
       enabled: false
       signozLogs: true
-      namespaces: []      # Only collect logs from these namespaces
-      pods: []            # Only collect logs from these pods
-      containers: []      # Only collect logs from these containers
+      namespaces: [] # Only collect logs from these namespaces
+      pods: [] # Only collect logs from these pods
+      containers: [] # Only collect logs from these containers
 ```
 
 **Best practices**:
+
 - Use blacklist for excluding noisy system pods
 - Enable whitelist when you need to monitor specific applications only
 - Consider disk usage implications when enabling file path/name inclusion
 
 ### 4. Kubernetes Metrics Collection
+
 ```yaml
 presets:
   kubeletMetrics:
     enabled: true
     collectionInterval: 30s
-    authType: serviceAccount    # Authentication method
+    authType: serviceAccount # Authentication method
     endpoint: ${env:K8S_HOST_IP}:10250
-    insecureSkipVerify: true   # Set to false in production
-    
+    insecureSkipVerify: true # Set to false in production
+
     # Metrics configuration
     metrics:
       k8s.pod.cpu_limit_utilization:
@@ -198,17 +204,19 @@ presets:
 ```
 
 **Important settings**:
+
 - Set appropriate `collectionInterval` based on cluster size
 - Configure `insecureSkipVerify: false` in production environments
 - Enable specific metrics based on monitoring requirements
 
 ### 5. Kubernetes Metadata Enrichment
+
 ```yaml
 presets:
   kubernetesAttributes:
     enabled: true
-    passthrough: false    # Set true to disable k8s API calls
-    
+    passthrough: false # Set true to disable k8s API calls
+
     # Control which metadata to collect
     extractMetadatas:
       - k8s.namespace.name
@@ -216,17 +224,17 @@ presets:
       - k8s.pod.name
       - k8s.node.name
       # Add or remove metadata fields
-    
+
     # Pod association configuration
     podAssociation:
       - sources:
-        - from: resource_attribute
-          name: k8s.pod.ip
+          - from: resource_attribute
+            name: k8s.pod.ip
       - sources:
-        - from: resource_attribute
-          name: k8s.pod.uid
+          - from: resource_attribute
+            name: k8s.pod.uid
       - sources:
-        - from: connection
+          - from: connection
     # This label/annotation extraction rule takes the value of the key from labels/annotations and maps it to the tag_name attribute which will be added to the associated resources
     extractLabels:
       # Example from pod
@@ -237,7 +245,7 @@ presets:
       - tag_name: os.type
         key: beta.kubernetes.io/os
         from: node
-    
+
     # Annotation extraction configuration
     extractAnnotations:
       # Example from node
@@ -247,6 +255,7 @@ presets:
 ```
 
 **Configuration tips**:
+
 - Enable only required metadata fields to optimize performance
 - Use `passthrough: true` in very large clusters to reduce API load
 - Configure pod association based on your networking setup
@@ -270,41 +279,54 @@ If you customize `podAssociation`, include the rules you need from the chart def
 </KeyPointCallout>
 
 ### 6. Cluster-level Metrics
+
 ```yaml
 presets:
   clusterMetrics:
     enabled: true
     collectionInterval: 30s
-    
+
     # Node conditions to monitor
     nodeConditionsToReport:
       - Ready
       - MemoryPressure
       - DiskPressure
       # Add conditions based on monitoring needs
-    
+
     # Resource types to monitor
     allocatableTypesToReport:
       - cpu
       - memory
       # - storage    # Uncomment if needed
+
+    # Fine-grained metric enablement
+    metrics:
+      k8s.pod.status_reason:
+        enabled: true
+      k8s.container.status.reason:
+        enabled: true
 ```
 
 **When to use**:
+
 - Enable for cluster health monitoring
 - Useful for capacity planning and resource optimization
 - Essential for multi-node cluster monitoring
 
+**What `metrics` powers**: `k8s.pod.status_reason` and `k8s.container.status.reason` are disabled by default in the upstream `k8s_cluster` receiver but enabled by default in this chart. Together they drive the kubectl-style **Pod Status** column on the Pods view (and the per-entity Pod Counts by Status breakdown). Keep them enabled to retain pod-status visibility; without them, pod status falls back to the lifecycle phase only.
+
 ### 7. Kubernetes Events
+
 ```yaml
 presets:
   k8sEvents:
     enabled: true
     authType: serviceAccount
-    namespaces: []    # Empty for all namespaces, or specify list
+    namespaces: [] # Empty for all namespaces, or specify list
 ```
 
 **Usage scenarios**:
+
 - Enable for debugging and audit trails
 - Monitor specific namespaces by listing them
 - Useful for compliance and security monitoring
@@ -317,13 +339,13 @@ Prometheus preset allows to scrapes metrics from pods that have the appropriate 
 presets:
   prometheus:
     enabled: true
-    annotationsPrefix: signoz.io    # Prefix for pod annotations
-    scrapeInterval: 60s              # How often to scrape metrics
-    namespaceScoped: false           # Limit to same namespace only
-    namespaces: []                   # Specific namespaces to scrape
-    includePodLabel: false           # Include pod labels (may increase cardinality)
-    includeContainerName: false      # Include container name in metrics
-    scrapeConfigs: []                # Custom scrape configurations
+    annotationsPrefix: signoz.io # Prefix for pod annotations
+    scrapeInterval: 60s # How often to scrape metrics
+    namespaceScoped: false # Limit to same namespace only
+    namespaces: [] # Specific namespaces to scrape
+    includePodLabel: false # Include pod labels (may increase cardinality)
+    includeContainerName: false # Include container name in metrics
+    scrapeConfigs: [] # Custom scrape configurations
 ```
 
 #### Custom Scrape Configurations
@@ -336,11 +358,11 @@ presets:
     enabled: true
     scrapeConfigs:
       # Scrape metrics from a specific service
-      - job_name: 'my-custom-service'
+      - job_name: "my-custom-service"
         static_configs:
-          - targets: ['my-service.default.svc.cluster.local:9090']
+          - targets: ["my-service.default.svc.cluster.local:9090"]
             labels:
-              environment: 'production'
+              environment: "production"
 ```
 
 ## Configurations
@@ -363,8 +385,10 @@ otelAgent:
 +        send_batch_size: 15000
 +        send_batch_max_size: 20000 # settings can be provided as key value pairs
 ```
+
 <Admonition type="info">
-Any setting supported by the OpenTelemetry batch processor can be set under `processors.batch` in the chart values.
+  Any setting supported by the OpenTelemetry batch processor can be set under `processors.batch` in
+  the chart values.
 </Admonition>
 
 ### Adding Custom Processors to Pipelines
@@ -380,6 +404,7 @@ When you override a pipeline's `processors` list, Helm replaces the entire list 
 ## Common Deployment Scenarios
 
 ### Production Cluster with Full Monitoring
+
 ```yaml
 presets:
   otlphttpExporter:
@@ -391,7 +416,7 @@ presets:
     enabled: true
     blacklist:
       enabled: true
-      namespaces: 
+      namespaces:
         - kube-system
   kubeletMetrics:
     enabled: true
@@ -405,6 +430,7 @@ presets:
 ```
 
 ### Resource-Constrained Environment
+
 ```yaml
 presets:
   otlphttpExporter:
@@ -416,7 +442,7 @@ presets:
     enabled: true
     whitelist:
       enabled: true
-      namespaces: 
+      namespaces:
         - production
   kubeletMetrics:
     enabled: true
@@ -458,11 +484,13 @@ ports:
 ```
 
 ## Configuring otelDeployment to collect from additional components
+
 The otelDeployment collector is configured to collect cluster metrics and events by default. There are some use cases where you might want to collect metrics from components other than the ones that are being collected by default.
 
 This section describes how to override the default configuration of the otelDeployment collector to collect metrics from additional components. The override-values.yaml file contains the configurations that you can override.
 
 #### Example 1: Redis Receiver Configuration
+
 The following configuration shows how to configure the `otelDeployment` collector to collect metrics from a Redis server running inside a namespace "redis-ns" with the name "redis-server" and port 6379:
 
 ```yaml
@@ -534,10 +562,10 @@ Helm replaces array values rather than merging them, so an override on `podAssoc
 Recommended resource allocations based on preset combinations:
 
 | Configuration | CPU Request | Memory Request | CPU Limit | Memory Limit |
-|--------------|-------------|----------------|-----------|--------------|
-| Minimal | 100m | 256Mi | 200m | 512Mi |
-| Standard | 200m | 512Mi | 500m | 1Gi |
-| Full | 500m | 1Gi | 1000m | 2Gi |
+| ------------- | ----------- | -------------- | --------- | ------------ |
+| Minimal       | 100m        | 256Mi          | 200m      | 512Mi        |
+| Standard      | 200m        | 512Mi          | 500m      | 1Gi          |
+| Full          | 500m        | 1Gi            | 1000m     | 2Gi          |
 
 Adjust these values based on your cluster size and monitoring requirements.
 

--- a/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
+++ b/data/docs/opentelemetry-collection-agents/k8s/otel-operator/configure.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-22
+date: 2026-06-30
 id: configure
 
 title: OpenTelemetry Operator - Configure
@@ -926,6 +926,8 @@ spec:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.container.status.reason:
+            enabled: true
         node_conditions_to_report:
           - Ready
           - MemoryPressure
@@ -1108,6 +1110,8 @@ spec:
           k8s.node.condition:
             enabled: true
           k8s.pod.status_reason:
+            enabled: true
+          k8s.container.status.reason:
             enabled: true
         node_conditions_to_report:
           - Ready


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Documents the new kubectl-style **Pod Status** and **Restarts** columns (Infra Monitoring v2) and the metrics they require. Two parts: (1) **Collection Agents** docs now cover the status metrics (`k8s.pod.status_reason`, `k8s.container.status.reason` — default-off upstream, on-by-default in the k8s-infra chart); (2) **Kubernetes Monitoring** docs describe the columns. Right approach because the values come from existing `k8s_cluster` metrics — the docs explain what's covered, what isn't and why, and how to enable the optional inputs.

- Pods page: **Pod Status** (priority cascade, full covered-status list, OTel-gap caveats) and **Restarts** (with the upstream "treat as 0 vs >0" warning, quoted + linked).
- 7 grouped entities (clusters, nodes, namespaces, deployments, daemonsets, statefulsets, jobs): **Pod Counts by Status** section, each linking to the Pods page for the shared taxonomy.
- Collection Agents: `configure-k8s-infra`, `k8s-metrics`, `otel-operator/configure` now enable/cover the status metrics.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5475
Full discussion ticket: https://github.com/SigNoz/engineering-pod/issues/5471

Closes #<docs-issue>

---

### ✅ Change Type

- [x] ✨ Feature _(documentation for a new feature)_

---

### 🧪 Testing Strategy

- **Tests added/updated:** none (prose docs).
- **Manual verification:** `yarn check:doc-redirects` passes; `yarn check:docs-metadata` passes for every file changed here; technical claims (metric defaults, enum values, restart caveat, kubectl status logic) verified against upstream OpenTelemetry + Kubernetes source.
- **Edge cases covered in copy:** statuses kubectl shows but the metrics can't derive (`Terminating`, `Init:*`, `Signal:N`/`ExitCode:N`); restart count resets per kubelet pruning; optional metrics absent → column not populated.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** documentation only — no code, API, or runtime impact.
- **Potential regressions:** none; additive MDX sections + metric-config snippets.
- **Rollback plan:** revert the PR.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance (Documentation) |
| Description | Documented the Pod Status and Restarts columns and per-entity Pod Counts by Status in Infra Monitoring, plus the `k8s_cluster` metrics they require. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none — additive)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Status taxonomy + caveats live once on the **Pods** page; the 7 grouped entities link to it rather than duplicating the list.
- **Restarts is pods-only** (matches the backend — grouped entities only got `podCountsByStatus`), so no Restarts column was added elsewhere.
- The full `yarn check:docs-metadata` run exits non-zero only from pre-existing branch-stale dates on files this PR doesn't touch (handled by the separate bulk date-bump) — every file changed here passes.