### PR TITLE
feat(infra-monitoring): docs for Pod Metric Charts

### DIFF
--- a/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/daemonsets.mdx
@@ -111,7 +111,7 @@ The **DaemonSets** view shows rollout status and aggregated resource usage. If A
 
 ## DaemonSet Detail Page
 
-Click a DaemonSet name to open the detail page. The header shows **DaemonSet Name**, **Cluster Name**, and **Namespace Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+Click a DaemonSet name to open the detail page. The header shows **DaemonSet Name**, **Cluster Name**, and **Namespace Name**. The detail page includes five tabs: **Metrics**, **Logs**, **Traces**, **Events**, and **Pod Metrics**.
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-daemonsets-detail.webp"
@@ -145,3 +145,37 @@ Click a DaemonSet name to open the detail page. The header shows **DaemonSet Nam
 - This chart relies on the OTel metric `k8s.pod.network.errors` from the kubeletstats receiver — a cumulative Sum with attributes `direction` and `interface`, shown as a per-second increase and aggregated across the DaemonSet's pods.
 - One line per `direction :: interface` combination, sourced from the kubelet's per-pod-interface error counters.
 - Sustained non-zero values warrant attention — common causes are misconfigured CNI plugins, MTU mismatches, or faulty NICs on the underlying nodes; correlate with the **Node Detail → Network Errors** chart on the specific node(s) hosting the DaemonSet's pods.
+
+### Pod Metrics
+
+The **Pod Metrics** tab breaks resource utilization down **per pod** across every pod in the DaemonSet (a DaemonSet runs one pod per node, so each line is effectively one node). All charts are scoped to this DaemonSet (filtered by `k8s.cluster.name`, `k8s.namespace.name`, and `k8s.daemonset.name`), grouped by `k8s.pod.name` (one line per pod), averaged within each step interval, and expressed as a percentage.
+
+#### CPU Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_limit_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU limits, emitted directly as a ratio.
+- Plots one line per pod in the DaemonSet, each showing that pod's CPU usage against its CPU limit; values near 100% mean the kernel is actively throttling that pod's CPU.
+- Use it to pinpoint *which* node's pod is throttled — a single line hugging 100% while the rest sit low points to one node carrying more work, whereas all pods running high means the DaemonSet's `limits.cpu` is too low for the workload.
+
+#### CPU Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU requests.
+- Plots one line per pod in the DaemonSet, each showing usage against its CPU request; values above 100% mean the pod is using more CPU than it reserved (allowed, but a sign the request is low).
+- Use it to judge reservation accuracy per pod — pods consistently far below 100% are over-provisioned, pods above it are under-requested; since a DaemonSet runs one pod per node, uneven values reflect differing per-node load.
+
+#### Memory Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_limit_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory limits.
+- Plots one line per pod in the DaemonSet, each showing that pod's memory usage against its memory limit; a line at or near 100% is a pod on the verge of an OOMKill.
+- Use it to isolate the node whose pod is at risk — a steady per-pod climb is a memory-leak signature on that node; raise `limits.memory` or fix the leak.
+
+#### Memory Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_request_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory requests.
+- Plots one line per pod in the DaemonSet, each showing usage against its memory request; values above 100% mean the pod exceeds its reservation.
+- Use it to right-size `requests.memory` and catch per-node imbalance — pods well below 100% reserve memory they never use, while pods above it risk eviction first under node memory pressure.
+
+#### FileSystem Usage Percentage By Pod Name
+
+- This chart is derived from two kubeletstats metrics — `k8s.pod.filesystem.usage` (bytes used) divided by `k8s.pod.filesystem.capacity` (total bytes); only the computed ratio is plotted, not the raw metrics.
+- Plots one line per pod in the DaemonSet, each showing that pod's local/ephemeral filesystem fill level as a percentage of its capacity.
+- Watch any pod trending toward 100% — that node's pod is filling its ephemeral storage (unrotated logs, cached artifacts, temp files) and writes will start failing or the pod may be evicted; the line isolates the node.

--- a/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/deployments.mdx
@@ -99,7 +99,7 @@ The **Deployments** view shows aggregated resource usage across all pods in each
 
 ## Deployment Detail Page
 
