### PR TITLE
docs: add dashboard layout constraints reference for API/AI creation

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -2271,6 +2271,11 @@
             "type": "doc",
             "route": "/docs/dashboards/terraform-provider-signoz",
             "label": "Terraform Provider"
+          },
+          {
+            "type": "doc",
+            "route": "/docs/dashboards/dashboard-layout-constraints",
+            "label": "Layout Constraints (API)"
           }
         ]
       },

--- a/data/docs/ai/use-cases/dashboard-creation-natural-language.mdx
+++ b/data/docs/ai/use-cases/dashboard-creation-natural-language.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-07-02
 title: Dashboard Creation from Natural Language
 meta_title: Create Dashboards with Natural Language
 description: Build SigNoz dashboards faster by describing the visualizations you need in plain English — AI assistants handle the rest via the MCP server.
@@ -51,6 +51,10 @@ You can open it in SigNoz under Dashboards → "Recommendation Service Overview"
 ```
 
 The dashboard is now live with all three panels displaying real-time metrics for the recommendation service.
+
+<Admonition type="info">
+The API validates the panel layout before saving. If your assistant produces an invalid grid (overlapping panels, an off-grid position, or the same panel placed twice), the request is rejected with a `dashboard_invalid_input` error. See [Dashboard layout constraints](https://signoz.io/docs/dashboards/dashboard-layout-constraints/) for the full rules.
+</Admonition>
 
 
 ## Final Summary

--- a/data/docs/dashboards/dashboard-layout-constraints.mdx
+++ b/data/docs/dashboards/dashboard-layout-constraints.mdx
@@ -1,0 +1,73 @@
+---
+date: 2026-07-02
+title: Dashboard Layout Constraints for API and AI Creation
+description: Reference the grid layout rules SigNoz validates when you create or update dashboards through the API or AI tools, including limits, bounds, and error codes.
+doc_type: reference
+---
+
+When you create or update a dashboard through the SigNoz API (including AI-assisted tools such as the [SigNoz MCP server](https://signoz.io/docs/ai/signoz-mcp-server/)), the backend validates the dashboard's grid layout before saving it. Layouts that break these rules are rejected with the `dashboard_invalid_input` error code and a message identifying the offending item.
+
+These constraints apply to every programmatic create and update request. Dashboards built through the UI stay within these bounds automatically, so you rarely hit them by hand. They matter most when a script or AI assistant generates the dashboard spec.
+
+## Grid model
+
+A dashboard spec places panels on a fixed grid:
+
+- `spec.panels` is a map of panel definitions, keyed by panel key.
+- `spec.layouts` is an ordered list of layout sections. Each section is a grid layout whose `spec.items` position panels on the grid.
+- Each item has an integer position (`x`, `y`) and size (`width`, `height`), and a `content` reference that points to a panel as `#/spec/panels/<key>`.
+- The grid is **12 columns** wide. Columns are fixed; rows grow downward without a limit.
+
+## Constraints
+
+| Rule | Constraint | Rejected when |
+|------|------------|---------------|
+| Section count | A dashboard may contain at most **500** layout sections. | `spec.layouts` has more than 500 entries. |
+| Items per section | Each section may contain at most **100** items. | A section's `spec.items` has more than 100 entries. |
+| Minimum width | `width` must be **≥ 1**. | `width` is 0 or negative. |
+| Minimum height | `height` must be **≥ 1**. | `height` is 0 or negative. |
+| Non-negative X | `x` must be **≥ 0**. | `x` is negative. |
+| Non-negative Y | `y` must be **≥ 0**. | `y` is negative. |
+| Width within grid | `width` must be **≤ 12**. | `width` exceeds the 12-column grid. |
+| X within grid | `x` must be **< 12**. | `x` is 12 or greater. |
+| Right edge within grid | `x + width` must be **≤ 12**. | The item extends past the right edge of the grid. |
+| No overlap | Two items in the same section must not occupy overlapping grid rectangles. | Any two items in one section intersect on both axes. |
+| No duplicate panel | A panel may be placed by **at most one** grid item across the whole dashboard. | The same panel key is referenced by more than one item. |
+| Resolvable reference | Every item's `content` must reference an existing panel as `#/spec/panels/<key>`. | The reference is missing, malformed, or points to an unknown panel key. |
+
+<Admonition type="info">
+Overlap is checked per section: two items overlap when their rectangles intersect on both the horizontal and vertical axes. Items in different sections never overlap, because each section stacks below the previous one.
+</Admonition>
+
+## Error code and messages
+
+All layout validation failures return the `dashboard_invalid_input` error code. The message names the layout and item by index (`spec.layouts[<section>].spec.items[<item>]`) so you can locate the problem in your request body.
+
+Example messages:
+
+```text
+spec.layouts: dashboard has 501 layouts; maximum is 500
+spec.layouts[0].spec.items: has 101 items; maximum is 100
+spec.layouts[0].spec.items[2]: width must be at least 1, got 0
+spec.layouts[0].spec.items[2]: height must be at least 1, got -1
+spec.layouts[0].spec.items[2]: x must not be negative, got -1
+spec.layouts[0].spec.items[2]: y must not be negative, got -1
+spec.layouts[0].spec.items[2]: width (14) exceeds grid width 12
+spec.layouts[0].spec.items[2]: x (12) must be less than grid width 12
+spec.layouts[0].spec.items[2]: x (8) + width (6) exceeds grid width 12
+spec.layouts[0].spec.items[0] and items[1] overlap
+spec.layouts[0].spec.items[1].content: panel "cpu-usage" is already placed by spec.layouts[0].spec.items[0].content
+spec.layouts[0].spec.items[0].content: references unknown panel "cpu-usage"
+```
+
+## Common causes
+
+- **AI-generated layouts:** an assistant may place two panels at the same coordinates or reuse a panel key across items. Regenerate or nudge the assistant to give each panel a unique key and non-overlapping position.
+- **Copy-pasted items:** duplicating an item without changing its `content` reference triggers the duplicate-panel error, since the same panel would be placed twice.
+- **Off-grid math:** a full-width panel is `x: 0, width: 12`. Setting `x: 6, width: 12` pushes the right edge to column 18 and is rejected.
+
+## Related
+
+- [Dashboard creation from natural language](https://signoz.io/docs/ai/use-cases/dashboard-creation-natural-language/) — build dashboards with an AI assistant via the MCP server.
+- [Terraform provider for SigNoz](https://signoz.io/docs/dashboards/terraform-provider-signoz/) — manage dashboards as code.
+- [Manage dashboards](https://signoz.io/docs/userguide/manage-dashboards/) — create and organize dashboards in the UI.


### PR DESCRIPTION
## Summary

- Adds a new reference page `data/docs/dashboards/dashboard-layout-constraints.mdx` documenting the grid layout validation now enforced on the dashboard create/update API (live, no feature flag). Covers: 500-section limit, 100-items-per-section limit, minimum item dimensions, non-negative positions, 12-column grid bounds, no overlapping panels, and no duplicate panel references. Includes the `dashboard_invalid_input` error code and example error messages taken from the backend.
- Cross-links the new page from the AI natural-language dashboard creation page (`data/docs/ai/use-cases/dashboard-creation-natural-language.mdx`) via an Admonition, since AI-generated layouts are the motivating scenario.
- Adds the page to the Dashboards sidebar (`data/docs-side-nav/main.json`).
- Updated frontmatter `date` to 2026-07-02 on all edited files.

## Scope note

Only the **live** API layout-validation change (features 9-15, PR #11921) is documented here. The Dashboards V2 list-page and settings changes (features 1-8, PR #11868) are gated behind the `use_dashboard_v2` flag and not yet GA, so they are intentionally **not** published in this PR. They should be documented when the flag ships by default.

No screenshots: the change is a backend API validation with no UI surface.

Source PRs: #11921

Auto-generated by docs-sync pipeline