### PR TITLE
docs: update Trace Explorer export documentation

### DIFF
--- a/data/docs/userguide/traces.mdx
+++ b/data/docs/userguide/traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: 2026-07-15
 title: Trace Explorer
 description: Understand the Trace Explorer in SigNoz — views, filtering, trace matching, and how to save and act on your results.
 doc_type: explanation
@@ -105,6 +105,28 @@ Both Time Series and Table views use the Query Builder for filtering, aggregatio
   alt="Query Builder showing Group By, Having, Order By, and Limit fields"
   caption="Query Builder in Time Series and Table views"
 />
+
+## Export Spans and Traces
+
+The **Download** button exports the current results to a file. It appears in the top-right controls of both the [List View](#list-view) and the [Traces View](#traces-view), next to the per-page dropdown.
+
+To export your results:
+
+1. Apply the filters and span scope you want to export. The export honors your current filters and the selected time range.
+2. Click the **Download** icon in the top-right controls.
+3. In the popover, choose a **Format** and the **Number of Rows** to export.
+4. Click **Export** to download the file.
+
+The popover offers the same options in both views:
+
+| Option | Choices | Default |
+|---|---|---|
+| **Format** | `csv`, `jsonl` | `csv` |
+| **Number of Rows** | `10k`, `30k`, `50k` | `10k` |
+
+<Admonition>
+The Download button is available in both the List View and the Traces View, with identical format and row-limit options. To export chart data instead of individual rows, use the download control in the [Time Series View](#time-series-view).
+</Admonition>
 
 ## Trace Matching
 


### PR DESCRIPTION
## Summary
- Added an **Export Spans and Traces** section to the Trace Explorer page (`data/docs/userguide/traces.mdx`) documenting the Download button.
- Documented that the Download button is now available in the **Traces (root spans) view** in addition to the List view (PR #12116), with a note that the options are identical across both views.
- Documented export options verified from source: **Format** (`csv`, `jsonl`; default `csv`) and **Number of Rows** (`10k`, `30k`, `50k`; default `10k`). The Columns scope option is not offered for traces in either view (both use `DataSource.TRACES`).
- Added a pointer distinguishing row export from Time Series chart-data export.
- Updated the frontmatter `date` to 2026-07-15.

## Open questions / notes
- **`docs not required` label on #12116** — this label is present on the source PR. Overriding per the docs-sync convention that export parity is user-facing; flagging for author confirmation.
- **Export parity (resolved)** — formats and row limits are identical between the List view and the new Traces view. Both pass `DataSource.TRACES`, so neither offers the Columns (All/Selected) scope that the Logs export provides. No Traces-view-specific constraints.
- **Screenshots pending** — demo credentials are not provisioned in this run and the demo lags today's merge, so this update is prose-only. Screenshots of the Download button and popover in both views to follow.
- **Table-tab export (PR #12070)** — infrastructure-only, no UI wired yet. Tracked as a follow-on; no docs action this batch.

Source PRs: #12116

Auto-generated by docs-sync pipeline