### PR TITLE
bugfix: url encoded pathname in search

### DIFF
--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -686,7 +686,7 @@ const Breadcrumbs = ({ url, hierarchy }: { url: string; hierarchy?: DocHit['hier
 
   try {
     const parsed = new URL(url)
-    const pathSegments = parsed.pathname
+    const pathSegments = decodeURIComponent(parsed.pathname)
       .split('/')
       .filter(Boolean)
       .map((segment) => segment.replace(/-/g, ' '))


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> The Cmd+K search modal displays URL breadcrumbs with raw `%2F` instead of `/` separators. This happens because the `Breadcrumbs` component in `SearchButton.tsx` parses the Algolia hit URL's pathname without decoding URI-encoded characters before splitting by `/`.
>
> The fix adds `decodeURIComponent()` on the pathname before splitting, so encoded slashes (`%2F`) are decoded to `/` and then properly split into separate breadcrumb segments.

#### Screenshots / Screen Recordings (if applicable)

**Before:**

<img width="727" height="594" alt="Screenshot 2026-07-14 at 20 04 47" src="https://github.com/user-attachments/assets/95245701-409e-40a3-9127-5aa478a236c9" />

**After:**

<img width="671" height="569" alt="Screenshot 2026-07-14 at 20 07 54" src="https://github.com/user-attachments/assets/888bc9ce-6d38-4486-8f67-a924443eb83d" />


#### Issues closed by this PR
NA

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> Algolia search results return URLs with encoded path separators (`%2F`). The `Breadcrumbs` component uses `new URL(url).pathname` which preserves percent-encoding, then splits by literal `/`. Since `%2F` is not a literal `/`, encoded segments aren't split and the raw `%2F` leaks into the displayed breadcrumb text.

#### Fix Strategy
> Added `decodeURIComponent()` on `parsed.pathname` before `.split('/')` in the `Breadcrumbs` component (`components/SearchButton.tsx`). This decodes `%2F` → `/` (and any other encoded characters) before splitting, producing correct breadcrumb segments.
>
> Verified no other instances of this pattern exist in the codebase.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A — display-only fix in a client component
- Manual verification: Search for terms like "kafka", "msk", "jmx" in the Cmd+K modal and confirm breadcrumb URLs show decoded `/` separators instead of `%2F`
- Edge cases covered: URLs without encoded characters are unaffected (`decodeURIComponent` is a no-op on already-decoded strings)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Minimal — only affects the breadcrumb display text under search results in the Cmd+K modal
- Potential regressions: None expected — `decodeURIComponent` on a pathname is safe; malformed percent sequences would fall through to the existing `catch` block
- Rollback plan: Revert the single-line change

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Single-line change in `components/SearchButton.tsx` (the `Breadcrumbs` component). The only instance of this pattern in the codebase — all other breadcrumb implementations use pre-built crumb arrays from `utils/breadcrumbSchema.ts` and don't parse raw URLs.

