### PR TITLE
feat: clickstack page update

### DIFF
--- a/app/(site)/clickstack-alternative/ClickStackAlternativePage.constants.tsx
+++ b/app/(site)/clickstack-alternative/ClickStackAlternativePage.constants.tsx
@@ -1,6 +1,5 @@
 import { ArrowRight, Atom, X } from 'lucide-react'
-import { type VendorKey } from './ClickStackAlternativePage.types'
-import { type ComparisonTableRow } from '@/shared/components/molecules/FeaturePages/ComparisonTable'
+import { type ComparisonCategory } from './ClickStackAlternativePage.types'
 import Link from 'next/link'
 
 export const QUERY_YOUR_DATA_CARDS = [
@@ -171,96 +170,272 @@ export const DASHBOARD_HELP_YOU_INVESTIGATE_CARDS = [
   },
 ]
 
-export const CLICKSTACK_COMPARISON_TABLE_ROWS: ComparisonTableRow<VendorKey>[] = [
+export const COMPARISON_GRID_DATA: ComparisonCategory[] = [
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Dashboard Drill-downs</span>,
-    vendors: {
-      signoz: { text: 'Logs, traces & metrics' },
-      clickstack: { text: 'View-only' },
-    },
+    category: 'Platform',
+    rows: [
+      {
+        feature: 'OTel Native',
+        signoz: { type: 'check' },
+        clickstack: { type: 'check' },
+      },
+      {
+        feature: 'Deployment Options',
+        signoz: {
+          type: 'text',
+          content: 'Open source + Cloud (GA) — Self-hosted, BYOC, managed cloud',
+        },
+        clickstack: { type: 'text', content: 'Open source + Cloud (Beta)' },
+      },
+      {
+        feature: 'Serverless Scaling',
+        signoz: { type: 'check', label: 'Platform handles scaling automatically' },
+        clickstack: {
+          type: 'text',
+          content: 'Manual upgrade required before sending data. No GA version available',
+        },
+      },
+      {
+        feature: 'MCP Server',
+        signoz: { type: 'check', label: 'All deployments' },
+        clickstack: { type: 'cross', label: 'No hosted MCP' },
+      },
+      {
+        feature: 'AI Assistant',
+        signoz: { type: 'check' },
+        clickstack: {
+          type: 'text',
+          content: 'Managed deployments only. AI Notebooks not available in self-hosted',
+        },
+      },
+      {
+        feature: 'State Store',
+        signoz: { type: 'text', content: 'PostgreSQL / SQLite (bundled)' },
+        clickstack: { type: 'text', content: 'MongoDB (managed separately)' },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Dashboard Variables</span>,
-    vendors: {
-      signoz: { supported: true, text: '' },
-      clickstack: { supported: false, text: '' },
-    },
+    category: 'Observability Coverage',
+    rows: [
+      {
+        feature: 'APM & Distributed Tracing',
+        signoz: { type: 'check' },
+        clickstack: { type: 'check' },
+      },
+      {
+        feature: 'Log Management',
+        signoz: { type: 'check' },
+        clickstack: { type: 'check' },
+      },
+      {
+        feature: 'Infrastructure Monitoring',
+        signoz: { type: 'check' },
+        clickstack: { type: 'cross', label: 'No infrastructure metrics product' },
+      },
+      {
+        feature: 'Errors & Exceptions',
+        signoz: { type: 'check', label: 'Dedicated page' },
+        clickstack: { type: 'cross' },
+      },
+      {
+        feature: 'LLM & AI Observability',
+        signoz: { type: 'check', label: 'Token tracing, cost attribution, model performance' },
+        clickstack: {
+          type: 'text',
+          content: 'Managed only. Via AI Notebooks',
+        },
+      },
+      {
+        feature: 'Native Correlation',
+        signoz: { type: 'check', label: 'Logs, traces, metrics in one click' },
+        clickstack: {
+          type: 'cross',
+          label: 'Logs and traces from the same service end up in different sources',
+        },
+      },
+      {
+        feature: 'Metrics Explorer',
+        signoz: { type: 'text', content: 'Comprehensive metrics data and correlation' },
+        clickstack: { type: 'cross', label: "Can't choose spatial and temporal aggregation" },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Pre-built Dashboards</span>,
-    vendors: {
-      signoz: { text: '30+ importable templates' },
-      clickstack: { text: '3 presets' },
-    },
+    category: 'User Experience & Dashboards',
+    rows: [
+      {
+        feature: 'UX maturity & feature completeness',
+        signoz: {
+          type: 'text',
+          content: 'Users share ease of use and maturity of product to move to SigNoz',
+        },
+        clickstack: {
+          type: 'text',
+          content: 'Confusing UX, unpolished. Takes more time to debug issues.',
+        },
+      },
+      {
+        feature: 'Dashboard Drill-down',
+        signoz: {
+          type: 'check',
+          label: 'Click into logs, traces, metrics from any panel',
+        },
+        clickstack: {
+          type: 'text',
+          content: 'View-only. Dashboards cannot be used for deeper troubleshooting',
+        },
+      },
+      {
+        feature: 'Dashboard Variables',
+        signoz: { type: 'check' },
+        clickstack: {
+          type: 'cross',
+          label: 'No dynamic updates to panels without changing each query individually',
+        },
+      },
+      {
+        feature: 'Pre-built Templates',
+        signoz: { type: 'text', content: '30+ importable templates' },
+        clickstack: { type: 'text', content: '3 presets' },
+      },
+      {
+        feature: 'Custom Quick Filters',
+        signoz: { type: 'check' },
+        clickstack: { type: 'cross' },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Alert Creation</span>,
-    vendors: {
-      signoz: { text: 'Alerts tab, dashboards, or queries' },
-      clickstack: { text: 'No dedicated alerts workflow' },
-    },
+    category: 'Alerting',
+    rows: [
+      {
+        feature: 'Alert Types',
+        signoz: {
+          type: 'text',
+          content: '6 types: Metrics, logs, traces, exceptions, anomaly, Apdex',
+        },
+        clickstack: { type: 'text', content: '2 types. Search + chart only' },
+      },
+      {
+        feature: 'Alert Creation',
+        signoz: { type: 'text', content: 'Alerts tab, dashboards, or queries' },
+        clickstack: {
+          type: 'text',
+          content: 'No dedicated alerts workflow. Must create from search or dashboard.',
+        },
+      },
+      {
+        feature: 'Anomaly Detection',
+        signoz: { type: 'check', label: 'Built-in. Seasonality + z-score' },
+        clickstack: { type: 'cross', label: 'DIY via SQL' },
+      },
+      {
+        feature: 'Alert History',
+        signoz: { type: 'check', label: 'With detailed attribute breakdowns' },
+        clickstack: { type: 'cross' },
+      },
+      {
+        feature: 'Notification Channels',
+        signoz: {
+          type: 'text',
+          content:
+            '9 channels: Slack, PagerDuty, Opsgenie, Teams, Email, Webhook, Incident.io, Rootly, Zenduty',
+        },
+        clickstack: { type: 'text', content: '3 channels: Slack, PagerDuty, Webhooks only' },
+      },
+      {
+        feature: 'Routing Policies',
+        signoz: { type: 'check', label: 'Label-based expressions' },
+        clickstack: { type: 'cross' },
+      },
+      {
+        feature: 'Maintenance Windows',
+        signoz: { type: 'check' },
+        clickstack: { type: 'cross' },
+      },
+      {
+        feature: 'Multi-severity per Rule',
+        signoz: { type: 'text', content: 'Warning / critical / info' },
+        clickstack: { type: 'cross' },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Anomaly Detection</span>,
-    vendors: {
-      signoz: { supported: true, text: '' },
-      clickstack: { supported: false, text: '' },
-    },
+    category: 'Query & Developer Experience',
+    rows: [
+      {
+        feature: 'Query Languages',
+        signoz: { type: 'text', content: 'Query Builder, ClickHouse SQL, PromQL' },
+        clickstack: { type: 'text', content: 'SQL, Lucene-style search' },
+      },
+      {
+        feature: 'UI Performance',
+        signoz: {
+          type: 'text',
+          content:
+            'Significantly faster search and aggregation. Auto-materialization of attributes and JSON column architecture',
+        },
+        clickstack: {
+          type: 'text',
+          content: 'Slow search and aggregation. Schema management is up to users',
+        },
+      },
+      {
+        feature: 'Terraform / IaC',
+        signoz: { type: 'check' },
+        clickstack: { type: 'cross' },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Alert History</span>,
-    vendors: {
-      signoz: { supported: true, text: 'Yes, with attribute breakdowns' },
-      clickstack: { supported: false, text: '' },
-    },
+    category: 'Pricing',
+    rows: [
+      {
+        feature: 'Pricing Model',
+        signoz: {
+          type: 'text',
+          content: 'All-inclusive per-GB. Predictable \u2014 one number covers everything',
+        },
+        clickstack: {
+          type: 'text',
+          content: 'Storage + compute (variable). Two separate bills',
+        },
+      },
+      {
+        feature: 'Storage Pricing',
+        signoz: { type: 'text', content: 'Included in $0.30/GB' },
+        clickstack: { type: 'text', content: '$0.03/GB separate' },
+      },
+      {
+        feature: 'Compute / Query Cost',
+        signoz: { type: 'text', content: 'No charge for querying. Included in per-GB price' },
+        clickstack: {
+          type: 'text',
+          content: '$0.22\u2013$0.39/compute-unit/hour. Billed as variable compute',
+        },
+      },
+      {
+        feature: 'Pro / Base Plan',
+        signoz: { type: 'text', content: '$0.30/GB, 30-day free trial' },
+        clickstack: { type: 'text', content: 'Usage-based' },
+      },
+      {
+        feature: 'Enterprise',
+        signoz: { type: 'text', content: 'Contact sales' },
+        clickstack: { type: 'text', content: 'Contact sales' },
+      },
+    ],
   },
   {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Query Language</span>,
-    vendors: {
-      signoz: { text: 'PromQL, visual builder & SQL' },
-      clickstack: { text: 'Lucene-style search & SQL' },
-    },
-  },
-  {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Query Cost</span>,
-    vendors: {
-      signoz: { text: 'No charge for querying' },
-      clickstack: { text: 'Billed as variable compute' },
-    },
-  },
-  {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">State Store</span>,
-    vendors: {
-      signoz: { text: 'PostgreSQL/SQLite (bundled)' },
-      clickstack: { text: 'MongoDB (managed separately)' },
-    },
-  },
-  {
-    feature: (
-      <span className="text-lg font-bold text-signoz_amber-400">Supported Ingestion Formats</span>
-    ),
-    vendors: {
-      signoz: { text: 'OTLP, Jaeger, Kafka, Zipkin, OpenCensus' },
-      clickstack: { text: 'OTLP, ClickHouse HTTP, Vector' },
-    },
-  },
-  {
-    feature: <span className="text-lg font-bold text-signoz_amber-400">Deployment Options</span>,
-    vendors: {
-      signoz: { text: 'Open source + Cloud (GA)' },
-      clickstack: { text: 'Open source + Cloud (Beta)' },
-    },
-  },
-]
-
-export const VENDORS = [
-  {
-    key: 'signoz',
-    label: <span className="text-xl text-signoz_forest-50">SigNoz</span>,
-  },
-  {
-    key: 'clickstack',
-    label: <span className="text-xl text-signoz_forest-50">ClickStack</span>,
+    category: 'Data Governance',
+    rows: [
+      {
+        feature: 'Data Residency',
+        signoz: { type: 'text', content: 'US, EU, India or your own VPC. BYOC available' },
+        clickstack: { type: 'text', content: 'Similar global coverage' },
+      },
+    ],
   },
 ]
 

--- a/app/(site)/clickstack-alternative/ClickStackAlternativePage.tsx
+++ b/app/(site)/clickstack-alternative/ClickStackAlternativePage.tsx
@@ -8,13 +8,12 @@ import FeaturePageHeader from '@/shared/components/molecules/FeaturePages/Featur
 import UsageBasedPricing from '@/shared/components/molecules/FeaturePages/UsageBasedPricing'
 import SigNozStats from '@/shared/components/molecules/FeaturePages/SignozStats'
 import IconTitleDescriptionCardGrid from '@/shared/components/molecules/FeaturePages/IconTitleDescriptionCard'
-import ComparisonTable from '@/shared/components/molecules/FeaturePages/ComparisonTable'
+import ComparisonGrid from './ComparisonGrid'
 import FeaturePageLayout from '@/shared/components/molecules/FeaturePages/FeaturePageLayout'
 import CustomerStoriesSection from '@/shared/components/molecules/FeaturePages/CustomerStoriesSection'
 import {
   CLICKSTACK_BILLING_CARDS,
-  VENDORS,
-  CLICKSTACK_COMPARISON_TABLE_ROWS,
+  COMPARISON_GRID_DATA,
   DASHBOARD_HELP_YOU_INVESTIGATE_CARDS,
   ALERTING_ABOVE_HISTORY_CARDS,
   ALERTING_BELOW_HISTORY_CARDS,
@@ -78,21 +77,17 @@ const QuickEvaluation: React.FC = () => {
   return (
     <SectionLayout
       variant="full-width"
-      className="relative mx-auto overflow-hidden border-b border-dashed border-signoz_slate-400"
+      className="relative mx-auto border-b border-dashed border-signoz_slate-400"
     >
       <div className="relative flex flex-col gap-6 pt-32 md:py-20">
-        <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
-          <div className="flex flex-col items-center gap-12 text-2xl leading-[3.25rem]">
+        <div className="mx-auto flex w-full flex-col items-center text-center">
+          <div className="flex w-full flex-col items-center gap-12 text-2xl leading-[3.25rem]">
             <h2 className="my-6 text-center text-4xl font-semibold text-signoz_sakura-100">
               A Quick Evaluation
             </h2>
-            <SectionLayout variant="no-border" className="flex items-center justify-center">
-              <ComparisonTable
-                vendors={VENDORS}
-                rows={CLICKSTACK_COMPARISON_TABLE_ROWS}
-                className="[&_td]:text-center [&_td_span]:justify-center [&_th]:text-center"
-              />
-            </SectionLayout>
+            <div className="w-full max-w-5xl">
+              <ComparisonGrid data={COMPARISON_GRID_DATA} />
+            </div>
           </div>
         </div>
       </div>
@@ -164,9 +159,9 @@ const CostComparison: React.FC = () => {
 const DashboardsThatHelpYouInvestigate: React.FC = () => {
   return (
     <section className="relative mx-auto max-w-8xl overflow-hidden">
-      <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 py-16 text-center md:py-20">
+      <div className="relative mx-auto flex flex-col items-center gap-6 py-16 text-center md:py-20">
         <div className="flex flex-col items-center gap-14 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
-          <div className="flex flex-col items-center gap-4">
+          <div className="flex max-w-4xl flex-col items-center gap-4">
             <h2 className="text-center text-4xl font-semibold text-signoz_sakura-100">
               Dashboards That Help You Investigate
             </h2>
@@ -198,9 +193,9 @@ const DashboardsThatHelpYouInvestigate: React.FC = () => {
 const AlertingThatTellsYouWhatMatters: React.FC = () => {
   return (
     <section className="relative mx-auto max-w-8xl overflow-hidden">
-      <div className="relative mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center">
-        <div className="flex flex-col items-center gap-14 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
-          <div className="flex flex-col items-center gap-4">
+      <div className="relative mx-auto flex flex-col items-center gap-6 text-center">
+        <div className="flex flex-col items-center gap-20 text-2xl font-medium leading-[3.25rem] text-signoz_sienna-100">
+          <div className="flex max-w-4xl flex-col items-center gap-4">
             <h2 className="text-center text-4xl font-semibold text-signoz_sakura-100">
               Alerting That Tells You What Matters
             </h2>

--- a/app/(site)/clickstack-alternative/ClickStackAlternativePage.types.ts
+++ b/app/(site)/clickstack-alternative/ClickStackAlternativePage.types.ts
@@ -1,7 +1,5 @@
 import type React from 'react'
 
-export type VendorKey = 'signoz' | 'clickstack'
-
 export type CellValue =
   | { type: 'check'; label?: string }
   | { type: 'cross'; label?: string }

--- a/app/(site)/clickstack-alternative/ClickStackAlternativePage.types.ts
+++ b/app/(site)/clickstack-alternative/ClickStackAlternativePage.types.ts
@@ -1,1 +1,19 @@
+import type React from 'react'
+
 export type VendorKey = 'signoz' | 'clickstack'
+
+export type CellValue =
+  | { type: 'check'; label?: string }
+  | { type: 'cross'; label?: string }
+  | { type: 'dash' }
+  | { type: 'text'; content: string | React.ReactNode }
+  | { type: 'badge'; icon: 'clock' | 'flame' | 'cloud' | 'server'; label: string }
+
+export type ComparisonCategory = {
+  category: string
+  rows: {
+    feature: string
+    signoz: CellValue
+    clickstack: CellValue
+  }[]
+}

--- a/app/(site)/clickstack-alternative/ComparisonGrid.tsx
+++ b/app/(site)/clickstack-alternative/ComparisonGrid.tsx
@@ -1,0 +1,124 @@
+import { Check, X, Clock, Flame, Cloud, Server } from 'lucide-react'
+import type { CellValue, ComparisonCategory } from './ClickStackAlternativePage.types'
+import TrackingLink from '@/components/TrackingLink'
+import FeatureComparisonGrid from '@/shared/components/molecules/FeaturePages/FeatureComparisonGrid'
+import type { ComparisonSection } from '@/shared/components/molecules/FeaturePages/FeatureComparisonGrid'
+
+const BADGE_ICONS = {
+  clock: Clock,
+  flame: Flame,
+  cloud: Cloud,
+  server: Server,
+} as const
+
+function renderCell(value: CellValue) {
+  switch (value.type) {
+    case 'check':
+      return (
+        <div className="flex items-center gap-1.5">
+          <Check size={15} className="shrink-0 text-green-400" />
+          {value.label && <span className="text-sm text-[#adb4c2]">{value.label}</span>}
+        </div>
+      )
+    case 'cross':
+      return (
+        <div className="flex items-center gap-1.5">
+          <X size={15} className="shrink-0 text-red-400" />
+          {value.label && <span className="text-sm text-[#adb4c2]">{value.label}</span>}
+        </div>
+      )
+    case 'dash':
+      return <span className="text-sm text-[#62687c]">&mdash;</span>
+    case 'text':
+      return <span className="text-sm leading-6 text-[#adb4c2]">{value.content}</span>
+    case 'badge': {
+      const Icon = BADGE_ICONS[value.icon]
+      return (
+        <div className="flex items-center gap-1.5">
+          <Icon size={15} className="shrink-0 text-[#adb4c2]" />
+          <span className="text-xs font-medium uppercase tracking-[0.48px] text-[#adb4c2]">
+            {value.label}
+          </span>
+        </div>
+      )
+    }
+  }
+}
+
+function toSections(data: ComparisonCategory[]): ComparisonSection[] {
+  return data.map((cat) => ({
+    title: cat.category,
+    rows: cat.rows.map((row) => ({
+      feature: <span className="text-sm leading-6 text-[#adb4c2]">{row.feature}</span>,
+      cells: {
+        signoz: renderCell(row.signoz),
+        clickstack: renderCell(row.clickstack),
+      },
+    })),
+  }))
+}
+
+const GRID_CLASS = 'grid-cols-[1fr_12rem_12rem]'
+
+const COLUMNS = [
+  {
+    key: 'signoz',
+    cellClassName: 'relative px-3 py-3',
+    sectionCellClassName: 'relative',
+  },
+  {
+    key: 'clickstack',
+    cellClassName: 'px-3 py-3',
+  },
+]
+
+export default function ComparisonGrid({ data }: { data: ComparisonCategory[] }) {
+  const sections = toSections(data)
+
+  return (
+    <div className="w-full text-left text-base leading-normal">
+      <div className="min-w-4xl relative">
+        {/* Sticky column headers — z-[9] stays below ProductNav (z-10) */}
+        <div className="sticky top-28 z-[9] bg-signoz_ink-500">
+          <div className={`grid ${GRID_CLASS}`}>
+            <div />
+            <div className="relative flex flex-col items-start gap-2.5 px-3 py-4">
+              <span className="text-base font-medium leading-7 text-[#eceef2]">SigNoz</span>
+              <TrackingLink
+                href="/teams/"
+                clickType="Primary CTA"
+                clickName="ClickStack Comparison Grid Get Started"
+                clickLocation="ClickStack Alternative Quick Evaluation"
+                clickText="Get Started"
+                className="flex h-8 w-40 items-center justify-center rounded-full border border-[#23262e] bg-[#4e74f8] text-xs font-medium tracking-wider text-[#eceef2] hover:bg-[#3d63e7]"
+              >
+                Get Started
+              </TrackingLink>
+            </div>
+            <div className="flex flex-col items-start gap-2.5 px-3 py-4">
+              <span className="text-base font-medium leading-7 text-[#eceef2]">ClickStack</span>
+            </div>
+          </div>
+          <div className="h-px w-full bg-[#23262e]" />
+        </div>
+
+        {/* Shared grid body */}
+        <FeatureComparisonGrid
+          columns={COLUMNS}
+          sections={sections}
+          gridClassName={GRID_CLASS}
+          sectionHeadingSize="sm"
+          stickyOffset="top-[215px]"
+          stickyBg="bg-signoz_ink-500"
+          stickyZIndex="z-[8]"
+          separator="border"
+          featureCellClassName="pl-6 py-3"
+          featureSectionClassName="pl-6"
+          overlay={
+            <div className="pointer-events-none absolute inset-y-0 right-48 z-0 w-48 rounded-lg bg-gradient-to-b from-[#16181d] from-[73%] to-transparent opacity-80" />
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(site)/clickstack-alternative/ComparisonGrid.tsx
+++ b/app/(site)/clickstack-alternative/ComparisonGrid.tsx
@@ -69,6 +69,7 @@ const COLUMNS = [
   {
     key: 'clickstack',
     cellClassName: 'px-3 py-3',
+    sectionCellClassName: 'bg-signoz_ink-500',
   },
 ]
 
@@ -78,10 +79,12 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
   return (
     <div className="w-full overflow-x-auto text-left text-base leading-normal md:overflow-visible">
       <div className="relative min-w-[40rem] md:min-w-0">
-        <div className="sticky top-28 z-10 bg-signoz_ink-500">
+        <div className="pointer-events-none absolute inset-y-0 right-48 z-0 w-48 rounded-lg bg-gradient-to-b from-[#16181d] from-[73%] to-transparent opacity-80" />
+
+        <div className="sticky top-28 z-[9]">
           <div className={`grid ${GRID_CLASS}`}>
-            <div />
-            <div className="relative flex flex-col items-start gap-2.5 px-3 py-4">
+            <div className="bg-signoz_ink-500" />
+            <div className="relative flex flex-col items-start gap-2.5 bg-[#14161a] px-3 py-4">
               <span className="text-base font-medium leading-7 text-[#eceef2]">SigNoz</span>
               <TrackingLink
                 href="/teams/"
@@ -94,7 +97,7 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
                 Get Started
               </TrackingLink>
             </div>
-            <div className="flex flex-col items-start gap-2.5 px-3 py-4">
+            <div className="flex flex-col items-start gap-2.5 bg-signoz_ink-500 px-3 py-4">
               <span className="text-base font-medium leading-7 text-[#eceef2]">ClickStack</span>
             </div>
           </div>
@@ -108,14 +111,11 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
           gridClassName={GRID_CLASS}
           sectionHeadingSize="sm"
           stickyOffset="top-[215px]"
-          stickyBg="bg-signoz_ink-500"
+          stickyBg=""
           stickyZIndex="z-[8]"
           separator="border"
           featureCellClassName="pl-6 py-3"
-          featureSectionClassName="pl-6"
-          overlay={
-            <div className="pointer-events-none absolute inset-y-0 right-48 z-0 w-48 rounded-lg bg-gradient-to-b from-[#16181d] from-[73%] to-transparent opacity-80" />
-          }
+          featureSectionClassName="pl-6 bg-signoz_ink-500"
         />
       </div>
     </div>

--- a/app/(site)/clickstack-alternative/ComparisonGrid.tsx
+++ b/app/(site)/clickstack-alternative/ComparisonGrid.tsx
@@ -78,8 +78,7 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
   return (
     <div className="w-full text-left text-base leading-normal">
       <div className="min-w-4xl relative">
-        {/* Sticky column headers — z-[9] stays below ProductNav (z-10) */}
-        <div className="sticky top-28 z-[9] bg-signoz_ink-500">
+        <div className="sticky top-28 z-10 bg-signoz_ink-500">
           <div className={`grid ${GRID_CLASS}`}>
             <div />
             <div className="relative flex flex-col items-start gap-2.5 px-3 py-4">
@@ -87,7 +86,7 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
               <TrackingLink
                 href="/teams/"
                 clickType="Primary CTA"
-                clickName="ClickStack Comparison Grid Get Started"
+                clickName="Sign Up Button"
                 clickLocation="ClickStack Alternative Quick Evaluation"
                 clickText="Get Started"
                 className="flex h-8 w-40 items-center justify-center rounded-full border border-[#23262e] bg-[#4e74f8] text-xs font-medium tracking-wider text-[#eceef2] hover:bg-[#3d63e7]"

--- a/app/(site)/clickstack-alternative/ComparisonGrid.tsx
+++ b/app/(site)/clickstack-alternative/ComparisonGrid.tsx
@@ -76,8 +76,8 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
   const sections = toSections(data)
 
   return (
-    <div className="w-full text-left text-base leading-normal">
-      <div className="min-w-4xl relative">
+    <div className="w-full overflow-x-auto text-left text-base leading-normal md:overflow-visible">
+      <div className="relative min-w-[40rem] md:min-w-0">
         <div className="sticky top-28 z-10 bg-signoz_ink-500">
           <div className={`grid ${GRID_CLASS}`}>
             <div />

--- a/app/(site)/clickstack-alternative/ComparisonGrid.tsx
+++ b/app/(site)/clickstack-alternative/ComparisonGrid.tsx
@@ -79,7 +79,7 @@ export default function ComparisonGrid({ data }: { data: ComparisonCategory[] })
   return (
     <div className="w-full overflow-x-auto text-left text-base leading-normal md:overflow-visible">
       <div className="relative min-w-[40rem] md:min-w-0">
-        <div className="pointer-events-none absolute inset-y-0 right-48 z-0 w-48 rounded-lg bg-gradient-to-b from-[#16181d] from-[73%] to-transparent opacity-80" />
+        <div className="pointer-events-none absolute inset-y-0 right-48 z-0 w-48 rounded-lg bg-gradient-to-b from-signoz_ink-300 from-[73%] to-transparent opacity-80" />
 
         <div className="sticky top-28 z-[9]">
           <div className={`grid ${GRID_CLASS}`}>

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -745,7 +745,7 @@ const ExploreAllFeatures: React.FC = () => {
       <div className="mx-auto mb-10 mt-6" id="all-features">
         {/* Header - Using CSS sticky positioning for smoother scrolling */}
         <div className="sticky top-[74px] z-20 bg-[#0f1013] before:absolute before:inset-x-0 before:-top-10 before:h-10 before:bg-[#0f1013] before:content-['']">
-          <div className="my-12">
+          <div className="mb-20 mt-12 sm:my-12">
             <div className="grid grid-cols-1">
               <div className="mx-6 flex justify-center">
                 <TrackingLink

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -798,8 +798,8 @@ const ExploreAllFeatures: React.FC = () => {
           sectionHeadingSize="lg"
           stickyOffset="top-[220px]"
           stickyBg="bg-[#0f1013]"
-          featureCellClassName=""
-          featureSectionClassName="mb-3 mt-8 py-2 pl-6 pr-2 text-center text-sm font-medium sm:text-lg md:text-left"
+          featureCellClassName="col-span-3 md:col-span-1"
+          featureSectionClassName="col-span-3 pl-6 pr-2 md:col-span-1"
         />
 
         {/* Bottom rounded corner for Teams column */}

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -728,9 +728,9 @@ const PRICING_COLUMNS = [
   {
     key: 'teams',
     cellClassName:
-      'relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-[#16181d] sm:p-5',
+      'relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-signoz_ink-300 sm:p-5',
     sectionCellClassName:
-      'relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]',
+      'relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-signoz_ink-300',
   },
   {
     key: 'enterprise',
@@ -773,7 +773,7 @@ const ExploreAllFeatures: React.FC = () => {
                 key={idx}
                 className={`${
                   idx === 2
-                    ? `relative z-10 flex scale-105 transform flex-col justify-between rounded-lg !rounded-b-none border border-signoz_slate-400/20 bg-signoz_ink-500 p-3 shadow-2xl sm:bg-[#16181d]`
+                    ? `relative z-10 flex scale-105 transform flex-col justify-between rounded-lg !rounded-b-none border border-signoz_slate-400/20 bg-signoz_ink-500 p-3 shadow-2xl sm:bg-signoz_ink-300`
                     : idx !== 0
                       ? `flex flex-col justify-between rounded-lg p-3 bg-opacity-${idx * 10}`
                       : 'hidden md:block'
@@ -797,7 +797,7 @@ const ExploreAllFeatures: React.FC = () => {
           gridClassName={PRICING_GRID}
           sectionHeadingSize="lg"
           stickyOffset="top-[220px]"
-          stickyBg="bg-[#0f1013]"
+          stickyBg="bg-signoz_ink-300"
           featureCellClassName="col-span-3 md:col-span-1"
           featureSectionClassName="col-span-3 pl-6 pr-2 md:col-span-1"
         />
@@ -806,7 +806,7 @@ const ExploreAllFeatures: React.FC = () => {
         <div className={`grid h-[18px] ${PRICING_GRID}`}>
           <div />
           <div />
-          <div className="relative z-10 scale-105 transform rounded-lg !rounded-t-none border-x border-b border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]" />
+          <div className="relative z-10 scale-105 transform rounded-lg !rounded-t-none border-x border-b border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-signoz_ink-300" />
           <div />
         </div>
       </div>

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -8,6 +8,8 @@ import {
   ServerSolid,
 } from '@/components/homepage-icons/icons'
 import Line from '@/components/ui/Line'
+import FeatureComparisonGrid from '@/shared/components/molecules/FeaturePages/FeatureComparisonGrid'
+import type { ComparisonSection } from '@/shared/components/molecules/FeaturePages/FeatureComparisonGrid'
 
 // Plan header type
 type PlanHeader = {
@@ -696,6 +698,47 @@ const ALL_FEATURES_DATA = {
   ],
 }
 
+function toPricingSections(): ComparisonSection[] {
+  return ALL_FEATURES_DATA.ROWS.map((section) => ({
+    title: section.section,
+    id: section.section === 'Choose When' ? 'choose-when-section' : undefined,
+    rows: section.features.map((f) => ({
+      feature: (
+        <h4 className="col-span-3 m-0 py-4 pl-6 pr-2 text-center text-sm font-normal text-signoz_vanilla-400 sm:py-5 md:col-span-1 md:text-left">
+          {f.feature}
+        </h4>
+      ),
+      cells: {
+        community: f.inCommunity,
+        teams: f.inTeams,
+        enterprise: f.inEnterprise,
+      },
+    })),
+  }))
+}
+
+const PRICING_GRID = 'grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]'
+
+const PRICING_COLUMNS = [
+  {
+    key: 'community',
+    cellClassName: 'flex items-center justify-center rounded-lg p-4 sm:p-5',
+    sectionCellClassName: '',
+  },
+  {
+    key: 'teams',
+    cellClassName:
+      'relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-[#16181d] sm:p-5',
+    sectionCellClassName:
+      'relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]',
+  },
+  {
+    key: 'enterprise',
+    cellClassName: 'flex items-center justify-center rounded-lg p-4 sm:p-5',
+    sectionCellClassName: '',
+  },
+]
+
 const ExploreAllFeatures: React.FC = () => {
   return (
     <>
@@ -724,7 +767,7 @@ const ExploreAllFeatures: React.FC = () => {
               </div>
             </div>
           </div>
-          <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
+          <div className={`grid ${PRICING_GRID}`}>
             {ALL_FEATURES_DATA.HEADER.map((header, idx) => (
               <div
                 key={idx}
@@ -747,52 +790,20 @@ const ExploreAllFeatures: React.FC = () => {
           <Line />
         </div>
 
-        {/* Feature sections */}
-        {ALL_FEATURES_DATA.ROWS.map((section, sectionIdx) => (
-          <div
-            key={sectionIdx}
-            id={section.section === 'Choose When' ? 'choose-when-section' : undefined}
-          >
-            {/* Section header */}
-            <div className="sticky top-[220px] z-10 bg-[#0f1013]">
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 md:grid-cols-[3fr_1fr_1fr_1fr]">
-                <div className="mb-3 mt-8 py-2 pl-6 pr-2 text-center text-sm font-medium sm:text-lg md:text-left">
-                  {section.section}
-                </div>
-                <div></div>
-                <div className="relative z-10 scale-105 transform border-x border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]"></div>
-                <div></div>
-              </div>
-            </div>
-            <Line />
-
-            {/* Features in this section */}
-            <div className="grid grid-cols-1">
-              {section.features.map((feature, featureIdx) => (
-                <div key={featureIdx}>
-                  <div className="grid grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
-                    <h4 className="col-span-3 m-0 py-4 pl-6 pr-2 text-center text-sm font-normal text-signoz_vanilla-400 sm:py-5 md:col-span-1 md:text-left">
-                      {feature.feature}
-                    </h4>
-                    <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
-                      {feature.inCommunity}
-                    </div>
-                    <div className="relative z-10 flex scale-105 transform items-center justify-center rounded-lg rounded-none border-x border-signoz_slate-400/20 bg-signoz_ink-500 p-4 shadow-2xl sm:bg-[#16181d] sm:p-5">
-                      {feature.inTeams}
-                    </div>
-                    <div className="flex items-center justify-center rounded-lg p-4 sm:p-5">
-                      {feature.inEnterprise}
-                    </div>
-                  </div>
-                  <Line />
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
+        {/* Feature sections using shared grid */}
+        <FeatureComparisonGrid
+          columns={PRICING_COLUMNS}
+          sections={toPricingSections()}
+          gridClassName={PRICING_GRID}
+          sectionHeadingSize="lg"
+          stickyOffset="top-[220px]"
+          stickyBg="bg-[#0f1013]"
+          featureCellClassName=""
+          featureSectionClassName="mb-3 mt-8 py-2 pl-6 pr-2 text-center text-sm font-medium sm:text-lg md:text-left"
+        />
 
         {/* Bottom rounded corner for Teams column */}
-        <div className="grid h-[18px] grid-cols-3 gap-4 md:grid-cols-[3fr_1fr_1fr_1fr]">
+        <div className={`grid h-[18px] ${PRICING_GRID}`}>
           <div />
           <div />
           <div className="relative z-10 scale-105 transform rounded-lg !rounded-t-none border-x border-b border-signoz_slate-400/20 bg-signoz_ink-500 shadow-2xl sm:bg-[#16181d]" />

--- a/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
+++ b/app/(site)/pricing/pricingv1/components/ExploreAllFeatures.tsx
@@ -744,7 +744,7 @@ const ExploreAllFeatures: React.FC = () => {
     <>
       <div className="mx-auto mb-10 mt-6" id="all-features">
         {/* Header - Using CSS sticky positioning for smoother scrolling */}
-        <div className="sticky top-[74px] z-20 bg-[#0f1013]">
+        <div className="sticky top-[74px] z-20 bg-[#0f1013] before:absolute before:inset-x-0 before:-top-10 before:h-10 before:bg-[#0f1013] before:content-['']">
           <div className="my-12">
             <div className="grid grid-cols-1">
               <div className="mx-6 flex justify-center">
@@ -797,7 +797,7 @@ const ExploreAllFeatures: React.FC = () => {
           gridClassName={PRICING_GRID}
           sectionHeadingSize="lg"
           stickyOffset="top-[220px]"
-          stickyBg="bg-signoz_ink-300"
+          stickyBg="bg-[#0f1013]"
           featureCellClassName="col-span-3 md:col-span-1"
           featureSectionClassName="col-span-3 pl-6 pr-2 md:col-span-1"
         />

--- a/shared/components/molecules/FeaturePages/FeatureComparisonGrid.tsx
+++ b/shared/components/molecules/FeaturePages/FeatureComparisonGrid.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import Line from '@/components/ui/Line'
+
+export type ComparisonColumn = {
+  key: string
+  cellClassName?: string
+  sectionCellClassName?: string
+}
+
+export type ComparisonSection = {
+  title: string
+  id?: string
+  rows: {
+    feature: React.ReactNode
+    cells: Record<string, React.ReactNode>
+  }[]
+}
+
+type FeatureComparisonGridProps = {
+  columns: ComparisonColumn[]
+  sections: ComparisonSection[]
+  gridClassName: string
+  sectionHeadingSize?: 'sm' | 'lg'
+  stickyOffset?: string
+  stickyBg?: string
+  stickyZIndex?: string
+  overlay?: React.ReactNode
+  className?: string
+  featureCellClassName?: string
+  featureSectionClassName?: string
+  separator?: 'line' | 'border'
+}
+
+export default function FeatureComparisonGrid({
+  columns,
+  sections,
+  gridClassName,
+  sectionHeadingSize = 'lg',
+  stickyOffset = 'top-[220px]',
+  stickyBg = 'bg-[#0f1013]',
+  stickyZIndex = 'z-10',
+  overlay,
+  className,
+  featureCellClassName,
+  featureSectionClassName,
+  separator = 'line',
+}: FeatureComparisonGridProps) {
+  const headingClass =
+    sectionHeadingSize === 'lg'
+      ? 'mb-3 mt-8 py-2 text-center text-sm font-medium sm:text-lg md:text-left'
+      : 'py-3 text-sm font-medium leading-6 text-white'
+
+  return (
+    <div className={`relative ${className ?? ''}`}>
+      {overlay}
+
+      {sections.map((section, sectionIdx) => (
+        <div key={sectionIdx} id={section.id}>
+          {/* Section header */}
+          <div className={`sticky ${stickyZIndex} ${stickyOffset} ${stickyBg}`}>
+            <div className={`grid ${gridClassName}`}>
+              <div className={`${headingClass} ${featureSectionClassName ?? ''}`}>
+                {section.title}
+              </div>
+              {columns.map((col) => (
+                <div key={col.key} className={col.sectionCellClassName ?? ''} />
+              ))}
+            </div>
+          </div>
+
+          {separator === 'line' ? <Line /> : <div className="h-px w-full bg-[#23262e]" />}
+
+          {/* Rows */}
+          <div className="grid grid-cols-1">
+            {section.rows.map((row, rowIdx) => (
+              <div key={rowIdx}>
+                <div className={`grid ${gridClassName}`}>
+                  <div className={featureCellClassName}>{row.feature}</div>
+                  {columns.map((col) => (
+                    <div key={col.key} className={col.cellClassName}>
+                      {row.cells[col.key]}
+                    </div>
+                  ))}
+                </div>
+
+                {separator === 'line' ? <Line /> : <div className="h-px w-full bg-[#23262e]" />}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The ClickStack comparison table used the old `ComparisonTable` component with a flat row structure. The new design needs a categorized grid layout with section headers (Platform, Observability Coverage, Alerting, etc.) like on pricing page, check/cross/text cell types, sticky column headers with a CTA, and a subtle column highlight overlay. The pricing page's feature table used inline JSX with duplicated grid/row markup - this refactor extracts it into the same shared component.

#### Screenshots / Screen Recordings (if applicable)

**ClickStack Comparison Grid (after — new design):**

<img width="1440" height="900" alt="clickstack-table-after-1" src="https://github.com/user-attachments/assets/72028251-575d-44e4-bc85-7508c0fdad18" />
<img width="1440" height="900" alt="clickstack-table-after-2" src="https://github.com/user-attachments/assets/0d2a255a-df90-4856-a8bd-e90f6944d47e" />
<img width="1440" height="900" alt="clickstack-table-after-3" src="https://github.com/user-attachments/assets/c7c64089-29d9-4eb7-90df-9bbe595c9a2f" />
<img width="1440" height="900" alt="clickstack-table-after-4" src="https://github.com/user-attachments/assets/9b01fdcb-e884-4c2d-816d-733c07b451b7" />

**Pricing Feature Table:**

Before:
<img width="1440" height="900" alt="pricing-table-before-1" src="https://github.com/user-attachments/assets/460a91aa-6064-4ea3-9148-0ca5f92e4bf1" />
<img width="1440" height="900" alt="pricing-table-before-2" src="https://github.com/user-attachments/assets/c3e02e5c-3b90-4fff-8328-10ad883ef201" />
<img width="1440" height="900" alt="pricing-table-before-3" src="https://github.com/user-attachments/assets/c12022cc-0f83-4e1c-a9cc-124ef375eaaa" />

After:
<img width="1440" height="900" alt="pricing-table-after-1" src="https://github.com/user-attachments/assets/1ed32675-198d-44e5-abc6-2f84b1cb66c0" />
<img width="1440" height="900" alt="pricing-table-after-2" src="https://github.com/user-attachments/assets/7e9fc2d5-8233-4560-a86f-5ea610ed71f3" />
<img width="1440" height="900" alt="pricing-table-after-3" src="https://github.com/user-attachments/assets/7221f5c6-d7f3-4ff5-89fe-aec95c334673" />

The pricing table is visually unchanged - this is a refactor to use the shared component.

#### Issues closed by this PR

Closes https://github.com/SigNoz/growth-pod/issues/983 

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] ♻️ Refactor

---

### 🐛 Bug Context
N/A

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Verified on preview for both the ClickStack alternative page and pricing page
- Edge cases covered: Sticky header behavior, column highlight overlay positioning

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: ClickStack alternative page (comparison section) and pricing page (Explore All Features section)
- Potential regressions: Pricing table layout could shift if `FeatureComparisonGrid` props don't match original inline styles exactly - visually verified on preview
- Rollback plan: Revert PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `FeatureComparisonGrid` is intentionally generic - it accepts arbitrary column keys, sticky offsets, and separator styles so it can serve both the 2-column ClickStack grid and the 3-column pricing table and any future use cases.
- The pricing page refactor is a pure extraction with no visual changes.
- The ClickStack comparison data in constants is expanded from the old flat table and has design and copy changes.

---
