### PR TITLE
docs: update Logs Quick Filters documentation

### DIFF
--- a/data/docs/logs-management/features/logs-quick-filters.mdx
+++ b/data/docs/logs-management/features/logs-quick-filters.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-07-07
 title: Logs Quick Filters
 description: Learn how to use quick filters in the SigNoz Logs Explorer to narrow log results by key attributes and speed up troubleshooting.
 doc_type: howto
@@ -36,6 +36,22 @@ The Logs Explorer comes with quick filters which allows filtering of logs based 
 7. **Clearing Filters**: If you need to reset a filter, click on the "Clear All" option next to the filter category. You can also clear all applied filters at once by clicking on a Reset button available at the top. It will reset the filters for the query it is in sync with.
 
 8. **Customizing Filters**: Click the settings icon at the top-right of the filters panel and select **Edit quick filters** to add or remove filters. You can add any resource or log attribute as a custom quick filter.
+
+## Resize the quick filters panel
+
+The quick filters panel is horizontally resizable, so you can widen it to read long filter values or narrow it to give the log results more room.
+
+1. **Resize**: Drag the grip handle on the panel's right edge to set any width between 240 px and 500 px (the default is 260 px). Widening the panel reveals filter values, such as long service names or Kubernetes resource names, that are otherwise truncated.
+
+2. **Persistence**: The width you set is saved automatically and restored the next time you reload the page.
+
+3. **Reset**: Double-click the grip handle to snap the panel back to its default width.
+
+Filter values that are too long to display in full are truncated with an ellipsis. Hover over a truncated value to see the complete value in a tooltip.
+
+<Admonition type="info">
+Resizable quick filters are currently available in the Logs Explorer only. Support for Traces, Infrastructure Monitoring, and API Monitoring is planned as follow-up work.
+</Admonition>
 
 ## Adding Custom Quick Filters
 


### PR DESCRIPTION
## Summary

- Added a **Resize the quick filters panel** section to the Logs Quick Filters doc covering the new resizable panel: drag the grip handle on the right edge to any width between 240 px and 500 px (default 260 px), width persists across sessions, and double-click the handle resets to the default width.
- Documented the tooltip that reveals a truncated filter value's full text on hover.
- Added an info Admonition noting resizable quick filters are currently available in the Logs Explorer only (Traces, Infra, and API Monitoring are follow-up work).
- Updated the `date` frontmatter to 2026-07-07 on the edited file.

## Screenshots — action needed
The existing `logs-quick-filters.webp` screenshot could **not** be refreshed to show the new grip handle: the demo environment (demo.in.signoz.cloud) has not yet been rebuilt with #11998, so the resizable panel / grip handle is not present there. Please refresh the panel screenshot(s) once the demo picks up this build.

## Notes
- No maintained "What's New"/changelog page exists under `data/docs`, so no changelog entry was added.
- No sidebar or new-page changes needed; the Logs Quick Filters page already exists in navigation.

Source PRs: #11998

Auto-generated by docs-sync pipeline