-Click a Deployment name to open the detail page. The header shows **Deployment Name**, **Cluster Name**, and **Namespace Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+Click a Deployment name to open the detail page. The header shows **Deployment Name**, **Cluster Name**, and **Namespace Name**. The detail page includes five tabs: **Metrics**, **Logs**, **Traces**, **Events**, and **Pod Metrics**.
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-deployments-detail.webp"
@@ -133,3 +133,37 @@ Click a Deployment name to open the detail page. The header shows **Deployment N
 - This chart relies on the OTel metric `k8s.pod.network.errors` from the kubeletstats receiver — a cumulative Sum with attributes `direction` and `interface`, shown as a per-second increase and aggregated across the Deployment's pods.
 - One line per `direction :: interface` combination, sourced from the kubelet's per-pod-interface error counters.
 - Sustained non-zero values warrant attention — common causes are misconfigured CNI plugins, MTU mismatches, or faulty NICs on the underlying nodes; correlate with the **Node Detail → Network Errors** chart on the specific node(s) hosting the Deployment's pods.
+
+### Pod Metrics
+
+The **Pod Metrics** tab breaks resource utilization down **per pod** across every pod in the Deployment. All charts are scoped to this Deployment (filtered by `k8s.cluster.name`, `k8s.namespace.name`, and `k8s.deployment.name`), grouped by `k8s.pod.name` (one line per pod), averaged within each step interval, and expressed as a percentage.
+
+#### CPU Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_limit_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU limits, emitted directly as a ratio.
+- Plots one line per pod in the Deployment, each showing that pod's CPU usage against its CPU limit; values near 100% mean the kernel is actively throttling that pod's CPU.
+- Use it to pinpoint *which* replica is throttled — a single line hugging 100% while the rest sit low points to a hot pod or uneven load balancing, whereas all pods running high means the Deployment's `limits.cpu` is too low.
+
+#### CPU Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU requests.
+- Plots one line per pod in the Deployment, each showing usage against its CPU request; values above 100% mean the pod is using more CPU than it reserved (allowed, but a sign the request is low).
+- Use it to judge reservation accuracy per replica — pods consistently far below 100% are over-provisioned, pods above it are under-requested; uneven values across identical replicas usually indicate skewed traffic rather than a sizing problem.
+
+#### Memory Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_limit_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory limits.
+- Plots one line per pod in the Deployment, each showing that pod's memory usage against its memory limit; a line at or near 100% is a pod on the verge of an OOMKill.
+- Use it to isolate the replica at risk — a steady per-pod climb is a memory-leak signature confined to that pod; raise `limits.memory` or fix the leak rather than scaling the whole Deployment.
+
+#### Memory Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_request_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory requests.
+- Plots one line per pod in the Deployment, each showing usage against its memory request; values above 100% mean the pod exceeds its reservation.
+- Use it to right-size `requests.memory` per replica and catch imbalance — pods well below 100% reserve memory they never use, while pods above it risk eviction first under node memory pressure.
+
+#### FileSystem Usage Percentage By Pod Name
+
+- This chart is derived from two kubeletstats metrics — `k8s.pod.filesystem.usage` (bytes used) divided by `k8s.pod.filesystem.capacity` (total bytes); only the computed ratio is plotted, not the raw metrics.
+- Plots one line per pod in the Deployment, each showing that pod's local/ephemeral filesystem fill level as a percentage of its capacity.
+- Watch any pod trending toward 100% — its ephemeral storage is filling (unrotated logs, cached artifacts, temp files) and writes will start failing or the pod may be evicted; a single climbing line isolates the culprit replica.

--- a/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/jobs.mdx
@@ -111,7 +111,7 @@ The **Jobs** view tracks job completion status alongside resource consumption, u
 
 ## Job Detail Page
 
