### PR TITLE
docs: update Dashboards V2 panel editor documentation

### DIFF
--- a/data/docs/dashboards/panel-types/bar.mdx
+++ b/data/docs/dashboards/panel-types/bar.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-02
 description: Information about Bar Chart
 doc_type: reference
 title: Bar Chart Panel Type
@@ -49,6 +49,10 @@ The following graph shows the requests per second (req/s) for a service over a p
 - **Y Axis Unit** — The unit of the y-axis (for example, `Milliseconds (ms)`, `Bytes`, `Percent`). The default is `None`.
 - **Decimal Precision** — Number of decimal places to display. The default is `2 decimals`.
 
+<Admonition type="info">
+When you create a new panel, the **Y Axis Unit** is pre-filled with the unit of the selected metric, so the axis matches how the metric was reported. If you choose a unit that is incompatible with the unit the metric was sent with, a warning icon appears on the unit selector. Hover over the icon to see a tooltip explaining the mismatch and the unit the metric was sent with.
+</Admonition>
+
 #### Axes
 
 - **Soft Min / Soft Max** — Adjust the y-axis scale for better visualization. When set, the y-axis range uses these values instead of auto-adjusting based on the data. Useful when you want to prevent small values from being magnified too much.
@@ -76,6 +80,10 @@ Thresholds are used to draw a line on the y-axis to highlight the value. The thr
   alt="Threshold configuration for bar chart"
   caption="Configure thresholds with value, unit, and color."
 />
+
+<Admonition type="info">
+Threshold edits stream into the panel preview as you type, so you see the effect on your data before you click **Save Changes**. Click **Discard** to roll the panel back to its state from before you started editing, which reverts the live preview as well. Thresholds are preserved when you change the panel's visualization type: their color, value, and unit carry over and are remapped to the new panel type's format.
+</Admonition>
 
 ### Get Help
 

--- a/data/docs/dashboards/panel-types/pie.mdx
+++ b/data/docs/dashboards/panel-types/pie.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Pie Chart Panel Type
-date: 2026-05-13
+date: 2026-07-02
 description: Learn how to use the Pie Chart panel type in SigNoz dashboards to visualize proportional data.
 doc_type: reference
 ---
@@ -19,6 +19,10 @@ A Pie chart is a plot chart that shows the proportion of a single or a few diffe
 - Metrics
 
 This panel type supports any time series data. The time series data can be from logs, traces, or metrics.
+
+<Admonition type="info">
+Pie charts support ClickHouse queries that return multiple aggregation columns (for example, `count() AS col1, sum(duration) AS col2`). Each value column renders as its own slice instead of collapsing into one. Single-value and grouped queries are unchanged. When a grouped query returns multiple value columns, each slice is labeled `group · column`.
+</Admonition>
 
 #### Examples
 
@@ -47,6 +51,10 @@ The following graph shows the distribution of the service requests over the serv
 
 - **Unit** — The unit for the displayed values (for example, `Bytes`, `Percent`, `Requests/s`). The default is `None`.
 - **Decimal Precision** — Number of decimal places to display. The default is `2 decimals`.
+
+<Admonition type="info">
+When you create a new panel, the **Unit** is pre-filled with the unit of the selected metric, so the values match how the metric was reported. If you choose a unit that is incompatible with the unit the metric was sent with, a warning icon appears on the unit selector. Hover over the icon to see a tooltip explaining the mismatch and the unit the metric was sent with.
+</Admonition>
 
 #### Legend
 

--- a/data/docs/dashboards/panel-types/table.mdx
+++ b/data/docs/dashboards/panel-types/table.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Table Panel Type
-date: 2026-05-13
+date: 2026-07-02
 description: Learn how to use the Table panel type in SigNoz dashboards to display and analyze metrics data in tabular format.
 doc_type: reference
 ---
@@ -55,6 +55,10 @@ Add context links to enable click-through navigation from the panel to other das
 #### Thresholds
 
 Thresholds are used to draw a line on the y-axis to highlight the value. The thresholds are defined as a list of tuples. Each tuple contains the value and the color. The color is optional and if not provided, the default color will be used.
+
+<Admonition type="info">
+Threshold edits stream into the panel preview as you type, so you see the effect on your data before you click **Save Changes**. Click **Discard** to roll the panel back to its state from before you started editing, which reverts the live preview as well. Thresholds are preserved when you change the panel's visualization type (for example, from Table to Time Series): their color, value, and unit carry over and are remapped to the new panel type's format.
+</Admonition>
 
 
 ### Get Help

--- a/data/docs/dashboards/panel-types/timeseries.mdx
+++ b/data/docs/dashboards/panel-types/timeseries.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Timeseries Panel Type
-date: 2026-05-13
+date: 2026-07-02
 description: Learn how to use the Timeseries Chart panel type in SigNoz dashboards to visualize metrics over time.
 doc_type: reference
 ---
@@ -44,10 +44,21 @@ The following graph shows the requests per second (req/s) for a service over a p
 - **Panel Time Preference** — Override the global dashboard time range for this panel. Set to `Global Time` to use the dashboard's time picker, or choose a fixed time range.
 - **Fill Gaps** — The `Fill Gaps` option fills the gaps in the result data with zero. This is useful when you want to interpret the no data as zero. It is more appropriate for when the data is sparse. For example, if the result of a query for 10 minutes is `{t1: 12, t3: 21, t5: 42, t7:29}`, the `Fill Gaps` option will result in `{t1: 12, t2: 0, t3: 21, t4: 0, t5: 42, t6: 0, t7: 29, t8: 0, t9: 0, t10: 0}`.
 
