### PR TITLE
docs: update Dashboards V2 drill-down, variables, saved views, and JSON editor

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -2269,6 +2269,16 @@
           },
           {
             "type": "doc",
+            "route": "/docs/dashboards/saved-views",
+            "label": "Saved Views"
+          },
+          {
+            "type": "doc",
+            "route": "/docs/dashboards/json-editor",
+            "label": "JSON Editor"
+          },
+          {
+            "type": "doc",
             "route": "/docs/dashboards/terraform-provider-signoz",
             "label": "Terraform Provider"
           }

--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -21,8 +21,10 @@ These interactive features make dashboards a powerful tool for root cause analys
 
 ## Features
 
-Interactive dashboards include multiple capabilities such as **View Logs and Traces**, **Breakout by**, **Context Links**, **Cross Filtering**, **Filter in Tables**, and **Cross-Panel Sync**. 
+Interactive dashboards include multiple capabilities such as **View Logs and Traces**, **View Trace Details**, **Breakout by**, **Context Links**, **Cross Filtering**, **Filter in Tables**, and **Cross-Panel Sync**. 
 Together, these features let you drill deeper, correlate across signals, and debug issues faster.
+
+You can trigger these interactions from a panel on the dashboard or from inside a panel's expanded **View** modal. See [Drill down in the expanded view](#drill-down-in-the-expanded-view) for how the two entry points differ.
 
 ### View Logs and Traces
 
@@ -56,19 +58,35 @@ This workflow shortens the gap between **observing anomalies** and **finding the
 - **Faster correlation:** Jump from metrics to traces and logs in context.
 - **Root cause focus:** Cut the time between spotting anomalies and debugging them.
 
