### PR TITLE
bugfix: social signups url cleanup

### DIFF
--- a/app/(site)/teams/TeamsPage.tsx
+++ b/app/(site)/teams/TeamsPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import Image from 'next/image'
 import { ArrowRight, CheckCircle, Loader2 } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
@@ -352,10 +352,18 @@ const SignupFormIsolated: React.FC<SignupFormIsolatedProps> = ({
   )
 }
 
+const cleanSocialSignupSearchParams = () => {
+  const url = new URL(window.location.href)
+  url.searchParams.delete('code')
+  url.searchParams.delete('has_sso_error')
+  window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+}
+
 const TeamsPage: React.FC = () => {
   const searchParams = useSearchParams()
   const authCode = searchParams.get('code')
   const ssoError = searchParams.get('has_sso_error')
+  const callbackTriggeredRef = useRef(false)
 
   const {
     errors,
@@ -368,8 +376,15 @@ const TeamsPage: React.FC = () => {
     logEvent,
   } = useSignupForm({ source: 'teams' })
 
+  useLayoutEffect(() => {
+    if (authCode || ssoError) cleanSocialSignupSearchParams()
+  }, [authCode, ssoError])
+
   useEffect(() => {
-    if (authCode) handleSocialSignupCallback({ code: authCode })
+    if (authCode && !callbackTriggeredRef.current) {
+      callbackTriggeredRef.current = true
+      handleSocialSignupCallback({ code: authCode })
+    }
   }, [authCode, handleSocialSignupCallback])
 
   useEffect(() => {

--- a/app/(site)/teams/TeamsPage.tsx
+++ b/app/(site)/teams/TeamsPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import Image from 'next/image'
 import { ArrowRight, CheckCircle, Loader2 } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
@@ -352,17 +352,12 @@ const SignupFormIsolated: React.FC<SignupFormIsolatedProps> = ({
   )
 }
 
-const cleanSocialSignupSearchParams = () => {
-  const url = new URL(window.location.href)
-  url.searchParams.delete('code')
-  url.searchParams.delete('has_sso_error')
-  window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+interface TeamsPageProps {
+  initialAuthCode: string | null
+  initialSsoError: string | null
 }
 
-const TeamsPage: React.FC = () => {
-  const searchParams = useSearchParams()
-  const authCode = searchParams.get('code')
-  const ssoError = searchParams.get('has_sso_error')
+const TeamsPage: React.FC<TeamsPageProps> = ({ initialAuthCode, initialSsoError }) => {
   const callbackTriggeredRef = useRef(false)
 
   const {
@@ -376,24 +371,20 @@ const TeamsPage: React.FC = () => {
     logEvent,
   } = useSignupForm({ source: 'teams' })
 
-  useLayoutEffect(() => {
-    if (authCode || ssoError) cleanSocialSignupSearchParams()
-  }, [authCode, ssoError])
-
   useEffect(() => {
-    if (authCode && !callbackTriggeredRef.current) {
+    if (initialAuthCode && !callbackTriggeredRef.current) {
       callbackTriggeredRef.current = true
-      handleSocialSignupCallback({ code: authCode })
+      handleSocialSignupCallback({ code: initialAuthCode })
     }
-  }, [authCode, handleSocialSignupCallback])
+  }, [initialAuthCode, handleSocialSignupCallback])
 
   useEffect(() => {
-    if (ssoError) handleError()
-  }, [handleError, ssoError])
+    if (initialSsoError) handleError()
+  }, [handleError, initialSsoError])
 
   const formSection = (
     <div className="w-full">
-      {(!isSubmitting && submitFailed) || ssoError ? (
+      {(!isSubmitting && submitFailed) || initialSsoError ? (
         <ErrorState error={errors.apiError || ''} />
       ) : (
         <SignupFormIsolated

--- a/app/(site)/teams/TeamsPage.tsx
+++ b/app/(site)/teams/TeamsPage.tsx
@@ -358,8 +358,6 @@ interface TeamsPageProps {
 }
 
 const TeamsPage: React.FC<TeamsPageProps> = ({ initialAuthCode, initialSsoError }) => {
-  const callbackTriggeredRef = useRef(false)
-
   const {
     errors,
     isSubmitting,
@@ -372,10 +370,7 @@ const TeamsPage: React.FC<TeamsPageProps> = ({ initialAuthCode, initialSsoError 
   } = useSignupForm({ source: 'teams' })
 
   useEffect(() => {
-    if (initialAuthCode && !callbackTriggeredRef.current) {
-      callbackTriggeredRef.current = true
-      handleSocialSignupCallback({ code: initialAuthCode })
-    }
+    if (initialAuthCode) handleSocialSignupCallback({ code: initialAuthCode })
   }, [initialAuthCode, handleSocialSignupCallback])
 
   useEffect(() => {

--- a/app/(site)/teams/page.tsx
+++ b/app/(site)/teams/page.tsx
@@ -1,7 +1,10 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import TeamsPage from './TeamsPage'
 
 import { Metadata } from 'next'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 export const metadata: Metadata = {
   title: {
@@ -16,10 +19,18 @@ export const metadata: Metadata = {
     'Sign up for SigNoz cloud and get 30 days of free trial with access to all features.',
 }
 
-export default function Teams() {
+export default async function Teams({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const params = await searchParams
+  const initialAuthCode = typeof params.code === 'string' ? params.code : null
+  const initialSsoError = typeof params.has_sso_error === 'string' ? params.has_sso_error : null
+
   return (
     <Suspense>
-      <TeamsPage />
+      <TeamsPage initialAuthCode={initialAuthCode} initialSsoError={initialSsoError} />
     </Suspense>
   )
 }

--- a/hooks/useSignupForm.ts
+++ b/hooks/useSignupForm.ts
@@ -237,11 +237,6 @@ export function useSignupForm({ source, onError }: UseSignupFormOptions) {
 
   const handleSocialSignupCallback = useCallback(
     async (payload: { code: string }) => {
-      const url = new URL(window.location.href)
-      url.searchParams.delete('code')
-      url.searchParams.delete('has_sso_error')
-      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
-
       setSubmitFailed(false)
       setIsSubmitting(true)
       try {

--- a/hooks/useSignupForm.ts
+++ b/hooks/useSignupForm.ts
@@ -237,6 +237,11 @@ export function useSignupForm({ source, onError }: UseSignupFormOptions) {
 
   const handleSocialSignupCallback = useCallback(
     async (payload: { code: string }) => {
+      const url = new URL(window.location.href)
+      url.searchParams.delete('code')
+      url.searchParams.delete('has_sso_error')
+      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+
       setSubmitFailed(false)
       setIsSubmitting(true)
       try {

--- a/hooks/useSignupForm.ts
+++ b/hooks/useSignupForm.ts
@@ -237,6 +237,11 @@ export function useSignupForm({ source, onError }: UseSignupFormOptions) {
 
   const handleSocialSignupCallback = useCallback(
     async (payload: { code: string }) => {
+      const cleanUrl = new URL(window.location.href)
+      cleanUrl.searchParams.delete('code')
+      cleanUrl.searchParams.delete('has_sso_error')
+      window.history.replaceState(window.history.state, '', cleanUrl.toString())
+
       setSubmitFailed(false)
       setIsSubmitting(true)
       try {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

After Google/GitHub OAuth callback, the `/teams` page keeps `?code={code}` in the URL after consuming it. Due to a Next.js 16 App Router client Route Cache edge case, navigating away from `/teams/?code=...` and clicking any "Get Started" link back to `/teams/` restores the stale `?code=` in the URL - even though the clicked link is a clean `/teams/`. This causes the expired OAuth code to be retried, which fails and leaves the user stuck on an error screen.

**Root cause:** The server page did not read `searchParams`, so the Route Cache keyed the entry at `renderedSearch=""`. The cached entry stored `canonicalUrl="/teams/?code=blabla"`. A subsequent clean `/teams/` navigation also looks up `search=""` → cache hit → stale URL served.

**Fix:** Make the server component read `searchParams` and pass the callback values as props. This makes `renderedSearch` include the actual search params (`"?code=blabla"`), so the cache key for a callback URL never collides with a clean `/teams/` navigation.

Defensive - Strip the code from param in useSignupForm once read so a refresh on the same page behaves as a fresh start.

Related next.js discussion: https://github.com/vercel/next.js/discussions/88535

#### Screenshots / Screen Recordings (if applicable)

Before:


https://github.com/user-attachments/assets/bbbbad25-a4e4-413b-937b-11eef0d06f09



After:


https://github.com/user-attachments/assets/4c074656-f518-449d-be11-5c4489608e85

Refresh should make the page behave like a fresh start

https://github.com/user-attachments/assets/0e77d488-0cd3-485f-9671-db76bf0621f6

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug


#### Root Cause

**Next.js 16 Route Cache behavior:** During hydration of `/teams/?code=blabla`, the Route Cache stores `canonicalUrl="/teams/?code=blabla"` keyed at `renderedSearch=""` (empty - because the server page didn't read `searchParams`). A later clean navigation to `/teams/` also has `search=""`, hits the cache, and gets the stale `canonicalUrl` pushed to the address bar. This only reproduces in production/staging. Dev mode masks it because HMR invalidates the cache.

#### Fix Strategy

Make the server component read `searchParams` so that `renderedSearch` includes the actual search params. This changes the Route Cache key from `search:""` to `search:"?code=blabla"`, so clean `/teams/` navigations never hit the stale entry.

The callback values (`code`, `has_sso_error`) are passed as props to the client component instead of being read from `useSearchParams()`. This decouples the callback from URL state entirely.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A
- Manual verification:
  - Verified on staging (`yarn build` + `yarn start`, not `yarn dev` - HMR masks the bug)
  - Visit `/teams/?code=blabla` → click logo to `/` → click "Get Started" → URL must be `/teams/`, not `/teams/?code=blabla`
  - Direct visit to `/teams/?code=blabla` still fires the callback correctly
  - Clean visit to `/teams/` shows the signup form normally
- Edge cases covered:
  - `has_sso_error` param handled the same way

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: `/teams` page only. No other routes affected.
- Potential regressions: `force-dynamic` means `/teams` is server-rendered on every request instead of being statically cached. This is fine - the page is a signup form with no static content worth caching.
- Rollback plan: Revert the two files. The stale-code bug returns but signup itself still works for first-time visitors.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The bug only reproduces in production/staging builds. `yarn dev` masks it because HMR invalidates the Next.js client Route Cache.
- `force-dynamic` is intentional - it ensures `renderedSearch` reflects the actual URL params, which is what prevents the cache key collision.
- Defensive - Strip the code from param in useSignupForm once read so a refresh on the same page behaves as a fresh start.

---
