### PR TITLE
docs: document V2 dashboard empty-panel Extend time range

### DIFF
--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -278,3 +278,30 @@ You can toggle individual series on and off through the chart legend. Hidden ser
 - If every matching series in the receiver is hidden, the receiver tooltip disappears entirely the next time you move the cursor on the source.
 
 This makes it easy to focus comparison on a specific subset by hiding the rest.
+
+## Empty panel state
+
+When a panel query runs successfully but returns nothing for the selected time range, the panel shows an empty state titled **No data in this time range** instead of a chart. From here you can widen the window and re-run the query without leaving the dashboard.
+
+### Extend time range
+
+The primary action in the empty state is **Extend time range**. Click it to widen the panel's time window to the next larger step and re-run the query.
+
+- **Standard windows** step up the zoom-out ladder: 15m, 45m, 2h, 7h, 21h, 1d, 2d, 3d, 1w, 2w, and 1 month. A 15-minute window widens to 45 minutes, a 45-minute window widens to 2 hours, and so on. When the new window matches one of these steps, the time picker shows it as a relative preset (for example, **Last 45 minutes**) instead of **Custom**.
+- **Narrow custom or drag-zoomed windows** shorter than 15 minutes expand about 3x around their midpoint until they reach 15 minutes, then follow the same ladder.
+- The window grows around its center. Once the widened end would move past the current time, the end anchors to now and the start moves further back instead.
+- At the widest step (1 month), **Extend time range** no longer appears.
+
+Extending from a panel on the dashboard updates the dashboard's global time range, so every panel refreshes on the wider window. This is the same behavior as the zoom-out control in the dashboard toolbar.
+
+### Retry
+
+When a retry handler is available, **Retry** appears as a secondary action alongside **Extend time range** and re-runs the query on the current window. If the window is already at the widest step and cannot be extended, **Retry** becomes the only action.
+
+### Loading state
+
+After you click **Extend time range**, a loading spinner replaces the empty-state message while the widened query is in flight. The panel moves from the spinner directly to the rendered chart, or back to the empty state if the wider window still has no data. This avoids snapping straight from the no-data message to a chart.
+
+### Panel View modal
+
+Opening a panel in its full-screen **View** modal gives that panel its own local time window, separate from the dashboard's global time range. If you move the modal's time window to a range with no data, the same **Extend time range** action appears. Extending inside the modal widens only the modal's local window. The dashboard's global time range, and any historical anchor set on the main dashboard, stay unchanged.


### PR DESCRIPTION
## Summary

Documents the empty-panel "Extend time range" behavior shipped in V2 dashboards (PR #11999). Added a new **Empty panel state** section to the Dashboards Interactivity page covering:

- The `No data in this time range` empty state and its **Extend time range** primary action (features 1–2).
- Zoom-out ladder behavior for standard windows and 3x expansion for narrow custom/drag-zoomed windows, including the 1-month cap where the action disappears (features 2–3).
- **Retry** demoted to a secondary action, becoming primary only when the window can't be widened (feature 4).
- The loading spinner shown mid-refetch (feature 5).
- The Panel View modal keeping its own local time window, so extending there does not move the dashboard's global time range (feature 6).
- Updated the `date` frontmatter to today's date on the edited file.

### Placement decision

The docs are not versioned into separate V1/V2 pages, and no standalone "Time Range Controls" or "Panel View Modal" pages exist. All six features were consolidated into one **Empty panel state** section on the existing panel-interactions page (`data/docs/dashboards/interactivity.mdx`) rather than creating three new pages. No URL changes, so no sidebar or redirect updates were needed.

### Open questions resolved from source

- **Button label:** Verified in `extendWindow.ts` that the label is always the constant `Extend time range`. The contextual copy mentioned in the PR description ("Extend to last <preset>", "Widen time range") did not ship, so the docs use the fixed label.
- **Ladder detail:** The exact ladder (15m, 45m, 2h, 7h, 21h, 1d, 2d, 3d, 1w, 2w, 1 month) is from `zoomOutUtils.ts`. The deliverable's "15m → 30m" example is inaccurate; the real next step from 15m is 45m, which the docs reflect.

### Screenshots pending

No screenshots were captured. The demo (`demo.in.signoz.cloud`) currently runs a V2 build that predates #11999: empty panels still render the old "No Data" state with a chart icon and no **Extend time range** button. Screenshots should be added once the demo build includes this feature.

Source PRs: #11999

Auto-generated by docs-sync pipeline