### PR TITLE
docs: document Open in Metrics Explorer button in Infrastructure Monitoring

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-14
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -87,6 +87,10 @@ Monitor host performance metrics across customizable time periods.
 - Choose from preset time ranges (e.g., last hour, last 24 hours)
 - Set custom time ranges using the date-time picker
 - Change your timezone according to your preference
+
+<Admonition type="info">
+Each time-series chart shows a compass icon to the right of its title. Click it to open the chart's query in [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/), carrying over the current time range. From there you can refine the query, change grouping, or add the metric to a dashboard. The icon appears only on time-series charts, not on table panels.
+</Admonition>
 
 ### Traces Tab
 
@@ -237,6 +241,10 @@ The **Metrics Tab** provides an in-depth visualization of CPU, memory, and netwo
 - Choose from preset time ranges (e.g., last 30 minutes, last 24 hours).
 - Customize time ranges using the date-time picker.
 - Change your timezone according to your preference.
+
+<Admonition type="info">
+Each time-series chart shows a compass icon to the right of its title. Click it to open the chart's query in [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/), carrying over the current time range. From there you can refine the query, change grouping, or add the metric to a dashboard. The icon appears only on time-series charts, not on table panels. This works the same way across every Kubernetes view (Pods, Nodes, Namespaces, Clusters, Deployments, and more) and in the Hosts view.
+</Admonition>
 
 ### Traces Tab: Pod Performance Monitoring
 

--- a/data/docs/metrics-management/metrics-explorer.mdx
+++ b/data/docs/metrics-management/metrics-explorer.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-15
+date: 2026-07-14
 title: Metrics Explorer
 description: Discover, explore, and visualize all metrics flowing into your SigNoz deployment using the Metrics Explorer.
 doc_type: reference
@@ -180,6 +180,10 @@ The "All Attributes" section displays the dimensional structure of the metric:
 />
 
 The Explorer tab provides an interactive query building environment:
+
+<Admonition type="info">
+You can open the Explorer directly from [Infrastructure Monitoring](https://signoz.io/docs/infrastructure-monitoring/overview/). In an entity's detail view (Hosts or any Kubernetes entity), click the compass icon next to a time-series chart title to load that chart's query here with its time range preserved.
+</Admonition>
 
 **Query Configuration**:
 - **Metric**: Select the metric to query — the field auto-completes as you type


### PR DESCRIPTION
## Summary
- Documented the new compass icon on Infrastructure Monitoring entity detail charts that opens the chart's query in Metrics Explorer with the current time range preserved (source PR #12107).
- Added a note in the **Host Details → Metrics Tab** and **Kubernetes → Pod Metrics Tab** sections of `infrastructure-monitoring/overview.mdx`. The K8s note also states the button appears across all Kubernetes views and the Hosts view (the feature is in the shared `EntityMetrics` component used by both).
- Clarified the two-step flow: refine/save/add-to-dashboard all happen inside Metrics Explorer (open question 4), not via a direct infra button.
- Added a reverse cross-reference in `metrics-management/metrics-explorer.mdx` (Explorer Interface section) noting the compass icon as a direct entry point.
- Updated frontmatter `date` to 2026-07-14 on both edited files.

## Verification / open questions resolved
- **Hosts vs K8s scope:** Confirmed from source that Hosts V2 details render the same `K8sBaseDetails` / `EntityMetrics` component modified by #12107, so the compass appears in both Hosts and Kubernetes entity views (not K8s-only).
- **Time-series only:** The button renders only when `graphType !== TABLE`, documented as "time-series charts, not table panels."
- **Destination:** The button opens `/metrics-explorer/explorer` (the Explorer tab), which maps to the "Explorer Interface" section of the Metrics Explorer doc.

## Screenshots pending
No screenshots captured. The demo (`demo.in.signoz.cloud`) serves a build that predates #12107: the Hosts detail Metrics tab shows chart titles with no compass icon. Screenshots (button location, hover tooltip, handoff to Metrics Explorer) are pending a demo build that includes #12107.

Source PRs: #12107

Auto-generated by docs-sync pipeline