### PR TITLE
feat(infra-monitoring): address gaps in docs of infra-monitoring

### DIFF
--- a/data/docs/infrastructure-monitoring/host-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/host-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-01
+date: 2026-07-09
 title: Host Monitoring
 description: Monitor host performance in SigNoz — CPU, memory, disk, network metrics with correlated traces, logs, containers, and processes.
 doc_type: explanation
@@ -167,6 +167,11 @@ Monitor host performance metrics across customizable time periods. Charts are zo
 
 - This chart relies on the OTel metric(s): `system.disk.operation_time`.
 - Plots the per-second rate of cumulative disk-busy time per `device::direction`, one line per device and direction. Values approaching `1s/s` on a single line mean that device is effectively saturated — the disk spent ~100% of wall-clock time servicing I/O. Compare against ops/s to distinguish "few slow ops" from "many fast ops".
+
+#### Disk Usage (%) by mountpoint
+
+- This chart relies on the OTel metric(s): `system.filesystem.usage`.
+- Plots each mountpoint's used space as a percentage of its own capacity (`state=used` ÷ total across all states), one line per `mountpoint`. Unlike the host-wide **Disk Usage** column, this breaks the figure out per filesystem — so a single mountpoint filling up (e.g. `/var` or `/`) is visible even when the host's overall usage looks fine. Watch any line trending toward 100%: that mountpoint is running low, which stalls writes for anything using it (log rotation, databases, container writes); a steady climb points to a leak or unrotated logs, a step change usually tracks a deploy or data import.
 
 **Time Range Selection:**
 

--- a/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-07-09
 title: DaemonSets
 description: Monitor Kubernetes DaemonSet rollout status and resource usage in SigNoz — available vs desired nodes with CPU and memory metrics.
 doc_type: explanation
@@ -27,6 +27,11 @@ The **DaemonSets** view shows rollout status and aggregated resource usage. If A
 - This column is derived from the resource attribute `k8s.namespace.name`.
 - Namespace the DaemonSet belongs to.
 - Use it to filter the list to a specific tenant or team and to navigate to the namespace-level view for aggregate workload status across Deployments, StatefulSets, DaemonSets, and Jobs.
+
+### Scheduled Nodes
+
+- A combined, always-visible summary of the daemonset's node scheduling — **Current** (green) and **Desired** (blue) shown side by side. Both are described in full in the [Current](#current) and [Desired](#desired) sections below. At a glance: **Current** equal to **Desired** means the daemon pod is running on every node it should; **Current** below **Desired** means some target nodes are not yet running it (scheduling pressure, taints, or a rollout in progress).
+- This summary is display-only and **cannot be sorted**. To sort the list by node count, enable the dedicated **Current Nodes** and **Desired Nodes** columns — both **hidden by default** — from the **Columns** selector.
 
 ### Current
 

--- a/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-07-09
 title: Deployments
 description: Monitor Kubernetes deployment availability and resource usage in SigNoz — CPU and memory with request/limit utilization and network activity.
 doc_type: explanation
@@ -27,6 +27,11 @@ The **Deployments** view shows aggregated resource usage across all pods in each
 - This column is derived from the resource attribute `k8s.namespace.name`.
 - Namespace the Deployment belongs to.
 - Use it to filter the list to a specific tenant or team and to navigate to the namespace-level view for aggregate workload status across Deployments, StatefulSets, DaemonSets, and Jobs.
+
+### Pod Replicas
+
+- A combined, always-visible summary of the deployment's pod replica counts — **Available** (green) and **Desired** (blue) shown side by side. Both are described in full in the [Available](#available) and [Desired](#desired) sections below. At a glance: **Available** equal to **Desired** means the rollout is complete and healthy; **Available** below **Desired** means a rollout, scaling event, or degraded state is in progress.
+- This summary is display-only and **cannot be sorted**. To sort the list by replica count, enable the dedicated **Available Pods** and **Desired Pods** columns — both **hidden by default** — from the **Columns** selector.
 
 ### Available
 

