### PR TITLE
docs: update Dashboard V2 panel and list documentation

### DIFF
--- a/data/docs/dashboards/panel-types/list.mdx
+++ b/data/docs/dashboards/panel-types/list.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: List Chart Panel Type
-date: 2026-05-13
+date: 2026-07-09
 description: Learn how to use the List Chart panel type in SigNoz dashboards to display ranked metrics data.
 doc_type: reference
 ---
@@ -33,6 +33,8 @@ The following graph shows the spans over a period of time in a list.
 ### Configuration
 
 The columns displayed in the list are configurable. You can add, remove, and reorder columns to show the attributes most relevant to your investigation.
+
+You can edit columns from the panel editor or directly in the expanded view. Open a List panel's action menu and select **View** to open it in the View modal, then add or remove columns without leaving the modal.
 
 ### Get Help
 

--- a/data/docs/dashboards/panel-types/pie.mdx
+++ b/data/docs/dashboards/panel-types/pie.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Pie Chart Panel Type
-date: 2026-05-13
+date: 2026-07-09
 description: Learn how to use the Pie Chart panel type in SigNoz dashboards to visualize proportional data.
 doc_type: reference
 ---
@@ -50,7 +50,8 @@ The following graph shows the distribution of the service requests over the serv
 
 #### Legend
 
-Customize the legend position and series colors.
+- **Position** — Set the legend position.
+- **Colors** — Assign a custom color to each slice. Pie chart panels support per-slice color overrides, so you can color every category individually. Select **Reset** to return a slice to its default color, or **Reset All** to reset every slice.
 
 #### Context Links
 

--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-09
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -48,6 +48,10 @@ From the Dashboards page, you can:
 
 7. When you've finished, select the **Save Layout** button.
 
+<Admonition type="info">
+In the updated dashboards experience, the blank-dashboard creation view shows a small icon picker to the left of the title input, so you can choose a dashboard icon at creation time. When you edit the dashboard title inline, clicking anywhere outside the title field saves the change, in addition to the checkmark button. These enhancements may not be available on every deployment yet.
+</Admonition>
+
 ## Dashboard Options Menu
 
 Click the **...** (three-dot) menu at the top of any dashboard to access the following options:
@@ -90,6 +94,23 @@ To change the position of a panel:
 1. From the sidebar, choose **Dashboard**.
 2. Find the dashboard you wish to remove. In the **Action** column, select the **Delete** button.
 
+## Manage Dashboard Tags
+
+<Admonition type="info">
+The inline tag editor described below is part of the updated dashboards experience and may not be available on every deployment yet.
+</Admonition>
+
+Tags help you group and filter dashboards on the Dashboards list page. You can edit a dashboard's tags without opening the dashboard:
+
+1. On the Dashboards list, open the action menu on the dashboard's row.
+2. Select **Add Tags** (if the dashboard has no tags) or **Edit Tags** (if it already has tags).
+3. In the modal, enter tags as `key:value` pairs.
+4. Save with the **Save** button or by pressing **Cmd/Ctrl + Enter**.
+
+Tags whose key and value are identical display both sides, so a tag entered as `env:env` renders as `env:env` rather than a bare `env`.
+
+The tag action is disabled on locked dashboards. Unlock the dashboard first to edit its tags.
+
 ## Add a Panel to a Dashboard
 
 SigNoz supports seven panel types: Time Series, Number, Table, List, Bar, Pie, and Histogram. To add a panel to a dashboard, follow the steps below:
@@ -123,7 +144,12 @@ Note the following about panels:
 - The total number of queries and functions you can plot on a single panel must be less or equal to ten.
 - Every time you add or modify a function or formula, you must select the **Stage & Run Query** button. If you do not select this button, the panel will not be updated and your changes will be lost whenever you move to a different tab.
 - You can hide or unhide a function or formula by selecting the eye icon at its left and then selecting the **Stage & Run Query** button.
