### PR TITLE
docs: update dashboard sections and drilldown documentation

### DIFF
--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -16,6 +16,12 @@ and click actions allow you to drill deeper, apply filters, and move to related 
 />
 
 These interactive features make dashboards a powerful tool for root cause analysis, helping you move from high-level trends to detailed records with just a few clicks.  
+
+<Admonition type="info">
+Drilldown is available only for panels built with the [Query Builder](https://signoz.io/docs/userguide/query-builder-v5/). Panels that use PromQL or ClickHouse SQL query modes do not support drilldown, and the **Click to drilldown** hint does not appear on them or inside the panel editor preview.
+
+Time Series, Bar, and Pie chart panels all support drilldown. On a Pie chart, click a slice to open the same context menu described below.
+</Admonition>
 
 <YouTube id="7MCiG_RFMiU" mute="false" />
 

--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -66,6 +66,30 @@ Click the **...** (three-dot) menu at the top of any dashboard to access the fol
 - **Copy as JSON** — Copy the dashboard JSON to your clipboard.
 - **Delete dashboard** — Permanently delete the dashboard.
 
+## Manage Sections
+
+Sections group related panels into labeled, collapsible blocks within a dashboard. Use them to separate concerns such as latency, throughput, and errors on the same dashboard.
+
+### Add a section
+
+1. Open the dashboard's **...** (three-dot) menu at the top.
+2. Select **New section**.
+
+The new section renders immediately with its title and an add-panel prompt, even before it contains any panels. The dashboard-level empty state (prompting you to create your first panel) appears only when the dashboard has no sections and no panels at all.
+
+### Clone a section
+
+Cloning copies a section and every panel inside it, so you can reuse a layout without rebuilding each panel.
+
+1. Hover over the section header and open its **...** (three-dot) menu.
+2. Select **Clone section** (located between **Rename** and **Delete**).
+
+The clone is created as `<original name> (Copy)` with all panels duplicated at the same positions and sizes. A loading toast appears while the clone saves, followed by a success or error toast.
+
+### Rename or delete a section
+
+Open a section's **...** (three-dot) menu to **Rename** or **Delete** the section. Deleting a section also removes the panels it contains.
+
 ## Update a Custom Dashboard
 
 To update the name, description and tags:
@@ -98,6 +122,8 @@ SigNoz supports seven panel types: Time Series, Number, Table, List, Bar, Pie, a
 2. Find the dashboard to which you want to add a new panel.
 3. Select **Add Panel**.
 4. Choose a panel type from the dialog.
+    - On a dashboard with a **single section**, selecting a panel type creates the panel immediately, with no section picker or confirm step.
+    - On a dashboard with **multiple sections**, select the section to place the panel in from the picker at the bottom of the dialog, then confirm.
 
 <Figure
   src="/img/docs/userguide/manage-panels/new-panel-dialog.webp"


### PR DESCRIPTION
## Summary

Documents the **GA (unflagged)** Dashboard V2 changes from batch `batch_20260708_121129`. Only the non-gated features are included here; the flagged work is held (see below).

### Sections (`data/docs/userguide/manage-dashboards.mdx`) — PR #12023
- New **Manage Sections** section covering **Clone section** (in the section three-dot menu, between Rename and Delete), the `<name> (Copy)` naming, panels duplicated at the same positions/sizes, and loading/success/error toast feedback.
- Note that empty sections now render with a title and add-panel prompt, and the dashboard-level empty state only appears when there are no sections and no panels.

### Panels — Add panel & drilldown — PR #12026
- `manage-dashboards.mdx`: single-section dashboards create a panel immediately on tile click; multi-section dashboards still show the section picker + confirm.
- `data/docs/dashboards/interactivity.mdx`: added an Admonition noting drilldown requires the Query Builder (PromQL/ClickHouse unsupported, no "Click to drilldown" hint), and that Pie chart panels now support drilldown (click a slice).

- Updated the `date` frontmatter to 2026-07-08 on both edited files.

## Held (gated, not included)
- **Legacy dashboards in the v2 list** (features 1–6, PR #12024, gated `DashboardsListPageV2`). The demo list shows no Legacy badges, confirming this is not yet live. Hold until flag GA.
- **Variables redesign / apply-to-panels / selection behavior** (features 17–36, PRs #12009 + #12013, gated `use_dashboard_v2`). Hold until flag GA.

## Screenshots pending
No new screenshots were added. The demo build (demo.in.signoz.cloud) lags today's merged PRs — the section three-dot menu still shows only Rename/New Panel (no Clone section), so the new controls could not be captured accurately. Screenshots should be added once the demo is rebuilt with #12023 and #12026. Existing screenshots on both pages remain accurate.

## Open questions addressed
- **Q1 (DashboardsListPageV2 GA):** Not live on the demo (no Legacy badges) — confirmed still gated.
- **Q5 (existing drilldown docs accuracy):** `interactivity.mdx` already scoped interactivity to Query-Builder panels and carried no stale pie-chart limitation, so nothing had to be removed — only the explicit query-mode note was added.

Source PRs: #12023, #12026

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)