### PR TITLE
docs: document clickable URLs in dashboard descriptions

### DIFF
--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-07
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -39,6 +39,10 @@ From the Dashboards page, you can:
   alt="Dashboard configuration — set name, description, and tags"
   caption="Dashboard configuration — set the name, description, and tags for your dashboard."
 />
+
+<Admonition type="tip">
+URLs in the description are rendered as clickable links automatically. Paste any `http`/`https` URL or a bare `www.` link and it becomes a link that opens in a new tab, with no special syntax required. Trailing punctuation (such as a period at the end of a sentence) is excluded from the link, and line breaks you enter are preserved when the description is displayed. This makes it easy to link runbooks, status pages, or related dashboards. In the new dashboard experience, the description also appears when you hover the info (ⓘ) icon in the toolbar, with the same clickable links.
+</Admonition>
 
 4. Select the **Save** button at the far right.
 


### PR DESCRIPTION
## Summary
- Added an `Admonition` note to the **Manage Dashboards** page (`Create a Custom Dashboard` section) explaining that URLs in a dashboard description are automatically rendered as clickable links that open in a new tab, with no special syntax required. Covers deliverable features 1–4:
  - `http`/`https` URLs and bare `www.` links are auto-linkified.
  - Trailing punctuation is excluded from the link.
  - Line breaks in the description are preserved.
  - In Dashboard V2, the same linkified description appears in the toolbar info (ⓘ) tooltip.
- Updated the `date` frontmatter to 2026-07-07 on the edited file.

## Screenshots
No new screenshots were captured. PR #11996 merged today (2026-07-07) and the linkification is not yet live on the demo (`demo.in.signoz.cloud`) — descriptions there still render as plain text with no clickable links and no ⓘ tooltip, so a demo screenshot would misrepresent the feature. The existing `dashboard-configuration.webp` still accurately shows the description field. Screenshots can be added once the feature reaches demo/staging.

## Notes
- There is no docs changelog/release-notes page in this repo, so the changelog entry from the deliverable has no home here.
- The V2 info tooltip side change (to `bottom`) has no docs impact; flagged for QA in the deliverable.

Source PRs: #11996

Auto-generated by docs-sync pipeline