### PR TITLE
docs(mcp): update server tool reference

### DIFF
--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-07
 title: SigNoz MCP Server
 meta_title: SigNoz MCP Server - AI Assistant Integration Guide
 description: Connect Claude, Cursor, Copilot, and other AI assistants to SigNoz via MCP for natural language access to metrics, logs, traces, and alerts.
@@ -823,13 +823,16 @@ After connecting, verify the server is working:
 The MCP server exposes the following tools to your AI assistant:
 
 <Admonition type="note">
-Alert-rule and notification-channel tools use newer SigNoz rules and channels APIs. Use SigNoz v0.120.0 or later for full compatibility with the latest MCP server. Older SigNoz deployments may return HTTP 404 for those tools.
+Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check_metric_usage`, and v0.120.0 or later for alert-rule tools. Notification-channel tools also use newer channels APIs. Older SigNoz deployments may return HTTP 404 from affected tools.
 </Admonition>
 
 | Tool | Description |
 |------|-------------|
 | `signoz_list_metrics` | Search and list available metrics |
 | `signoz_query_metrics` | Query metrics with smart aggregation defaults |
+| `signoz_get_top_metrics` | Return top 100 metrics ranked by ingested sample volume with percentages for cost and volume analysis |
+| `signoz_check_metric_usage` | Given a list of metric names (up to 50 per call), return which dashboards and alerts reference each one |
+| `signoz_check_metric_cardinality` | Return label/attribute keys for a single metric with cardinality counts and sample values, sorted highest-cardinality first |
 | `signoz_get_field_keys` | Discover available field keys for metrics, traces, or logs |
 | `signoz_get_field_values` | Get possible values for a field key |
 | `signoz_list_alerts` | List firing, silenced, or inhibited Alertmanager alert instances |
@@ -856,7 +859,7 @@ Alert-rule and notification-channel tools use newer SigNoz rules and channels AP
 | `signoz_aggregate_logs` | Aggregate logs (count, avg, p99, etc.) with grouping |
 | `signoz_search_logs` | Search logs with flexible filtering |
 | `signoz_aggregate_traces` | Aggregate trace statistics with grouping |
-| `signoz_search_traces` | Search traces with flexible filtering |
+| `signoz_search_traces` | Search traces with flexible filtering. Raw result rows use canonical snake_case keys such as `trace_id`, `span_id`, `duration_nano`, and `has_error` |
 | `signoz_get_trace_details` | Get full trace with all spans |
 | `signoz_execute_builder_query` | Execute a raw Query Builder v5 query |
 | `signoz_search_docs` | Search official SigNoz docs for product, setup, instrumentation, config, API, deployment, or troubleshooting questions |
@@ -866,6 +869,10 @@ Alert-rule and notification-channel tools use newer SigNoz rules and channels AP
 | `signoz_create_notification_channel` | Create a notification channel and send a test notification |
 | `signoz_update_notification_channel` | Update a notification channel and send a test notification |
 | `signoz_delete_notification_channel` | Delete a notification channel by ID |
+
+<Admonition type="info">
+Resource read tools such as `signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_get_alert`, `signoz_list_services`, `signoz_search_traces`, and `signoz_get_trace_details` include a `webUrl` field when the request includes a SigNoz instance URL. Use that URL to open the matching resource in the SigNoz UI.
+</Admonition>
 
 For detailed parameter reference, see the <a href="https://github.com/SigNoz/signoz-mcp-server?tab=readme-ov-file#available-tools" target="_blank" rel="noopener noreferrer nofollow">GitHub repository README</a>.
 

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -859,7 +859,7 @@ Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check
 | `signoz_aggregate_logs` | Aggregate logs (count, avg, p99, etc.) with grouping |
 | `signoz_search_logs` | Search logs with flexible filtering |
 | `signoz_aggregate_traces` | Aggregate trace statistics with grouping |
-| `signoz_search_traces` | Search traces with flexible filtering. Raw result rows use canonical snake_case keys such as `trace_id`, `span_id`, `duration_nano`, and `has_error` |
+| `signoz_search_traces` | Search traces with flexible filtering |
 | `signoz_get_trace_details` | Get full trace with all spans |
 | `signoz_execute_builder_query` | Execute a raw Query Builder v5 query |
 | `signoz_search_docs` | Search official SigNoz docs for product, setup, instrumentation, config, API, deployment, or troubleshooting questions |
@@ -869,10 +869,6 @@ Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check
 | `signoz_create_notification_channel` | Create a notification channel and send a test notification |
 | `signoz_update_notification_channel` | Update a notification channel and send a test notification |
 | `signoz_delete_notification_channel` | Delete a notification channel by ID |
-
-<Admonition type="info">
-Resource read tools such as `signoz_list_dashboards`, `signoz_get_dashboard`, `signoz_list_alerts`, `signoz_get_alert`, `signoz_list_services`, `signoz_search_traces`, and `signoz_get_trace_details` include a `webUrl` field when the request includes a SigNoz instance URL. Use that URL to open the matching resource in the SigNoz UI.
-</Admonition>
 
 For detailed parameter reference, see the <a href="https://github.com/SigNoz/signoz-mcp-server?tab=readme-ov-file#available-tools" target="_blank" rel="noopener noreferrer nofollow">GitHub repository README</a>.
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Update the SigNoz MCP Server docs for the latest `SigNoz/signoz-mcp-server` releases.

The recent releases added user-facing metric tools that were not reflected in the docs page:

- `v0.7.0` added `signoz_check_metric_usage` and `signoz_check_metric_cardinality`
- `v0.6.0` added `signoz_get_top_metrics`
- `signoz_check_metric_usage` requires SigNoz `v0.131.0+`, so the compatibility note now calls that out for self-hosted users

#### Screenshots / Screen Recordings (if applicable)
N/A, docs-only reference update.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
- [x] Documentation

---

### 🐛 Bug Context
N/A

#### Root Cause
N/A

#### Fix Strategy
N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A, docs-only change.
- Manual verification: Compared current docs against `gh release list` / `gh release view` for `SigNoz/signoz-mcp-server` and the upstream README tool reference at `v0.7.0`.
- Edge cases covered: Self-hosted compatibility caveat now includes the `v0.131.0+` requirement for `signoz_check_metric_usage`.

Validation run:

- `yarn check:docs-metadata`
- `yarn check:doc-redirects`
- `yarn test:docs-metadata`
- `yarn test:doc-redirects`
- pre-commit hook checks: docs redirects, docs metadata, stale URL scan, CMS asset scan

---

### ⚠️ Risk & Impact Assessment

- Blast radius: One docs page, `data/docs/ai/signoz-mcp-server.mdx`.
- Potential regressions: Incorrect tool wording or version caveat.
- Rollback plan: Revert this docs commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | Update SigNoz MCP Server docs for the latest metric tools and self-hosted compatibility caveat. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Docs-only update based on `signoz-mcp-server` `v0.6.0` and `v0.7.0` release notes plus the upstream README tool reference.

---
