### PR TITLE
docs: update SSO role mapping for custom roles and slug role names

### DIFF
--- a/data/docs/manage/administrator-guide/iam/roles.mdx
+++ b/data/docs/manage/administrator-guide/iam/roles.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-26
+date: 2026-07-01
 title: Roles
 description: Create and manage roles in SigNoz — managed roles, custom roles, and configuring transactions with the interactive or JSON editor.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -13,6 +13,10 @@ Fine-grained access control is currently in beta.
 ## Overview
 
 Roles are the core unit of access control in SigNoz. A role groups transactions together — when a principal is assigned a role, they receive all the transactions that role contains.
+
+<Admonition type="info">
+Custom roles you create here are also available as assignment targets in SSO role mapping — they appear in the **Default Role** and per-group **Role** dropdowns alongside the built-in roles. See [SSO Role Mapping](https://signoz.io/docs/manage/administrator-guide/sso/overview/#how-sso-works-in-signoz).
+</Admonition>
 
 ## Prerequisites
 

--- a/data/docs/manage/administrator-guide/sso/overview.mdx
+++ b/data/docs/manage/administrator-guide/sso/overview.mdx
@@ -1,6 +1,6 @@
 ---
 published_date: 2026-02-26
-updated_date: 2026-06-12
+updated_date: 2026-07-01
 
 title: Single Sign on (SSO) - Overview
 description: Overview of single sign-on (SSO) in SigNoz.
@@ -23,7 +23,7 @@ At a high level, you connect your organization’s email domain to an IdP, and S
 2. **Choose Method**: For that domain, select SAML, OIDC, or Google (for Workspace) and provide the IdP details.
 3. **Just‑in‑Time access**: Users with emails on that domain can sign in via your IdP without a prior invite.
 4. **Attribute/Claim Mapping**: Map IdP attributes (SAML) or token claims (OIDC/Google) to SigNoz user fields like email, display name, groups, and role.
-5. **Role Mapping**: Automatically assign SigNoz roles (VIEWER, EDITOR, ADMIN) based on IdP group memberships or a direct role attribute — no manual role assignment needed.
+5. **Role Mapping**: Automatically assign SigNoz roles (`signoz-viewer`, `signoz-editor`, `signoz-admin`, or any custom role) based on IdP group memberships or a direct role attribute — no manual role assignment needed.
 
 ## Setup at a glance
 

--- a/data/docs/manage/administrator-guide/sso/user-guides/oidc-keycloak.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/oidc-keycloak.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-23
+date: 2026-07-01
 
 title: Setting Up SSO OIDC With Keycloak
 description: Setting Up Single Sign-On (SSO) OpenID Connect (OIDC) With Keycloak, including claim mapping and role mapping.
@@ -189,7 +189,7 @@ If you want to assign SigNoz roles directly via a Keycloak user attribute, add a
 #### Set the Attribute on Users
 
 1. Go to **Users** → select a user → **Attributes** tab
-2. Set the key `signoz_role` with a value of `ADMIN`, `EDITOR`, or `VIEWER`
+2. Set the key `signoz_role` with a value of `signoz-admin`, `signoz-editor`, or `signoz-viewer` (or the name of a custom role)
 3. Click **Save**
 
 ![KeyCloak Set User Role Attribute](/img/docs/oidc-keycloak/keycloak-set-user-signoz-role.webp)
@@ -211,16 +211,20 @@ You only need to configure claims that differ from the defaults. The standard OI
 
 ## Configure Role Mapping (Optional)
 
-Role mapping automatically assigns SigNoz roles (VIEWER, EDITOR, ADMIN) to users when they log in via OIDC, based on their Keycloak groups or a custom role claim.
+Role mapping automatically assigns SigNoz roles (`signoz-viewer`, `signoz-editor`, `signoz-admin`, or any custom role) to users when they log in via OIDC, based on their Keycloak groups or a custom role claim.
+
+<Admonition type="info">
+Both the **Default Role** dropdown and the per-group **Role** dropdown list every role in your organization — the built-in `signoz-viewer`, `signoz-editor`, and `signoz-admin` roles plus any [custom roles](https://signoz.io/docs/manage/administrator-guide/iam/roles/) you have created. Options are loaded from the SigNoz API; if the list fails to load, click **Retry** to reload it.
+</Admonition>
 
 ### Role Resolution Priority
 
 When a user logs in, SigNoz determines their role using this priority (highest to lowest):
 
 1. **Use Role Attribute** — if enabled and the token contains a role claim, that value is used directly
-2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (ADMIN > EDITOR > VIEWER)
+2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (`signoz-admin` > `signoz-editor` > `signoz-viewer`)
 3. **Default Role** — fallback role from configuration
-4. **VIEWER** — ultimate default if nothing else is configured
+4. **`signoz-viewer`** — ultimate default if nothing else is configured
 
 ### Option A: Group-Based Role Mapping
 
@@ -249,14 +253,14 @@ Map Keycloak groups to SigNoz roles. Users are assigned the highest-privilege ro
 2. Go to **Settings** → **Organization Settings** → **Members & SSO** → **Authenticated Domains**
 3. Click on your OIDC domain to edit it
 4. In the **Role Mapping** section:
-   - Set **Default Role** to `VIEWER`
+   - Set **Default Role** to `signoz-viewer`
    - Under **Group Mappings**, add entries mapping each Keycloak group name to a SigNoz role:
 
      | Keycloak Group | SigNoz Role |
      |----------------|-------------|
-     | `signoz-admins` | `ADMIN` |
-     | `signoz-editors` | `EDITOR` |
-     | `signoz-viewers` | `VIEWER` |
+     | `signoz-admins` | `signoz-admin` |
+     | `signoz-editors` | `signoz-editor` |
+     | `signoz-viewers` | `signoz-viewer` |
 
    - Leave **Use Role Attribute Directly** turned **OFF**
 5. Click **Save**
@@ -271,7 +275,7 @@ Assign SigNoz roles directly via a custom user attribute in Keycloak, without us
 
 1. [Register the `signoz_role` custom attribute](#register-the-custom-attribute) in the user profile
 2. [Create the token mapper](#create-the-token-mapper) for the attribute
-3. [Set the `signoz_role` attribute](#set-the-attribute-on-users) on each user to `ADMIN`, `EDITOR`, or `VIEWER`
+3. [Set the `signoz_role` attribute](#set-the-attribute-on-users) on each user to `signoz-admin`, `signoz-editor`, or `signoz-viewer` (or the name of a custom role)
 
 #### Configure in SigNoz
 
@@ -279,14 +283,14 @@ Assign SigNoz roles directly via a custom user attribute in Keycloak, without us
 2. Go to **Settings** → **Organization Settings** → **Members & SSO** → **Authenticated Domains**
 3. Click on your OIDC domain to edit it
 4. In the **Role Mapping** section:
-   - Set **Default Role** to `VIEWER` (used as fallback)
+   - Set **Default Role** to `signoz-viewer` (used as fallback)
    - Turn **Use Role Attribute** to **ON**
 5. Click **Save**
 
 ![SigNoz OIDC Direct Role Mapping Configuration](/img/docs/oidc-keycloak/signoz-oidc-direct-role-mapping-configuration.webp)
 
 <Admonition type="info">
-The role value in the token is matched case-insensitively — `admin`, `Admin`, and `ADMIN` all resolve to the ADMIN role. If the value doesn't match any valid role, SigNoz falls back to group mappings (if configured) and then the default role.
+The role value in the token must match a SigNoz role name — `signoz-viewer`, `signoz-editor`, `signoz-admin`, or a custom role — and is matched case-insensitively (`signoz-admin`, `Signoz-Admin`, and `SIGNOZ-ADMIN` all resolve to the `signoz-admin` role). If the value doesn't match any valid role, SigNoz falls back to group mappings (if configured) and then the default role.
 </Admonition>
 
 ## Troubleshooting

--- a/data/docs/manage/administrator-guide/sso/user-guides/saml-keycloak.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/saml-keycloak.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-22
+date: 2026-07-01
 
 title: Setting Up SSO SAML 2.0 With Keycloak
 description: Setting Up Single Sign-On (SSO) SAML 2.0 With Keycloak, including attribute mapping and role mapping.
@@ -214,7 +214,7 @@ If you want to assign SigNoz roles directly via a Keycloak user attribute (inste
 #### Set the Attribute on Users
 
 1. Go to **Users** → select a user → **Attributes** tab
-2. Set the key `signoz_role` with a value of `ADMIN`, `EDITOR`, or `VIEWER`
+2. Set the key `signoz_role` with a value of `signoz-admin`, `signoz-editor`, or `signoz-viewer` (or the name of a custom role)
 3. Click **Save**
 
 ![KeyCloak Set User SigNoz Role](/img/docs/saml-keycloak/keycloak-set-user-signoz-role.webp)
@@ -237,16 +237,20 @@ You only need to configure attributes that differ from the defaults. If you did 
 
 ## Configure Role Mapping (Optional)
 
-Role mapping automatically assigns SigNoz roles (VIEWER, EDITOR, ADMIN) to users when they log in via SAML, based on their Keycloak groups or a custom role attribute.
+Role mapping automatically assigns SigNoz roles (`signoz-viewer`, `signoz-editor`, `signoz-admin`, or any custom role) to users when they log in via SAML, based on their Keycloak groups or a custom role attribute.
+
+<Admonition type="info">
+Both the **Default Role** dropdown and the per-group **Role** dropdown list every role in your organization — the built-in `signoz-viewer`, `signoz-editor`, and `signoz-admin` roles plus any [custom roles](https://signoz.io/docs/manage/administrator-guide/iam/roles/) you have created. Options are loaded from the SigNoz API; if the list fails to load, click **Retry** to reload it.
+</Admonition>
 
 ### Role Resolution Priority
 
 When a user logs in, SigNoz determines their role using this priority (highest to lowest):
 
 1. **Use Role Attribute** — if enabled and the SAML assertion contains a role attribute, that value is used directly
-2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (ADMIN > EDITOR > VIEWER)
+2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (`signoz-admin` > `signoz-editor` > `signoz-viewer`)
 3. **Default Role** — fallback role from configuration
-4. **VIEWER** — ultimate default if nothing else is configured
+4. **`signoz-viewer`** — ultimate default if nothing else is configured
 
 ### Option A: Group-Based Role Mapping
 
@@ -275,14 +279,14 @@ Map Keycloak groups to SigNoz roles. Users are assigned the highest-privilege ro
 2. Go to **Settings** → **Organization Settings** → **Members & SSO** → **Authenticated Domains**
 3. Click on your SAML domain to edit it
 4. In the **Role Mapping** section:
-   - Set **Default Role** to `VIEWER`
+   - Set **Default Role** to `signoz-viewer`
    - Under **Group Mappings**, add entries mapping each Keycloak group name to a SigNoz role:
 
      | Keycloak Group | SigNoz Role |
      |----------------|-------------|
-     | `signoz-admins` | `ADMIN` |
-     | `signoz-editors` | `EDITOR` |
-     | `signoz-viewers` | `VIEWER` |
+     | `signoz-admins` | `signoz-admin` |
+     | `signoz-editors` | `signoz-editor` |
+     | `signoz-viewers` | `signoz-viewer` |
 
    - Leave **Use Role Attribute** turned **OFF**
 5. Click **Save**
@@ -297,7 +301,7 @@ Assign SigNoz roles directly via a custom user attribute in Keycloak, without us
 
 1. [Register the `signoz_role` custom attribute](#register-the-custom-attribute) in the user profile
 2. [Create the SAML mapper](#create-the-saml-mapper) for the attribute
-3. [Set the `signoz_role` attribute](#set-the-attribute-on-users) on each user to `ADMIN`, `EDITOR`, or `VIEWER`
+3. [Set the `signoz_role` attribute](#set-the-attribute-on-users) on each user to `signoz-admin`, `signoz-editor`, or `signoz-viewer` (or the name of a custom role)
 
 #### Configure in SigNoz
 
@@ -305,14 +309,14 @@ Assign SigNoz roles directly via a custom user attribute in Keycloak, without us
 2. Go to **Settings** → **Organization Settings** → **Members & SSO** → **Authenticated Domains**
 3. Click on your SAML domain to edit it
 4. In the **Role Mapping** section:
-   - Set **Default Role** to `VIEWER` (used as fallback)
+   - Set **Default Role** to `signoz-viewer` (used as fallback)
    - Turn **Use Role Attribute** to **ON**
 5. Click **Save**
 
 ![SigNoz Direct Role Mapping](/img/docs/saml-keycloak/signoz-direct-role-mapping.webp)
 
 <Admonition type="info">
-The role value in the SAML assertion is matched case-insensitively — `admin`, `Admin`, and `ADMIN` all resolve to the ADMIN role. If the value doesn't match any valid role, SigNoz falls back to group mappings (if configured) and then the default role.
+The role value in the SAML assertion must match a SigNoz role name — `signoz-viewer`, `signoz-editor`, `signoz-admin`, or a custom role — and is matched case-insensitively (`signoz-admin`, `Signoz-Admin`, and `SIGNOZ-ADMIN` all resolve to the `signoz-admin` role). If the value doesn't match any valid role, SigNoz falls back to group mappings (if configured) and then the default role.
 </Admonition>
 
 ## Troubleshooting

--- a/data/docs/manage/administrator-guide/sso/user-guides/sso-google.mdx
+++ b/data/docs/manage/administrator-guide/sso/user-guides/sso-google.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-22
+date: 2026-07-01
 description: Set up Google Workspace SSO authentication with SigNoz, including group-based access control and role mapping.
 title: Single Sign-on Authentication With Google Workspace
 doc_type: tutorial
@@ -136,30 +136,34 @@ You can restrict SigNoz access to specific Google Workspace groups and use group
 
 ### Step 6: Configure Role Mapping (Optional)
 
-Role mapping automatically assigns SigNoz roles (VIEWER, EDITOR, ADMIN) to users when they log in, based on their Google Workspace group memberships.
+Role mapping automatically assigns SigNoz roles (`signoz-viewer`, `signoz-editor`, `signoz-admin`, or any custom role) to users when they log in, based on their Google Workspace group memberships.
+
+<Admonition type="info">
+Both the **Default Role** dropdown and the per-group **Role** dropdown list every role in your organization — the built-in `signoz-viewer`, `signoz-editor`, and `signoz-admin` roles plus any [custom roles](https://signoz.io/docs/manage/administrator-guide/iam/roles/) you have created. Options are loaded from the SigNoz API; if the list fails to load, click **Retry** to reload it.
+</Admonition>
 
 #### Role Resolution Priority
 
 When a user logs in, SigNoz determines their role using this priority (highest to lowest):
 
 1. **Use Role Attribute** — if enabled and the IDP token contains a role claim, that role is used directly
-2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (ADMIN > EDITOR > VIEWER)
+2. **Group Mappings** — if the user belongs to multiple mapped groups, the highest-privilege role wins (`signoz-admin` > `signoz-editor` > `signoz-viewer`)
 3. **Default Role** — fallback role from configuration
-4. **VIEWER** — ultimate default if nothing else is configured
+4. **`signoz-viewer`** — ultimate default if nothing else is configured
 
 #### Configure in SigNoz
 
 1. Go to **Settings** → **Organization Settings** → **Members & SSO** → **Authenticated Domains**
 2. Click on your Google Auth domain to edit it
 3. In the **Role Mapping** section, configure the following:
-   - **Default Role**: Select the role assigned when no other mapping matches (e.g., `VIEWER`)
+   - **Default Role**: Select the role assigned when no other mapping matches (e.g., `signoz-viewer`)
    - **Group Mappings**: Add entries mapping Google Workspace group emails to SigNoz roles:
 
      | Google Workspace Group | SigNoz Role |
      |------------------------|-------------|
-     | `platform-admins@company.com` | `ADMIN` |
-     | `engineering@company.com` | `EDITOR` |
-     | `everyone@company.com` | `VIEWER` |
+     | `platform-admins@company.com` | `signoz-admin` |
+     | `engineering@company.com` | `signoz-editor` |
+     | `everyone@company.com` | `signoz-viewer` |
 
    - **Use Role Attribute**: Turn **ON** to use a role claim directly from the IDP token instead of group-based mapping. Leave **OFF** for group-based role mapping. This option applies only if your IDP token already includes a role claim. For standard Google Workspace OAuth, this is not typically available — use group-based mapping instead.
 4. Click **Save**


### PR DESCRIPTION
## Summary
- Updated SSO docs for the new role identifier format: replaced the uppercase tokens `VIEWER`, `EDITOR`, `ADMIN` with the slug format `signoz-viewer`, `signoz-editor`, `signoz-admin` in the Default Role dropdown, group-mapping tables, role-resolution priority lists, and IdP role-attribute values.
- Added a note in each SSO guide (SAML/OIDC Keycloak, Google Workspace) that the Default Role and per-group Role dropdowns list custom roles alongside the built-in roles, that options are loaded from the SigNoz API, and that a **Retry** action appears if loading fails.
- Updated the "Use Role Attribute Directly" guidance to state the role value must match a SigNoz role name (`signoz-viewer`, `signoz-editor`, `signoz-admin`, or a custom role).
- Updated the SSO overview role-mapping description.
- Cross-linked the IAM Roles doc to SSO role mapping to note custom roles are usable as SSO assignment targets.
- Updated frontmatter dates on all edited files.

### Files changed
- `data/docs/manage/administrator-guide/sso/overview.mdx`
- `data/docs/manage/administrator-guide/sso/user-guides/saml-keycloak.mdx`
- `data/docs/manage/administrator-guide/sso/user-guides/oidc-keycloak.mdx`
- `data/docs/manage/administrator-guide/sso/user-guides/sso-google.mdx`
- `data/docs/manage/administrator-guide/iam/roles.mdx`

### Notes / follow-ups
- **Screenshots not refreshed.** The Role Mapping screenshots in the Keycloak/OIDC guides still show the old dropdown values. The demo instance (demo.in.signoz.cloud) does not expose the Authentication Domains SSO configuration (admin-gated — the content pane renders empty), so fresh captures of the Default Role dropdown, group-mapping dropdown, tooltips, and the API error/Retry state could not be taken. These images should be recaptured in an admin-capable environment.
- **Held per deliverable open questions:** no migration/upgrade callout was added for stored uppercase role values (backward-compat behavior unconfirmed), and no docs were added for the role-deletion guard when a role is mapped in SSO (not present in PR #11894).

Source PRs: #11894

Auto-generated by docs-sync pipeline