--- a/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-07-09
 title: Jobs
 description: Monitor Kubernetes job status and resource usage in SigNoz — active, successful, and failed pod counts with CPU and memory metrics.
 doc_type: explanation
@@ -27,6 +27,11 @@ The **Jobs** view tracks job completion status alongside resource consumption, u
 - This column is derived from the resource attribute `k8s.namespace.name`.
 - Namespace the Job belongs to.
 - Use it to filter the list to a specific tenant or team and to navigate to the namespace-level view for aggregate workload status across Deployments, StatefulSets, DaemonSets, and Jobs.
+
+### Completions
+
+- A combined, always-visible summary of the job's pod counts — **Active** (blue), **Failed** (red), **Successful** (green), and **Desired** (blue) shown side by side. Each is described in full in the [Active](#active), [Failed](#failed), [Successful](#successful), and [Desired Successful](#desired-successful) sections below. At a glance: **Successful** reaching **Desired** means the job finished; a climbing **Failed** count or an **Active** count that never converges points to a job that is retrying or stuck.
+- This summary is display-only and **cannot be sorted**. To sort the list by any single count, enable the dedicated **Active Pods**, **Failed Pods**, **Successful Pods**, and **Desired Successful Pods** columns — all **hidden by default** — from the **Columns** selector.
 
 ### Successful
 

--- a/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-07-09
 title: StatefulSets
 description: Monitor Kubernetes StatefulSet availability and resource usage in SigNoz — available vs desired pods with CPU and memory utilization percentages.
 doc_type: explanation
@@ -27,6 +27,11 @@ The **StatefulSets** view shows rollout status and resource utilization. Statefu
 - This column is derived from the resource attribute `k8s.namespace.name`.
 - Namespace the StatefulSet belongs to.
 - Use it to filter the list to a specific tenant or team and to navigate to the namespace-level view for aggregate workload status across Deployments, StatefulSets, DaemonSets, and Jobs.
+
+### Pod Replicas
+
+- A combined, always-visible summary of the statefulset's pod replica counts — **Current** (green) and **Desired** (blue) shown side by side. Both are described in full in the [Current](#current) and [Desired](#desired) sections below. At a glance: **Current** equal to **Desired** means the controller has created all the pods for the current revision; **Current** below **Desired** means the statefulset is still rolling out or scaling (its pods are created one at a time, in order).
+- This summary is display-only and **cannot be sorted**. To sort the list by replica count, enable the dedicated **Current Pods** and **Desired Pods** columns — both **hidden by default** — from the **Columns** selector.
 
 ### Current
 


### PR DESCRIPTION
## 📄 Summary

Documents the new combined status columns added in the infra-monitoring v2 UI refactor, plus a missing host chart:

- **Deployments / StatefulSets** → `Pod Replicas` (Available/Current vs Desired)
- **DaemonSets** → `Scheduled Nodes` (Current vs Desired)
- **Jobs** → `Completions` (Active/Failed/Successful/Desired)
- **Hosts** → `Disk Usage (%) by mountpoint` chart

Each combined-column section explains what it shows, links to the underlying per-value column docs, and notes those columns are hidden by default and enableable for sorting.

Part of SigNoz/engineering-pod#5640

---

### ✅ Change Type

- [x] ✨ Feature (docs)

---

### 🧪 Testing Strategy

- Manual verification: `yarn check:docs-metadata` + `yarn check:doc-redirects` pass. Anchors-only, no new URLs → no redirects needed.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Docs for new infra-monitoring combined status columns (Pod Replicas, Scheduled Nodes, Completions) and the per-mountpoint host disk-usage chart. |

---

## 👀 Notes for Reviewers

- Combined-column headings intentionally renamed from the frontend's `Replica/Pod/Node/Completion Status` — see the frontend comment on the linked issue for rationale (unit-backed naming, avoid collision with real Pod-Status/node-condition columns).
- Only bumped `date:` on the 5 edited files; rest of the infra section has pre-existing stale dates (out of scope).