### PR TITLE
docs(agent-skills): add Devin CLI install tab, update Claude Code flow

### DIFF
--- a/data/docs/ai/agent-skills.mdx
+++ b/data/docs/ai/agent-skills.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-14
+date: 2026-07-02
 title: Agent Skills & Plugin
 meta_title: SigNoz Agent Skills & Plugin - AI Coding Assistant Setup
 description: Install the SigNoz plugin and Agent Skills so AI assistants like Claude Code, Codex, Cursor, and Gemini can query data, build dashboards, manage alerts, and explore SigNoz docs.
@@ -12,7 +12,7 @@ When you ask your AI assistant something like "why did this alert fire," "create
 
 SigNoz ships these skills two ways:
 
-- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, and Gemini CLI.
+- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, Gemini CLI, and Devin CLI.
 - **Individual skills via skills.sh** - install one or more skill files on their own, for any skills.sh-compatible agent.
 
 ## Install the plugin
@@ -27,14 +27,9 @@ Add the marketplace and install the plugin:
 /plugin install signoz@signoz-skills
 ```
 
-On install, Claude Code prompts for your **SigNoz Cloud Region** (defaults to `us`; one of `us`, `us2`, `eu`, `eu2`, `in`, `in2`). Find your region under **Settings → Ingestion** in SigNoz, or see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/overview/#how-do-i-find-my-ingestion-url).
+On install, Claude Code prompts for your **SigNoz MCP endpoint**. For SigNoz Cloud, use `https://mcp.<region>.signoz.cloud/mcp` and replace `<region>` with your region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`). Find your region under **Settings → Ingestion** in SigNoz, or see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/overview/#how-do-i-find-my-ingestion-url). For a self-hosted SigNoz, enter your own HTTP `/mcp` URL instead, for example `http://localhost:8000/mcp`.
 
-Then run `/mcp`, select the `signoz` server, and complete authentication.
-
-<Admonition type="info" title="Using Self-hosted SigNoz?" defaultCollapsed="true">
-When the installer asks **Self-hosted SigNoz?**, answer `yes` to skip the region. 
-Then start a new session (`/clear` or restart Claude Code) and run `/signoz-mcp-setup <your-mcp-url>` (for example `/signoz-mcp-setup http://localhost:8000/mcp`) to point the MCP server at your instance.
-</Admonition>
+Then run `/mcp`, select the `signoz` server, and complete the authentication flow if prompted. To change the endpoint later, reconfigure the plugin's options or run `signoz-mcp-setup` with the new region or MCP URL.
 
 To update after new releases:
 
@@ -42,6 +37,10 @@ To update after new releases:
 /plugin marketplace update
 /plugin update signoz@signoz-skills
 ```
+
+<Admonition type="note">
+The plugin ships a `PreToolUse` hook that auto-allows `WebFetch` to `signoz.io` domains. This does not affect `Bash`-based network calls (`curl`, `wget`), which follow the normal permission flow.
+</Admonition>
 
 </TabItem>
 <TabItem value="codex" label="Codex">
@@ -94,6 +93,25 @@ When prompted, enter your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, o
 ```
 
 Follow the prompts to enter your SigNoz instance URL and API key.
+
+</TabItem>
+<TabItem value="devin-cli" label="Devin CLI">
+
+Install the plugin:
+
+```bash
+devin plugins install SigNoz/agent-skills
+```
+
+This installs at user level and works across all projects. Devin's plugin system does not bundle MCP servers or prompt for install-time config, so run the setup skill afterward in a Devin session with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL:
+
+```bash
+/signoz:signoz-mcp-setup <region-or-mcp-url>
+```
+
+Devin namespaces plugin skills as `/<plugin>:<skill>`, so the setup skill is invoked as `/signoz:signoz-mcp-setup`. This writes a `signoz` entry into the highest-precedence Devin config scope that already has one, or `~/.config/devin/config.json` by default.
+
+For SigNoz Cloud, start a new session and run `devin mcp login signoz` to complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the server runs with `OAUTH_ENABLED=true`.
 
 </TabItem>
 </Tabs>

--- a/data/docs/ai/agent-skills.mdx
+++ b/data/docs/ai/agent-skills.mdx
@@ -20,16 +20,20 @@ SigNoz ships these skills two ways:
 <Tabs entityName="agent-client">
 <TabItem value="claude-code" label="Claude Code" default>
 
-Add the marketplace and install the plugin:
+1. Add the marketplace and install the plugin:
 
-```bash
-/plugin marketplace add SigNoz/agent-skills
-/plugin install signoz@signoz-skills
-```
+   ```bash
+   /plugin marketplace add SigNoz/agent-skills
+   /plugin install signoz@signoz-skills
+   ```
 