-Click a Job name to open the detail page. The header shows **Job Name**, **Cluster Name**, and **Namespace Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+Click a Job name to open the detail page. The header shows **Job Name**, **Cluster Name**, and **Namespace Name**. The detail page includes five tabs: **Metrics**, **Logs**, **Traces**, **Events**, and **Pod Metrics**.
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-jobs-detail.webp"
@@ -145,3 +145,37 @@ Click a Job name to open the detail page. The header shows **Job Name**, **Clust
 - This chart relies on the OTel metric `k8s.pod.network.errors` from the kubeletstats receiver — a cumulative Sum with attributes `direction` and `interface`, shown as a per-second increase and aggregated across the Job's pods.
 - One line per `direction :: interface` combination, sourced from the kubelet's per-pod-interface error counters.
 - Sustained non-zero values warrant attention — common causes are misconfigured CNI plugins, MTU mismatches, or faulty NICs on the underlying nodes; correlate with the **Node Detail → Network Errors** chart on the specific node(s) hosting the Job's pods.
+
+### Pod Metrics
+
+The **Pod Metrics** tab breaks resource utilization down **per pod** across every pod the Job runs (including parallel and retried pods). All charts are scoped to this Job (filtered by `k8s.cluster.name`, `k8s.namespace.name`, and `k8s.job.name`), grouped by `k8s.pod.name` (one line per pod), averaged within each step interval, and expressed as a percentage.
+
+#### CPU Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_limit_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU limits, emitted directly as a ratio.
+- Plots one line per pod in the Job, each showing that pod's CPU usage against its CPU limit; values near 100% mean the kernel is actively throttling that pod's CPU.
+- Use it to pinpoint *which* of the Job's pods is throttled — a single line hugging 100% while the rest sit low points to one pod doing more work, whereas all pods running high means the Job's `limits.cpu` is too low.
+
+#### CPU Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU requests.
+- Plots one line per pod in the Job, each showing usage against its CPU request; values above 100% mean the pod is using more CPU than it reserved (allowed, but a sign the request is low).
+- Use it to judge reservation accuracy per pod — pods consistently far below 100% are over-provisioned, while pods above it are under-requested and may crowd their node.
+
+#### Memory Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_limit_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory limits.
+- Plots one line per pod in the Job, each showing that pod's memory usage against its memory limit; a line at or near 100% is a pod on the verge of an OOMKill.
+- Use it to isolate the pod at risk — a steady climb toward the limit is what precedes an OOMKill; raise `limits.memory` or reduce the per-pod workload.
+
+#### Memory Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_request_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory requests.
+- Plots one line per pod in the Job, each showing usage against its memory request; values above 100% mean the pod exceeds its reservation.
+- Use it to right-size `requests.memory` — pods well below 100% reserve memory they never use, while pods above it risk eviction first under node memory pressure.
+
+#### FileSystem Usage Percentage By Pod Name
+
+- This chart is derived from two kubeletstats metrics — `k8s.pod.filesystem.usage` (bytes used) divided by `k8s.pod.filesystem.capacity` (total bytes); only the computed ratio is plotted, not the raw metrics.
+- Plots one line per pod in the Job, each showing that pod's local/ephemeral filesystem fill level as a percentage of its capacity.
+- Watch any pod trending toward 100% — its ephemeral storage is filling (output files, downloaded data, temp files) and writes will start failing or the pod may be evicted before the Job completes.

--- a/data/docs/infrastructure-monitoring/kubernetes/namespaces.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/namespaces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-07-16
 title: Namespaces
 description: Monitor Kubernetes namespace resource usage in SigNoz — aggregated CPU and memory, top pods, network activity, and workload health.
 doc_type: explanation
@@ -54,7 +54,7 @@ The **Namespaces** view shows aggregated resource usage per namespace, useful fo
 
 ## Namespace Detail Page
 
-Click a namespace name to open the detail page. The header shows **Namespace Name** and **Cluster Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+Click a namespace name to open the detail page. The header shows **Namespace Name** and **Cluster Name**. The detail page includes five tabs: **Metrics**, **Logs**, **Traces**, **Events**, and **Pod Metrics**.
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-namespaces-detail.webp"
@@ -124,3 +124,37 @@ Click a namespace name to open the detail page. The header shows **Namespace Nam
 - This chart relies on the OTel metrics `k8s.deployment.desired` and `k8s.deployment.available` from the k8s_cluster receiver, rendered as a table with one row per Deployment in the namespace; an extra column shows the `available/desired` utilization as a percentage.
 - **Desired** is `.spec.replicas`; **Available** is pods ready for at least `minReadySeconds` (`.status.availableReplicas`).
 - Available % consistently below 100% means a rollout is stuck or pods are crashing — `kubectl rollout status deployment/<name>` and pod events surface the root cause (image-pull failure, readiness-probe failure, insufficient capacity).
