### PR TITLE
docs: update Span Gaps documentation for time series panels

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-10
+date: 2026-07-11
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
 description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
 doc_type: howto
@@ -15,6 +15,10 @@ SigNoz is rolling out a redesigned **Dashboards** experience. Your existing dash
 - Dashboards will be migrated in the week of 27th July.
 - Nothing breaks on the platform. Your existing dashboards keep working, and this rolls out alongside them.
 - If you don't use Terraform or don't have any scripts directly working with the SigNoz Dashboards APIs, no action is required from you today.
+
+<Admonition type="warning">
+The time series `chartAppearance.spanGaps` field is now validated. When `fillOnlyBelow` is `true`, `fillLessThan` is required and must be a positive duration. `fillLessThan` accepts second (`s`), minute (`m`), hour (`h`), day (`d`), and week (`w`) units (for example `5m`, `1d`, `1w`). Any dashboard payload with `fillOnlyBelow: true` and a missing, empty, or non-positive `fillLessThan` fails validation on save or load. Update those panels or API/Terraform payloads with a valid duration before migrating. See [Span Gaps in the Timeseries panel](https://signoz.io/docs/dashboards/panel-types/timeseries/#visualization).
+</Admonition>
 
 ### If you have scripts that use the Dashboards API directly
 

--- a/data/docs/dashboards/panel-types/timeseries.mdx
+++ b/data/docs/dashboards/panel-types/timeseries.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Timeseries Panel Type
-date: 2026-05-13
+date: 2026-07-11
 description: Learn how to use the Timeseries Chart panel type in SigNoz dashboards to visualize metrics over time.
 doc_type: reference
 ---
@@ -43,6 +43,13 @@ The following graph shows the requests per second (req/s) for a service over a p
 
 - **Panel Time Preference** — Override the global dashboard time range for this panel. Set to `Global Time` to use the dashboard's time picker, or choose a fixed time range.
 - **Fill Gaps** — The `Fill Gaps` option fills the gaps in the result data with zero. This is useful when you want to interpret the no data as zero. It is more appropriate for when the data is sparse. For example, if the result of a query for 10 minutes is `{t1: 12, t3: 21, t5: 42, t7:29}`, the `Fill Gaps` option will result in `{t1: 12, t2: 0, t3: 21, t4: 0, t5: 42, t6: 0, t7: 29, t8: 0, t9: 0, t10: 0}`.
+- **Span Gaps** — Control how the line is drawn across null (missing) data points. By default, the line connects across every gap. Enable **Fill Only Below** to connect only gaps shorter than a threshold, then set **Fill Less Than** to that threshold duration. Gaps longer than the threshold stay disconnected, which keeps genuine outages visible instead of drawing a line over them.
+  - **Fill Less Than** accepts durations in seconds (`s`), minutes (`m`), hours (`h`), days (`d`), and weeks (`w`), including compound values such as `1h30m`. For example, `30s`, `5m`, `2h`, `1d`, and `1w` are all valid.
+  - When **Fill Only Below** is enabled, **Fill Less Than** is required and must be a positive duration. A panel saved with **Fill Only Below** on and no (or a zero) **Fill Less Than** value fails validation.
+
+<Admonition type="warning">
+Dashboards saved before this change with **Fill Only Below** enabled but no **Fill Less Than** value now fail validation on save or load. Open the affected time series panels, set **Fill Less Than** to a positive duration (for example `5m`), and save to migrate them.
+</Admonition>
 
 #### Formatting & Units
 


### PR DESCRIPTION
## Summary
- Added a **Span Gaps** entry to the Timeseries panel doc covering the `Fill Only Below` / `Fill Less Than` chart appearance controls.
- Documented that `Fill Less Than` accepts second (`s`), minute (`m`), hour (`h`), day (`d`), and week (`w`) units, including compound values like `1h30m` (day and week are newly accepted per #12065).
- Documented that `Fill Less Than` is now required and must be a positive duration when `Fill Only Below` is enabled, and flagged the breaking change for dashboards saved before this fix (warning Admonition on both pages).
- Added a schema/migration note for `chartAppearance.spanGaps` to the Dashboards V2 API guide.
- Updated frontmatter `date` to 2026-07-11 on all edited files.

## Notes for reviewer
- **No UI screenshots.** The demo build (demo.in.signoz.cloud) does not yet expose the `Span Gaps` / `Fill Only Below` / `Fill Less Than` controls in the panel editor (only the existing `Fill Gaps` toggle is present), so the capture plan steps could not be executed. `spanGaps` is currently a V2 Perses `chartAppearance` schema field. Screenshots are pending a demo build that surfaces the control.
- Exact validation errors from the source (`perses_signoz_plugins.go`): `spanGaps.fillLessThan is required when fillOnlyBelow is true`, `invalid spanGaps.fillLessThan duration`, `spanGaps.fillLessThan duration must be positive`. The docs describe the behavior rather than quoting the raw API error strings.
- The full `SpanGaps` schema (with field descriptions) is surfaced automatically by the auto-generated API Reference, so it was not hand-duplicated.

Source PRs: #12065

Auto-generated by docs-sync pipeline