### PR TITLE
docs: update Infrastructure Monitoring Hosts detail panel documentation

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-09
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -52,7 +52,7 @@ The main screen of the Host interface displays a list of all monitored hosts in 
 
 ### Host Details
 
-Selecting a host opens a detailed view with three main sections: Metrics, Traces, and Logs.
+Selecting a host opens a detailed view with three tabs: Metrics, Logs, and Traces.
 
 ### Metrics Tab
 
@@ -108,6 +108,10 @@ View and analyze distributed traces associated with the selected host.
 - **Operation type**: Filter by specific operations or endpoints (e.g., GET, POST)
 - **Status/Error codes**: Identify traces with specific success or error statuses
 - **Custom attributes**: Refine traces using user-defined tags or metadata
+
+**Reading the trace table:**
+- **HTTP Method**: Each method value renders as a blue outline badge (for example, `GET` or `POST`). Rows without an HTTP method show plain `N/A` text.
+- **Status Code**: Response codes render as color-coded badges by range, so you can scan for failures at a glance: green for `2xx`, blue for `3xx`, amber for `4xx`, and red for `5xx`. Non-numeric or missing status codes appear as plain text.
 
 ### Logs Tab
 
@@ -260,6 +264,10 @@ Users can apply various filters to refine trace analysis:
 - **Operation type**: Filter by specific operations or endpoints (e.g., GET, POST)
 - **Status/Error codes**: Identify traces with specific success or error statuses
 - **Custom attributes**: Refine traces using user-defined tags or metadata
+
+### Reading the trace table
+- **HTTP Method**: Each method value renders as a blue outline badge (for example, `GET` or `POST`). Rows without an HTTP method show plain `N/A` text.
+- **Status Code**: Response codes render as color-coded badges by range: green for `2xx`, blue for `3xx`, amber for `4xx`, and red for `5xx`. Non-numeric or missing status codes appear as plain text.
 
 ### Logs Tab: Pod Performance Monitoring
 


### PR DESCRIPTION
## Summary

Updates the Infrastructure Monitoring overview docs to match PR #12019 (Hosts entity detail panel).

- Corrected the Host Details tab list to **Metrics, Logs, Traces** (matches UI order). The Containers and Processes tabs were removed in #12019; the docs prose never referenced them, so no removals were needed there.
- Documented the Traces-table badges in both the **Host** and **Kubernetes** Traces tab sections (the trace table is a shared component): HTTP Method as a blue outline badge with an `N/A` fallback, and color-coded Status Code badges (2xx green, 3xx blue, 4xx amber, 5xx red; non-numeric shown as plain text).
- Updated the `date` frontmatter to 2026-07-09 on the edited file.

Source PRs: #12019 (author @H4ad)

## ⚠️ Reviewer action needed — screenshots & a spec discrepancy

**1. Stale screenshots (blocked by demo lag).** The demo (demo.in.signoz.cloud) has not yet picked up #12019 — it still shows the removed Containers/Processes tabs and the old single-color (pink) trace badges — so accurate replacement screenshots could not be captured. The following existing images still show the removed **Containers** and **Processes** tabs and need re-capture once the demo build updates:
- `host-metrics-details.webp` (overview.mdx → Metrics Tab)
- `host-traces-details.webp` (overview.mdx → Traces Tab)
- `host-logs-details.webp` (overview.mdx → Logs Tab)
- `host-setup-output-detailed.webp` (hostmetrics.mdx → Verification)

The new Traces tab also warrants a fresh screenshot showing the blue Method badge and the color-coded Status Code badges once available.

**2. Deliverable discrepancy — Events tab.** The docs-sync deliverable listed the remaining Hosts tabs as "Metrics, Logs, Traces, and Events." The shipped code (`Hosts.tsx`, `tabsConfig={{ showEvents: false }}`) does **not** show an Events tab on Hosts — the real set is Metrics, Logs, Traces. The docs reflect the code. Please confirm this is intended.

Auto-generated by docs-sync pipeline