### PR TITLE
docs: update Meter Explorer query persistence documentation

### DIFF
--- a/data/docs/cost-meter/meter-explorer.mdx
+++ b/data/docs/cost-meter/meter-explorer.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-25
+date: 2026-07-03
 
 title: Meter Explorer - Query & Analyze Cost Metrics
 description: Use Meter Explorer to query and analyze telemetry ingestion costs in SigNoz. Drill down by service, environment, or host to identify cost drivers and optimize spend.
@@ -103,6 +103,12 @@ Meter Explorer supports saved views, allowing you to create and reuse common que
 You can select a previously saved view from the **Select a view** dropdown to quickly load it without rebuilding the query each time.
 
 For more details on creating and managing saved views, see the [Saved Views in Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/#saved-views-in-metrics-explorer).
+
+## Persistent and shareable queries
+
+Meter Explorer encodes your full query in the page URL, including the selected metric, aggregation method, groupBy field, and tag filters. Refreshing the page restores the same view instead of resetting to defaults, so you keep your configuration across reloads.
+
+Because the query lives in the URL, you can also bookmark it or share the link with a teammate to reproduce the exact same view without rebuilding the query. For queries you reuse regularly, save them as a [saved view](#saved-views) instead.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Added a "Persistent and shareable queries" section to the Meter Explorer reference page documenting that the full query (metric, aggregation, groupBy, tag filters) is encoded in the URL, so a page refresh restores the view and the URL can be bookmarked or shared to reproduce an exact query.
- Updated the `date` frontmatter to 2026-07-03 on the edited file.

## Notes
- No pre-existing "filters lost on refresh" caveat/known-issue note was found in the Meter Explorer docs, so there was nothing to remove.
- The docs changelog is CMS-driven (Strapi), not stored as MDX in this repo, so the July 2026 bug-fix changelog entry needs to be added there manually rather than in this PR.
- Verified on the demo that Meter Explorer lives at the `/meter/explorer` route and encodes query state in the URL. Full URL-restoration of the metric was not yet live on the demo build at capture time (it lags the merged PR), so no new "after" screenshot was added; existing screenshots remain accurate.

Source PRs: #11948

Auto-generated by docs-sync pipeline