-On install, Claude Code prompts for your **SigNoz MCP endpoint**. For SigNoz Cloud, use `https://mcp.<region>.signoz.cloud/mcp` and replace `<region>` with your region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`). Find your region under **Settings → Ingestion** in SigNoz, or see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/overview/#how-do-i-find-my-ingestion-url). For a self-hosted SigNoz, enter your own HTTP `/mcp` URL instead, for example `http://localhost:8000/mcp`.
+2. When prompted for your **SigNoz MCP endpoint**:
+   - **SigNoz Cloud** - use `https://mcp.<region>.signoz.cloud/mcp` and replace `<region>` with your region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`). Find your region under **Settings → Ingestion** in SigNoz, or see the [region reference](https://signoz.io/docs/ingestion/signoz-cloud/overview/#how-do-i-find-my-ingestion-url).
+   - **Self-hosted SigNoz** - enter your own HTTP `/mcp` URL instead, for example `http://localhost:8000/mcp`.
 
-Then run `/mcp`, select the `signoz` server, and complete the authentication flow if prompted. To change the endpoint later, reconfigure the plugin's options or run `signoz-mcp-setup` with the new region or MCP URL.
+3. Run `/mcp`, select the `signoz` server, and complete the authentication flow if prompted.
+
+To change the endpoint later, reconfigure the plugin's options or run `signoz-mcp-setup` with the new region or MCP URL.
 
 To update after new releases:
 
@@ -97,21 +101,25 @@ Follow the prompts to enter your SigNoz instance URL and API key.
 </TabItem>
 <TabItem value="devin-cli" label="Devin CLI">
 
-Install the plugin:
+1. Install the plugin:
 
-```bash
-devin plugins install SigNoz/agent-skills
-```
+   ```bash
+   devin plugins install SigNoz/agent-skills
+   ```
 
-This installs at user level and works across all projects. Devin's plugin system does not bundle MCP servers or prompt for install-time config, so run the setup skill afterward in a Devin session with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL:
+   This installs at user level and works across all projects. Devin's plugin system does not bundle MCP servers or prompt for install-time config, so the next steps set that up.
 
-```bash
-/signoz:signoz-mcp-setup <region-or-mcp-url>
-```
+2. In a Devin session, run the setup skill with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL. Devin namespaces plugin skills as `/<plugin>:<skill>`, so it's invoked as `/signoz:signoz-mcp-setup`:
 
-Devin namespaces plugin skills as `/<plugin>:<skill>`, so the setup skill is invoked as `/signoz:signoz-mcp-setup`. This writes a `signoz` entry into the highest-precedence Devin config scope that already has one, or `~/.config/devin/config.json` by default.
+   ```bash
+   /signoz:signoz-mcp-setup <region-or-mcp-url>
+   ```
 
-For SigNoz Cloud, start a new session and run `devin mcp login signoz` to complete OAuth. For self-hosted SigNoz, no OAuth step is needed unless the server runs with `OAUTH_ENABLED=true`.
+   This writes a `signoz` entry into the highest-precedence Devin config scope that already has one, or `~/.config/devin/config.json` by default.
+
+3. Authenticate:
+   - **SigNoz Cloud** - start a new session and run `devin mcp login signoz` to complete OAuth.
+   - **Self-hosted SigNoz** - no OAuth step is needed unless the server runs with `OAUTH_ENABLED=true`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Adds Devin CLI installation instructions to the Agent Skills & Plugin doc and
corrects the Claude Code installation instructions to match the current
`SigNoz/agent-skills` plugin behavior (MCP endpoint prompt instead of the
older Cloud Region + separate self-hosted flow, plus a note on the
`PreToolUse` hook that auto-allows `WebFetch` to `signoz.io`).

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

N/A — docs-only content change.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
- [x] 📚 Docs

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
N/A — not a bug fix. The Claude Code section was out of date relative to the current plugin install flow described in `SigNoz/agent-skills`.

#### Fix Strategy
N/A

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (docs content)
- Manual verification: `yarn check:docs-metadata`, `yarn test:docs-metadata`, `yarn check:doc-redirects`, `yarn test:doc-redirects` all pass
- Edge cases covered: N/A

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Single docs page (`data/docs/ai/agent-skills.mdx`); no code paths affected.
- Potential regressions: None expected; content-only change.
- Rollback plan: Revert the commit.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | N/A (docs site) |
| Change Type | Docs |
| Description | Added Devin CLI install instructions and corrected Claude Code install instructions on the Agent Skills & Plugin doc. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

Instructions were cross-checked against the current `~/Documents/agent-skills` README (source of truth for the plugin's actual install behavior) rather than assumed from the previous doc content.

---
