### PR TITLE
docs: update locked dashboard behavior documentation

### DIFF
--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,6 +1,6 @@
 ---
-date: 2026-05-13
-description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
+date: 2026-07-08
+description: Learn how to create, edit, delete, lock, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
 ---
@@ -58,13 +58,28 @@ Click the **...** (three-dot) menu at the top of any dashboard to access the fol
   caption="Dashboard options menu — lock, rename, export, and more."
 />
 
-- **Lock Dashboard** — Prevent accidental edits by locking the dashboard. When locked, panels cannot be added, removed, resized, or rearranged. Unlock the dashboard from the same menu to resume editing.
+- **Lock Dashboard** — Prevent accidental edits by locking the dashboard. When locked, a **LOCKED** indicator appears at the bottom of the page and the editing controls are turned off. Unlock the dashboard from the same menu to resume editing. See [Locked dashboard behavior](https://signoz.io/docs/userguide/manage-dashboards/#locked-dashboard-behavior) for details.
 - **Rename** — Quickly rename the dashboard without opening the full configuration drawer.
 - **Full screen** — View the dashboard in full-screen mode for presentations or wall displays.
 - **New section** — Add a section to organize panels into logical groups within the dashboard.
 - **Export JSON** — Download the dashboard configuration as a JSON file for backup or sharing.
 - **Copy as JSON** — Copy the dashboard JSON to your clipboard.
 - **Delete dashboard** — Permanently delete the dashboard.
+
+### Locked dashboard behavior
+
+Lock a dashboard to keep it read-only and protect it from accidental changes. A pink **LOCKED** bar with a lock icon stays fixed at the bottom of the page while the dashboard is locked, so everyone viewing it can tell the dashboard is read-only.
+
+What the lock does depends on your permissions:
+
+- **Users with edit permission** keep seeing every editing control, but each one is disabled. This covers the **New Panel** and **Configure** toolbar buttons, the **Actions** menu items, the per-panel action menu (Edit panel, Clone, Move to section, Delete panel), and the section actions (Add panel, Rename section, Delete section). Hovering a disabled control shows a "This dashboard is locked" tooltip. Unlock the dashboard from the **Actions** menu to re-enable them.
+- **Users without edit permission** do not see the editing controls at all.
+
+The JSON editor opens in read-only mode while the dashboard is locked: the editor field is non-editable and the **Apply**, **Format**, and **Reset** buttons are disabled. Viewing, copying, and downloading the JSON continue to work.
+
+<Admonition type="info">
+Toggling the lock updates only the locked state. Panel charts are not reloaded when you lock or unlock a dashboard, so the data on screen stays stable.
+</Admonition>
 
 ## Update a Custom Dashboard
 


### PR DESCRIPTION
## Summary

Updates the "Lock Dashboard" documentation in `data/docs/userguide/manage-dashboards.mdx` to reflect the Dashboard V2 read-only lock behavior shipped in SigNoz/signoz#12017:

- Introduce the pink **LOCKED** indicator bar fixed at the bottom of the page.
- Clarify the edit-permitted vs viewer distinction: edit-permitted users now see editing controls **disabled with a "This dashboard is locked" tooltip**, while viewers see controls **hidden**.
- Document the JSON editor **read-only mode** when locked (Apply/Format/Reset disabled; view/copy/download still work).
- Note that toggling the lock no longer reloads panel charts.
- Updated the `date` frontmatter to today (2026-07-08) and refreshed the `description`.

Source PRs: SigNoz/signoz#12017 (author: @AshwinBhatkal)

## ⚠️ Reviewer verification needed (demo build lags this merge)

No new screenshots were added. PR #12017 merged today (2026-07-08) and the **demo environment (v0.132.0) does not yet include the new behavior**, so the new UI could not be captured or fully verified:

- On the demo, **Configure** / **New Panel** and the **Rename** / **New section** menu items are still **hidden** when locked (the old behavior), not disabled-with-tooltip. Only **Delete Dashboard** is disabled; there are no "This dashboard is locked" tooltips.
- The pink **LOCKED** bar **is** present on the demo, but renders as a thin sliver with illegible text in a full-page capture, so it was not worth shipping as a figure.

The prose above is written from the merged PR description. **Please confirm it matches the shipped UI**, and screenshots (LOCKED bar, disabled toolbar/menu/panel/section controls with tooltip, read-only JSON editor, viewer vs edit-permitted comparison) can be added in a follow-up once the demo build catches up.

## Open questions for the author

1. **Dashboard V2 GA status:** Is the V2 locked-dashboard experience the default for all deployments yet, or still behind a flag/incremental rollout? If not GA, this page may need a version/availability note.
2. **Clone visibility change:** PR #12017 also makes "Clone dashboard"/"Delete dashboard" edit-permission-only, which means viewers can no longer clone a locked dashboard. This reads like a possible side-effect rather than intended behavior, so it was **not documented** here. Please confirm whether it is intentional (and should be documented) or a regression to fix.

Auto-generated by docs-sync pipeline