### PR TITLE
docs: update pie panel documentation for multi-column ClickHouse queries

### DIFF
--- a/data/docs/dashboards/panel-types/pie.mdx
+++ b/data/docs/dashboards/panel-types/pie.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Pie Chart Panel Type
-date: 2026-05-13
+date: 2026-07-01
 description: Learn how to use the Pie Chart panel type in SigNoz dashboards to visualize proportional data.
 doc_type: reference
 ---
@@ -19,6 +19,18 @@ A Pie chart is a plot chart that shows the proportion of a single or a few diffe
 - Metrics
 
 This panel type supports any time series data. The time series data can be from logs, traces, or metrics.
+
+#### ClickHouse SQL queries
+
+When a pie panel is backed by a ClickHouse SQL query, each aggregation (value) column in the query renders as its own slice.
+
+- A query with two or more value columns — for example, `SELECT count() AS total_count, sum(value) AS total_value FROM ...` — produces one slice per column, labelled with the column alias (`total_count`, `total_value`).
+- When the query also has group-by columns, each slice is labelled `<group> · <column>` (with a middle-dot separator) so slices stay distinct across groups.
+- A single-aggregation ClickHouse query renders one slice, and grouped Query Builder (PromQL/metrics) panels are unaffected — each group is one slice as before.
+
+<Admonition type="info">
+Only positive, numeric values are plotted. Columns that resolve to zero, a negative number, or a non-numeric value are dropped from the chart.
+</Admonition>
 
 #### Examples
 


### PR DESCRIPTION
## Summary
- Added a **ClickHouse SQL queries** subsection to the Pie Chart panel doc explaining that each aggregation (value) column in a multi-column ClickHouse SQL query now renders as its own slice (e.g. `count() AS total_count, sum(value) AS total_value` → two slices labelled by column alias).
- Documented the `<group> · <column>` (middle-dot) label format used when a query combines group-by columns with multiple value columns.
- Clarified that single-aggregation ClickHouse queries and grouped Query Builder (PromQL/metrics) panels are unchanged.
- Updated the `date` frontmatter field to today's date (2026-07-01).

Source PRs: SigNoz/signoz#11919

## Verification notes
- Behavior verified against the fix in SigNoz/signoz#11919 (`preparePieChartData.ts`): multiple value columns → one slice per column; label = column name, or `<group> · <column>` when grouped; single-column / grouped-metrics paths unchanged; non-positive/non-numeric values dropped.
- **No new screenshot added.** The demo (`demo.in.signoz.cloud`) build predates this fix — a two-column ClickHouse pie there still collapses to a single query-named slice, so any screenshot would show the pre-fix behavior. A screenshot of the fixed multi-slice pie should be captured once the fix reaches the demo.
- **Changelog / release notes not editable here.** The SigNoz changelog is sourced from Strapi (CMS), not from MDX in this repo — the changelog entry for this fix must be added there separately.

Auto-generated by docs-sync pipeline