### PR TITLE
chore: bump PR reviewer model to claude-opus-4-8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -223,7 +223,7 @@ jobs:
             For docs PRs, follow the onboarding-label policy and summary format in `contributing/docs-review.md` via the `signoz-docs-pr-review` skill.
 
           claude_args: |
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-8"
             --allowedTools "WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue edit:*),Bash(gh api:*),Bash(cat:*),Bash(curl:*),Bash(grep:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(ls:*)"
 
       - name: Claude interactive PR comments
@@ -255,5 +255,5 @@ jobs:
 
             CRITICAL: If you make ANY changes to files during this interaction, you MUST review your own changes using the relevant skill(s) before finishing. Verify they are correct, follow the style guide, and match the user's intent.
           claude_args: |
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-8"
             --allowedTools "WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue edit:*),Bash(gh api:*),Bash(cat:*),Bash(curl:*),Bash(grep:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(ls:*)"


### PR DESCRIPTION
## Summary

Bumps the Claude PR reviewer in `.github/workflows/claude.yml` from `claude-opus-4-6` to `claude-opus-4-8` (latest Opus).

Updates the `--model` flag in both steps:
- **Claude automated PR review** (`pull_request` trigger)
- **Claude interactive PR comments** (`@claude` trigger)

No other behavior changes — same allowed tools, prompts, and triggers.

Note: `claude-doc-update.yaml` does not pin a `--model` and is intentionally left unchanged (it uses the action default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)