+- When the query body is long enough to scroll, the query-type tabs and the **Run Query** button stay pinned at the top of the editor so they remain reachable while you scroll through the query.
 - When you install SigNoz, only the data provided by the Hostmetric receiver is available. To enable more metric receivers, see the [Send Metrics to SigNoz](https://signoz.io/docs/metrics-management/send-metrics/) section.
+
+<Admonition type="info">
+When a panel uses a fixed **Panel Time Preference** (for example, `Last 6 hours`) instead of `Global Time`, it ignores the dashboard-wide time range. If such a panel returns no data, its empty state shows only a **Retry** button and hides **Extend time range**, because the panel's fixed window cannot be widened from the dashboard time picker.
+</Admonition>
 
 ## Update a Panel
 
@@ -131,6 +157,18 @@ Note the following about panels:
 2. Find the dashboard in which you created the panel you wish to update, and then select the pencil icon located at the top right corner of your panel.
 3. Make the changes.
 4. When you've finished, select the **Save** button.
+
+## Organize Panels into Sections
+
+Sections group related panels into collapsible blocks within a dashboard. Add a section from the **New section** option in the [dashboard options menu](#dashboard-options-menu).
+
+To move a panel between sections:
+
+1. Open the panel's action menu (the three-dot menu on the panel header).
+2. Hover **Move to section**.
+3. Choose the target section from the submenu. Select **Dashboard (root)**, the first entry, to move the panel out of any section back to the top level of the dashboard.
+
+The **Move to section** submenu is hidden when there is nowhere to move the panel (for example, when the dashboard has no sections and the panel is already at the root).
 
 ## Next Steps
 

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-09
 title: Manage Variables in SigNoz
 description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
@@ -166,6 +166,17 @@ If you have a specific use case where dynamic variables don't work:
 2. Or reach out to support for assistance
 
 We're actively working on dynamic variables and all feedback is welcome.
+
+## The Variables Bar
+
+Dashboard variables appear in a bar at the top of the dashboard, where viewers select values without editing queries.
+
+<Admonition type="info">
+The behavior described below is part of the updated dashboards experience and may not be available on every deployment yet.
+</Admonition>
+
+- **Persistent expand/collapse state**: Use the **More**/**Less** toggle to expand or collapse the variables bar. The state is saved per dashboard and restored on your next visit, so a bar you left expanded loads expanded (with the **Less** toggle already shown) instead of resetting to collapsed.
+- **Capped multi-select pills**: When a multi-select variable has many values selected, the bar shows at most two value pills (each truncated to 20 characters) and counts the remaining selections in an overflow indicator. This keeps the bar from growing to fit every selected value.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Documents the Dashboard V2 panel-polish and list-UX changes from the two source PRs.

### Live now (PR #12033, no feature flag)
- **Pie chart legend colors** (`panel-types/pie.mdx`): documented the per-slice **Colors** control in the Legend section (Reset / Reset All). Bar, histogram, and timeseries pages already documented Legend Colors, so no change was needed there.
- **List columns in View modal** (`panel-types/list.mdx`): noted that List panel columns can be added/removed directly in the expanded **View** modal.
- **Move to section** (`manage-dashboards.mdx`): new *Organize Panels into Sections* section documenting the unified **Move to section** submenu with **Dashboard (root)** as the first entry, and that the submenu is hidden when there is nowhere to move the panel. (Replaces the former standalone "Move out of section" action.)
- **Fixed-time empty state** (`manage-dashboards.mdx`): Admonition explaining that panels with a fixed Panel Time Preference show only **Retry** (no **Extend time range**) in the empty state.
- **Sticky query tabs** (`manage-dashboards.mdx`): note that the query-type tabs and **Run Query** button stay pinned when the query body scrolls.

### Flag-gated (PR #12040, `use_dashboard_v2`) — prepared, gated with an info Admonition
- **Manage dashboard tags** (`manage-dashboards.mdx`): Add/Edit Tags row action, key:value modal, Cmd/Ctrl+Enter save, key==value display, locked-dashboard restriction.
- **Create-modal enhancements** (`manage-dashboards.mdx`): icon picker on the blank-dashboard view and outside-click commit for inline title editing.
- **Variables bar** (`manage-variables.mdx`): new *The Variables Bar* section documenting persistent expand/collapse state and capped multi-select pills with overflow indicator.

- Updated the `date` frontmatter to 2026-07-09 on all edited files.

## Screenshots
No screenshots added. Both source PRs merged today (2026-07-09) and the demo build lags them: the panel action menu on demo still shows only View/Edit/Clone/Delete/Create Alerts (no **Move to section**), and dashboard panels render **No Data** under the demo's default variable values, so clean captures of the new legend/View-modal/move controls are not yet possible. Screenshots to be added once the demo catches up and populated panels are available (capture plan is in the deliverable).

## Deferred / open questions for reviewers
- **Templates tab redesign (feature 17)** — not documented. The source-PR comment describes the new browse-and-request layout as a placeholder "until the templates BE lands." Should this be documented now (with a coming-soon note) or after the backend ships? The existing template-browse guidance in `manage-dashboards.mdx` was left unchanged.
- **`use_dashboard_v2` GA status** — the flag-gated sections above are wrapped in an info Admonition ("may not be available on every deployment yet"). Once the flag is GA, the Admonitions can be dropped. Please confirm rollout stage.
- **Cloud-only template request form** — where should the cloud-only request form be documented (shared page with a cloud/self-hosted callout vs. cloud-specific section)?

Source PRs: #12033, #12040

Auto-generated by docs-sync pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)