### PR TITLE
docs: add GCP Cloud Integration and Cloud SQL for PostgreSQL

### DIFF
--- a/constants/listicles/integrations.json
+++ b/constants/listicles/integrations.json
@@ -158,6 +158,26 @@
       ]
     },
     {
+      "id": "gcp",
+      "label": "GCP",
+      "title": "GCP Integrations",
+      "sectionName": "GCP Integrations",
+      "items": [
+        {
+          "name": "GCP Cloud Integration",
+          "href": "/docs/integrations/gcp/gcp-cloud-integration",
+          "clickName": "GCP Cloud Integration Link",
+          "icon": "/img/icons/gcp-icon.svg"
+        },
+        {
+          "name": "Cloud SQL for PostgreSQL",
+          "href": "/docs/integrations/gcp/cloud-sql-postgresql",
+          "clickName": "GCP Cloud SQL for PostgreSQL Integration Link",
+          "icon": "/img/icons/listicle/si-postgresql.svg"
+        }
+      ]
+    },
+    {
       "id": "other",
       "label": "Other",
       "title": "Other Integrations",

--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -3976,6 +3976,19 @@
         ]
       },
       {
+        "type": "category",
+        "isExpanded": false,
+        "label": "GCP Cloud Integration",
+        "route": "/docs/integrations/gcp/gcp-cloud-integration",
+        "items": [
+          {
+            "type": "doc",
+            "route": "/docs/integrations/gcp/cloud-sql-postgresql",
+            "label": "Cloud SQL for PostgreSQL"
+          }
+        ]
+      },
+      {
         "label": "Kong Gateway",
         "type": "category",
         "isExpanded": false,

--- a/data/docs/integrations/gcp/cloud-sql-postgresql.mdx
+++ b/data/docs/integrations/gcp/cloud-sql-postgresql.mdx
@@ -1,0 +1,78 @@
+---
+date: 2026-07-13
+title: GCP Cloud SQL for PostgreSQL Monitoring with SigNoz
+description: Monitor GCP Cloud SQL for PostgreSQL with SigNoz. Collect 13 metrics covering health, connections, transactions, query execution, and replication.
+doc_type: howto
+tags: [SigNoz Cloud]
+---
+
+The GCP Cloud SQL for PostgreSQL integration collects metrics and logs from your Cloud SQL for PostgreSQL instances and ships an out-of-the-box overview dashboard covering health, connections, transactions, query execution, and replication. It is the first available GCP service in the [GCP Cloud Integration](https://signoz.io/docs/integrations/gcp/gcp-cloud-integration/).
+
+<Admonition type="info">
+This integration is available on SigNoz Cloud and Self-Hosted Enterprise.
+</Admonition>
+
+## Getting started
+
+Connect your GCP account first. See [GCP Cloud Integration](https://signoz.io/docs/integrations/gcp/gcp-cloud-integration/) for the account configuration fields and supported regions.
+
+Once connected:
+
+1. In SigNoz, navigate to **Integrations** > **GCP**.
+2. Select **GCP Cloud SQL for PostgreSQL**.
+3. Toggle **Metrics** and **Logs** on. Each signal is controlled independently.
+
+Enabling the integration creates the **GCP Cloud SQL for PostgreSQL Overview** dashboard automatically. Data starts flowing within a few minutes.
+
+## Data collected
+
+The integration tracks 13 metrics from Cloud SQL for PostgreSQL:
+
+| Metric | Unit | Type | Description |
+|--------|------|------|-------------|
+| `cloudsql.googleapis.com/database/up` | Count | Gauge | Instance up/down status. |
+| `cloudsql.googleapis.com/database/cpu/utilization` | Percent | Gauge | CPU utilization. |
+| `cloudsql.googleapis.com/database/memory/utilization` | Percent | Gauge | Memory utilization. |
+| `cloudsql.googleapis.com/database/memory/usage` | Bytes | Gauge | Memory used, in bytes. |
+| `cloudsql.googleapis.com/database/disk/bytes_used` | Bytes | Gauge | Disk space used, in bytes. |
+| `cloudsql.googleapis.com/database/postgresql/num_backends` | Count | Gauge | PostgreSQL backend connection count. |
+| `cloudsql.googleapis.com/database/postgresql/num_backends_by_state` | Count | Gauge | Backend connections grouped by state. |
+| `cloudsql.googleapis.com/database/postgresql/transaction_count` | Count | Gauge | Transaction count. |
+| `cloudsql.googleapis.com/database/postgresql/deadlock_count` | Count | Gauge | Deadlock count. |
+| `cloudsql.googleapis.com/database/postgresql/vacuum/oldest_transaction_age` | Count | Gauge | Age of the oldest un-vacuumed transaction. |
+| `cloudsql.googleapis.com/database/postgresql/insights/aggregate/execution_time` | Microseconds | Gauge | Aggregate query execution time. |
+| `cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time` | Microseconds | Gauge | Per-query execution time. |
+| `cloudsql.googleapis.com/database/postgresql/replication/replica_byte_lag` | Bytes | Gauge | Replication lag in bytes, per replica. |
+
+## Overview dashboard
+
+The **GCP Cloud SQL for PostgreSQL Overview** dashboard is organized into five sections:
+
+- **Health, CPU, Memory, Disk**: Server Up, CPU Utilization, Memory Utilization, Memory Usage, Disk Usage.
+- **Connections**: PostgreSQL Connections (by database) and Cloud SQL Connections (by state).
+- **Transactions**: Number of Transactions (by type), Deadlocks, and Oldest Transaction Age.
+- **Execution**: Aggregate Execution Time, IO Execution Time, and Query Execution Time (top 10 slowest queries).
+- **Replication**: Replication Lag (bytes per replica).
+
+Pre-built dashboards are locked and cannot be edited. To customize, use **Export JSON** from the dashboard menu and import it as a new dashboard.
+
+### Filter variables
+
+The dashboard includes two filter variables that scope every panel:
+
+- **Project ID**: single-select, with an **All** option to show every monitored project.
+- **Database ID**: multi-select, to focus on one or more databases.
+
+## Migrating from the earlier `cloudsql` integration
+
+The service ID was renamed from `cloudsql` to `cloudsql_postgres`. If you configured the earlier stub integration under the old ID, re-enable the service under **GCP Cloud SQL for PostgreSQL** so metrics and logs continue to flow to the current dashboard.
+
+## Next steps
+
+- [Create alerts](https://signoz.io/docs/alerts/) on CPU saturation, connection counts, deadlocks, or replication lag.
+- [Build custom dashboards](https://signoz.io/docs/userguide/manage-dashboards/) to correlate database metrics with application performance.
+
+## Get Help
+
+<GetHelp />
+</content>

--- a/data/docs/integrations/gcp/gcp-cloud-integration.mdx
+++ b/data/docs/integrations/gcp/gcp-cloud-integration.mdx
@@ -1,0 +1,81 @@
+---
+date: 2026-07-13
+title: GCP Cloud Integration Setup and Configuration Guide
+description: Connect Google Cloud to SigNoz with the GCP Cloud Integration. Configure the deployment project, region, and monitored projects to collect metrics and logs.
+doc_type: howto
+tags: [SigNoz Cloud]
+---
+
+The GCP Cloud Integration connects your Google Cloud projects to SigNoz so you can collect metrics and logs from supported GCP services and view them on out-of-the-box dashboards. GCP joins AWS and Microsoft Azure as a supported cloud provider in the Integrations module.
+
+<Admonition type="info">
+GCP Cloud Integration is available on SigNoz Cloud and Self-Hosted Enterprise. It is distinct from the [manual GCP monitoring guides](https://signoz.io/docs/gcp-monitoring/), which configure the OpenTelemetry Collector yourself. Use this integration for a managed setup driven from the SigNoz UI.
+</Admonition>
+
+## Overview
+
+When you connect a GCP account, you tell SigNoz three things: where to deploy the collection agent, which region to deploy it in, and which GCP projects to monitor. SigNoz then collects telemetry from the services you enable and ships an out-of-the-box dashboard for each one.
+
+Unlike the AWS and Azure integrations, GCP uses a manual connection flow: there is no automated CloudFormation stack or Azure Deployment Stack. You provide the configuration below in the SigNoz UI, then complete the collector and log-routing setup in your GCP project.
+
+## Prerequisites
+
+- A SigNoz Cloud or Self-Hosted Enterprise account.
+- A Google Cloud organization with one or more projects you want to monitor.
+- A GCP project to host the shared Pub/Sub topic used for log delivery.
+- Permission to deploy resources (an OpenTelemetry Collector) and configure Pub/Sub and IAM in that project.
+
+## Account configuration
+
+In SigNoz, go to **Integrations**, select **GCP**, and provide the following fields when connecting an account:
+
+| Field | Config key | Description |
+|-------|-----------|-------------|
+| Deployment project ID | `deploymentProjectId` | The GCP project that hosts the central Pub/Sub topic used to deliver logs to SigNoz. |
+| Deployment region | `deploymentRegion` | The GCP region where the OpenTelemetry Collector is deployed. Must be one of the [supported regions](#supported-regions). |
+| Project IDs | `projectIds` | The list of GCP project IDs to monitor. At least one is required. |
+
+All three fields are required. You can monitor multiple GCP projects from a single connected account by adding more entries to **Project IDs**.
+
+<Admonition type="warning">
+The step-by-step procedure for deploying the collector and configuring the Pub/Sub topic and IAM roles in your GCP project is being finalized with the product team. This page documents the verified configuration reference; the connection walkthrough and screenshots will follow once available on the demo environment.
+</Admonition>
+
+## Supported regions
+
+The deployment region must be a supported GCP region. Supported regions span Africa, Asia-Pacific, Europe, the Middle East, North America, South America, and the US:
+
+- **Africa**: `africa-south1`
+- **Asia-Pacific**: `asia-east1`, `asia-east2`, `asia-northeast1`, `asia-northeast2`, `asia-northeast3`, `asia-south1`, `asia-south2`, `asia-southeast1`, `asia-southeast2`, `asia-southeast3`, `australia-southeast1`, `australia-southeast2`
+- **Europe**: `europe-central2`, `europe-north1`, `europe-north2`, `europe-southwest1`, `europe-west1`, `europe-west2`, `europe-west3`, `europe-west4`, `europe-west6`, `europe-west8`, `europe-west9`, `europe-west10`, `europe-west12`
+- **Middle East**: `me-central1`, `me-central2`, `me-west1`
+- **North America**: `northamerica-northeast1`, `northamerica-northeast2`, `northamerica-south1`
+- **South America**: `southamerica-east1`, `southamerica-west1`
+- **US**: `us-central1`, `us-east1`, `us-east4`, `us-east5`, `us-south1`, `us-west1`, `us-west2`, `us-west3`, `us-west4`
+
+## Enable a service
+
+After connecting an account, enable the services you want to monitor:
+
+1. In **Integrations** > **GCP**, select a service (for example, [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/)).
+2. Toggle **Metrics** and **Logs** on or off. Each signal is controlled independently, so you can collect metrics only, logs only, or both.
+3. Enabling a service creates its out-of-the-box dashboard automatically.
+
+## Supported services
+
+| Service | Signals |
+|---------|---------|
+| [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/) | Metrics, Logs |
+
+More GCP services will be added in future releases.
+
+## Next steps
+
+- Enable [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/) and explore its overview dashboard.
+- [Create alerts](https://signoz.io/docs/alerts/) on the metrics you collect.
+
+## Get Help
+
+<GetHelp />
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

- New page **GCP Cloud Integration** (`data/docs/integrations/gcp/gcp-cloud-integration.mdx`): supported provider, account config fields (`deploymentProjectId`, `deploymentRegion`, `projectIds`), supported regions, per-service metrics/logs toggles.
- New page **GCP Cloud SQL for PostgreSQL** (`data/docs/integrations/gcp/cloud-sql-postgresql.mdx`): all 13 tracked metrics with descriptions, the five-section overview dashboard, and the Project ID / Database ID filter variables. Includes a migration note for the `cloudsql` → `cloudsql_postgres` rename.
- Added GCP to the integrations sidebar (`data/docs-side-nav/main.json`) and the integrations listicle (`constants/listicles/integrations.json`).
- Updated frontmatter dates on all edited files.

Source PRs: #11892, #12072

## Facts verified against product source
- Service ID is `cloudsql_postgres`; 13 metrics and dashboard sections taken from the merged `integration.json` and `overview.json` definitions.
- Filter variables: **Project ID** is single-select (with an All option) and **Database ID** is multi-select, per the dashboard JSON. (Deliverable described both as multi-select; corrected to match the shipped dashboard.)
- 40+ supported GCP regions confirmed from `cloudintegrationtypes/regions.go`.
- Scoped to SigNoz Cloud / Self-Hosted Enterprise (`ee/` module), mirroring the Azure integration tier and tags.

## Open questions flagged for the author (@swapnil-signoz)
- **Connection procedure (needs input):** GCP uses a manual flow (`GCPConnectionArtifact` is empty — no CloudFormation/Deployment-Stack equivalent). The exact user steps to deploy the collector and configure the shared Pub/Sub topic + IAM are not in the source. The setup page documents the verified config reference and marks the connection walkthrough as pending via an Admonition. Please provide the manual steps.
- **Screenshots pending:** The demo (v0.132.2) does not yet expose GCP in Integrations (searching "gcp" returns "No integrations found"), so no screenshots were captured. Screenshots per the capture plan should be added once GCP is live on the demo.
- **Cloud SQL variants:** Only `cloudsql_postgres` exists today. Pages use an engine-specific filename (`cloud-sql-postgresql`) so MySQL/SQL Server variants can be added as siblings later.
- **`cloudsql` → `cloudsql_postgres` rename:** Documented as a migration note. Confirm whether a stronger deprecation callout is needed for anyone on the old stub.

## Notes
- `node --test tests/component-items-sync.test.js` could not run in this environment (`Cannot find module 'typescript'`, dev deps not installed). The listicle JSON parses and follows the existing item schema.

Auto-generated by docs-sync pipeline