+
+### Pod Metrics
+
+The **Pod Metrics** tab breaks resource utilization down **per pod** across every pod in the namespace, spanning all of its workloads. All charts are scoped to this namespace (filtered by `k8s.cluster.name` and `k8s.namespace.name`), grouped by `k8s.pod.name` (one line per pod), averaged within each step interval, and expressed as a percentage.
+
+#### CPU Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_limit_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU limits, emitted directly as a ratio.
+- Plots one line per pod in the namespace, each showing that pod's CPU usage against its CPU limit; values near 100% mean the kernel is actively throttling that pod's CPU.
+- Use it to spot which pod in the namespace is being throttled across all its workloads — a single hot line isolates one pod, while broadly high utilization suggests limits are set too low across the namespace's workloads.
+
+#### CPU Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU requests.
+- Plots one line per pod in the namespace, each showing usage against its CPU request; values above 100% mean the pod is using more CPU than it reserved (allowed, but a sign the request is low).
+- Use it to find over- and under-provisioned pods across the namespace — pods far below 100% waste reserved capacity, while pods above it are under-requested and may crowd their node.
+
+#### Memory Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_limit_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory limits.
+- Plots one line per pod in the namespace, each showing that pod's memory usage against its memory limit; a line at or near 100% is a pod on the verge of an OOMKill.
+- Use it to catch the pod at OOMKill risk anywhere in the namespace — a steady per-pod climb is a memory-leak signature; raise that workload's `limits.memory` or fix the leak.
+
+#### Memory Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_request_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory requests.
+- Plots one line per pod in the namespace, each showing usage against its memory request; values above 100% mean the pod exceeds its reservation.
+- Use it to right-size memory requests across the namespace's workloads — pods well below 100% reserve memory they never use, while pods above it risk eviction first under node memory pressure.
+
+#### FileSystem Usage Percentage By Pod Name
+
+- This chart is derived from two kubeletstats metrics — `k8s.pod.filesystem.usage` (bytes used) divided by `k8s.pod.filesystem.capacity` (total bytes); only the computed ratio is plotted, not the raw metrics.
+- Plots one line per pod in the namespace, each showing that pod's local/ephemeral filesystem fill level as a percentage of its capacity.
+- Watch any pod trending toward 100% — its ephemeral storage is filling (unrotated logs, cached artifacts, temp files) and writes will start failing or the pod may be evicted; the line isolates the culprit pod.

--- a/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/statefulsets.mdx
@@ -99,7 +99,7 @@ The **StatefulSets** view shows rollout status and resource utilization. Statefu
 
 ## StatefulSet Detail Page
 
-Click a StatefulSet name to open the detail page. The header shows **StatefulSet Name** and **Namespace Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+Click a StatefulSet name to open the detail page. The header shows **StatefulSet Name** and **Namespace Name**. The detail page includes five tabs: **Metrics**, **Logs**, **Traces**, **Events**, and **Pod Metrics**.
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-statefulsets-detail.webp"
@@ -145,3 +145,37 @@ Click a StatefulSet name to open the detail page. The header shows **StatefulSet
 - This chart relies on the OTel metric `k8s.pod.network.errors` from the kubeletstats receiver — a cumulative Sum with attributes `direction` and `interface`, shown as a per-second increase and aggregated across the StatefulSet's pods.
 - One line per `direction :: interface` combination, sourced from the kubelet's per-pod-interface error counters.
 - Sustained non-zero values warrant attention — common causes are misconfigured CNI plugins, MTU mismatches, or faulty NICs on the underlying nodes; correlate with the **Node Detail → Network Errors** chart on the specific node(s) hosting the StatefulSet's pods.
