### PR TITLE
docs: document public dashboard auto-refresh

### DIFF
--- a/data/docs/dashboards/overview.mdx
+++ b/data/docs/dashboards/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-03
 title: Dashboards
 description: Build custom dashboards to visualize metrics, logs, and traces in SigNoz.
 doc_type: explanation
@@ -16,7 +16,7 @@ Dashboards in SigNoz let you build custom visualizations over any telemetry sign
 
 - **[Pre-built Dashboard templates](https://signoz.io/docs/dashboards/dashboard-templates/overview/)**: Import community-maintained dashboard templates for popular integrations and skip setup entirely.
 - **[Dynamic variables](https://signoz.io/docs/userguide/manage-variables/)**: Define template variables to make dashboards interactive — filter by environment, service, host, or any attribute without duplicating dashboards.
-- **[Public sharing](https://signoz.io/docs/dashboards/public-sharing/)**: Share dashboards publicly via a link — no login required.
+- **[Public sharing](https://signoz.io/docs/dashboards/public-sharing/)**: Share dashboards publicly via a link, with no login required. Viewers can also [auto-refresh panels](https://signoz.io/docs/dashboards/public-sharing/#auto-refresh-for-viewers) on an interval.
 - **[Interactivity](https://signoz.io/docs/dashboards/interactivity/)**: Drill down from any panel with context menus — view underlying logs and traces, break out by attributes, cross-filter with dashboard variables, filter in tables, sync crosshairs and tooltips across panels, and navigate to external tools via context links.
 - **[Terraform automation](https://signoz.io/docs/dashboards/terraform-provider-signoz/)**: Manage dashboards as code using the SigNoz Terraform provider for repeatable, version-controlled deployments.
 

--- a/data/docs/dashboards/public-sharing.mdx
+++ b/data/docs/dashboards/public-sharing.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-05-13
-title: Public Sharing in Dashboards
-description: Share SigNoz dashboards publicly with a generated link and control the default time range available to viewers.
+date: 2026-07-03
+title: Public Dashboard Sharing - Share Dashboards via a Link
+description: Share SigNoz dashboards publicly with a generated link, control the default time range, and let viewers auto-refresh panels on an interval.
 doc_type: howto
 ---
 
@@ -34,6 +34,22 @@ Use public sharing when you want to make a dashboard available with a link outsi
   alt="Public sharing configuration in SigNoz"
   caption="Once published, copy the public dashboard URL or open it directly. Dashboard variables won't work in public dashboards."
 />
+
+## Auto-refresh for viewers
+
+Public dashboard viewers can reload every panel on a fixed interval without logging in. The auto-refresh selector (a refresh icon with a dropdown) appears in the dashboard header, to the left of the time picker.
+
+- **Availability**: The selector appears only when you turn on **Enable time range** on the Publish form. If the dashboard is locked to a fixed default time range, viewers see no auto-refresh control.
+- **Intervals**: Viewers can choose **Off**, **5s**, **10s**, **30s**, **1m**, **5m**, **10m**, **30m**, **1h**, **2h**, or **1d**.
+- **Default is Off**: Existing public dashboards keep their current behavior until a viewer picks an interval.
+- **Custom ranges**: When a viewer switches the time picker to a custom fixed start and end time, the selector is disabled, matching the authenticated app.
+
+On each tick, auto-refresh advances the rolling window from the selected relative range (for example, "Last 30 minutes") and refetches every panel.
+
+<Admonition type="info">
+  Auto-refresh works only with relative time ranges. Selecting a fixed custom range pauses it until the
+  viewer returns to a relative range.
+</Admonition>
 
 ## Disable Public Sharing
 


### PR DESCRIPTION
## Summary
- Added an "Auto-refresh for viewers" section to the Public Dashboard Sharing page covering: visibility gated on the publisher's **Enable time range** setting, the full interval list (Off, 5s, 10s, 30s, 1m, 5m, 10m, 30m, 1h, 2h, 1d), the default of **Off**, and the control being disabled for custom fixed time ranges.
- Updated the Dashboards overview page with a one-line callout linking to the new section.
- Updated the `date` frontmatter to 2026-07-03 on both edited files. Also refined the sharing page title (50-60 chars, keyword-led) and description to reflect auto-refresh.

## Open questions resolved (from deliverable)
- **Interval list**: Confirmed from product constants (`AutoRefreshV2/constants.ts`): Off, 5s, 10s, 30s, 1m, 5m, 10m, 30m, 1h, 2h, 1d.
- **Publisher setting label**: The actual UI label is **Enable time range** (deliverable said "Allow time range"). Docs use the real label.
- **Time-conversion change is NOT a bug fix**: The diff replaces the `1e9` literal with `NANO_SECOND_MULTIPLIER` (1e6): `minTime / NANO_SECOND_MULTIPLIER / 1000` == `minTime / 1e9`. Math is identical, so this is a pure refactor. No "Fixed" changelog note added.

## Screenshots
No new screenshots. PR #11938 merged today (2026-07-03) and the auto-refresh control is not yet present on the demo build (verified: the public dashboard header shows only the time picker). Screenshots should be added once the demo picks up the release. The existing "Enable time range" publish screenshot remains accurate.

Source PRs: #11938

Auto-generated by docs-sync pipeline