### PR TITLE
docs: document dashboard stale detection and reload prompt

### DIFF
--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -131,6 +131,23 @@ Note the following about panels:
 2. Find the dashboard in which you created the panel you wish to update, and then select the pencil icon located at the top right corner of your panel.
 3. Make the changes.
 4. When you've finished, select the **Save** button.
+
+## Collaborative editing
+
+Dashboards are shared resources, so the same dashboard can be open in more than one browser tab or edited by more than one person at the same time. To stop you from overwriting or missing someone else's changes, SigNoz records the version you loaded and checks for newer saved versions in the background.
+
+Every time you return focus to a tab with an open dashboard, SigNoz checks whether that dashboard was saved by another user or in another browser tab since you loaded it. If a newer version exists, the **Dashboard updated elsewhere** dialog appears over the dashboard:
+
+> This dashboard was changed in another tab or by another user. Reload to see the latest version.
+
+The dialog offers two actions:
+
+- **Reload**: Fetches the latest saved version and re-arms the check, so any later change triggers a new prompt.
+- **Dismiss**: Closes the dialog and keeps your current view. The prompt is suppressed only for that specific saved revision. If the dashboard is saved again afterward, the dialog reappears the next time you focus the tab.
+
+<Admonition type="info">
+This check runs automatically for every open dashboard with no configuration required. It compares saved versions only, so your own in-progress edits and saves never trigger the prompt.
+</Admonition>
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Added a **Collaborative editing** section to `data/docs/userguide/manage-dashboards.mdx` describing Dashboard V2 stale detection: what triggers the "Dashboard updated elsewhere" dialog (returning focus to a tab whose dashboard was saved elsewhere), and what **Reload** and **Dismiss** each do.
- Documented that the check runs automatically with no configuration, compares saved versions only (your own in-progress edits/saves never trigger it), and that **Dismiss** suppresses the prompt only for that specific saved revision, so a later save re-triggers it.
- Updated the `date` frontmatter to 2026-07-08.

UI strings and behavior were taken directly from the source PR (dialog title, body copy, button labels, and the focus-based staleness/dismiss logic).

## Open questions resolved from source
- **GA/flag scope:** behavior is unconditional within Dashboard V2 (no feature flag), so it is documented as automatic without a GA/flag callout.
- **Throttle:** the check refetches on window focus with no separate cooldown; not called out as a limitation.
- **Dismiss nuance:** suppression is per server revision and is implicit in the UI, so the docs explain it explicitly.

## Screenshots
No new screenshots were captured. The feature merged today (2026-07-08) and the demo build lags freshly-merged PRs, and reproducing the dialog requires two concurrent sessions editing the same dashboard plus a real tab-focus event, which is not reliably automatable with a single controlled browser tab. A follow-up should add a screenshot of the dialog once the demo build includes the feature.

Source PRs: #12022

Auto-generated by docs-sync pipeline