### PR TITLE
feat(infra-monitoring): description about ready and misscheduled nodes

### DIFF
--- a/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
@@ -40,6 +40,18 @@ The **DaemonSets** view shows rollout status and aggregated resource usage. If A
 - This is the K8s `.status.desiredNumberScheduled` field — the count of nodes that match the DaemonSet's selectors and where the controller intends to run the pod. Again a *node* count, not a pod count; the value grows as new matching nodes join the cluster (Cluster Autoscaler scale-up) and shrinks when nodes are removed.
 - Sudden changes in Desired usually trace back to a `nodeSelector` / `affinity` edit on the DaemonSet, a node-label change, or cluster auto-scaling — pair with **Current** to spot lag between scheduling intent and actual coverage.
 
+### Ready
+
+- This column relies on the OTel metric `k8s.daemonset.ready_nodes` from the k8s_cluster receiver, defined as "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready".
+- This is the K8s `.status.numberReady` field — the count of nodes where the DaemonSet's pod is not just placed but has passed its readiness probe. A *node* count, not a pod count; it is a subset of **Current** (a pod can be scheduled and running yet not Ready).
+- Ready < Desired means the rollout isn't fully healthy even where pods are placed — typical causes are failing/slow readiness probes, CrashLoopBackOff, or resource pressure on those nodes. Watch the gap between **Ready** and **Current**: Current says "pod is placed", Ready says "pod is actually serving".
+
+### Misscheduled
+
+- This column relies on the OTel metric `k8s.daemonset.misscheduled_nodes` from the k8s_cluster receiver, defined as "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod".
+- This is the K8s `.status.numberMisscheduled` field — the count of nodes running the DaemonSet's pod even though they no longer match its `nodeSelector` / `affinity` / `taints`. A *node* count, not a pod count; the DaemonSet controller reconciles these by evicting the stray pods, so the value should normally be **0**.
+- A non-zero value is usually transient right after a `nodeSelector` / `affinity` edit or a node relabel, while the controller cleans up stale pods. Sustained non-zero (green at 0, warning when > 0) points to pods that can't be evicted — check for recent selector/label changes or terminating-pod issues on the affected nodes.
+
 ### CPU Req Usage (%)
 
 - This column relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver, averaged across the DaemonSet's pods.


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Documents the two new DaemonSet list columns — **Ready** (`k8s.daemonset.ready_nodes`) and **Misscheduled** (`k8s.daemonset.misscheduled_nodes`) — added to infra-monitoring. New sections in `daemonsets.mdx` follow the existing Current/Desired 3-bullet structure (metric + definition → K8s `.status` field & derivation → real-world use/advice), so the docs stay in sync with the shipped columns.

#### Issues closed by this PR

Part of https://github.com/SigNoz/engineering-pod/issues/5288

---

### ✅ Change Type

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- Manual verification: `yarn check:docs-metadata` and `yarn check:doc-redirects` pass; content grounded in otel-collector-contrib k8scluster receiver + K8s `DaemonSetStatus` (`numberReady` / `numberMisscheduled`).

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Docs for the new DaemonSet Ready and Misscheduled node-count columns. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (docs-only)
- [x] Manually tested
- [x] Backward compatibility considered (additive docs)

---

## 👀 Notes for Reviewers

- Docs-only; pairs with the backend PR that adds these columns.
- Both are **node counts, not pod counts** (noted inline, matching Current/Desired).
- No path/URL change → no redirect needed.