### PR TITLE
(blog) Insert topical flows and interlinks in Monitoring/APM articles

### DIFF
--- a/data/blog/api-monitoring-tools.mdx
+++ b/data/blog/api-monitoring-tools.mdx
@@ -1,9 +1,11 @@
 ---
 title: Top 17 API Monitoring Tools for 2026 [Includes Free & Open-Source]
-date: 2026-01-01
+meta_title: "Top API Monitoring Tools for 2026"
+published_date: "2024-02-08"
+updated_date: "2026-06-30"
 tags: [Tech Resources, api monitoring]
 authors: [simran_kumari, sai_deepesh]
-description: Compare the 17 best API monitoring tools in 2026 — from open-source options like SigNoz and Prometheus to enterprise tools like Datadog, New Relic, and Moesif. Track uptime, errors, latency, and more.
+description: "API monitoring tools for 2026: compare options for uptime, latency, and error tracking, plus where OpenTelemetry-native SigNoz fits."
 image: /img/blog/2022/07/api_monitoring_tools_cover.webp
 keywords: [api,api monitoring,api monitoring tools]
 related_articles:
@@ -78,14 +80,16 @@ For teams heavily invested in cloud-native stacks.
 
 ## SigNoz
 
-Open-source [alternative to Datadog](https://signoz.io/blog/datadog-alternatives/) built for developers. It provides unified observability with logs, metrics, and traces, and natively supports OpenTelemetry, making it a great choice for API monitoring.
+In 2026, the key differentiator among API monitoring tools is whether they ingest [OpenTelemetry](https://signoz.io/opentelemetry/): an [OTLP](https://signoz.io/blog/what-is-otlp/)-native tool reads the spans your services already emit, so latency and error tracking come from real request traces rather than synthetic checks bolted on top.
+
+[SigNoz](https://signoz.io/teams/) is the Open-source [alternative to Datadog](https://signoz.io/blog/datadog-alternatives/) built for developers. It provides unified observability with logs, metrics, and traces, and natively supports OpenTelemetry, making it a great choice for API monitoring.
 
 <Figure src="/img/blog/2025/04/api-monitoring-tools-image.webp" alt="API Monitoring using SigNoz" caption="API Monitoring using SigNoz" />
 
 ### Pros
 
 - Unified observability (logs + metrics + traces), ideal for full-stack API monitoring
-- [OpenTelemetry](https://signoz.io/opentelemetry/)-native — automatic instrumentation for APIs
+- OpenTelemetry-native — automatic instrumentation for APIs
 - Self-hostable, giving you control over your API telemetry
 - Real-time monitoring and alerting of API performance metrics like latency, request rates, and error rates
 
@@ -548,3 +552,10 @@ APIs should be monitored continuously in real time. However, the frequency of de
 
 - Synthetic monitoring simulates API calls at regular intervals from various locations to test availability and performance. It's proactive and helps identify issues before real users encounter them.
 - Real user monitoring (RUM) captures actual user interactions with your APIs. It provides insights into real-world performance and user experience but is reactive as it detects issues after they occur.
+
+---
+
+To further explore related topics, start with our [API monitoring guide](https://signoz.io/guides/api-monitoring/) for the fundamentals and our breakdown of [API latency](https://signoz.io/guides/what-is-api-latency/) to understand the metric that drives most user-facing complaints.<br />
+If you're evaluating broader tooling, compare [APM tools](https://signoz.io/blog/apm-tools/) and [open source APM tools](https://signoz.io/blog/open-source-apm-tools/) for full-stack tracing, or narrow the scope with roundups of [microservices monitoring tools](https://signoz.io/comparisons/microservices-monitoring-tools/) and [end-to-end monitoring tools](https://signoz.io/comparisons/end-to-end-monitoring-tools/).
+
+Since API failures often surface first in your logs, our guide to [log management](https://signoz.io/blog/best-open-source-log-management-tools/) tools rounds out the picture.

--- a/data/blog/claude-code-monitoring-with-opentelemetry.mdx
+++ b/data/blog/claude-code-monitoring-with-opentelemetry.mdx
@@ -1,9 +1,11 @@
 ---
 title: 'Bringing Observability to Claude Code: OpenTelemetry in Action'
-date: 2026-05-19
+meta_title: "Claude Code Monitoring with OpenTelemetry"
+published_date: "2025-09-03"
+updated_date: "2026-06-30"
 tags: [OpenTelemetry, Claude Code, SigNoz]
 authors: [goutham_karthi]
-description: Monitor Claude Code usage with OpenTelemetry and SigNoz. This blog walks you through implementing comprehensive observability for your Claude Code activity using OpenTelemetry and SigNoz.
+description: "Monitor Claude Code with OpenTelemetry: export its metrics and logs over OTLP to SigNoz to track usage, token cost, and performance across your team."
 keywords: [monitor, observe, opentelemetry, Claude Code, integrations, SigNoz]
 related_articles:
   - '/blog/claude-code-model-comparison'
@@ -69,6 +71,14 @@ In our case, that means building dashboards that track:
 By combining OpenTelemetry's standardized data collection with SigNoz's rich visualization and alerting, you get a complete [observability stack](https://signoz.io/guides/observability-stack/) for Claude Code. The result is not just raw logs and metrics. It's a full picture of Claude Code in action, right where you need it.
 
 ## Monitoring Claude Code
+
+<KeyPointCallout title="Evolving Standards">
+
+As you'll see below, Claude Code exports its telemetry through [OTLP](https://signoz.io/blog/what-is-otlp/), the standard protocol for OpenTelemetry, so it lands in any OTLP backend like SigNoz alongside the rest of your observability data with no proprietary agent required. This is part of a broader 2026 pattern of developer and AI tools emitting OpenTelemetry directly.
+
+Where telemetry covers model interactions, the GenAI semantic conventions (the `gen_ai.*` attributes for model, token usage, and tool calls) standardize how they are recorded, which you can see in action in our guide to [observing LLM applications with OpenTelemetry](https://signoz.io/blog/opentelemetry-llm/).
+
+</KeyPointCallout>
 
 Check out the [Claude Code monitoring guide](https://signoz.io/docs/claude-code-monitoring/) for detailed instructions on setting up OpenTelemetry instrumentation.
 
@@ -391,3 +401,9 @@ As AI coding assistants like Claude Code become part of daily developer workflow
 From tracking tokens and costs, to understanding which tools and models developers actually rely on, to surfacing adoption trends and decision patterns, observability gives you the power to manage Claude Code with the same rigor you bring to any other critical piece of infrastructure. Dashboards then tie it all together, turning streams of data into a real-time pulse of how Claude Code powers development.
 
 The result? Teams gain the confidence to scale Claude Code usage responsibly, optimize for performance and spend, and most importantly, make evidence-backed decisions about how AI fits into their engineering culture. With visibility comes clarity and with clarity, Claude Code becomes not just an assistant, but a measurable driver of developer productivity.
+
+<KeyPointCallout title="Further reading">
+
+To go deeper, see how SigNoz compares to dedicated [LLM observability tools](https://signoz.io/comparisons/llm-observability-tools/) and what to look for when [model monitoring](https://signoz.io/guides/model-monitoring/) AI workloads in production. If you're folding Claude Code telemetry into a wider stack, our guides on [APM tools](https://signoz.io/blog/apm-tools/), [distributed tracing](https://signoz.io/blog/distributed-tracing/), and the [APM metrics](https://signoz.io/guides/apm-metrics/) that matter give you the foundations, while [single pane of glass monitoring](https://signoz.io/blog/single-pane-of-glass-monitoring/) shows how to bring it all into one view. And if you're weighing your instrumentation approach, [OpenTelemetry vs APM](https://signoz.io/comparisons/opentelemetry-vs-apm/) lays out the trade-offs.
+
+</KeyPointCallout>

--- a/data/blog/kubernetes-monitoring-tools.mdx
+++ b/data/blog/kubernetes-monitoring-tools.mdx
@@ -1,9 +1,10 @@
 ---
-title: Top 11 Kubernetes Monitoring Tools in 2026 [Open Source Included] 
-date: 2026-01-01
+title: "Kubernetes Monitoring Tools: 11 Options Compared"
+published_date: "2023-12-21"
+updated_date: "2026-06-30"
 tags: [kubernetes, tools-comparison, monitoring]
 authors: [adil_shaikh, debanjan]
-description: Explore 11 top Kubernetes monitoring tools — including open-source and SaaS options — to track pod health, logs, metrics, and performance in 2026.
+description: "Kubernetes monitoring tools for 2026: 11 open-source and SaaS options compared for pod health, logs, and metrics, plus where SigNoz fits."
 image: /img/blog/2023/12/k8s-monitoring-tools-cover.jpeg
 hide_table_of_contents: false
 keywords: [opentelemetry,signoz,observability,kubernetes,monitoring]
@@ -35,6 +36,8 @@ In this guide, we've compiled **11 popular Kubernetes monitoring tools**, includ
 📝 **Note:** Open-source tools like **SigNoz** and **Grafana** can be self-hosted, which means you only pay for the underlying infrastructure and maintenance—not for the software license itself.
 
 ## Top Kubernetes Monitoring Tools at a glance
+
+Quick note before we move forward: this roundup is the tool-selection page. For the hands-on how-to, the [Kubernetes monitoring guide](https://signoz.io/blog/kubernetes-monitoring/) is the canonical guide for this topic, and the two are kept distinct so they no longer compete for the same search.
 
 | **Tool** | **Best For** | **Standout Feature for K8s Monitoring** | **Weaknesses** | **Pricing** |
 | --- | --- | --- | --- | --- |
@@ -203,7 +206,7 @@ The **EFK Stack** (Elasticsearch, Fluentd, Kibana) is a popular open-source solu
 
 ### Limitations
 
-- **Paid Tiers for Key Features**: Full observability features like APM, tracing, and advanced dashboards are available only in higher pricing tiers.
+- **Paid Tiers for Key Features**: Full observability features like [APM](https://signoz.io/blog/apm-tools/), tracing, and advanced dashboards are available only in higher pricing tiers.
 - **Cost Grows with Scale**: Pricing can grow quickly in dynamic environments with many containers.
 - **Data Retention Limits**: Historical data retention depends on your subscription plan.
 
@@ -438,3 +441,7 @@ bpfman excels in **eBPF program management** and **secure deployment**. It is hi
 - Consider the long-term scalability and cost-effectiveness of your chosen monitoring solution.
 - Understanding your application's performance within the Kubernetes context is key for optimization.
 - Open standards like [OpenTelemetry](https://signoz.io/opentelemetry/) offer flexibility and avoid vendor lock-in for observability data.
+
+If you're interested in further reading, our guide to [Kubernetes monitoring best practices](https://signoz.io/guides/kubernetes-monitoring-best-practices/) covers what to instrument and alert on, while the broader [cloud-native monitoring](https://signoz.io/guides/cloud-native-monitoring/) and [container monitoring](https://signoz.io/guides/container-monitoring/) guides set the wider context for observability beyond the cluster.
+
+Alternatively, if you're weighing backends, the [Prometheus alternatives](https://signoz.io/comparisons/prometheus-alternatives/) and [infrastructure monitoring tools](https://signoz.io/comparisons/infrastructure-monitoring-tools/) comparisons help you pick, and our roundup of [DevOps monitoring tools](https://signoz.io/guides/devops-monitoring-tools/) rounds out the toolchain for shipping reliably.

--- a/data/blog/kubernetes-monitoring-tools.mdx
+++ b/data/blog/kubernetes-monitoring-tools.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Kubernetes Monitoring Tools: 11 Options Compared"
+title: "Top 11 Kubernetes Monitoring Tools in 2026 [Open Source Included]"
+meta_title: "Top 11 Kubernetes Monitoring Tools in 2026"
 published_date: "2023-12-21"
 updated_date: "2026-06-30"
 tags: [kubernetes, tools-comparison, monitoring]
@@ -442,6 +443,8 @@ bpfman excels in **eBPF program management** and **secure deployment**. It is hi
 - Understanding your application's performance within the Kubernetes context is key for optimization.
 - Open standards like [OpenTelemetry](https://signoz.io/opentelemetry/) offer flexibility and avoid vendor lock-in for observability data.
 
-If you're interested in further reading, our guide to [Kubernetes monitoring best practices](https://signoz.io/guides/kubernetes-monitoring-best-practices/) covers what to instrument and alert on, while the broader [cloud-native monitoring](https://signoz.io/guides/cloud-native-monitoring/) and [container monitoring](https://signoz.io/guides/container-monitoring/) guides set the wider context for observability beyond the cluster.
+---
 
-Alternatively, if you're weighing backends, the [Prometheus alternatives](https://signoz.io/comparisons/prometheus-alternatives/) and [infrastructure monitoring tools](https://signoz.io/comparisons/infrastructure-monitoring-tools/) comparisons help you pick, and our roundup of [DevOps monitoring tools](https://signoz.io/guides/devops-monitoring-tools/) rounds out the toolchain for shipping reliably.
+To go deeper, check out our [Kubernetes monitoring best practices](https://signoz.io/guides/kubernetes-monitoring-best-practices/) to learn what to instrument and alert on. For the wider context beyond the cluster, the [cloud-native monitoring](https://signoz.io/guides/cloud-native-monitoring/) and [container monitoring](https://signoz.io/guides/container-monitoring/) guides frame observability at each layer.
+
+If you're weighing backends and tooling, the [Prometheus alternatives](https://signoz.io/comparisons/prometheus-alternatives/) and [infrastructure monitoring tools](https://signoz.io/comparisons/infrastructure-monitoring-tools/) comparisons help you pick a stack, our roundup of [DevOps monitoring tools](https://signoz.io/guides/devops-monitoring-tools/) rounds out the delivery toolchain.

--- a/data/blog/mongodb-monitoring-tools.mdx
+++ b/data/blog/mongodb-monitoring-tools.mdx
@@ -24,7 +24,11 @@ There are many monitoring tools out there, and choosing the right one can be con
 
 ## Top 11 MongoDB Monitoring Tools at a glance
 
+<KeyPointCallout title="Note">
+
 Quick note before we move forward: this roundup is the tool-selection page. If you wish to understand how you would monitor MongoDB in the first place, check out the [MongoDB monitoring tutorial](https://signoz.io/blog/mongodb-monitoring/).
+
+</KeyPointCallout>
 
 |  | Best For | Standout Feature | Pricing |
 | --- | --- | --- | --- |

--- a/data/blog/mongodb-monitoring-tools.mdx
+++ b/data/blog/mongodb-monitoring-tools.mdx
@@ -5,7 +5,7 @@ published_date: "2024-01-11"
 updated_date: "2026-06-30"
 tags: [OpenTelemetry]
 authors: [debanjan]
-description: Discover the top 11 MongoDB monitoring tools for 2024. Learn how to optimize your database performance and choose the right tool for your needs.
+description: "MongoDB monitoring tools for 2026: compare options for operation, connection, and replication metrics, plus monitoring MongoDB with OpenTelemetry."
 image: /img/blog/2024/01/mongodb-monitoring-tools-cover.jpeg
 hide_table_of_contents: false
 keywords: [opentelemetry,signoz,observability,mongodb]
@@ -109,7 +109,6 @@ Now let’s dive deep into the top mongoDB monitoring tools.
 3. OpenTelemetry native nature lets you future-proof your application instrumentations, and the collector lets you collect telemetry data from a wide range of sources.
 4. You can create your custom visualizations using the feature-rich dashboard.
 
-You can read more about [how to set up your MongoDB monitoring with SigNoz](https://signoz.io/blog/mongodb-metrics-monitoring-with-opentelemetry/).
 
 ## MongoDB Commands
 
@@ -381,10 +380,7 @@ Yes, many tools offer forecasting features that analyze historical data to predi
 
 **Further reading**
 
-For a broader survey beyond MongoDB, compare options in our roundup of [database monitoring tools](https://signoz.io/comparisons/database-monitoring-tools/) and ground the fundamentals with our guide to [database monitoring](https://signoz.io/guides/database-monitoring/). 
+For a broader survey beyond MongoDB, compare options in our roundup of [database monitoring tools](https://signoz.io/comparisons/database-monitoring-tools/) and ground the fundamentals with our guide to [database monitoring](https://signoz.io/guides/database-monitoring/).
 
-If you run more than one engine, we have focused walkthroughs for [Cassandra monitoring](https://signoz.io/guides/cassandra-monitoring/), as well as comparisons of [PostgreSQL monitoring tools](https://signoz.io/comparisons/postgresql-monitoring-tools/) and [MySQL monitoring tools](https://signoz.io/blog/mysql-monitoring-tools/). 
+If you run more than one engine, we have focused walkthroughs for [Cassandra monitoring](https://signoz.io/guides/cassandra-monitoring/), as well as comparisons of [PostgreSQL monitoring tools](https://signoz.io/comparisons/postgresql-monitoring-tools/) and [MySQL monitoring tools](https://signoz.io/blog/mysql-monitoring-tools/), plus caching-layer coverage in [Redis monitoring](https://signoz.io/blog/redis-monitoring/).
 
-For caching layers, see how to approach [Redis monitoring](https://signoz.io/blog/redis-monitoring/).
-
-Finally, if you're evaluating complete observability platforms to monitor these engines alongside your applications, see why teams choose SigNoz as their [open-source Datadog alternative](https://signoz.io/blog/open-source-datadog-alternative/).

--- a/data/blog/mongodb-monitoring-tools.mdx
+++ b/data/blog/mongodb-monitoring-tools.mdx
@@ -1,6 +1,8 @@
 ---
 title: 11 Top MongoDB Monitoring Tools - Including Free & Open-Source [2026]
-date: 2026-01-01
+meta_title: "MongoDB Monitoring Tools: Top Choices Compared"
+published_date: "2024-01-11"
+updated_date: "2026-06-30"
 tags: [OpenTelemetry]
 authors: [debanjan]
 description: Discover the top 11 MongoDB monitoring tools for 2024. Learn how to optimize your database performance and choose the right tool for your needs.
@@ -22,6 +24,8 @@ There are many monitoring tools out there, and choosing the right one can be con
 
 ## Top 11 MongoDB Monitoring Tools at a glance
 
+Quick note before we move forward: this roundup is the tool-selection page. If you wish to understand how you would monitor MongoDB in the first place, check out the [MongoDB monitoring tutorial](https://signoz.io/blog/mongodb-monitoring/).
+
 |  | Best For | Standout Feature | Pricing |
 | --- | --- | --- | --- |
 | SigNoz (open-source) | OpenTelemetry native monitoring, and creating a wide range of MongoDB metric visualizations. | Open-source. Lets you track MELT under a single pane of glass. | Free community edition. \$49/month for cloud. Custom price for enterprises. |
@@ -34,7 +38,7 @@ There are many monitoring tools out there, and choosing the right one can be con
 | SolarWinds Database Performance Monitor | Retrieving data about queries, databases, and infrastructure automatically and with a global view. | Automated profiling analysis for a centralized view of latency and throughput errors in real-time. | Free trial for 30 days with customized pricing. |
 | Site 24×7 MongoDB Monitoring Tool | Preventing alert fatigue and monitoring several settings concurrently. | Alerting engine, which has an advanced rules system to take corrective measures. | Free trial for 30 days, with pro edition at \$ |
 | ManageEngine Applications Manager MongoDB Monitoring | On-premise monitoring of different applications and granular traffic analysis. | Applications’ dependency map for identifying resource shortages. | Free edition, with customized enterprise solutions. |
-| Sematext MongoDB Integration | Cluster and container environments, thanks to its auto-discovery capabilities of new service instances. | Anomaly detection in alerting systems. | Free 14-day trial with prices starting at — log management at \$40/month, monitoring at \$3.24/month, experience at \$8/month, and synthetics at \$4.5/month annually. |
+| Sematext MongoDB Integration | Cluster and container environments, thanks to its auto-discovery capabilities of new service instances. | Anomaly detection in alerting systems. | Free 14-day trial with prices starting at — [log management](https://signoz.io/blog/best-open-source-log-management-tools/) at \$40/month, monitoring at \$3.24/month, experience at \$8/month, and synthetics at \$4.5/month annually. |
 
 ## What is MongoDB Monitoring and Why is it Crucial?
 
@@ -96,7 +100,7 @@ Now let’s dive deep into the top mongoDB monitoring tools.
 <figcaption><i>Create Monitoring Dashboards in SigNoz for monitoring</i></figcaption>
 </figure>
 
-[SigNoz](https://signoz.io/docs/introduction/) is an [OpenTelemetry](https://signoz.io/opentelemetry/) native APM platform. What this means for you is that you can monitor any application that can generate monitoring signals. And MongoDB is no exception. Along with SigNoz, all you need is an [OpenTelemetry collector](https://signoz.io/blog/opentelemetry-collector-complete-guide/). On one end, this collector will connect with your MongoDB and ingest metrics. On the other end, it will feed the metrics to your SigNoz deployment, whether on the cloud or on-premises.
+[SigNoz](https://signoz.io/docs/introduction/) is an [OpenTelemetry](https://signoz.io/opentelemetry/) native [APM](https://signoz.io/blog/apm-tools/) platform. What this means for you is that you can monitor any application that can generate monitoring signals. And MongoDB is no exception. Along with SigNoz, all you need is an [OpenTelemetry collector](https://signoz.io/blog/opentelemetry-collector-complete-guide/). On one end, this collector will connect with your MongoDB and ingest metrics. On the other end, it will feed the metrics to your SigNoz deployment, whether on the cloud or on-premises.
 
 **Features of SigNoz**
 
@@ -109,7 +113,7 @@ You can read more about [how to set up your MongoDB monitoring with SigNoz](http
 
 ## MongoDB Commands
 
-The MongoDB installation comes with its set of [command-line utilities](https://signoz.io/blog/mongodb-monitoring/). Two of them would be of particular interest to you.
+The MongoDB installation comes with its set of command-line utilities. Two of them would be of particular interest to you.
 
 - **mongotop** — Track the current read/write activity of your MongoDB instance on a per-collection basis.
 - **mongostat** — See a count of the number of database operations by type (insert, query, update, delete, etc.).
@@ -375,8 +379,12 @@ Yes, many tools offer forecasting features that analyze historical data to predi
 
 ---
 
-**Further Reading**
+**Further reading**
 
-[Guide to MongoDB performance monitoring](https://signoz.io/blog/mongodb-monitoring/)
+For a broader survey beyond MongoDB, compare options in our roundup of [database monitoring tools](https://signoz.io/comparisons/database-monitoring-tools/) and ground the fundamentals with our guide to [database monitoring](https://signoz.io/guides/database-monitoring/). 
 
-[SigNoz - Open-Source alternative to Datadog](https://signoz.io/blog/open-source-datadog-alternative/)
+If you run more than one engine, we have focused walkthroughs for [Cassandra monitoring](https://signoz.io/guides/cassandra-monitoring/), as well as comparisons of [PostgreSQL monitoring tools](https://signoz.io/comparisons/postgresql-monitoring-tools/) and [MySQL monitoring tools](https://signoz.io/blog/mysql-monitoring-tools/). 
+
+For caching layers, see how to approach [Redis monitoring](https://signoz.io/blog/redis-monitoring/).
+
+Finally, if you're evaluating complete observability platforms to monitor these engines alongside your applications, see why teams choose SigNoz as their [open-source Datadog alternative](https://signoz.io/blog/open-source-datadog-alternative/).

--- a/data/blog/opentelemetry-apm.mdx
+++ b/data/blog/opentelemetry-apm.mdx
@@ -1,12 +1,12 @@
 ---
 
 title: "OpenTelemetry APM: An Open Source Approach"
-meta_title: "OpenTelemetry APM: What It Is & How to Choose One"
-published_date: 2023-09-14
-updated_date: 2026-06-16
+meta_title: "OpenTelemetry APM: Using OTel as Your APM"
+published_date: "2023-09-14"
+updated_date: "2026-06-30"
 tags: [OpenTelemetry, SigNoz, APM]
 authors: [ankit_anand, dhruv_ahuja]
-description: What an OpenTelemetry APM is, how to choose one, and best practices for OTel instrumentation. Learn how SigNoz delivers open-source, OTel-native APM.
+description: "OpenTelemetry APM: how to use OpenTelemetry as your application performance monitoring stack, what it covers, and how it compares to traditional APM."
 image: /img/blog/2023/03/opentelemetry_apm_cover-min.jpg
 keywords: [opentelemetry,opentelemetry apm,opentelemetry specification,open source,opentelemetry native,apm tools,application performance monitoring]
 related_articles:
@@ -29,6 +29,12 @@ But setting up a robust monitoring and [observability stack](https://signoz.io/g
 [![Get Started - Free CTA](/img/launch_week/try-signoz-cloud-blog-cta.png)](https://signoz.io/teams/)
 
 ## What is OpenTelemetry?
+
+<KeyPointCallout title="Note">
+
+This page focuses on using OpenTelemetry as your APM solution, the practical setup and what OTel-based APM covers in production. The [what is APM](https://signoz.io/guides/what-is-apm/) guide covers the definitional background, what application performance monitoring is and the core concepts, so the two are complementary rather than competing for one search.
+
+</KeyPointCallout>
 
 [OpenTelemetry](https://signoz.io/opentelemetry/) is an open-source collection of tools, APIs, and SDKs that aims to standardize the way we generate and collect telemetry data. The <a href = "https://github.com/open-telemetry/opentelemetry-specification" rel="noopener noreferrer nofollow" target="_blank">OpenTelemetry specification</a> has design and implementation guidelines on how the instrumentation libraries should be implemented. In addition, it provides client libraries in all the major programming languages which follow the specification.
 
@@ -81,7 +87,7 @@ SigNoz supports OpenTelemetry semantic conventions and provides visualization fo
 
 The steps to send telemetry data to SigNoz involves:
 
-- [Instrumenting your application's code](https://signoz.io/docs/instrumentation/) with language-specific OpenTelemetry libraries
+- Instrumenting your application's code with language-specific OpenTelemetry libraries
 - Configure OpenTelemetry Exporters to send data to SigNoz
 - Visualize and analyze telemetry data using SigNoz dashboards and signal-specific views
 
@@ -169,3 +175,5 @@ To implement OpenTelemetry APM effectively, you should have:
 As you gain experience with OpenTelemetry, you'll develop a deeper understanding of its capabilities and best practices for application monitoring. 
 
 Remember, you can start small: auto-instrumentation at the code level and general APM dashboards alone can help you maintain reliable application systems. They might even be enough for your needs for a considerable period of time until your systems grow in complexity, and require more investment into observability!
+
+To go deeper: our roundup of [APM tools](https://signoz.io/blog/apm-tools/) walks through the leading options so you can weigh an OpenTelemetry-native approach against traditional vendors, while the guide to [distributed tracing](https://signoz.io/blog/distributed-tracing/) explains the core technique for following requests across services that underpins OTel-based APM.

--- a/data/blog/opentelemetry-apm.mdx
+++ b/data/blog/opentelemetry-apm.mdx
@@ -32,7 +32,7 @@ But setting up a robust monitoring and [observability stack](https://signoz.io/g
 
 <KeyPointCallout title="Note">
 
-This page focuses on using OpenTelemetry as your APM solution, the practical setup and what OTel-based APM covers in production. The [what is APM](https://signoz.io/guides/what-is-apm/) guide covers the definitional background, what application performance monitoring is and the core concepts, so the two are complementary rather than competing for one search.
+This page focuses on using OpenTelemetry as your APM solution, the practical setup and what OTel-based APM covers in production. The [what is APM](https://signoz.io/guides/what-is-apm/) guide covers the definitional background, what application performance monitoring is and the core concepts.
 
 </KeyPointCallout>
 

--- a/data/blog/opentelemetry-django.mdx
+++ b/data/blog/opentelemetry-django.mdx
@@ -1,7 +1,8 @@
 ---
 title: A Practical OpenTelemetry Django Auto-Instrumentation Guide
-published_date: 2024-02-08
-updated_date: 2026-06-16
+meta_title: "OpenTelemetry Django Instrumentation Explained"
+published_date: "2024-02-08"
+updated_date: "2026-06-30"
 tags: [Observability, Python, OpenTelemetry, Monitoring]
 authors: [ankit_anand, dhruv_ahuja]
 description: Learn how to set up OpenTelemetry Django auto-instrumentation using opentelemetry-instrumentation-django to monitor traces, metrics, and logs.
@@ -23,6 +24,11 @@ In this hands-on guide, we will set up OpenTelemetry Django auto-instrumentation
 Finally, we'll verify that telemetry flows end to end, visualize your application's telemetry, and understand how it works under the hood.
 
 ## What is OpenTelemetry Django?
+
+<KeyPointCallout title="Note">
+Before we begin, note that the scope of this guide is limited to instrumenting Django with OpenTelemetry, auto-instrumentation, manual spans and metrics, and exporting telemetry.<br />
+For what to monitor once data is flowing (the Django metrics that matter, dashboards, and alerts), the dedicated [Django monitoring guide](https://signoz.io/guides/django-monitoring/) covers that side, so the two are complementary rather than two pages chasing the same search.
+</KeyPointCallout>
 
 [OpenTelemetry instrumentation](https://signoz.io/docs/instrumentation/opentelemetry-python/) with Django enables the generation and management of telemetry data (logs, metrics, and traces) from your Django application. This data is then used to observe the application and gain insights into its performance and behavior.<br />
 [OpenTelemetry](https://signoz.io/opentelemetry/) provides an open-source standard with a consistent data format and collection mechanism. As application owners, you will always have the freedom to choose different vendors to visualize the collected telemetry data, and can consume this data in a variety of formats.
@@ -420,3 +426,10 @@ Check out the <a href="https://opentelemetry-python-contrib.readthedocs.io/en/la
 ### How do I prevent tracing health checks or noisy endpoints in Django?
 
 Use OpenTelemetry Python configuration to exclude URLs. OpenTelemetry provides [Python-specific environment variables](https://opentelemetry.io/docs/zero-code/python/configuration/#excluded-urls) for exclusions. You can set a global excluded URL pattern (`OTEL_PYTHON_EXCLUDED_URLS`) list, or set Django-specific excluded URL patterns (`OTEL_PYTHON_DJANGO_EXCLUDED_URLS`). This is a common best practice to reduce noise and cost while keeping high-value traces.
+
+**Further reading**
+
+To go deeper once Django telemetry is flowing, the [Python performance monitoring guide](https://signoz.io/guides/python-performance-monitoring/) and broader [Python application monitoring guide](https://signoz.io/blog/python-application-monitoring/) help you turn that data into actionable insights.<br />
+To understand the concepts behind the traces you're collecting, see our primer on [distributed tracing](https://signoz.io/blog/distributed-tracing/) and how it fits into the wider landscape of [APM tools](https://signoz.io/blog/apm-tools/).
+
+And if you want to know when to reach for the instrumentation API versus the SDK, our breakdown of the [OpenTelemetry API vs SDK](https://signoz.io/comparisons/opentelemetry-api-vs-sdk/) clarifies the distinction.

--- a/data/blog/opentelemetry-django.mdx
+++ b/data/blog/opentelemetry-django.mdx
@@ -26,8 +26,10 @@ Finally, we'll verify that telemetry flows end to end, visualize your applicatio
 ## What is OpenTelemetry Django?
 
 <KeyPointCallout title="Note">
+
 Before we begin, note that the scope of this guide is limited to instrumenting Django with OpenTelemetry, auto-instrumentation, manual spans and metrics, and exporting telemetry.<br />
-For what to monitor once data is flowing (the Django metrics that matter, dashboards, and alerts), the dedicated [Django monitoring guide](https://signoz.io/guides/django-monitoring/) covers that side, so the two are complementary rather than two pages chasing the same search.
+For what to monitor once data is flowing (the Django metrics that matter, dashboards, and alerts), the dedicated [Django monitoring guide](https://signoz.io/guides/django-monitoring/) covers that side.
+
 </KeyPointCallout>
 
 [OpenTelemetry instrumentation](https://signoz.io/docs/instrumentation/opentelemetry-python/) with Django enables the generation and management of telemetry data (logs, metrics, and traces) from your Django application. This data is then used to observe the application and gain insights into its performance and behavior.<br />


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Interlinks other relevant blogs, and better defines the intent of blogs or adds freshness callouts where necessary.
