### PR TITLE
docs: document role-based dashboard list actions (V2 list page)

### DIFF
--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-08
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -131,6 +131,35 @@ Note the following about panels:
 2. Find the dashboard in which you created the panel you wish to update, and then select the pencil icon located at the top right corner of your panel.
 3. Make the changes.
 4. When you've finished, select the **Save** button.
+
+## Row Actions and Role Access on the Dashboards List
+
+<Admonition type="info">
+The per-row actions menu and the Saved Views rail described below apply to the redesigned dashboards list page, which is currently experimental and enabled with the `use_dashboard_v2` feature flag. On the standard list page, dashboard actions appear in the **Action** column of the table.
+</Admonition>
+
+Every user sees the per-row actions menu on the dashboards list, but the actions it offers depend on their permission. Read-only actions are available to all roles, and edit actions are available only to users with edit permission (Editor, Author, and Admin roles).
+
+**Read-only actions (all roles, including Viewer):**
+
+- **View** — Open the dashboard.
+- **Open in New Tab** — Open the dashboard in a new browser tab.
+- **Copy Link** — Copy a direct link to the dashboard.
+
+**Edit actions (Editor, Author, and Admin roles):**
+
+- **Rename** — Rename the dashboard.
+- **Duplicate** — Create a copy of the dashboard.
+- **Delete** — Permanently delete the dashboard.
+
+Viewers keep the read-only actions, so they can still open, view, and share dashboards, but the edit actions stay hidden from them.
+
+### Saved Views rail
+
+The Saved Views rail lets you save and switch between filtered views of the dashboards list.
+
+- Selecting a saved view, applying filters, and **Reset filter** are available to all roles.
+- **Add view (+)**, **Rename**, **Delete**, **Save**, **Save as…**, and **Save as new view** are available only to users with edit permission (Editor, Author, and Admin roles).
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Documents the role-based visibility of dashboard list-page actions introduced in [SigNoz/signoz#12021](https://github.com/SigNoz/signoz/pull/12021).

- Added a **Row Actions and Role Access on the Dashboards List** section to `data/docs/userguide/manage-dashboards.mdx`:
  - Read-only actions (View, Open in New Tab, Copy Link) available to all roles including Viewer.
  - Edit actions (Rename, Duplicate, Delete) gated to users with edit permission (Editor, Author, Admin).
  - Saved Views rail: Add/Rename/Delete/Save/Save as… gated to edit permission; selecting views, filtering, and Reset filter available to all roles.
- Updated the `date` frontmatter to 2026-07-08 on the edited file.

## Scope decisions and caveats (for reviewer)

- **Experimental flag, not GA.** `use_dashboard_v2` is `StageExperimental` and **disabled by default** (`pkg/flagger/registry.go`). The V2 list page is not the default experience, so the new section is wrapped in an Admonition scoping it to the `use_dashboard_v2` flag rather than presented as GA. The legacy list page (Action-column Delete) is left documented as-is.
- **Screenshots omitted.** The deliverable's screenshot plan requires capturing viewer vs. editor/admin menus. This isn't possible: the demo (`demo.in.signoz.cloud`) auto-authenticates as a single editor/admin user (no role switching), and it currently **lags PR #12021** — its editor row menu still shows *View / Open in New Tab / Copy Link / Export JSON / Delete Dashboard* (no Rename/Duplicate), an older build. Role-differentiated screenshots are pending the demo deploy.
- **'Author' role not added to the roles reference.** `edit_dashboard` includes the AUTHOR role in product code, but AUTHOR is **not** a user-assignable role in the invite UI (only Viewer/Editor/Admin are offered) and is not documented anywhere in the docs. Adding it to `invite-team-member.mdx` would imply it's assignable, so it was left out. The new section references "Editor, Author, and Admin" for edit permission to match the product. If the roles reference should formally document the Author role and/or gain a dashboard permissions matrix (deliverable target 3), that's a follow-up decision.

Source PRs: SigNoz/signoz#12021

Auto-generated by docs-sync pipeline