### PR TITLE
docs: add S3-compatible object storage section to the S3 retention tutorial

### DIFF
--- a/data/docs/tutorial/infinite-retention-aws-s3.mdx
+++ b/data/docs/tutorial/infinite-retention-aws-s3.mdx
@@ -165,7 +165,7 @@ exporters:
       s3_bucket: '<bucket-name>'
       s3_prefix: 'logs'
       compression: gzip
-      endpoint: 'https://t3.storage.dev'
+      endpoint: '<s3-compatible-endpoint>'
       s3_force_path_style: true
 ```
 

--- a/data/docs/tutorial/infinite-retention-aws-s3.mdx
+++ b/data/docs/tutorial/infinite-retention-aws-s3.mdx
@@ -146,6 +146,44 @@ For the full list of configuration options, see the <a href="https://github.com/
 
 </details>
 
+<details>
+<ToggleHeading>
+## Using S3-Compatible Object Storage
+</ToggleHeading>
+
+The `awss3` exporter works with any S3-compatible object store, for example <a href="https://min.io" target="_blank" rel="noopener noreferrer nofollow">MinIO</a>, <a href="https://developers.cloudflare.com/r2/" target="_blank" rel="noopener noreferrer nofollow">Cloudflare R2</a>, or <a href="https://www.tigrisdata.com" target="_blank" rel="noopener noreferrer nofollow">Tigris</a>. Set `endpoint` to the store's URL and enable path-style requests:
+
+```yaml:otel-collector-config.yaml
+exporters:
+  awss3/logs:
+    s3uploader:
+      region: 'auto'
+      s3_bucket: '<bucket-name>'
+      s3_prefix: 'logs'
+      compression: gzip
+      endpoint: 'https://t3.storage.dev'
+      s3_force_path_style: true
+```
+
+Replace the placeholders:
+
+- `endpoint`: your store's URL. The example shows Tigris; a local MinIO would be `http://localhost:9000`.
+- `region`: still required by the AWS SDK, but the expected value depends on the store. Use `auto` for Tigris and Cloudflare R2, and `us-east-1` for a default MinIO deployment.
+
+Two of the options above behave differently outside AWS:
+
+- Provide credentials as a static key pair via the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. `role_arn` requires STS, which most S3-compatible stores do not implement.
+- `storage_class` values are AWS-specific. Leave the default unless your store documents support for them.
+
+To validate, point the AWS CLI at the same endpoint:
+
+```bash
+aws s3 ls s3://<bucket-name>/logs/ --recursive \
+  --endpoint-url https://t3.storage.dev | head
+```
+
+</details>
+
 ## Validate in S3
 
 This data will not appear in the SigNoz UI — verify delivery directly in S3. After deploying your updated Collector config, check that objects are appearing in your bucket:
@@ -187,6 +225,11 @@ If no objects appear, check the Collector logs for S3 permission errors or confi
 
 - Confirm you are using the `otelcol-contrib` distribution, which includes the `awss3` exporter. The core `otelcol` distribution does not include it.
 - Check YAML indentation and that exporter names use the `type/name` format with a forward slash (e.g., `awss3/logs`, not `awss3logs`).
+
+**`SignatureDoesNotMatch` or `301 Moved Permanently` with an S3-compatible store**
+
+- Set `region` to the value your store expects. Some stores validate the request signing region.
+- Confirm `s3_force_path_style: true` is set. Most non-AWS stores expect path-style requests.
 
 </details>
 

--- a/data/docs/tutorial/infinite-retention-aws-s3.mdx
+++ b/data/docs/tutorial/infinite-retention-aws-s3.mdx
@@ -153,6 +153,10 @@ For the full list of configuration options, see the <a href="https://github.com/
 
 The `awss3` exporter works with any S3-compatible object store, for example <a href="https://min.io" target="_blank" rel="noopener noreferrer nofollow">MinIO</a>, <a href="https://developers.cloudflare.com/r2/" target="_blank" rel="noopener noreferrer nofollow">Cloudflare R2</a>, or <a href="https://www.tigrisdata.com" target="_blank" rel="noopener noreferrer nofollow">Tigris</a>. Set `endpoint` to the store's URL and enable path-style requests:
 
+<Admonition type="note">
+The AWS S3 Exporter is at **alpha** stability for traces, metrics, and logs. Its configuration can change between Collector releases.
+</Admonition>
+
 ```yaml:otel-collector-config.yaml
 exporters:
   awss3/logs:

--- a/data/docs/tutorial/infinite-retention-aws-s3.mdx
+++ b/data/docs/tutorial/infinite-retention-aws-s3.mdx
@@ -165,10 +165,11 @@ exporters:
       s3_force_path_style: true
 ```
 
-Replace the placeholders:
+**Verify these values:**
 
-- `endpoint`: your store's URL. The example shows Tigris; a local MinIO would be `http://localhost:9000`.
-- `region`: still required by the AWS SDK, but the expected value depends on the store. Use `auto` for Tigris and Cloudflare R2, and `us-east-1` for a default MinIO deployment.
+- `<bucket-name>`: your bucket name
+- `<s3-compatible-endpoint>`: your store's URL (e.g., `https://t3.storage.dev` for Tigris, `http://localhost:9000` for a local MinIO)
+- `region`: defaults to `us-east-1`. Set the value your store expects: `auto` for Tigris and Cloudflare R2, `us-east-1` for a default MinIO deployment.
 
 Two of the options above behave differently outside AWS:
 

--- a/data/docs/tutorial/infinite-retention-aws-s3.mdx
+++ b/data/docs/tutorial/infinite-retention-aws-s3.mdx
@@ -184,7 +184,7 @@ To validate, point the AWS CLI at the same endpoint:
 
 ```bash
 aws s3 ls s3://<bucket-name>/logs/ --recursive \
-  --endpoint-url https://t3.storage.dev | head
+  --endpoint-url <s3-compatible-endpoint> | head
 ```
 
 </details>


### PR DESCRIPTION
The infinite-retention tutorial already hints that the `awss3` exporter works
beyond AWS — `endpoint` and `s3_force_path_style` are listed in the options —
but there's no working recipe, so folks using MinIO, R2, Tigris, etc. have to
piece it together themselves and usually hit the same two errors on the way
(`SignatureDoesNotMatch` from the signing region, 301s from addressing style).

This adds a small collapsible section with a complete non-AWS config: which
region value different stores expect, that credentials must be a static key
pair since most S3-compatible stores don't do STS, and how to validate with
`aws s3 ls --endpoint-url`. Plus one troubleshooting entry for those two
errors. Follows the existing page's ToggleHeading pattern and authoring rules.