+#### Span Gaps
+
+Use the **Span Gaps** (Disconnect Values) control to decide how the line handles gaps in a series, meaning intervals that have no data point.
+
+- **Never**: connect the line across gaps so the series stays continuous.
+- **Threshold**: disconnect the line when a gap is longer than a duration you set. When you switch to `Threshold`, the duration is seeded from the query's step interval instead of a fixed default, so it reflects the resolution the panel actually queries at. The duration input validates as you type and shows an error inline for invalid values, so you do not need to leave the field to see the problem.
+
 #### Formatting & Units
 
 - **Y Axis Unit** — The unit of the y-axis (for example, `Milliseconds (ms)`, `Bytes`, `Percent`). The default is `None`.
 - **Decimal Precision** — Number of decimal places to display. The default is `2 decimals`.
+
+<Admonition type="info">
+When you create a new panel, the **Y Axis Unit** is pre-filled with the unit of the selected metric, so the axis matches how the metric was reported. If you choose a unit that is incompatible with the unit the metric was sent with, a warning icon appears on the unit selector. Hover over the icon to see a tooltip explaining the mismatch and the unit the metric was sent with.
+</Admonition>
 
 #### Axes
 
@@ -70,6 +81,10 @@ Add context links to enable click-through navigation from the panel to other das
 #### Thresholds
 
 Thresholds are used to draw a line on the y-axis to highlight the value. The thresholds are defined as a list of tuples. Each tuple contains the value and the color. The color is optional and if not provided, the default color will be used.
+
+<Admonition type="info">
+Threshold edits stream into the panel preview as you type, so you see the effect on your data before you click **Save Changes**. Click **Discard** to roll the panel back to its state from before you started editing, which reverts the live preview as well. Thresholds are preserved when you change the panel's visualization type (for example, from Time Series to Table): their color, value, and unit carry over and are remapped to the new panel type's format.
+</Admonition>
 
 ### Get Help
 

--- a/data/docs/dashboards/panel-types/value.mdx
+++ b/data/docs/dashboards/panel-types/value.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Number Panel Type
-date: 2026-05-13
+date: 2026-07-02
 description: Learn how to use the Number panel type in SigNoz dashboards to display single aggregated metric values.
 doc_type: reference
 ---
@@ -56,6 +56,10 @@ The following graph shows the combined average requests per second (req/s) for a
 - **Unit** — The unit of the displayed value (for example, `Bytes`, `Percent`, `Requests/s`). The default is `None`.
 - **Decimal Precision** — Number of decimal places to display. The default is `2 decimals`.
 
+<Admonition type="info">
+When you create a new panel, the **Unit** is pre-filled with the unit of the selected metric, so the value matches how the metric was reported. If you choose a unit that is incompatible with the unit the metric was sent with, a warning icon appears on the unit selector. Hover over the icon to see a tooltip explaining the mismatch and the unit the metric was sent with.
+</Admonition>
+
 #### Alerts
 
 Link existing alert rules to this panel or create new alerts directly from the panel configuration.
@@ -67,6 +71,10 @@ Add context links to enable click-through navigation from the panel to other das
 #### Thresholds
 
 Thresholds are used to draw a line on the y-axis to highlight the value. The thresholds are defined as a list of tuples. Each tuple contains the value and the color. The color is optional and if not provided, the default color will be used.
+
+<Admonition type="info">
+Threshold edits stream into the panel preview as you type, so you see the effect on your data before you click **Save Changes**. Click **Discard** to roll the panel back to its state from before you started editing, which reverts the live preview as well. Thresholds are preserved when you change the panel's visualization type: their color, value, and unit carry over and are remapped to the new panel type's format.
+</Admonition>
 
 ### Get Help
 


### PR DESCRIPTION
## Summary

Documents the Dashboards V2 panel editor enhancements shipped in [SigNoz#11918](https://github.com/SigNoz/signoz/pull/11918) (merged 2026-07-02, no feature flag, active by default). Changes land in the per-panel-type reference pages under `data/docs/dashboards/panel-types/`:

- **Thresholds** (`timeseries`, `table`, `value`, `bar`): note that thresholds live-stream into the panel preview as you type, that **Discard** reverts the panel to its pre-edit state, and that thresholds are preserved (color/value/unit remapped) when switching visualization type.
- **Formatting / Y-Axis Units** (`timeseries`, `bar`, `value`, `pie`): document that a new panel pre-fills the unit from the selected metric, and that an incompatible unit shows a warning icon with a mismatch tooltip on hover.
- **Span Gaps** (`timeseries`): new `#### Span Gaps` subsection covering the Disconnect Values control (Never vs Threshold), step-interval seeding of the threshold duration, and inline validation as you type.
- **Pie Chart** (`pie`): note that multi-column ClickHouse scalar queries render one slice per value column, with grouped multi-column slices labeled `group · column`.
- Updated the `date` frontmatter to 2026-07-02 on all five edited files.

## Screenshots

No new screenshots were added. The demo (demo.in.signoz.cloud) currently runs an intermediate build that predates PR #11918: the panel editor still defaults the Y-Axis Unit to "Please select a unit" (no metric auto-seed) and has no Span Gaps / Disconnect Values control. Screenshots of the new behaviors should be captured once the change reaches the demo, rather than fabricated from the old UI.

Source PRs: #11918

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)