### PR TITLE
docs: update K8s infrastructure filter sidebar documentation

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-07
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -147,7 +147,7 @@ with their performance metrics.
 
 ### Kubernetes Monitoring Views
 
-The Kubernetes monitoring interface offers multiple views to analyze different aspects of your Kubernetes cluster. Users can switch between:
+The Kubernetes monitoring interface offers multiple views to analyze different aspects of your Kubernetes cluster. Switch between them by clicking a category in the **Viewing · Resource** selector on the left:
 - **Pods View** *(Default)*: Displays all active pods and their resource consumption.
 - **Nodes View**: Provides insights into the performance of individual nodes.
 - **Namespaces View**: Allows monitoring of resource usage per namespace.
@@ -180,12 +180,17 @@ The **Pods View** provides real-time visibility into pod resource utilization, e
 - **Group By Attribute**: Group pods by Namespace, Node, or Deployment.
 - **Sortable Metrics**: Sort columns for better trend analysis.
 
-### Filtering and Selection Panel
+### Resource selector and filters panel
 
-The left-side **Filters Panel** allows users to navigate through different Kubernetes resources, applying filters to refine their view.
+The left-side panel has two sections: a **Viewing · Resource** category selector at the top and a **Filter by** section below it.
 
+To switch the resource you are monitoring, click a category in the **Viewing · Resource** list. The selected category is highlighted with a filled accent background, and the table updates to show that resource. A single click switches the view: there are no category sections to expand or collapse.
 
-#### Available Filters:
+The **Filter by** section shows quick-filter checkboxes for the selected category. Select values to narrow the table to matching resources. The available filters change to match the category you are viewing.
+
+To hide the panel and give the table more room, use the collapse toggle in the **Viewing · Resource** header row. Click the filter icon to bring the panel back.
+
+#### Available categories
 
 - **Pods**: View and filter by active Kubernetes pods.
 - **Nodes**: Monitor resource utilization for different Kubernetes nodes.


### PR DESCRIPTION
## Summary

Updates the Infrastructure Monitoring Kubernetes overview to match the reworked filter sidebar from SigNoz/signoz#11957.

- Rewrote the **Filtering and Selection Panel** section (now **Resource selector and filters panel**) to describe the new interaction model:
  - A persistent **Viewing · Resource** category button list. A single click switches the resource; the active row is highlighted with a filled accent background. No expanding/collapsing of category sections.
  - A separate **Filter by** section below the category list holds the quick-filter checkboxes for the selected category.
  - The panel collapse/expand toggle now lives inline in the **Viewing · Resource** header row.
- Updated the **Kubernetes Monitoring Views** intro to point at the new selector.
- Renamed *Available Filters* to *Available categories* (unchanged list: Pods, Nodes, Namespaces, Clusters, Deployments, Jobs, DaemonSets, StatefulSets, Volumes). **Containers** stays omitted, matching the product (it is not in the selector).
- Updated the `date` frontmatter to 2026-07-07 on the edited file.

## ⚠️ Screenshots not recaptured (needs follow-up)

The screenshot capture plan could not be completed: the demo environment (`demo.in.signoz.cloud`) still runs the **old accordion** build and has not yet picked up #11957 (merged 2026-07-06). Capturing now would only reproduce the outdated accordion UI.

Two existing images still show the old accordion and must be recaptured once the new build reaches the demo/Cloud:
- `data-assets/img/docs/infrastructure-monitoring/kubernetes-list.webp` (used in the overview **and** in `data/docs/aws-monitoring/eks/eks-ec2-nodes.mdx`)
- `data-assets/img/docs/infrastructure-monitoring/kubernetes-nodes-view.webp`

Both are referenced by URL, so recapturing the `.webp` files updates every page automatically. No prose change is needed on the EKS page.

Source PRs: SigNoz/signoz#11957

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)