+
+### Pod Metrics
+
+The **Pod Metrics** tab breaks resource utilization down **per pod** across every pod in the StatefulSet. All charts are scoped to this StatefulSet (filtered by `k8s.cluster.name`, `k8s.namespace.name`, and `k8s.statefulset.name`), grouped by `k8s.pod.name` (one line per pod), averaged within each step interval, and expressed as a percentage.
+
+#### CPU Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_limit_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU limits, emitted directly as a ratio.
+- Plots one line per pod in the StatefulSet, each showing that pod's CPU usage against its CPU limit; values near 100% mean the kernel is actively throttling that pod's CPU.
+- Use it to pinpoint *which* replica is throttled — a single line hugging 100% while the rest sit low points to a hot pod or uneven load balancing, whereas all pods running high means the StatefulSet's `limits.cpu` is too low.
+
+#### CPU Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.cpu_request_utilization` from the kubeletstats receiver — a pod's CPU usage as a fraction of the sum of its containers' CPU requests.
+- Plots one line per pod in the StatefulSet, each showing usage against its CPU request; values above 100% mean the pod is using more CPU than it reserved (allowed, but a sign the request is low).
+- Use it to judge reservation accuracy per replica — pods consistently far below 100% are over-provisioned, pods above it are under-requested; uneven values across identical replicas usually indicate skewed traffic rather than a sizing problem.
+
+#### Memory Limit Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_limit_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory limits.
+- Plots one line per pod in the StatefulSet, each showing that pod's memory usage against its memory limit; a line at or near 100% is a pod on the verge of an OOMKill.
+- Use it to isolate the replica at risk — a steady per-pod climb is a memory-leak signature confined to that pod; raise `limits.memory` or fix the leak rather than scaling the whole StatefulSet.
+
+#### Memory Request Utilization By Pod Name
+
+- This chart relies on the OTel metric `k8s.pod.memory_request_utilization` from the kubeletstats receiver — a pod's memory usage as a fraction of the sum of its containers' memory requests.
+- Plots one line per pod in the StatefulSet, each showing usage against its memory request; values above 100% mean the pod exceeds its reservation.
+- Use it to right-size `requests.memory` per replica and catch imbalance — pods well below 100% reserve memory they never use, while pods above it risk eviction first under node memory pressure.
+
+#### FileSystem Usage Percentage By Pod Name
+
+- This chart is derived from two kubeletstats metrics — `k8s.pod.filesystem.usage` (bytes used) divided by `k8s.pod.filesystem.capacity` (total bytes); only the computed ratio is plotted, not the raw metrics.
+- Plots one line per pod in the StatefulSet, each showing that pod's local/ephemeral filesystem fill level as a percentage of its capacity.
+- Watch any pod trending toward 100% — its ephemeral storage is filling (unrotated logs, cached artifacts, temp files) and writes will start failing or the pod may be evicted; a single climbing line isolates the culprit replica.


### PR DESCRIPTION
## Pull Request

### 📄 Summary

Documents the new **Pod Metrics** tab added to the infra-monitoring workload detail pages. The tab breaks resource utilization down per pod across a workload's constituent pods, and had no docs. Adds a `### Pod Metrics` section (5 charts each) to **Deployments, StatefulSets, DaemonSets, Jobs, and Namespaces**, in the existing 3-bullet chart style (metric → what it plots → use case).

Part of SigNoz/engineering-pod#5640

---

### ✅ Change Type

- [x] ✨ Feature (docs)

---

### 🧪 Testing Strategy

- Manual verification: `yarn check:docs-metadata` + `yarn check:doc-redirects` pass. Anchors-only, no new URLs → no redirects needed.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Docs for the new per-pod **Pod Metrics** charts (CPU/Memory limit & request utilization, filesystem usage) on the Deployments, StatefulSets, DaemonSets, Jobs, and Namespaces detail pages. |

---

## 👀 Notes for Reviewers

- The 5 charts are identical across entities (only the workload filter key differs), so the section is a reused block with per-entity tailoring: **DaemonSets** reframed to per-node pods (no "replica"), **Jobs** notes parallel/retried pods, **Namespaces** filters by cluster + namespace only (pods span all workloads).
- Bumped `namespaces.mdx` `date` (stale); other 4 files already current.