### PR TITLE
docs: update Infrastructure Monitoring Hosts documentation

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-07
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -82,6 +82,11 @@ Monitor host performance metrics across customizable time periods.
 - **System Disk I/O (Bytes)**: Total bytes read/written to disk
 - **System Disk Operations/s**: Rate of read/write operations
 - **Disk Operations Time**: Average time taken for disk operations
+- **Disk Usage (%) by mountpoint**: Filesystem space used as a percentage of total capacity, with one line per mountpoint on the host. Zero-size filesystems are excluded so only real volumes appear.
+
+<Admonition type="info">
+  Disk usage is derived from the `system.filesystem.usage` metric, which the OpenTelemetry [hostmetrics receiver](https://signoz.io/docs/infrastructure-monitoring/hostmetrics/) collects through its `filesystem` scraper. That scraper is enabled in the default host metrics configuration, so no extra setup is needed for this chart.
+</Admonition>
 
 **Time Range Selection:**
 - Choose from preset time ranges (e.g., last hour, last 24 hours)


### PR DESCRIPTION
## Summary

- Added **Disk Usage (%) by mountpoint** to the Hosts detail view Metrics tab chart list in `data/docs/infrastructure-monitoring/overview.mdx` (under Disk Performance).
- Documented what the chart shows: filesystem space used as a percentage of total capacity, one line per mountpoint, with zero-size filesystems excluded.
- Added an `Admonition` noting the chart is derived from the `system.filesystem.usage` metric collected by the hostmetrics receiver's `filesystem` scraper, which is enabled by default (no extra setup needed).
- Updated the `date` frontmatter to today's date on the edited file.

## Notes

- **No new screenshot added.** The existing page documents all ~12 Metrics-tab charts as plain bullets with a single whole-tab screenshot; it does not screenshot individual charts, so a per-chart image would be inconsistent. The new chart is also not yet visible on the demo instance (`demo.in.signoz.cloud`), which had not picked up #11990 at authoring time, so a live capture was not possible. The whole-tab screenshot can be refreshed once the demo reflects the chart.

## Open questions resolved

- The Hosts docs page does enumerate charts individually; the new chart was added under Disk Performance, matching its position at the bottom of the panel.
- The `system.filesystem.usage` metric is collected by the hostmetrics `filesystem` scraper, already present in the default config in the [host metrics setup doc](https://signoz.io/docs/infrastructure-monitoring/hostmetrics/). No new collector config callout was required.
- Related backend change #10262 is a query-engine prerequisite and needs no separate docs note.

Source PRs: #11990

Auto-generated by docs-sync pipeline