### PR TITLE
chore: remove headlessui react

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,6 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html
       lang={siteMetadata.language}
       className={`dark ${inter.className}`}
+      data-theme="default"
       data-scroll-behavior="smooth"
       suppressHydrationWarning
     >

--- a/components/OpenInAI/OpenInAI.view.tsx
+++ b/components/OpenInAI/OpenInAI.view.tsx
@@ -18,26 +18,15 @@ import { AI_OPTIONS, COPY_FEEDBACK_DURATION_MS } from './OpenInAI.constants'
 import type { AIOption, OpenInAIProps } from './OpenInAI.types'
 import { getAbsoluteUrl } from './OpenInAI.utils'
 
-/* Inline styles required: @signozhq/ui CSS modules beat Tailwind for background/border */
-const menuContentStyle: CSSProperties = {
-  minWidth: 280,
-  backgroundColor: '#121317',
-  border: '1px solid #1D212D',
-  borderRadius: '0.5rem',
-  padding: '0.25rem 0',
-  boxShadow: '0 20px 25px -5px rgba(0,0,0,0.4)',
-}
-
-const menuItemStyle: CSSProperties = {
-  padding: '0.75rem 1rem',
-  borderRadius: 0,
-  gap: '0.75rem',
-  minWidth: 0,
-}
-
-const menuSeparatorStyle: CSSProperties = {
-  backgroundColor: '#1D212D',
-}
+const openInAIMenuVars = {
+  '--dropdown-menu-content-min-width': '17.5rem',
+  '--dropdown-menu-content-border-radius': 'var(--spacing-4)',
+  '--dropdown-menu-content-padding': 'var(--spacing-2) 0',
+  '--dropdown-menu-item-padding': 'var(--spacing-6) var(--spacing-8)',
+  '--dropdown-menu-item-border-radius': '0',
+  '--dropdown-menu-item-gap': 'var(--spacing-6)',
+  '--dropdown-menu-item-min-width': '0',
+} as CSSProperties
 
 function OpenInAI({
   markdownContent,
@@ -152,14 +141,13 @@ function OpenInAI({
             </Button>
           </DropdownMenuTrigger>
 
-          <DropdownMenuContent align="end" sideOffset={8} style={menuContentStyle} className="z-50">
+          <DropdownMenuContent align="end" sideOffset={8} style={openInAIMenuVars} className="z-50">
             <DropdownMenuItem
               disabled={isCopyDisabled}
               clickable
               onSelect={() => {
                 void handleCopy()
               }}
-              style={menuItemStyle}
               className="items-start"
             >
               <div
@@ -181,14 +169,13 @@ function OpenInAI({
               </div>
             </DropdownMenuItem>
 
-            <DropdownMenuSeparator style={menuSeparatorStyle} />
+            <DropdownMenuSeparator />
 
             {AI_OPTIONS.map((option) => (
               <DropdownMenuItem
                 key={option.id}
                 clickable
                 onSelect={() => handleOpenInAI(option)}
-                style={menuItemStyle}
                 className="items-start"
               >
                 <div className="mt-0.5 flex-shrink-0 text-signoz_vanilla-400">

--- a/components/OpenInAI/OpenInAI.view.tsx
+++ b/components/OpenInAI/OpenInAI.view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useMemo, useRef, useState, type CSSProperties } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,22 +18,26 @@ import { AI_OPTIONS, COPY_FEEDBACK_DURATION_MS } from './OpenInAI.constants'
 import type { AIOption, OpenInAIProps } from './OpenInAI.types'
 import { getAbsoluteUrl } from './OpenInAI.utils'
 
-const menuContentClassName = cn(
-  'min-w-[280px]',
-  '[--dropdown-menu-content-min-width:280px]',
-  '[--dropdown-menu-content-border-radius:theme(borderRadius.lg)]',
-  '[--dropdown-menu-content-border-color:theme(colors.signoz_slate.400)]',
-  '[--dropdown-menu-content-background:theme(colors.signoz_ink.400)]',
-  '[--dropdown-menu-content-padding:0.25rem_0]',
-  '[--dropdown-menu-content-box-shadow:0_20px_25px_-5px_rgba(0,0,0,0.4)]',
-  '[--dropdown-menu-item-padding:0.75rem_1rem]',
-  '[--dropdown-menu-item-border-radius:0]',
-  '[--dropdown-menu-item-hover-background:theme(colors.signoz_ink.300)]',
-  '[--dropdown-menu-item-focus-background:theme(colors.signoz_ink.300)]',
-  '[--dropdown-menu-item-min-width:0]',
-  '[--dropdown-menu-item-gap:0.75rem]',
-  '[--dropdown-menu-separator-background:theme(colors.signoz_slate.400)]'
-)
+/* Inline styles required: @signozhq/ui CSS modules beat Tailwind for background/border */
+const menuContentStyle: CSSProperties = {
+  minWidth: 280,
+  backgroundColor: '#121317',
+  border: '1px solid #1D212D',
+  borderRadius: '0.5rem',
+  padding: '0.25rem 0',
+  boxShadow: '0 20px 25px -5px rgba(0,0,0,0.4)',
+}
+
+const menuItemStyle: CSSProperties = {
+  padding: '0.75rem 1rem',
+  borderRadius: 0,
+  gap: '0.75rem',
+  minWidth: 0,
+}
+
+const menuSeparatorStyle: CSSProperties = {
+  backgroundColor: '#1D212D',
+}
 
 function OpenInAI({
   markdownContent,
@@ -148,13 +152,14 @@ function OpenInAI({
             </Button>
           </DropdownMenuTrigger>
 
-          <DropdownMenuContent align="end" sideOffset={8} className={menuContentClassName}>
+          <DropdownMenuContent align="end" sideOffset={8} style={menuContentStyle} className="z-50">
             <DropdownMenuItem
               disabled={isCopyDisabled}
               clickable
               onSelect={() => {
                 void handleCopy()
               }}
+              style={menuItemStyle}
               className="items-start"
             >
               <div
@@ -176,13 +181,14 @@ function OpenInAI({
               </div>
             </DropdownMenuItem>
 
-            <DropdownMenuSeparator />
+            <DropdownMenuSeparator style={menuSeparatorStyle} />
 
             {AI_OPTIONS.map((option) => (
               <DropdownMenuItem
                 key={option.id}
                 clickable
                 onSelect={() => handleOpenInAI(option)}
+                style={menuItemStyle}
                 className="items-start"
               >
                 <div className="mt-0.5 flex-shrink-0 text-signoz_vanilla-400">

--- a/components/OpenInAI/OpenInAI.view.tsx
+++ b/components/OpenInAI/OpenInAI.view.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import { Fragment, memo, useCallback, useMemo, useRef, useState } from 'react'
-import { Menu, Transition } from '@headlessui/react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@signozhq/ui/dropdown-menu'
 import { ChevronDown, Copy, Check, ExternalLink } from 'lucide-react'
 
 import { cn } from '../../app/lib/utils'
@@ -11,6 +17,23 @@ import Button from '@/components/ui/Button'
 import { AI_OPTIONS, COPY_FEEDBACK_DURATION_MS } from './OpenInAI.constants'
 import type { AIOption, OpenInAIProps } from './OpenInAI.types'
 import { getAbsoluteUrl } from './OpenInAI.utils'
+
+const menuContentClassName = cn(
+  'min-w-[280px]',
+  '[--dropdown-menu-content-min-width:280px]',
+  '[--dropdown-menu-content-border-radius:theme(borderRadius.lg)]',
+  '[--dropdown-menu-content-border-color:theme(colors.signoz_slate.400)]',
+  '[--dropdown-menu-content-background:theme(colors.signoz_ink.400)]',
+  '[--dropdown-menu-content-padding:0.25rem_0]',
+  '[--dropdown-menu-content-box-shadow:0_20px_25px_-5px_rgba(0,0,0,0.4)]',
+  '[--dropdown-menu-item-padding:0.75rem_1rem]',
+  '[--dropdown-menu-item-border-radius:0]',
+  '[--dropdown-menu-item-hover-background:theme(colors.signoz_ink.300)]',
+  '[--dropdown-menu-item-focus-background:theme(colors.signoz_ink.300)]',
+  '[--dropdown-menu-item-min-width:0]',
+  '[--dropdown-menu-item-gap:0.75rem]',
+  '[--dropdown-menu-separator-background:theme(colors.signoz_slate.400)]'
+)
 
 function OpenInAI({
   markdownContent,
@@ -22,6 +45,7 @@ function OpenInAI({
 }: OpenInAIProps) {
   const [copied, setCopied] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [open, setOpen] = useState(false)
   const isCopyingRef = useRef(false)
   const logEvent = useLogEvent()
 
@@ -102,119 +126,85 @@ function OpenInAI({
 
         <div className="h-4 w-px bg-signoz_slate-400" aria-hidden="true" />
 
-        <Menu as="div" className="relative">
-          {({ open }) => (
-            <>
-              <Menu.Button
-                as={Button}
-                isButton={true}
-                type="button"
-                variant="secondary"
-                size="sm"
+        <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              isButton={true}
+              type="button"
+              variant="secondary"
+              size="sm"
+              className={cn(
+                'size-9 rounded-l-none rounded-r-md px-0',
+                open && 'bg-signoz_ink-300 text-signoz_vanilla-100'
+              )}
+              aria-label="More options"
+              title="More options"
+            >
+              <ChevronDown
+                size={14}
+                aria-hidden="true"
+                className={cn('transition-transform duration-150', open && 'rotate-180')}
+              />
+            </Button>
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent align="end" sideOffset={8} className={menuContentClassName}>
+            <DropdownMenuItem
+              disabled={isCopyDisabled}
+              clickable
+              onSelect={() => {
+                void handleCopy()
+              }}
+              className="items-start"
+            >
+              <div
                 className={cn(
-                  'size-9 rounded-l-none rounded-r-md px-0',
-                  open && 'bg-signoz_ink-300 text-signoz_vanilla-100'
+                  'mt-0.5 flex-shrink-0',
+                  copied ? 'text-signoz_forest-500' : 'text-signoz_vanilla-400'
                 )}
-                aria-label="More options"
-                title="More options"
+                aria-hidden="true"
               >
-                <ChevronDown
-                  size={14}
-                  aria-hidden="true"
-                  className={cn('transition-transform duration-150', open && 'rotate-180')}
-                />
-              </Menu.Button>
+                {copied ? <Check size={16} /> : <Copy size={16} />}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-signoz_vanilla-100">
+                  {copied ? 'Copied!' : 'Copy page'}
+                </span>
+                <span className="text-xs text-signoz_vanilla-400">
+                  Copy page as Markdown for LLMs
+                </span>
+              </div>
+            </DropdownMenuItem>
 
-              <Transition
-                as={Fragment}
-                enter="transition ease-out duration-100"
-                enterFrom="transform opacity-0 scale-95"
-                enterTo="transform opacity-100 scale-100"
-                leave="transition ease-in duration-75"
-                leaveFrom="transform opacity-100 scale-100"
-                leaveTo="transform opacity-0 scale-95"
+            <DropdownMenuSeparator />
+
+            {AI_OPTIONS.map((option) => (
+              <DropdownMenuItem
+                key={option.id}
+                clickable
+                onSelect={() => handleOpenInAI(option)}
+                className="items-start"
               >
-                <Menu.Items
-                  modal={false}
-                  className="absolute right-0 z-50 mt-2 min-w-[280px] origin-top-right rounded-lg border border-signoz_slate-400 bg-signoz_ink-400 py-1 shadow-xl focus:outline-none"
-                >
-                  <Menu.Item disabled={isCopyDisabled}>
-                    {({ active, disabled }) => (
-                      <button
-                        type="button"
-                        onClick={handleCopy}
-                        disabled={disabled}
-                        className={cn(
-                          'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors',
-                          active && 'bg-signoz_ink-300',
-                          disabled && 'cursor-not-allowed opacity-50'
-                        )}
-                      >
-                        <div
-                          className={cn(
-                            'mt-0.5 flex-shrink-0',
-                            copied ? 'text-signoz_forest-500' : 'text-signoz_vanilla-400'
-                          )}
-                          aria-hidden="true"
-                        >
-                          {copied ? <Check size={16} /> : <Copy size={16} />}
-                        </div>
-                        <div className="flex flex-col">
-                          <span className="text-sm font-medium text-signoz_vanilla-100">
-                            {copied ? 'Copied!' : 'Copy page'}
-                          </span>
-                          <span className="text-xs text-signoz_vanilla-400">
-                            Copy page as Markdown for LLMs
-                          </span>
-                        </div>
-                      </button>
-                    )}
-                  </Menu.Item>
-
-                  <div
-                    className="my-1 border-t border-signoz_slate-400"
-                    role="separator"
-                    aria-hidden="true"
-                  />
-
-                  {AI_OPTIONS.map((option) => (
-                    <Menu.Item key={option.id}>
-                      {({ active }) => (
-                        <button
-                          type="button"
-                          onClick={() => handleOpenInAI(option)}
-                          className={cn(
-                            'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors',
-                            active && 'bg-signoz_ink-300'
-                          )}
-                        >
-                          <div className="mt-0.5 flex-shrink-0 text-signoz_vanilla-400">
-                            <option.Icon className="h-4 w-4" aria-hidden="true" />
-                          </div>
-                          <div className="flex flex-col">
-                            <div className="flex items-center gap-1.5">
-                              <span className="text-sm font-medium text-signoz_vanilla-100">
-                                {option.name}
-                              </span>
-                              <ExternalLink
-                                size={12}
-                                className="text-signoz_vanilla-400"
-                                aria-hidden="true"
-                              />
-                            </div>
-                            <span className="text-xs text-signoz_vanilla-400">
-                              {option.description}
-                            </span>
-                          </div>
-                        </button>
-                      )}
-                    </Menu.Item>
-                  ))}
-                </Menu.Items>
-              </Transition>
-            </>
-          )}
-        </Menu>
+                <div className="mt-0.5 flex-shrink-0 text-signoz_vanilla-400">
+                  <option.Icon className="h-4 w-4" aria-hidden="true" />
+                </div>
+                <div className="flex flex-col">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm font-medium text-signoz_vanilla-100">
+                      {option.name}
+                    </span>
+                    <ExternalLink
+                      size={12}
+                      className="text-signoz_vanilla-400"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <span className="text-xs text-signoz_vanilla-400">{option.description}</span>
+                </div>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   )

--- a/components/ResourceCenter/Search.tsx
+++ b/components/ResourceCenter/Search.tsx
@@ -1,6 +1,5 @@
 import { type FC } from 'react'
 import { Search } from 'lucide-react'
-import { Input } from '@signozhq/ui/input'
 
 interface SearchInputProps {
   placeholder: string
@@ -9,16 +8,19 @@ interface SearchInputProps {
 
 const SearchInput: FC<SearchInputProps> = ({ placeholder, onSearch }) => {
   return (
-    <Input
-      prefix={<Search size={16} />}
-      name="full_name"
-      type="text"
-      placeholder={placeholder}
-      onChange={onSearch}
-      autoComplete="off"
-      containerClassName="mt-0 w-full max-md:max-w-full text-base leading-6 text-zinc-600 [--input-wrapper-height:auto] [--input-wrapper-box-shadow:none] [--input-wrapper-border-radius:theme(borderRadius.DEFAULT)] dark:[--input-wrapper-border-color:theme(colors.gray.900)] dark:[--input-wrapper-background:theme(colors.signoz_ink.400)]"
-      className="dark:text-white"
-    />
+    <div className="mt-0 flex w-full items-center rounded border border-solid px-3 text-base leading-6 text-zinc-600 dark:border-gray-900 dark:bg-signoz_ink-400 max-md:max-w-full max-md:pr-5">
+      <div className="flex w-full items-center gap-2.5">
+        <Search size={16} />
+        <input
+          className="w-full border-none bg-transparent focus:border-none focus:outline-none focus:ring-0 active:border-none dark:bg-signoz_ink-400 dark:text-white"
+          name="full_name"
+          type="text"
+          placeholder={placeholder}
+          onChange={onSearch}
+          autoComplete="off"
+        />
+      </div>
+    </div>
   )
 }
 

--- a/components/ResourceCenter/Search.tsx
+++ b/components/ResourceCenter/Search.tsx
@@ -1,6 +1,6 @@
 import { type FC } from 'react'
-import { Input } from '@headlessui/react'
 import { Search } from 'lucide-react'
+import { Input } from '@signozhq/ui/input'
 
 interface SearchInputProps {
   placeholder: string
@@ -9,20 +9,16 @@ interface SearchInputProps {
 
 const SearchInput: FC<SearchInputProps> = ({ placeholder, onSearch }) => {
   return (
-    <div className="mt-0 flex w-full items-center rounded border border-solid px-3 text-base leading-6 text-zinc-600 dark:border-gray-900 dark:bg-signoz_ink-400 max-md:max-w-full max-md:pr-5">
-      <div className="flex w-full items-center gap-2.5">
-        <Search size={16} />
-
-        <Input
-          className="w-full border-none focus:border-none active:border-none dark:bg-signoz_ink-400 dark:text-white"
-          name="full_name"
-          type="text"
-          placeholder={placeholder}
-          onChange={onSearch}
-          autoComplete="off"
-        />
-      </div>
-    </div>
+    <Input
+      prefix={<Search size={16} />}
+      name="full_name"
+      type="text"
+      placeholder={placeholder}
+      onChange={onSearch}
+      autoComplete="off"
+      containerClassName="mt-0 w-full max-md:max-w-full text-base leading-6 text-zinc-600 [--input-wrapper-height:auto] [--input-wrapper-box-shadow:none] [--input-wrapper-border-radius:theme(borderRadius.DEFAULT)] dark:[--input-wrapper-border-color:theme(colors.gray.900)] dark:[--input-wrapper-background:theme(colors.signoz_ink.400)]"
+      className="dark:text-white"
+    />
   )
 }
 

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -340,14 +340,14 @@ const searchOverlayStyle: CSSProperties = {
   zIndex: 80,
 }
 
-const searchContentStyle = {
-  '--l2-background': 'var(--l2-background-transparent)',
-  '--l2-border': 'transparent',
+const searchContentStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
   boxShadow: 'none',
   maxWidth: '42rem',
   zIndex: 80,
   width: '100%',
-} as CSSProperties
+}
 
 const SearchHeader = ({
   onClose,

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -296,7 +296,6 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
       }}
     >
       <DialogPortal>
-        {/* Inline styles required: @signozhq/ui CSS modules beat Tailwind for z-index/background */}
         <DialogOverlay style={searchOverlayStyle} />
       </DialogPortal>
       <DialogContent
@@ -338,20 +337,17 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
 }
 
 const searchOverlayStyle: CSSProperties = {
-  backgroundColor: 'rgba(0, 0, 0, 0.55)',
   zIndex: 80,
 }
 
-const searchContentStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
+const searchContentStyle = {
+  '--l2-background': 'var(--l2-background-transparent)',
+  '--l2-border': 'transparent',
   boxShadow: 'none',
-  borderRadius: 0,
-  padding: 0,
   maxWidth: '42rem',
   zIndex: 80,
   width: '100%',
-}
+} as CSSProperties
 
 const SearchHeader = ({
   onClose,

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -17,7 +17,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
 } from 'react'
@@ -296,7 +295,7 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
       }}
     >
       <DialogPortal>
-        <DialogOverlay style={searchOverlayStyle} />
+        <DialogOverlay className="!z-[80]" />
       </DialogPortal>
       <DialogContent
         showOverlay={false}
@@ -304,8 +303,11 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
         width="wide"
         animation="fade"
         offset={96}
-        style={searchContentStyle}
-        className="overflow-visible text-white"
+        className={cn(
+          // ! overrides needed: @signozhq/ui CSS modules beat normal Tailwind
+          'overflow-visible !border-none !bg-transparent text-white !shadow-none',
+          '!z-[80] !w-full !max-w-2xl'
+        )}
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           focusSearchInput()
@@ -334,19 +336,6 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
       </DialogContent>
     </Dialog>
   )
-}
-
-const searchOverlayStyle: CSSProperties = {
-  zIndex: 80,
-}
-
-const searchContentStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-  maxWidth: '42rem',
-  zIndex: 80,
-  width: '100%',
 }
 
 const SearchHeader = ({

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -1,10 +1,15 @@
 'use client'
 
-import { Dialog, Transition } from '@headlessui/react'
+import {
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@signozhq/ui/dialog'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
 import { useRouter } from 'next/navigation'
 import {
-  Fragment,
   forwardRef,
   useCallback,
   useEffect,
@@ -12,6 +17,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
 } from 'react'
@@ -283,56 +289,68 @@ const SearchModal = ({ isOpen, onClose, onSelect, searchClient, indexName }: Sea
   }, [mode, focusSearchInput, onClose])
 
   return (
-    <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-[80]" onClose={onClose}>
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-200"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-150"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black/55" />
-        </Transition.Child>
-
-        <div className="fixed inset-0 overflow-y-auto">
-          <div className="flex min-h-full items-start justify-center px-3 py-10 sm:px-4 sm:py-24">
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-200"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-150"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
-            >
-              <Dialog.Panel className="relative w-full max-w-2xl overflow-visible bg-transparent text-white">
-                <InstantSearch indexName={indexName} searchClient={searchClient}>
-                  <SearchHeader
-                    mode={mode}
-                    onModeChange={setMode}
-                    onClose={onClose}
-                    registerInput={registerInput}
-                    resultsRef={resultsRef}
-                  />
-                  {mode === 'search' ? (
-                    <SearchResults
-                      ref={resultsRef}
-                      onSelect={onSelect}
-                      onClose={onClose}
-                      onFocusInput={focusSearchInput}
-                    />
-                  ) : null}
-                </InstantSearch>
-              </Dialog.Panel>
-            </Transition.Child>
-          </div>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogPortal>
+        {/* Inline styles required: @signozhq/ui CSS modules beat Tailwind for z-index/background */}
+        <DialogOverlay style={searchOverlayStyle} />
+      </DialogPortal>
+      <DialogContent
+        showOverlay={false}
+        position="top"
+        width="wide"
+        animation="fade"
+        offset={96}
+        style={searchContentStyle}
+        className="overflow-visible text-white"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          focusSearchInput()
+        }}
+      >
+        <DialogTitle className="sr-only">Search docs</DialogTitle>
+        <div className="relative w-full max-w-2xl overflow-visible bg-transparent px-3 text-white sm:px-4">
+          <InstantSearch indexName={indexName} searchClient={searchClient}>
+            <SearchHeader
+              mode={mode}
+              onModeChange={setMode}
+              onClose={onClose}
+              registerInput={registerInput}
+              resultsRef={resultsRef}
+            />
+            {mode === 'search' ? (
+              <SearchResults
+                ref={resultsRef}
+                onSelect={onSelect}
+                onClose={onClose}
+                onFocusInput={focusSearchInput}
+              />
+            ) : null}
+          </InstantSearch>
         </div>
-      </Dialog>
-    </Transition>
+      </DialogContent>
+    </Dialog>
   )
+}
+
+const searchOverlayStyle: CSSProperties = {
+  backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  zIndex: 80,
+}
+
+const searchContentStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  borderRadius: 0,
+  padding: 0,
+  maxWidth: '42rem',
+  zIndex: 80,
+  width: '100%',
 }
 
 const SearchHeader = ({

--- a/components/TopNav/MobileMenu.tsx
+++ b/components/TopNav/MobileMenu.tsx
@@ -25,29 +25,15 @@ interface MobileMenuProps {
 
 const TOP_NAV_OFFSET_PX = 56
 
-const mobileMenuContentStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
+const mobileMenuContentStyle = {
+  '--l2-background': 'var(--l2-background-transparent)',
+  '--l2-border': 'transparent',
   boxShadow: 'none',
-  borderRadius: 0,
-  padding: 0,
   top: TOP_NAV_OFFSET_PX,
   height: `calc(100% - ${TOP_NAV_OFFSET_PX}px)`,
   maxWidth: 'min(100%, 24rem)',
   width: '100%',
-}
-
-const visuallyHiddenStyle: CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  borderWidth: 0,
-}
+} as CSSProperties
 
 export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuProps) {
   const router = useRouter()
@@ -64,7 +50,7 @@ export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuP
         style={mobileMenuContentStyle}
         className="overflow-y-auto"
       >
-        <DialogTitle style={visuallyHiddenStyle}>Menu</DialogTitle>
+        <DialogTitle className="sr-only">Menu</DialogTitle>
         <div className="flex min-h-full w-full flex-col bg-signoz_ink-500 px-6 py-24 pt-[calc(6rem-56px)] sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
           <div className="flex items-center justify-between">
             <TrackingLink

--- a/components/TopNav/MobileMenu.tsx
+++ b/components/TopNav/MobileMenu.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { Dialog } from '@headlessui/react'
+import { Dialog, DialogContent, DialogTitle } from '@signozhq/ui/dialog'
 import { ArrowRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { type CSSProperties } from 'react'
 import TrackingLink from '@/components/TrackingLink'
 import TrackingButton from '@/components/TrackingButton'
 import { Button } from '@/components/ui/Button'
@@ -22,37 +23,73 @@ interface MobileMenuProps {
   isSignupRoute: boolean
 }
 
+const TOP_NAV_OFFSET_PX = 56
+
+const mobileMenuContentStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  borderRadius: 0,
+  padding: 0,
+  top: TOP_NAV_OFFSET_PX,
+  height: `calc(100% - ${TOP_NAV_OFFSET_PX}px)`,
+  maxWidth: 'min(100%, 24rem)',
+  width: '100%',
+}
+
+const visuallyHiddenStyle: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  borderWidth: 0,
+}
+
 export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuProps) {
   const router = useRouter()
   const closeMobileMenu = () => onClose(false)
 
   return (
-    <Dialog as="div" open={open} onClose={onClose}>
-      <div className="fixed inset-0 top-[56px]" />
-      <Dialog.Panel className="fixed inset-y-0 right-0 z-50 mt-[56px] w-full overflow-y-auto bg-signoz_ink-500 px-6 py-24 !pt-[calc(6rem-56px)] sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 ">
-        <div className="flex items-center justify-between">
-          <TrackingLink
-            href="/"
-            className="-m-1.5 p-1.5"
-            clickType="Nav Click"
-            clickName="SigNoz Logo"
-            clickText="SigNoz"
-            clickLocation="Mobile Menu"
-            onClick={closeMobileMenu}
-          >
-            <span className="sr-only">SigNoz</span>
-          </TrackingLink>
-        </div>
-        <div className="mt-6 flow-root">
-          <div className="-my-6 divide-y divide-gray-500/10">
-            <MainMenuContent
-              isSignupRoute={isSignupRoute}
-              onClose={closeMobileMenu}
-              router={router}
-            />
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent
+        showOverlay={false}
+        position="right"
+        heightMode="full"
+        animation="slide"
+        width="narrow"
+        style={mobileMenuContentStyle}
+        className="overflow-y-auto"
+      >
+        <DialogTitle style={visuallyHiddenStyle}>Menu</DialogTitle>
+        <div className="flex min-h-full w-full flex-col bg-signoz_ink-500 px-6 py-24 pt-[calc(6rem-56px)] sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
+          <div className="flex items-center justify-between">
+            <TrackingLink
+              href="/"
+              className="-m-1.5 p-1.5"
+              clickType="Nav Click"
+              clickName="SigNoz Logo"
+              clickText="SigNoz"
+              clickLocation="Mobile Menu"
+              onClick={closeMobileMenu}
+            >
+              <span className="sr-only">SigNoz</span>
+            </TrackingLink>
+          </div>
+          <div className="mt-6 flow-root">
+            <div className="-my-6 divide-y divide-gray-500/10">
+              <MainMenuContent
+                isSignupRoute={isSignupRoute}
+                onClose={closeMobileMenu}
+                router={router}
+              />
+            </div>
           </div>
         </div>
-      </Dialog.Panel>
+      </DialogContent>
     </Dialog>
   )
 }

--- a/components/TopNav/MobileMenu.tsx
+++ b/components/TopNav/MobileMenu.tsx
@@ -3,7 +3,6 @@
 import { Dialog, DialogContent, DialogTitle } from '@signozhq/ui/dialog'
 import { ArrowRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { type CSSProperties } from 'react'
 import TrackingLink from '@/components/TrackingLink'
 import TrackingButton from '@/components/TrackingButton'
 import { Button } from '@/components/ui/Button'
@@ -23,18 +22,6 @@ interface MobileMenuProps {
   isSignupRoute: boolean
 }
 
-const TOP_NAV_OFFSET_PX = 56
-
-const mobileMenuContentStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-  top: TOP_NAV_OFFSET_PX,
-  height: `calc(100% - ${TOP_NAV_OFFSET_PX}px)`,
-  maxWidth: 'min(100%, 24rem)',
-  width: '100%',
-}
-
 export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuProps) {
   const router = useRouter()
   const closeMobileMenu = () => onClose(false)
@@ -47,8 +34,11 @@ export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuP
         heightMode="full"
         animation="slide"
         width="narrow"
-        style={mobileMenuContentStyle}
-        className="overflow-y-auto"
+        className={cn(
+          // ! overrides needed: @signozhq/ui CSS modules beat normal Tailwind for these
+          'overflow-y-auto !border-none !bg-transparent !shadow-none',
+          '!top-14 !h-[calc(100%-3.5rem)] !w-full !max-w-[min(100%,24rem)]'
+        )}
       >
         <DialogTitle className="sr-only">Menu</DialogTitle>
         <div className="flex min-h-full w-full flex-col bg-signoz_ink-500 px-6 py-24 pt-[calc(6rem-56px)] sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">

--- a/components/TopNav/MobileMenu.tsx
+++ b/components/TopNav/MobileMenu.tsx
@@ -25,15 +25,15 @@ interface MobileMenuProps {
 
 const TOP_NAV_OFFSET_PX = 56
 
-const mobileMenuContentStyle = {
-  '--l2-background': 'var(--l2-background-transparent)',
-  '--l2-border': 'transparent',
+const mobileMenuContentStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
   boxShadow: 'none',
   top: TOP_NAV_OFFSET_PX,
   height: `calc(100% - ${TOP_NAV_OFFSET_PX}px)`,
   maxWidth: 'min(100%, 24rem)',
   width: '100%',
-} as CSSProperties
+}
 
 export default function MobileMenu({ open, onClose, isSignupRoute }: MobileMenuProps) {
   const router = useRouter()

--- a/components/TopNav/ProductDropdown.tsx
+++ b/components/TopNav/ProductDropdown.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { Button } from '@headlessui/react'
 import { ArrowRight, ChevronDown } from 'lucide-react'
 import Image from 'next/image'
 import TrackingLink from '@/components/TrackingLink'
+import { Button } from '@/components/ui/Button'
 import shapedMarkIcon from '@/public/img/case_study/logos/shaped-mark.svg?url'
 import { productDropdownItemsSorted, comparisonItems, SECTION_HEADING_CLASS } from './constants'
 import { useNavDropdown } from './NavDropdownContext'
@@ -14,6 +14,9 @@ export default function ProductDropdown() {
   return (
     <div onPointerEnter={open} onPointerLeave={close} className="flex items-center">
       <Button
+        isButton
+        unstyled
+        type="button"
         ref={triggerRef}
         className="truncate rounded-full px-2.5 py-1 text-sm outline-none transition-colors hover:bg-signoz_robin-200/20"
         onClick={() => (isOpen ? close() : open())}

--- a/components/TopNav/ResourcesDropdown.tsx
+++ b/components/TopNav/ResourcesDropdown.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Button } from '@headlessui/react'
 import { ArrowRight, ChevronDown } from 'lucide-react'
 import TrackingLink from '@/components/TrackingLink'
+import { Button } from '@/components/ui/Button'
 import { resourcesDropdownItems, ResourceItem, SECTION_HEADING_CLASS } from './constants'
 import { useNavDropdown } from './NavDropdownContext'
 
@@ -12,6 +12,9 @@ export default function ResourcesDropdown() {
   return (
     <div onPointerEnter={open} onPointerLeave={close} className="flex items-center">
       <Button
+        isButton
+        unstyled
+        type="button"
         ref={triggerRef}
         className="truncate rounded-full px-2.5 py-1 text-sm outline-none transition-colors hover:bg-signoz_robin-200/20"
         onClick={() => (isOpen ? close() : open())}

--- a/components/TopNav/UseCasesDropdown.tsx
+++ b/components/TopNav/UseCasesDropdown.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Button } from '@headlessui/react'
 import { ArrowRight, ChevronDown } from 'lucide-react'
 import TrackingLink from '@/components/TrackingLink'
+import { Button } from '@/components/ui/Button'
 import { useCasesDropdownItemsSorted } from './constants'
 import { useNavDropdown } from './NavDropdownContext'
 
@@ -12,6 +12,9 @@ export default function UseCasesDropdown() {
   return (
     <div onPointerEnter={open} onPointerLeave={close} className="flex items-center">
       <Button
+        isButton
+        unstyled
+        type="button"
         ref={triggerRef}
         className="truncate rounded-full px-2.5 py-1 text-sm outline-none transition-colors hover:bg-signoz_robin-200/20"
         onClick={() => (isOpen ? close() : open())}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -10,21 +10,21 @@ import {
   type DialogSize,
 } from '@signozhq/ui/dialog'
 import { X } from 'lucide-react'
-import { type CSSProperties, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { cn } from 'app/lib/utils'
 
-const sizeMaxWidth = {
-  sm: '24rem',
-  md: '28rem',
-  lg: '32rem',
-  xl: '36rem',
-  '2xl': '42rem',
-  '3xl': '48rem',
-  '4xl': '56rem',
-  '5xl': '64rem',
+const sizeMaxWidthClass = {
+  sm: '!max-w-sm',
+  md: '!max-w-md',
+  lg: '!max-w-lg',
+  xl: '!max-w-xl',
+  '2xl': '!max-w-2xl',
+  '3xl': '!max-w-3xl',
+  '4xl': '!max-w-4xl',
+  '5xl': '!max-w-5xl',
 } as const
 
-const sizeToDialogWidth: Record<keyof typeof sizeMaxWidth, DialogSize> = {
+const sizeToDialogWidth: Record<keyof typeof sizeMaxWidthClass, DialogSize> = {
   sm: 'narrow',
   md: 'narrow',
   lg: 'base',
@@ -35,7 +35,7 @@ const sizeToDialogWidth: Record<keyof typeof sizeMaxWidth, DialogSize> = {
   '5xl': 'extra-wide',
 }
 
-export type AppModalSize = keyof typeof sizeMaxWidth
+export type AppModalSize = keyof typeof sizeMaxWidthClass
 
 type AppModalProps = {
   isOpen: boolean
@@ -45,18 +45,6 @@ type AppModalProps = {
   panelClassName?: string
   backdrop?: 'blur' | 'default'
   showCloseButton?: boolean
-}
-
-const transparentDialogSurfaceStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-}
-
-const blurOverlayStyle: CSSProperties = {
-  backgroundColor: 'color-mix(in srgb, var(--bg-ink-500) 30%, transparent)',
-  backdropFilter: 'blur(12px) saturate(150%)',
-  WebkitBackdropFilter: 'blur(12px) saturate(150%)',
 }
 
 export function AppModal({
@@ -71,18 +59,23 @@ export function AppModal({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogPortal>
-        <DialogOverlay {...(backdrop === 'blur' ? { style: blurOverlayStyle } : {})} />
+        <DialogOverlay
+          className={cn(
+            // ! overrides needed: @signozhq/ui CSS modules beat normal Tailwind
+            backdrop === 'blur' &&
+              '!bg-[color-mix(in_srgb,var(--bg-ink-500)_30%,transparent)] backdrop-blur-[12px] backdrop-saturate-150'
+          )}
+        />
       </DialogPortal>
       <DialogContent
         showOverlay={false}
         width={sizeToDialogWidth[size]}
         position="center"
         animation="fade"
-        style={{
-          ...transparentDialogSurfaceStyle,
-          maxWidth: sizeMaxWidth[size],
-        }}
-        className="overflow-hidden text-left shadow-xl"
+        className={cn(
+          'overflow-hidden !border-none !bg-transparent text-left !shadow-none',
+          sizeMaxWidthClass[size]
+        )}
       >
         <DialogTitle className="sr-only">Dialog</DialogTitle>
         <div className={cn('relative w-full', panelClassName)}>

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -47,10 +47,11 @@ type AppModalProps = {
   showCloseButton?: boolean
 }
 
-const transparentDialogSurfaceVars = {
-  '--l2-background': 'var(--l2-background-transparent)',
-  '--l2-border': 'transparent',
-} as CSSProperties
+const transparentDialogSurfaceStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+}
 
 const blurOverlayStyle: CSSProperties = {
   backgroundColor: 'color-mix(in srgb, var(--bg-ink-500) 30%, transparent)',
@@ -78,8 +79,7 @@ export function AppModal({
         position="center"
         animation="fade"
         style={{
-          ...transparentDialogSurfaceVars,
-          boxShadow: 'none',
+          ...transparentDialogSurfaceStyle,
           maxWidth: sizeMaxWidth[size],
         }}
         className="overflow-hidden text-left shadow-xl"

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,22 +1,41 @@
 'use client'
 
-import { Dialog, DialogPanel, DialogBackdrop } from '@headlessui/react'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  type DialogSize,
+} from '@signozhq/ui/dialog'
 import { X } from 'lucide-react'
-import { type ReactNode } from 'react'
+import { type CSSProperties, type ReactNode } from 'react'
 import { cn } from 'app/lib/utils'
 
-const sizeClass = {
-  sm: 'max-w-sm',
-  md: 'max-w-md',
-  lg: 'max-w-lg',
-  xl: 'max-w-xl',
-  '2xl': 'max-w-2xl',
-  '3xl': 'max-w-3xl',
-  '4xl': 'max-w-4xl',
-  '5xl': 'max-w-5xl',
+const sizeMaxWidth = {
+  sm: '24rem',
+  md: '28rem',
+  lg: '32rem',
+  xl: '36rem',
+  '2xl': '42rem',
+  '3xl': '48rem',
+  '4xl': '56rem',
+  '5xl': '64rem',
 } as const
 
-export type AppModalSize = keyof typeof sizeClass
+const sizeToDialogWidth: Record<keyof typeof sizeMaxWidth, DialogSize> = {
+  sm: 'narrow',
+  md: 'narrow',
+  lg: 'base',
+  xl: 'base',
+  '2xl': 'wide',
+  '3xl': 'wide',
+  '4xl': 'extra-wide',
+  '5xl': 'extra-wide',
+}
+
+export type AppModalSize = keyof typeof sizeMaxWidth
 
 type AppModalProps = {
   isOpen: boolean
@@ -28,6 +47,26 @@ type AppModalProps = {
   showCloseButton?: boolean
 }
 
+const neutralizedSurfaceStyle: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  borderRadius: 0,
+  padding: 0,
+}
+
+const visuallyHiddenStyle: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  borderWidth: 0,
+}
+
 export function AppModal({
   isOpen,
   onOpenChange,
@@ -37,46 +76,49 @@ export function AppModal({
   backdrop = 'default',
   showCloseButton = true,
 }: AppModalProps) {
-  return (
-    <Dialog
-      as="div"
-      className="fixed inset-0 z-50 h-screen w-screen"
-      open={isOpen}
-      onClose={() => onOpenChange(false)}
-      transition
-    >
-      <DialogBackdrop
-        transition
-        className={cn(
-          'fixed inset-0 transition duration-200 ease-out data-[closed]:opacity-0',
-          backdrop === 'blur' ? 'bg-black/30 backdrop-blur-md backdrop-saturate-150' : 'bg-black/55'
-        )}
-      />
+  const overlayStyle: CSSProperties =
+    backdrop === 'blur'
+      ? {
+          backgroundColor: 'rgba(0, 0, 0, 0.3)',
+          backdropFilter: 'blur(12px) saturate(150%)',
+          WebkitBackdropFilter: 'blur(12px) saturate(150%)',
+        }
+      : {
+          backgroundColor: 'rgba(0, 0, 0, 0.55)',
+        }
 
-      <div className="fixed inset-0 overflow-y-auto">
-        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-6">
-          <DialogPanel
-            transition
-            className={cn(
-              'relative w-full transform overflow-hidden text-left align-middle shadow-xl transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0',
-              sizeClass[size],
-              panelClassName
-            )}
-          >
-            {showCloseButton && (
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogOverlay style={overlayStyle} />
+      </DialogPortal>
+      <DialogContent
+        showOverlay={false}
+        width={sizeToDialogWidth[size]}
+        position="center"
+        animation="fade"
+        style={{
+          ...neutralizedSurfaceStyle,
+          maxWidth: sizeMaxWidth[size],
+        }}
+        className="overflow-hidden text-left shadow-xl"
+      >
+        <DialogTitle style={visuallyHiddenStyle}>Dialog</DialogTitle>
+        <div className={cn('relative w-full', panelClassName)}>
+          {showCloseButton && (
+            <DialogClose asChild>
               <button
                 type="button"
                 aria-label="Close modal"
-                className="absolute right-1 top-1 select-none appearance-none rounded-full p-2 text-zinc-400 outline-none transition-[background-color,color] [-webkit-tap-highlight-color:transparent] hover:bg-zinc-700/40 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signoz_robin-500 active:bg-zinc-600/40"
-                onClick={() => onOpenChange(false)}
+                className="absolute right-1 top-1 z-10 select-none appearance-none rounded-full p-2 text-zinc-400 outline-none transition-[background-color,color] [-webkit-tap-highlight-color:transparent] hover:bg-zinc-700/40 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signoz_robin-500 active:bg-zinc-600/40"
               >
                 <X className="h-5 w-5" strokeWidth={2} aria-hidden />
               </button>
-            )}
-            {children}
-          </DialogPanel>
+            </DialogClose>
+          )}
+          {children}
         </div>
-      </div>
+      </DialogContent>
     </Dialog>
   )
 }

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -47,24 +47,15 @@ type AppModalProps = {
   showCloseButton?: boolean
 }
 
-const neutralizedSurfaceStyle: CSSProperties = {
-  backgroundColor: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-  borderRadius: 0,
-  padding: 0,
-}
+const transparentDialogSurfaceVars = {
+  '--l2-background': 'var(--l2-background-transparent)',
+  '--l2-border': 'transparent',
+} as CSSProperties
 
-const visuallyHiddenStyle: CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  borderWidth: 0,
+const blurOverlayStyle: CSSProperties = {
+  backgroundColor: 'color-mix(in srgb, var(--bg-ink-500) 30%, transparent)',
+  backdropFilter: 'blur(12px) saturate(150%)',
+  WebkitBackdropFilter: 'blur(12px) saturate(150%)',
 }
 
 export function AppModal({
@@ -76,21 +67,10 @@ export function AppModal({
   backdrop = 'default',
   showCloseButton = true,
 }: AppModalProps) {
-  const overlayStyle: CSSProperties =
-    backdrop === 'blur'
-      ? {
-          backgroundColor: 'rgba(0, 0, 0, 0.3)',
-          backdropFilter: 'blur(12px) saturate(150%)',
-          WebkitBackdropFilter: 'blur(12px) saturate(150%)',
-        }
-      : {
-          backgroundColor: 'rgba(0, 0, 0, 0.55)',
-        }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogPortal>
-        <DialogOverlay style={overlayStyle} />
+        <DialogOverlay {...(backdrop === 'blur' ? { style: blurOverlayStyle } : {})} />
       </DialogPortal>
       <DialogContent
         showOverlay={false}
@@ -98,12 +78,13 @@ export function AppModal({
         position="center"
         animation="fade"
         style={{
-          ...neutralizedSurfaceStyle,
+          ...transparentDialogSurfaceVars,
+          boxShadow: 'none',
           maxWidth: sizeMaxWidth[size],
         }}
         className="overflow-hidden text-left shadow-xl"
       >
-        <DialogTitle style={visuallyHiddenStyle}>Dialog</DialogTitle>
+        <DialogTitle className="sr-only">Dialog</DialogTitle>
         <div className={cn('relative w-full', panelClassName)}>
           {showCloseButton && (
             <DialogClose asChild>

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1,4 +1,5 @@
 @import '@signozhq/design-tokens/dist/style.css';
+@import '@signozhq/design-tokens/dist/themes/signoz-tokens.css';
 
 @tailwind base;
 @tailwind components;
@@ -162,7 +163,8 @@
         height: 90vw;
       }
 
-      background: radial-gradient(
+      background:
+        radial-gradient(
           circle,
           transparent 48%,
           rgba(239, 160, 112, 0.07) 48.18%,
@@ -405,11 +407,12 @@ pre.p-0 {
   --ifm-font-color-base: var(--ifm-color-content);
   --ifm-font-color-base-inverse: var(--ifm-color-content-inverse);
   --ifm-font-color-secondary: var(--ifm-color-content-secondary);
-  --ifm-font-family-base: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans,
-    sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+  --ifm-font-family-base:
+    system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif,
+    BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol';
-  --ifm-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-    'Courier New', monospace;
+  --ifm-font-family-monospace:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   --ifm-font-size-base: 100%;
 
   --ifm-font-weight-light: 300;
@@ -1424,20 +1427,14 @@ html[data-theme='dark'] {
 }
 
 .primary-gradient {
-  background: linear-gradient(
-      273.58deg,
-      rgba(221, 80, 49, 0.9) -2.13%,
-      rgba(255, 108, 75, 0.9) 110.24%
-    ),
+  background:
+    linear-gradient(273.58deg, rgba(221, 80, 49, 0.9) -2.13%, rgba(255, 108, 75, 0.9) 110.24%),
     linear-gradient(93.31deg, #ffb4a4 0.38%, #ff5e3a 100.69%);
   transition: all 0.5s ease-out;
 }
 .primary-gradient:hover {
-  background: linear-gradient(
-      273.58deg,
-      rgba(255, 108, 75, 0.9) -2.13%,
-      rgba(221, 80, 49, 0.9) 110.24%
-    ),
+  background:
+    linear-gradient(273.58deg, rgba(255, 108, 75, 0.9) -2.13%, rgba(221, 80, 49, 0.9) 110.24%),
     linear-gradient(93.31deg, #ff5e3a 0.38%, #ffb4a4 100.69%);
 }
 a.no-underline {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@growthbook/growthbook": "^1.4.1",
-    "@headlessui/react": "^2.0.3",
     "@next/bundle-analyzer": "^16.2.9",
     "@next/third-parties": "^16.2.9",
     "@radix-ui/react-popover": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@signozhq/badge": "^0.0.2",
     "@signozhq/design-tokens": "1.1.4",
     "@signozhq/pagination": "^0.0.1",
+    "@signozhq/ui": "^0.0.23",
     "@stoplight/elements": "^9.0.11",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.12",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@signozhq/badge": "^0.0.2",
-    "@signozhq/design-tokens": "1.1.4",
+    "@signozhq/design-tokens": "2.1.6",
     "@signozhq/pagination": "^0.0.1",
     "@signozhq/ui": "^0.0.23",
     "@stoplight/elements": "^9.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,6 +1121,11 @@
   dependencies:
     css-tree "^3.0.0"
 
+"@chenglou/pretext@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@chenglou/pretext/-/pretext-0.0.5.tgz#1a6734df005c951c6aecaa0decced0d2a82034f2"
+  integrity sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==
+
 "@commitlint/cli@^17.6.7":
   version "17.8.1"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.8.1.tgz#10492114a022c91dcfb1d84dac773abb3db76d33"
@@ -1407,6 +1412,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
+
+"@date-fns/tz@^1.4.1":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.5.0.tgz#e9e79b7583f0b1322c53db884a0112551095e3f3"
+  integrity sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"
@@ -2806,12 +2816,38 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.4.tgz#47ef0f6cff4a1a1c09ebbf6d79159b7f01b967cf"
   integrity sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==
 
+"@radix-ui/primitive@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.5.tgz#cfeb31acbf332c72eb0b13831963c21ad6ca3e32"
+  integrity sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==
+
 "@radix-ui/react-arrow@1.1.10":
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz#67b778e5811d21d2ed6d8e6cafdbe5e6280abeb0"
   integrity sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==
   dependencies:
     "@radix-ui/react-primitive" "2.1.6"
+
+"@radix-ui/react-arrow@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz#be2a068bffe4453bd6941fc44eed1f1ea0e8226f"
+  integrity sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-checkbox@^1.2.3":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.7.tgz#481da0046052ca1abf59208c6c64ec4dc32adfae"
+  integrity sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
 
 "@radix-ui/react-collection@1.1.10":
   version "1.1.10"
@@ -2823,7 +2859,17 @@
     "@radix-ui/react-primitive" "2.1.6"
     "@radix-ui/react-slot" "1.3.0"
 
-"@radix-ui/react-compose-refs@1.1.3":
+"@radix-ui/react-collection@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.12.tgz#1ca96614de0643b39f786f6545c3db0b0e7daa8c"
+  integrity sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-compose-refs@1.1.3", "@radix-ui/react-compose-refs@^1.1.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz#5f1e61e1a5f52800d31e7f8affa6d046e38f50d1"
   integrity sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==
@@ -2832,6 +2878,11 @@
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.4.tgz#5e39f26ebbefed27836e46e763e8f71e09999ccd"
   integrity sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==
+
+"@radix-ui/react-context@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.2.0.tgz#81e75eb5bdeb55bbe019547f13fb5c78598d44e2"
+  integrity sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==
 
 "@radix-ui/react-dialog@^1.1.1":
   version "1.1.17"
@@ -2853,6 +2904,26 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.7.2"
 
+"@radix-ui/react-dialog@^1.1.11", "@radix-ui/react-dialog@^1.1.6":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz#ecdf153deb213c2d92ac02e10955dd288ceb3b3e"
+  integrity sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
 "@radix-ui/react-direction@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.2.tgz#9cc69edd659d79fba4101ee0e2dbcffc2024504f"
@@ -2869,6 +2940,30 @@
     "@radix-ui/react-use-callback-ref" "1.1.2"
     "@radix-ui/react-use-escape-keydown" "1.1.2"
 
+"@radix-ui/react-dismissable-layer@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz#accf8c7b6ec77e7544d2f6c411426d453ca66bcb"
+  integrity sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+
+"@radix-ui/react-dropdown-menu@^2.1.16":
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.20.tgz#dfc4a2fb67a382aed43d26f8d2717bf2d3a393a6"
+  integrity sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-menu" "2.1.20"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
 "@radix-ui/react-focus-guards@1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz#3ef07a117ae7aa1430442aaebd766507e69d391c"
@@ -2883,17 +2978,71 @@
     "@radix-ui/react-primitive" "2.1.6"
     "@radix-ui/react-use-callback-ref" "1.1.2"
 
+"@radix-ui/react-focus-scope@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz#5a8b099c80271a0667ff2e74b25ced3ea58e8ee3"
+  integrity sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+
 "@radix-ui/react-icons@^1.3.0":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.3.2.tgz#09be63d178262181aeca5fb7f7bc944b10a7f441"
   integrity sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==
 
-"@radix-ui/react-id@1.1.2":
+"@radix-ui/react-id@1.1.2", "@radix-ui/react-id@^1.1.0":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.2.tgz#6fe97e7289c7133b44f8c9c61fdddf2a6be1421d"
   integrity sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-menu@2.1.20":
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.1.20.tgz#67416e26e9f0d64e724b8216fca84e68b369cc92"
+  integrity sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-popover@^1.1.15":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.19.tgz#c3c29d5f0be101f36d4d89bda6796f33e1a1de4a"
+  integrity sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
 
 "@radix-ui/react-popover@^1.1.6":
   version "1.1.17"
@@ -2932,12 +3081,36 @@
     "@radix-ui/react-use-size" "1.1.2"
     "@radix-ui/rect" "1.1.2"
 
+"@radix-ui/react-popper@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.3.3.tgz#3f27f929118d8cb8ffced905d33fa887b9e1432b"
+  integrity sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.11"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-rect" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+    "@radix-ui/rect" "1.1.2"
+
 "@radix-ui/react-portal@1.1.12", "@radix-ui/react-portal@^1.0.1":
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.12.tgz#e62f8b5882c71bdda87cf74465ebb6a219a09971"
   integrity sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==
   dependencies:
     "@radix-ui/react-primitive" "2.1.6"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-portal@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.13.tgz#8b80b8b33ef4fff449c6d3ab62492f4dca162c7e"
+  integrity sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
     "@radix-ui/react-use-layout-effect" "1.1.2"
 
 "@radix-ui/react-presence@1.1.6":
@@ -2947,12 +3120,67 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.2"
 
+"@radix-ui/react-presence@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.7.tgz#42b69b29984fb6431338988615bc8b9767814dad"
+  integrity sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
 "@radix-ui/react-primitive@2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz#8e7c170a35d538325a5ff9194f7a842562a1d57d"
   integrity sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==
   dependencies:
     "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-primitive@2.1.7", "@radix-ui/react-primitive@^2.0.2":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz#1f487a06434770f865dbfb6c9a55bbefcbad8c82"
+  integrity sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-progress@^1.1.8":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.12.tgz#b827f000d5cd70dee9887f973ec0000138ca0253"
+  integrity sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==
+  dependencies:
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+
+"@radix-ui/react-radio-group@^1.3.4":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.4.3.tgz#5c7cd85cd607f892ea022b78bf01dfe5597f80f2"
+  integrity sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-roving-focus@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz#fd24daf2b849b201c5e2626e1bf8bcbc57f6a715"
+  integrity sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-is-hydrated" "0.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
 "@radix-ui/react-select@^2.2.5":
   version "2.3.1"
@@ -2982,6 +3210,34 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.7.2"
 
+"@radix-ui/react-select@^2.2.6":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.3.3.tgz#4dbe0554543d481c82c4d2a867641663962bacb8"
+  integrity sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.12"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-visually-hidden" "1.2.7"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
 "@radix-ui/react-slider@^1.2.2":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.4.1.tgz#39f296a8756ecbeaf7334224b19c4590eeaf8a20"
@@ -2999,12 +3255,78 @@
     "@radix-ui/react-use-previous" "1.1.2"
     "@radix-ui/react-use-size" "1.1.2"
 
-"@radix-ui/react-slot@1.3.0", "@radix-ui/react-slot@^1.1.1", "@radix-ui/react-slot@^1.2.0":
+"@radix-ui/react-slider@^1.3.6":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.4.3.tgz#1f07ed15343f3b3efe5bdb571318d86a298365da"
+  integrity sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==
+  dependencies:
+    "@radix-ui/number" "1.1.2"
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-collection" "1.1.12"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-slot@1.3.0", "@radix-ui/react-slot@^1.1.1", "@radix-ui/react-slot@^1.2.0", "@radix-ui/react-slot@^1.2.3":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.3.0.tgz#e311c7a6c8d65b1af9e69af8e3318c6c7105a212"
   integrity sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.3"
+
+"@radix-ui/react-switch@^1.1.4":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.3.3.tgz#1caf4e29983fdc76eb6da61d8cbd61d86d9143cd"
+  integrity sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-use-previous" "1.1.2"
+    "@radix-ui/react-use-size" "1.1.2"
+
+"@radix-ui/react-tabs@^1.1.3":
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz#e236f55e8bd88e5a0bb493628379c57b5bfc4436"
+  integrity sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-toggle-group@^1.1.7":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.15.tgz#15666c92f26cd1c8cd3547b1de67645958136e62"
+  integrity sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-roving-focus" "1.1.15"
+    "@radix-ui/react-toggle" "1.1.14"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-toggle@1.1.14", "@radix-ui/react-toggle@^1.1.6":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.1.14.tgz#76323bdbbb2791009b938b83658a3e7ace00fbcf"
+  integrity sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
 
 "@radix-ui/react-tooltip@^1.1.8":
   version "1.2.10"
@@ -3023,6 +3345,24 @@
     "@radix-ui/react-slot" "1.3.0"
     "@radix-ui/react-use-controllable-state" "1.2.3"
     "@radix-ui/react-visually-hidden" "1.2.6"
+
+"@radix-ui/react-tooltip@^1.2.6":
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.12.tgz#f38a646eda98036e66fd33fc4725621e2f7aa812"
+  integrity sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.5"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.2.0"
+    "@radix-ui/react-dismissable-layer" "1.1.15"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-popper" "1.3.3"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.7"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    "@radix-ui/react-visually-hidden" "1.2.7"
 
 "@radix-ui/react-use-callback-ref@1.1.2":
   version "1.1.2"
@@ -3050,6 +3390,11 @@
   integrity sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==
   dependencies:
     "@radix-ui/react-use-callback-ref" "1.1.2"
+
+"@radix-ui/react-use-is-hydrated@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz#61a18cb03430a6d2e704eb2afd3067505ed0f292"
+  integrity sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==
 
 "@radix-ui/react-use-layout-effect@1.1.2":
   version "1.1.2"
@@ -3081,6 +3426,13 @@
   integrity sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==
   dependencies:
     "@radix-ui/react-primitive" "2.1.6"
+
+"@radix-ui/react-visually-hidden@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz#64fc5994ebd39b3b19f4e93c11da22bf03af684b"
+  integrity sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
 
 "@radix-ui/rect@1.1.2":
   version "1.1.2"
@@ -3514,6 +3866,42 @@
     tailwind-merge "^2.5.2"
     tailwindcss-animate "^1.0.7"
 
+"@signozhq/ui@^0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@signozhq/ui/-/ui-0.0.23.tgz#325c5d11930968a296cd3d5d59565519212e9ed7"
+  integrity sha512-JqIYlVHksPf07rLGWm1mgV+qpaTFfXIrXUdW0YsDN57wnW5Mu2TaMcertegJVJz/XK/sWcUVVCGXwmx1F//wqQ==
+  dependencies:
+    "@chenglou/pretext" "^0.0.5"
+    "@radix-ui/react-checkbox" "^1.2.3"
+    "@radix-ui/react-dialog" "^1.1.11"
+    "@radix-ui/react-dropdown-menu" "^2.1.16"
+    "@radix-ui/react-icons" "^1.3.0"
+    "@radix-ui/react-popover" "^1.1.15"
+    "@radix-ui/react-progress" "^1.1.8"
+    "@radix-ui/react-radio-group" "^1.3.4"
+    "@radix-ui/react-select" "^2.2.6"
+    "@radix-ui/react-slider" "^1.3.6"
+    "@radix-ui/react-slot" "^1.2.3"
+    "@radix-ui/react-switch" "^1.1.4"
+    "@radix-ui/react-tabs" "^1.1.3"
+    "@radix-ui/react-toggle" "^1.1.6"
+    "@radix-ui/react-toggle-group" "^1.1.7"
+    "@radix-ui/react-tooltip" "^1.2.6"
+    "@tanstack/react-table" "^8.21.3"
+    "@tanstack/react-virtual" "^3.13.9"
+    "@types/lodash-es" "^4.17.12"
+    clsx "^2.1.1"
+    cmdk "^1.1.1"
+    copy-text-to-clipboard "^3.2.2"
+    dayjs "^1.11.10"
+    lodash-es "^4.18.1"
+    motion "^11.11.17"
+    next-themes "^0.4.6"
+    nuqs "^2.8.9"
+    react-day-picker "^9.8.1"
+    react-resizable-panels "^4.7.1"
+    sonner "^2.0.7"
+
 "@sigstore/bundle@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-3.1.0.tgz#74f8f3787148400ddd364be8a9a9212174c66646"
@@ -3576,6 +3964,11 @@
   dependencies:
     "@adobe/react-spectrum-workflow" "2.3.5"
     "@swc/helpers" "^0.5.0"
+
+"@standard-schema/spec@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
 
 "@standard-schema/spec@^1.0.0", "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -4066,6 +4459,11 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tabby_ai/hijri-converter@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz#b664994892348a402ae7529e648c819eee39208b"
+  integrity sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==
+
 "@tailwindcss/forms@^0.5.7":
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.11.tgz#e77039e96fa7b87c3d001a991f77f9418e666700"
@@ -4080,12 +4478,24 @@
   dependencies:
     postcss-selector-parser "6.0.10"
 
+"@tanstack/react-table@^8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
+  dependencies:
+    "@tanstack/table-core" "8.21.3"
+
 "@tanstack/react-virtual@^3.13.9":
   version "3.14.4"
   resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz#e7c8469a90d8525d743180a4121f8c6bed1acf82"
   integrity sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==
   dependencies:
     "@tanstack/virtual-core" "3.17.2"
+
+"@tanstack/table-core@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
 
 "@tanstack/virtual-core@3.17.2":
   version "3.17.2"
@@ -4318,6 +4728,18 @@
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.16.8.tgz#80bf3e0814d09a846412a0b0f140946b79c36c3e"
   integrity sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==
+
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.24"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.24.tgz#4ae334fc62c0e915ca8ed8e35dcc6d4eeb29215f"
+  integrity sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==
 
 "@types/mdast@^3.0.0":
   version "3.0.15"
@@ -5543,6 +5965,16 @@ cmd-shim@^7.0.0:
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-7.0.0.tgz#23bcbf69fff52172f7e7c02374e18fb215826d95"
   integrity sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==
 
+cmdk@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "^1.1.1"
+    "@radix-ui/react-dialog" "^1.1.6"
+    "@radix-ui/react-id" "^1.1.0"
+    "@radix-ui/react-primitive" "^2.0.2"
+
 collapse-white-space@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-2.1.0.tgz#640257174f9f42c740b40f3b55ee752924feefca"
@@ -5687,6 +6119,11 @@ cookiejar@^2.1.0:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
+
+copy-text-to-clipboard@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz#99bc79db3f2d355ec33a08d573aff6804491ddb9"
+  integrity sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==
 
 copy-to-clipboard@^3.3.1:
   version "3.3.3"
@@ -5971,10 +6408,25 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns-jalali@4.1.0-0:
+  version "4.1.0-0"
+  resolved "https://registry.yarnpkg.com/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz#9c7fb286004fab267a300d3e9f1ada9f10b4b6b0"
+  integrity sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==
+
 date-fns@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
+date-fns@^4.1.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.4.0.tgz#806539edf45c616b2b76b5f78b88c56ed3c7e036"
+  integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
+
+dayjs@^1.11.10:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
 debounce@^1.2.1:
   version "1.2.1"
@@ -7083,7 +7535,7 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-framer-motion@^11.13.5:
+framer-motion@^11.13.5, framer-motion@^11.18.2:
   version "11.18.2"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.18.2.tgz#0c6bd05677f4cfd3b3bdead4eb5ecdd5ed245718"
   integrity sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==
@@ -9038,6 +9490,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -10316,6 +10773,14 @@ motion-utils@^11.18.1:
   resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-11.18.1.tgz#671227669833e991c55813cf337899f41327db5b"
   integrity sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==
 
+motion@^11.11.17:
+  version "11.18.2"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-11.18.2.tgz#17fb372f3ed94fc9ee1384a25a9068e9da1951e7"
+  integrity sha512-JLjvFDuFr42NFtcVoMAyC2sEjnpA8xpy6qWPyzQvCloznAyQ8FIXioxWfHiLtgYhoVpfUqSWpn1h9++skj9+Wg==
+  dependencies:
+    framer-motion "^11.18.2"
+    tslib "^2.4.0"
+
 mrmime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
@@ -10430,6 +10895,11 @@ next-themes@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.3.0.tgz#b4d2a866137a67d42564b07f3a3e720e2ff3871a"
   integrity sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==
+
+next-themes@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.4.6.tgz#8d7e92d03b8fea6582892a50a928c9b23502e8b6"
+  integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
 next@^16.2.9:
   version "16.2.9"
@@ -10737,6 +11207,13 @@ nth-check@^2.0.0, nth-check@^2.0.1:
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
+
+nuqs@^2.8.9:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/nuqs/-/nuqs-2.9.0.tgz#398efd8c07a46ef1e819c1bf93df176510fd7b5b"
+  integrity sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==
+  dependencies:
+    "@standard-schema/spec" "1.0.0"
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -11451,6 +11928,16 @@ react-aria@3.50.0, react-aria@^3.48.0:
     react-stately "3.48.0"
     use-sync-external-store "^1.6.0"
 
+react-day-picker@^9.8.1:
+  version "9.14.0"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-9.14.0.tgz#b2975b48366d0c3a180520e1a4063b5a7d6c5a57"
+  integrity sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==
+  dependencies:
+    "@date-fns/tz" "^1.4.1"
+    "@tabby_ai/hijri-converter" "1.0.5"
+    date-fns "^4.1.0"
+    date-fns-jalali "4.1.0-0"
+
 react-dom@^19.2.7:
   version "19.2.7"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.7.tgz#0450dc9ae9ddbff76ef196401cd8b8c7fb466ccc"
@@ -11581,6 +12068,11 @@ react-remove-scroll@^2.7.2:
     tslib "^2.1.0"
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
+
+react-resizable-panels@^4.7.1:
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/react-resizable-panels/-/react-resizable-panels-4.12.2.tgz#8402870ef686757c683235496e82771f0fb7f820"
+  integrity sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==
 
 react-router-dom@^6.28.0:
   version "6.30.4"
@@ -12803,6 +13295,11 @@ socks@^2.8.3:
   dependencies:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
+
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,23 +1734,14 @@
     "@floating-ui/core" "^1.7.5"
     "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/react-dom@^2.0.0", "@floating-ui/react-dom@^2.1.2":
+"@floating-ui/react-dom@^2.0.0":
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
   integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
   dependencies:
     "@floating-ui/dom" "^1.7.6"
 
-"@floating-ui/react@^0.26.16":
-  version "0.26.28"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.28.tgz#93f44ebaeb02409312e9df9507e83aab4a8c0dc7"
-  integrity sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==
-  dependencies:
-    "@floating-ui/react-dom" "^2.1.2"
-    "@floating-ui/utils" "^0.2.8"
-    tabbable "^6.0.0"
-
-"@floating-ui/utils@^0.2.11", "@floating-ui/utils@^0.2.8":
+"@floating-ui/utils@^0.2.11":
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
   integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
@@ -1805,17 +1796,6 @@
     long "^5.0.0"
     protobufjs "^7.5.5"
     yargs "^17.7.2"
-
-"@headlessui/react@^2.0.3":
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-2.2.10.tgz#ad69258abcb9efea27a4b37e06e8c9cafd39ca63"
-  integrity sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==
-  dependencies:
-    "@floating-ui/react" "^0.26.16"
-    "@react-aria/focus" "^3.20.2"
-    "@react-aria/interactions" "^3.25.0"
-    "@tanstack/react-virtual" "^3.13.9"
-    use-sync-external-store "^1.5.0"
 
 "@humanfs/core@^0.19.2":
   version "0.19.2"
@@ -3120,23 +3100,6 @@
     "@swc/helpers" "^0.5.0"
     react-aria "^3.48.0"
 
-"@react-aria/focus@^3.20.2":
-  version "3.22.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.22.1.tgz#7e7ba6a2250135728eb68ffa21e422ec25a16800"
-  integrity sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==
-  dependencies:
-    "@swc/helpers" "^0.5.0"
-    react-aria "^3.48.0"
-
-"@react-aria/interactions@^3.25.0":
-  version "3.28.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.28.1.tgz#852294ae63f6a7d8aeeba3a1e7343daa8cd8507c"
-  integrity sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==
-  dependencies:
-    "@react-types/shared" "^3.34.0"
-    "@swc/helpers" "^0.5.0"
-    react-aria "^3.48.0"
-
 "@react-aria/toggle@^3.13.0":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@react-aria/toggle/-/toggle-3.13.1.tgz#f16beceef0d5b3f1f3590e78fb5061844b6ed756"
@@ -3254,7 +3217,7 @@
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.9.0.tgz#d834f3e6e2c992089192f3c83fb7963e3a6f5207"
   integrity sha512-YYksINfR6q92P10AhPEGo47Hd7oz1hrnZ6Vx8Gsrq62IbqDdv1XOTzPBaj17Z1ymNY2pitLUSEXsLmozt4wxxQ==
 
-"@react-types/shared@^3.34.0", "@react-types/shared@^3.36.0", "@react-types/shared@^3.8.0", "@react-types/shared@^3.9.0":
+"@react-types/shared@^3.36.0", "@react-types/shared@^3.8.0", "@react-types/shared@^3.9.0":
   version "3.36.0"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.36.0.tgz#52e713c6bae8e117967bf1d19d89db3a56219037"
   integrity sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==
@@ -13294,11 +13257,6 @@ synckit@^0.11.13:
   dependencies:
     "@pkgr/core" "^0.3.6"
 
-tabbable@^6.0.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.5.0.tgz#a65101385a4fd6cbd580b7546da0170f307b535d"
-  integrity sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==
-
 tailwind-merge@^2.5.2:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.6.1.tgz#a9d58240f664d21c33c379a092d9a273f833443b"
@@ -14054,7 +14012,7 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0, use-sync-external-store@^1.6.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3838,10 +3838,10 @@
     tailwind-merge "^2.5.2"
     tailwindcss-animate "^1.0.7"
 
-"@signozhq/design-tokens@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@signozhq/design-tokens/-/design-tokens-1.1.4.tgz#5d5de5bd9d19b6a3631383db015cc4b70c3f7661"
-  integrity sha512-ICZz5szxTq8NcKAsk6LP+nSybPyEcyy8eu2zfxlPQCnJ1YjJP1PglaKLlF0N6+D60gAd3yC5he06BqR8/HxjNg==
+"@signozhq/design-tokens@2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@signozhq/design-tokens/-/design-tokens-2.1.6.tgz#42af947b19a7cd1bf3ebea14c91250b749d4936a"
+  integrity sha512-n0cH4TRS1Xj7BR38HGiwIBDekIOAnDgl2JyYmAyUvws0L1nlE0txSHO5NiOBJ22Dm8uMva0v5/rOHxpKsGQbsw==
 
 "@signozhq/icons@^0.0.1":
   version "0.0.1"


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Removes the `@headlessui/react` dependency and replaces all usages with `@signozhq/ui` (Radix-based) components and native HTML elements. This aligns the website with the shared SigNoz component library and eliminates a redundant UI dependency.

**Components migrated:**
- `SearchButton` - `Dialog`/`Transition` → `@signozhq/ui/dialog`
- `Modal` - `Dialog`/`Transition` → `@signozhq/ui/dialog`
- `MobileMenu` - `Dialog`/`Transition` → `@signozhq/ui/dialog`
- `OpenInAI` - `Menu`/`Transition` → `@signozhq/ui/dropdown-menu`
- `ResourceCenter/Search` - `Input` → native `<input>`
- `ProductDropdown`, `ResourcesDropdown`, `UseCasesDropdown` - removed unused `@headlessui/react` import

#### Screenshots / Screen Recordings (if applicable)

<details>
<summary><strong>Top Nav</strong></summary>

| Before | After |
|--------|-------|
| <img width="720" alt="01-topnav-before" src="https://github.com/user-attachments/assets/69d6df6c-070a-4022-b675-f8c92a64d956" /> | <img width="720" alt="01-topnav-after" src="https://github.com/user-attachments/assets/09e96109-46d2-4ebb-833f-3e1565d00522" /> |

</details>

<details>
<summary><strong>Product Dropdown</strong></summary>

| Before | After |
|--------|-------|
| <img width="720" alt="02-product-dropdown-before" src="https://github.com/user-attachments/assets/49df3a56-4b23-4b86-bee7-4d8e211d0599" /> | <img width="720" alt="02-product-dropdown-after" src="https://github.com/user-attachments/assets/50e92c16-f306-495a-b601-6c2c31bbdac1" /> |

</details>

<details>
<summary><strong>Resources Dropdown</strong></summary>

| Before | After |
|--------|-------|
| <img width="720" alt="03-resources-dropdown-before" src="https://github.com/user-attachments/assets/c382b25a-deec-4f36-8774-6a9176ddd2f6" /> | <img width="720" alt="03-resources-dropdown-after" src="https://github.com/user-attachments/assets/4166421e-0f9a-43eb-a8eb-4b937d6b773d" /> |

</details>

<details>
<summary><strong>Use Cases Dropdown</strong></summary>

| Before | After |
|--------|-------|
| <img width="720" alt="04-usecases-dropdown-before" src="https://github.com/user-attachments/assets/c639906e-19fd-43f3-a276-2fbac1e642cd" /> | <img width="720" alt="04-usecases-dropdown-after" src="https://github.com/user-attachments/assets/fd19cf75-fcab-4372-91d5-cd3369701a1a" /> |

</details>

<details>
<summary><strong>Search Modal (Cmd+K)</strong></summary>

| Before | After |
|--------|-------|
| <img width="720" alt="05-search-modal-before" src="https://github.com/user-attachments/assets/52c9a584-cee0-4d09-b436-29221dd3962d" /> | <img width="720" alt="05-search-modal-after" src="https://github.com/user-attachments/assets/e044ad7e-197f-4df9-b13b-31ca4a03a2a1" /> |

</details>

<details>
<summary><strong>OpenInAI - Closed</strong></summary>

| Before | After |
|--------|-------|
| <img width="300" alt="06-open-in-ai-closed-before" src="https://github.com/user-attachments/assets/93c428dc-36e7-47ef-9df2-1eef82a67691" /> | <img width="300" alt="06-open-in-ai-closed-after" src="https://github.com/user-attachments/assets/14c0b192-4a05-406a-b2cb-d3a86694b978" /> |

</details>

<details>
<summary><strong>OpenInAI - Dropdown Open</strong></summary>

| Before | After |
|--------|-------|
| <img width="300" alt="07-open-in-ai-opened-before" src="https://github.com/user-attachments/assets/caecbef2-4e67-4032-9825-9ca14670079f" /> | <img width="300" alt="07-open-in-ai-opened-after" src="https://github.com/user-attachments/assets/a6701bd7-a6b0-4893-acf1-0e26199efd31" /> |

</details>

<details>
<summary><strong>Resource Center Search</strong></summary>

| Before | After |
|--------|-------|
| <img width="370" alt="08-resource-center-search-before" src="https://github.com/user-attachments/assets/2c9e6dbe-5492-4e67-b191-c9c4486992b8" /> | <img width="370" alt="08-resource-center-search-after" src="https://github.com/user-attachments/assets/e218f03e-e175-4b22-a4e0-9f4b68202a4c" /> |

</details>

<details>
<summary><strong>Mobile Top Nav</strong></summary>

| Before | After |
|--------|-------|
| <img width="195" alt="09-mobile-topnav-before" src="https://github.com/user-attachments/assets/75dab99b-e4f1-4041-88cd-74fed5e4cd2e" /> | <img width="195" alt="09-mobile-topnav-after" src="https://github.com/user-attachments/assets/f01a50c5-70f2-4b9b-a6bf-a7b8ab2a3f27" /> |

</details>

<details>
<summary><strong>Mobile Menu</strong></summary>

| Before | After |
|--------|-------|
| <img width="195" alt="10-mobile-menu-opened-before" src="https://github.com/user-attachments/assets/4b404407-a96e-4276-9bff-35e5bb38095d" /> | <img width="195" alt="10-mobile-menu-opened-after" src="https://github.com/user-attachments/assets/f8f89bff-3610-4a54-9298-c61a437d7a3f" /> |

</details>


#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/4342 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A - no behavioral changes
- Manual verification: Before/after screenshots of every migrated component across desktop and mobile viewports
- Edge cases covered:
  - Search modal open/close with keyboard shortcut
  - OpenInAI dropdown menu positioning and background opacity
  - Mobile hamburger menu slide-in/out and scroll behavior
  - Resource center search input focus styling
  - Top nav hover dropdowns (Product, Resources, Use Cases)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: UI-only - affects top nav, search, docs header, mobile menu, resource center search, and modal components
- Potential regressions: Styling differences from `@signozhq/ui` CSS module specificity (mitigated with inline styles where needed)
- Rollback plan: Revert the PR

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- `@signozhq/ui` CSS modules have higher specificity than Tailwind, so several components use inline `style` props to override background/border/z-index (see comments in code). This will be replaced with semantic tokens when properly hooking up design tokens for light and dark mode in future.
- The `ResourceCenter/Search` uses a native `<input>` instead of `@signozhq/ui/input` because the original headlessui `Input` was just a thin wrapper - the signozhq Input brought CSS module conflicts for this use case.
- The dropdowns (Product, Resources, Use Cases) only had an unused `Popover` import from headlessui removed - they already used native hover-based dropdowns.

---