+### View Trace Details
+
+When the data point or table row you click carries a `trace_id`, a **View Trace Details** link is added to the context menu automatically. You do not need to configure a [context link](#context-links) for it.
+
+#### How it works
+
+1. Click a data point in a chart, a pie slice, or a row in a table whose query returns a `trace_id`.
+2. Select **View Trace Details** from the context menu.
+3. The trace detail page for that `trace_id` opens in a new browser tab, so your dashboard stays open.
+
+<Admonition type="info">
+**View Trace Details** appears only when the clicked data includes a `trace_id` field. If your query does not select `trace_id`, use a [context link](#context-links) to build a custom trace URL instead.
+</Admonition>
+
 ### Breakout by
 
 The **Breakout by** option allows you to **drill deeper into aggregated data** by regrouping it with another attribute.  
 Instead of building a new query from scratch, you can click on a datapoint or table cell and break it down further to uncover patterns and anomalies.  
 
 #### How it works
-1. Click on a chart datapoint, bar segment, or table cell.  
+1. Click on a chart datapoint, bar segment, pie slice, or table cell.  
 2. From the context menu, select **Breakout by...**.  
 3. Choose an attribute from the list (for example, `k8s.pod.name` or `host.name`).  
-4. The panel is updated in place to show the new breakdown:  
+4. The regrouped result opens in the expanded **View** modal:  
    - Existing filters, time range, and dashboard variables are preserved.  
    - The **selected data is applied as a filter** so the new breakdown focuses only on that slice.  
    - The chosen attribute becomes the **new group by dimension** (it replaces the previous grouping).  
+
+   From the same modal you can keep drilling. See [Drill down in the expanded view](#drill-down-in-the-expanded-view).
 
 This lets you move from a broad overview to more granular insights step by step.  
 
@@ -192,12 +210,22 @@ The **Filter in Tables** option allows you to quickly narrow results by applying
    - **Number**: `=`, `>`, `<`, `>=`, `<=`  
    - **Boolean**: `is true`, `is false`  
 5. Enter or confirm the filter value.  
-6. The table refreshes in place with the new filter applied — no manual edits or page reloads needed.  
+6. The refined result opens in the expanded **View** modal with the new filter applied. The filter state is written to the URL, so you can share or reload the drilled-down view. No manual query edits are needed.  
 
 #### Why use it
 - **Faster narrowing**: Apply filters directly from the data you are inspecting.
 - **Context-aware operators**: Only valid operators for the column type are shown.
 - **No query editing**: Instantly re-run the query without touching the Query Builder.
+
+### Drill down in the expanded view
+
+Every panel can be expanded into a full-screen **View** modal (click the expand icon on the panel header). Drill-down interactions are available inside this modal, not just on the dashboard grid.
+
+- **Filter by value** and **Breakout by** work the same way inside the modal: click a data point, pie slice, or table cell and choose an action.
+- The result refines **in place** — the query re-runs and the chart or table updates within the same modal. A nested modal does not open.
+- Each drill-down step updates the URL, so the refined state is preserved when you reload or share the link.
+
+This lets you start from an aggregate view and keep narrowing (filter, then break out, then filter again) without leaving the expanded panel.
 
 ### Cross-Panel Sync
 

--- a/data/docs/dashboards/json-editor.mdx
+++ b/data/docs/dashboards/json-editor.mdx
@@ -1,0 +1,52 @@
+---
+date: 2026-07-08
+title: JSON Editor - Edit and Validate Dashboard Layout JSON
+description: Edit a SigNoz dashboard as raw JSON, read the orphaned panel and missing layout warnings, and resolve save errors so every panel renders after you save.
+doc_type: howto
+---
+
+The JSON editor lets you edit a dashboard's full specification as raw JSON. A dashboard spec has two parts that must stay in sync:
+
+- **`panels`** — the panels defined on the dashboard.
+- **layout** — the sections and positions that place each panel on the grid.
+
+When these two drift apart, panels can silently disappear after saving. The JSON editor surfaces those mismatches as warnings before you save.
+
+## Open the JSON editor
+
+1. From the sidebar, choose **Dashboards** and open a dashboard.
+2. Select the JSON editor button in the dashboard toolbar to open the editor drawer.
+3. Edit the JSON. The validation warnings in the drawer footer update as you type.
+
+## Validation warnings
+
+The editor shows amber warning banners in the drawer footer when the spec and layout do not match. You can save while a warning is present, but the affected panels will not render as expected until you resolve it.
+
+### Panels not present in layout
+
+If one or more panels exist in the spec but are not placed in any layout section, an amber banner reports the count:
+
+> N panels not present in layout — they won't be shown after saving
+
+Hover the banner to see the affected panel IDs.
+
+**Resolve it:** add a layout entry for each listed panel ID, or remove the unused panels from the spec if you no longer need them.
+
+### Layout references a missing panel
+
+If a layout item points to a panel ID that no longer exists in the spec, a second amber banner reports the count and lists the broken IDs on hover.
+
+**Resolve it:** remove the layout items that reference deleted panels, or restore the missing panel definitions in the spec so the IDs match.
+
+## Save errors
+
+When a save fails, the error modal shows the actual API rejection reason instead of a blank message. For example, editing a [locked dashboard](https://signoz.io/docs/userguide/manage-dashboards/#dashboard-options-menu) returns the lock error directly, so you know to unlock the dashboard before retrying.
+
+## Next Steps
+
+- [Manage Dashboards](https://signoz.io/docs/userguide/manage-dashboards/) — Create, edit, and organize dashboards and panels.
+- [Import a Dashboard](https://signoz.io/docs/dashboards/import-dashboard/) — Import a dashboard from JSON or a Grafana export.
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/dashboards/overview.mdx
+++ b/data/docs/dashboards/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 title: Dashboards
 description: Build custom dashboards to visualize metrics, logs, and traces in SigNoz.
 doc_type: explanation
@@ -31,6 +31,8 @@ Dashboards in SigNoz let you build custom visualizations over any telemetry sign
 - [Variables](https://signoz.io/docs/userguide/manage-variables/) — Create query, custom, and textbox variables for dynamic filtering.
 - [Using variables in queries](https://signoz.io/docs/dashboards/using-variables-in-queries/) — Reference variables inside panel queries.
 - [Interactivity](https://signoz.io/docs/dashboards/interactivity/) — Navigate between dashboards, link panels, and use click-through actions.
+- [Saved views](https://signoz.io/docs/dashboards/saved-views/) — Filter and organize the dashboards list, then save and reuse views.
+- [JSON editor](https://signoz.io/docs/dashboards/json-editor/) — Edit a dashboard as raw JSON and validate its panels and layout.
 - [Public sharing](https://signoz.io/docs/dashboards/public-sharing/) — Share dashboards publicly via a link.
 - [Terraform provider](https://signoz.io/docs/dashboards/terraform-provider-signoz/) — Manage dashboards as code.
 

--- a/data/docs/dashboards/saved-views.mdx
+++ b/data/docs/dashboards/saved-views.mdx
@@ -1,0 +1,55 @@
+---
+date: 2026-07-08
+title: Saved Views - Filter and Organize Your Dashboards List
+description: Create, rename, and manage saved views on the SigNoz dashboards list page to filter, organize, and quickly return to the dashboard sets your team uses most.
+doc_type: howto
+---
+
+Saved views let you store a filter and search configuration on the dashboards list page and return to it in one click. Use them to keep a focused list of the dashboards a team owns, dashboards you created, or any other slice you look at often.
+
+## Prerequisites
+
+<PrereqsInstrument />
+
+## Apply and save a view
+
+1. From the sidebar, choose **Dashboards**.
+2. Use the search box and filter chips (for example, **Created by** or tags) to narrow the list.
+3. Save the current filters as a view. The name must be **128 characters or fewer** — the confirm button is disabled while the name is over the limit.
+
+Saved views appear in the **Views** list alongside the built-in views.
+
+## Rename a saved view
+
+1. Hover over a custom saved view in the **Views** list. A pencil (rename) and a trash (delete) icon appear on the right of the row.
+2. Select the pencil icon to open the **Rename view** popover, pre-filled with the current name.
+3. Edit the name and confirm. As with saving, the name is capped at **128 characters** and the confirm button stays disabled while the limit is exceeded.
+
+The rename is applied optimistically, so the new name shows immediately.
+
+## Spot unsaved changes
+
+When the active view's current filters differ from what was saved, a small warning-colored dot appears next to the view's heading. Hover the dot to see the **Unsaved changes** tooltip.
+
+To discard the unsaved changes and revert to the view's saved state, select **Reset** in the modified-view footer. (This action was previously labeled **Clear**.)
+
+## Filter by creator
+
+The **Created by** filter chip lists every member of your organization by display name, in the format `Display Name (email)`. This includes members who are not authors of any dashboard on the current page, so you can filter to a colleague's dashboards even when none are visible yet.
+
+<Admonition type="info">
+The org-wide member list is sourced from the organization members API. Availability can vary by deployment type — if the list shows only creators of dashboards already on the page, the org-wide list is not enabled in your deployment.
+</Admonition>
+
+## Locked view
+
+Selecting the built-in **Locked** view places `locked = true` directly into the visible search box as an editable constraint, rather than applying it as a hidden filter. You can see the constraint, edit it, or combine it with other filters like any search term.
+
+## Next Steps
+
+- [Manage Dashboards](https://signoz.io/docs/userguide/manage-dashboards/) — Create, edit, and organize custom dashboards.
+- [Interactivity in Dashboards](https://signoz.io/docs/dashboards/interactivity/) — Drill down from panels into logs, traces, and related dashboards.
+
+## Get Help
+
+<GetHelp />

--- a/data/docs/dashboards/using-variables-in-queries.mdx
+++ b/data/docs/dashboards/using-variables-in-queries.mdx
@@ -1,11 +1,15 @@
 ---
-date: 2026-06-27
+date: 2026-07-08
 title: Using Variables in Queries
 description: Use dashboard variables in Query Builder, ClickHouse SQL, and PromQL queries in SigNoz.
 doc_type: howto
 ---
 
 Variables are referenced using `$var` syntax across all query types.
+
+<Admonition type="tip">
+Type `$` in a query or filter field, in the panel editor or the dashboard-page query builder, to open an autocomplete list of the dashboard's variable names. Select a name to insert the reference without typing it in full.
+</Admonition>
 
 ## Query Builder
 

--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -120,6 +120,7 @@ SigNoz supports seven panel types: Time Series, Number, Table, List, Bar, Pie, a
 
 Note the following about panels:
 
+- For a new panel, the **Save** button stays disabled until you configure at least one query. List panels are the exception: they auto-seed a query, so they can be saved immediately.
 - The total number of queries and functions you can plot on a single panel must be less or equal to ten.
 - Every time you add or modify a function or formula, you must select the **Stage & Run Query** button. If you do not select this button, the panel will not be updated and your changes will be lost whenever you move to a different tab.
 - You can hide or unhide a function or formula by selecting the eye icon at its left and then selecting the **Stage & Run Query** button.
@@ -131,6 +132,8 @@ Note the following about panels:
 2. Find the dashboard in which you created the panel you wish to update, and then select the pencil icon located at the top right corner of your panel.
 3. Make the changes.
 4. When you've finished, select the **Save** button.
+
+For an existing saved panel, the editor header also shows a **Switch to View Mode** button. Select it to leave the full-page editor without saving and return to the dashboard with that panel opened in the expanded **View** modal. The modal is pre-seeded with your current unsaved query and the dashboard's active variables, so you can inspect the result before deciding whether to save. This button is not shown for brand-new panels that have never been saved.
 
 ## Next Steps
 

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 title: Manage Variables in SigNoz
 description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
@@ -137,6 +137,30 @@ Note for Dynamic Variables: If you're using dynamic variables, explicit chaining
     WHERE metric_name = 'signoz_calls_total' AND JSONExtractString(labels, 'service.name') IN $service.name
     ```
 
+
+## How variables load and refresh
+
+SigNoz resolves dashboard variables in dependency order and refreshes only the panels that need it. Understanding this behavior helps you build fast, predictable dashboards.
+
+### Dependency-ordered loading
+
+Query variables load in [dependency](#chaining-variables) order. When a child variable references a parent variable (for example, a `pod` query that filters on `$namespace`), the child does not start fetching until the parent has resolved. This prevents the child from loading a stale or empty option list before the parent value is known.
+
+Dynamic variables wait for all Query variables on the dashboard to finish resolving before they fetch their own options. This removes the race conditions that could otherwise show incomplete option lists on the first load.
+
+### Selective panel refresh
+
+When you change a variable, SigNoz reloads only the panels that actually reference that variable. Panels that do not use the changed variable keep their current data and do not trigger new queries, so unrelated parts of the dashboard stay responsive.
+
+While a referenced variable is updating, each affected panel keeps showing its last-known data and renders a loading indicator in the background. The panel does not go blank during the update.
+
+### The variables bar
+
+Selected variables appear in the variables bar at the top of the dashboard. When there are more variables than fit, the bar collapses the overflow into a **+N** button. Hover the **+N** button to see a tooltip listing each hidden variable's name and its currently selected value.
+
+<Admonition type="info">
+A default value set on a variable can be cleared at any time. Clearing the selection applies no filter for that variable (see [Note about ALL](#note-about-all) for how the empty selection behaves for dynamic variables).
+</Admonition>
 
 ## Why avoid ClickHouse query variables
 


### PR DESCRIPTION
## Summary

Documents the Dashboards V2 changes from seven recently merged PRs. **All changes are behind the `use_dashboard_v2` flag — keep this PR as a draft until V2 reaches general availability.**

### Changed pages
- **Interactivity in dashboards** (`dashboards/interactivity.mdx`) — added **View Trace Details** auto-link (fires when a data point/row carries `trace_id`), a new **Drill down in the expanded view** section (filter-by-value and breakout inside the View modal, refining in place with URL state), pie-slice support for Breakout by, and updated Filter-in-tables to open the refined result in the View modal.
- **Manage Variables** (`userguide/manage-variables.mdx`) — new **How variables load and refresh** section: dependency-ordered loading, dynamic-waits-for-query, selective panel refresh, stale-data-during-update, the **+N** overflow tooltip, and the default-value clearing fix.
- **Using Variables in Queries** (`dashboards/using-variables-in-queries.mdx`) — `$` autocomplete for variable names in query/filter fields.
- **Manage Dashboards** (`userguide/manage-dashboards.mdx`) — Save disabled until a new panel has a query (List panels excepted), and the **Switch to View Mode** button for existing saved panels.

### New pages
- **Saved Views** (`dashboards/saved-views.mdx`) — rename views, 128-char name limit, unsaved-changes dot, org-wide **Created by** filter, editable **Locked** view constraint, **Clear → Reset** rename.
- **JSON Editor** (`dashboards/json-editor.mdx`) — orphaned-panel warning, missing-layout-reference warning, and real API save-error messages.

### Other
- Updated `frontmatter` `date` to 2026-07-08 on all edited files.
- Added Saved Views and JSON Editor to the sidebar (`data/docs-side-nav/main.json`) and to the Dashboards overview.

### Verification notes
- Verified on the demo (intermediate V2 build): the drill-down context menu (Dashboard Variables, View in Logs/Traces, Breakout by) renders as documented.
- **Screenshots pending:** the demo build lags these PRs (merged 2026-07-06/07). The saved-views sidebar, JSON editor warnings, panel-editor "Switch to View Mode", and the `trace_id` auto-link were not yet exposed, so no new figures were captured for those. Capture them from the GA build before marking ready.

### Open questions carried from the deliverable
- GA date / flag-removal tracking for `use_dashboard_v2`.
- Permission model for the drilldown "Create var" action (all viewers vs. editors).
- Whether the org-wide "Created by" filter (List-users API) is available on self-hosted OSS (noted as a caveat in the doc).

Source PRs: #11959, #11964, #11982, #11989, #12002, #12003, #12004

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)