### PR TITLE
chore: add utilities and update related articles to ensure urls have trailing slash

### DIFF
--- a/app/(site)/faqs/[...slug]/page.tsx
+++ b/app/(site)/faqs/[...slug]/page.tsx
@@ -12,7 +12,7 @@ import { MDXContent } from '@/utils/strapi'
 import { generateStructuredData } from '@/utils/structuredData'
 import { compileMDX, MDXRemoteProps } from 'next-mdx-remote/rsc'
 import readingTime from 'reading-time'
-import { mdxOptions, generateTOC } from '@/utils/mdxUtils'
+import { mdxOptions, generateTOC, ensureTrailingSlash } from '@/utils/mdxUtils'
 import { getAuthorKeys, getTagValues } from '@/utils/contentHelpers'
 import { resolveLatestDate } from '@/utils/dateUtils'
 
@@ -37,11 +37,6 @@ function getRelatedArticleDoc(entry: MDXContent): { doc: MDXContent; contentType
   }
 
   return null
-}
-
-function ensureTrailingSlash(url: string): string {
-  if (url.endsWith('/')) return url
-  return `${url}/`
 }
 
 function buildRelatedArticles(content: MDXContent): RelatedArticleProps[] {

--- a/app/(site)/faqs/[...slug]/page.tsx
+++ b/app/(site)/faqs/[...slug]/page.tsx
@@ -39,6 +39,11 @@ function getRelatedArticleDoc(entry: MDXContent): { doc: MDXContent; contentType
   return null
 }
 
+function ensureTrailingSlash(url: string): string {
+  if (url.endsWith('/')) return url
+  return `${url}/`
+}
+
 function buildRelatedArticles(content: MDXContent): RelatedArticleProps[] {
   if (Array.isArray(content.related_articles) && content.related_articles.length > 0) {
     return content.related_articles
@@ -52,7 +57,7 @@ function buildRelatedArticles(content: MDXContent): RelatedArticleProps[] {
         return {
           title: doc.title,
           publishedOn: resolveLatestDate(doc) ?? '',
-          url: `/${routePrefix}${doc.path || ''}`,
+          url: ensureTrailingSlash(`/${routePrefix}${doc.path || ''}`),
         }
       })
       .filter(Boolean) as RelatedArticleProps[]
@@ -62,7 +67,7 @@ function buildRelatedArticles(content: MDXContent): RelatedArticleProps[] {
     return content.related_faqs.map((faq: MDXContent) => ({
       title: faq.title,
       publishedOn: resolveLatestDate(faq) ?? '',
-      url: `/faqs${faq.path || ''}`,
+      url: ensureTrailingSlash(`/faqs${faq.path || ''}`),
     }))
   }
 

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -17,7 +17,7 @@ import { MDXContent } from './strapi'
 import { deriveDates, resolveLatestDate } from './dateUtils'
 import siteMetadata from '@/data/siteMetadata'
 
-function ensureTrailingSlash(url: string): string {
+export function ensureTrailingSlash(url: string): string {
   if (url.endsWith('/')) return url
   return `${url}/`
 }

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -17,6 +17,11 @@ import { MDXContent } from './strapi'
 import { deriveDates, resolveLatestDate } from './dateUtils'
 import siteMetadata from '@/data/siteMetadata'
 
+function ensureTrailingSlash(url: string): string {
+  if (url.endsWith('/')) return url
+  return `${url}/`
+}
+
 // Heroicon mini link for auto-linking headers
 const linkIcon = fromHtmlIsomorphic(
   `<span class="content-header-link"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5 linkicon"><path d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z" /><path d="M11.603 7.963a.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865Z" /></svg></span>`,
@@ -121,7 +126,7 @@ function transformRelatedArticles(content: MDXContent): any[] {
         title: doc.title,
         date: resolveLatestDate(doc),
         publishedOn: resolveLatestDate(doc),
-        url: `${siteMetadata.siteUrl}/${routePrefix}${doc.path || ''}`,
+        url: ensureTrailingSlash(`${siteMetadata.siteUrl}/${routePrefix}${doc.path || ''}`),
         content_type: contentType,
       })
     }
@@ -147,7 +152,7 @@ function transformRelatedArticles(content: MDXContent): any[] {
           _id: item.documentId || String(item.id),
           _raw: {},
           path: `${prefix}${item.path || ''}`,
-          url: `${siteMetadata.siteUrl}/${prefix}${item.path || ''}`,
+          url: ensureTrailingSlash(`${siteMetadata.siteUrl}/${prefix}${item.path || ''}`),
           slug: (item.path || '').split('/').pop() || '',
           title: item.title,
           date: resolveLatestDate(item),


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Related articles miss trailing slash in links which adds redirect due to trailing slash true in next.config, related to https://github.com/SigNoz/signoz.io/pull/3430 which went previously but CMS paths do not have trailing slash in path, so when the related articles relation resolves, these paths do not have trailing slash so they are added to the component.



#### Screenshots / Screen Recordings (if applicable)
> NA


#### Issues closed by this PR
> NA

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: URLs only on related articles
- Potential regressions: Urls in related articles section do not have trailing slash, or add double trailing slash
- Rollback plan: Revert the PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
