### PR TITLE
docs: add Antigravity CLI install instructions to Agent Skills doc

### DIFF
--- a/data/docs/ai/agent-skills.mdx
+++ b/data/docs/ai/agent-skills.mdx
@@ -12,7 +12,7 @@ When you ask your AI assistant something like "why did this alert fire," "create
 
 SigNoz ships these skills two ways:
 
-- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, Gemini CLI, and Devin CLI.
+- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, and Antigravity CLI.
 - **Individual skills via skills.sh** - install one or more skill files on their own, for any skills.sh-compatible agent.
 
 ## Install the plugin
@@ -120,6 +120,28 @@ Follow the prompts to enter your SigNoz instance URL and API key.
 3. Authenticate:
    - **SigNoz Cloud** - start a new session and run `devin mcp login signoz` to complete OAuth.
    - **Self-hosted SigNoz** - no OAuth step is needed unless the server runs with `OAUTH_ENABLED=true`.
+
+</TabItem>
+<TabItem value="antigravity-cli" label="Antigravity CLI">
+
+1. Install the plugin directly from the repository. Antigravity stages the repo root as a native plugin and registers the `signoz` MCP server and its skills automatically:
+
+   ```bash
+   agy plugin install https://github.com/SigNoz/agent-skills
+   agy plugin list   # confirm signoz is loaded
+   ```
+
+   Reinstall with the same command to update.
+
+2. The plugin defaults to the SigNoz Cloud `us` endpoint (`https://mcp.us.signoz.cloud/mcp`). To point it at a different region or a self-hosted instance, run the setup skill in the `agy` prompt with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL (ex: `http://localhost:8000/mcp`):
+
+   ```bash
+   /signoz:signoz-mcp-setup <region-or-mcp-url>
+   ```
+
+   This rewrites `serverUrl` in the installed `mcp_config.json`. SigNoz Cloud `us` users can skip this step.
+
+3. Authenticate. In the `agy` prompt, type `/mcp`, select the `signoz` server, and choose **Authenticate** to start the OAuth flow, then complete it in the browser. Self-hosted endpoints need no OAuth unless the server runs with `OAUTH_ENABLED=true`.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds **Antigravity CLI** install instructions to the Agent Skills & Plugin doc (`data/docs/ai/agent-skills.mdx`). A new "Antigravity CLI" tab documents installing the `SigNoz/agent-skills` plugin via `agy plugin install`, pointing the `signoz` MCP server at a region or self-hosted endpoint with the `/signoz:signoz-mcp-setup` skill, and completing OAuth via `/mcp`. The intro line is also updated to list Antigravity CLI alongside the other supported agents.

#### Screenshots / Screen Recordings (if applicable)

N/A — docs-only content change.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
- [x] 📚 Docs

---

### 🐛 Bug Context

#### Root Cause
N/A — not a bug fix. The doc previously did not cover Antigravity CLI as a supported plugin install path.

#### Fix Strategy
N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A (docs content)
- Manual verification: `yarn check:docs-metadata` and `yarn test:docs-metadata` pass; `yarn check:doc-redirects` passes (all run via pre-commit hooks)
- Edge cases covered: N/A

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Single docs page (`data/docs/ai/agent-skills.mdx`); no code paths affected.
- Potential regressions: None expected; content-only change.
- Rollback plan: Revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A (docs site) |
| Change Type | Docs |
| Description | Added Antigravity CLI install instructions to the Agent Skills & Plugin doc. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Only the `data/docs/ai/agent-skills.mdx` change is included in this PR. Local changes to `.github/PULL_REQUEST_TEMPLATE.md` and `tsconfig.json` are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
