### PR TITLE
docs: document K8s Instrumentation checks panel

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-16
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -144,6 +144,10 @@ with their performance metrics.
     <img className="box-shadowed-image" src="/img/docs/infrastructure-monitoring/kubernetes-list.webp" alt="Kubernetes Cluster View"/>
     <figcaption><i>Kubernetes Cluster Overview</i></figcaption>
 </figure>
+
+<Admonition type="info">
+When SigNoz detects that Kubernetes monitoring is not fully configured for an entity type, an **Instrumentation checks** callout appears above the entity table. It shows which required metrics and attributes are present or missing, links to the setup steps for each missing item, and includes a **Recheck** button to confirm fixes without reloading the page. See [Telemetry Data Requirements](https://signoz.io/docs/infrastructure-monitoring/user-guides/telemetry-data-requirements/#instrumentation-checks-panel) for how to read and act on it.
+</Admonition>
 
 ### Kubernetes Monitoring Views
 

--- a/data/docs/infrastructure-monitoring/user-guides/telemetry-data-requirements.mdx
+++ b/data/docs/infrastructure-monitoring/user-guides/telemetry-data-requirements.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-05-18
+date: 2026-07-16
 title: Telemetry Data Requirements for Infrastructure Monitoring
-description: Understand the required resource attributes and metric types for SigNoz Infrastructure Monitoring. Verify host.name, entity UIDs, and data source dependencies for accurate dashboards.
+description: Verify the resource attributes and metrics SigNoz Infrastructure Monitoring needs, and use the Instrumentation checks panel to fix missing Kubernetes telemetry.
 
 doc_type: reference
 ---
@@ -9,6 +9,25 @@ doc_type: reference
 ## Overview
 
 The Infrastructure Monitoring depends on a set of resource attributes and metric types. When those attributes are missing or mis-typed, SigNoz cannot link list views (Hosts, Pods, Nodes, Deployments, etc.) with their details and queries fail silently. Use this guide to verify the required attributes, understand data source dependencies, and identify platform-specific gaps.
+
+## Instrumentation checks panel
+
+For Kubernetes entities, SigNoz surfaces the requirements below directly in the product. When it detects that monitoring is not fully configured for an entity type, an **Instrumentation checks** callout appears above the entity table on that list view (Pods, Nodes, Namespaces, Clusters, Deployments, StatefulSets, DaemonSets, Jobs, and Volumes). Use it to see what telemetry is already arriving and what is still missing, without leaving the list view.
+
+The callout groups the checks into two parts:
+
+- **Present**: metrics and attributes already being received, each marked with a green checkmark. Items are grouped under **Default enabled metrics**, **Optional metrics**, and **Required attributes**.
+- **Missing**: metrics and attributes that are absent, each marked with a warning triangle next to the associated component name. Items are grouped under **Missing default metrics**, **Missing optional metrics**, and **Missing required attributes**.
+
+To resolve a missing item:
+
+1. Find the row in the missing list and note the component it belongs to.
+2. Select the **Learn here** link on that row to open the relevant setup documentation in a new tab, then apply the change to your collector or agent configuration. Some rows may not have a link; when none is shown, use [Kubernetes Metrics setup](https://signoz.io/docs/infrastructure-monitoring/k8s-metrics/) as the starting point.
+3. After your change takes effect, select **Recheck** in the callout header to re-fetch the instrumentation status on demand. The panel updates in place, so you can confirm the fix without reloading the page.
+
+<Admonition type="info">
+The callout can be expanded or collapsed from its header. The expanded or collapsed choice is remembered per entity type across page navigations, so collapsing it on one list view does not affect the others. The panel does not appear once all required metrics and attributes for an entity type are being received.
+</Admonition>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Documents the new **Instrumentation checks** callout added to Kubernetes entity list views in Infrastructure Monitoring (source PR SigNoz/signoz#12119).

- Added an **Instrumentation checks panel** section to `infrastructure-monitoring/user-guides/telemetry-data-requirements.mdx` covering when the callout appears, how to read Present vs. Missing groups (Default enabled metrics / Optional metrics / Required attributes), the `Learn here` remediation links, the `Recheck` button, and the persisted collapsible state (features 1-6).
- Added a brief `Admonition` in `infrastructure-monitoring/overview.mdx` (Kubernetes tab) surfacing the live configuration status indicator, linking to the section above.
- Updated the `date` frontmatter to 2026-07-16 on both edited files; tightened the telemetry-data-requirements description to stay within the 160-char limit.

### Feature 7 (error-state change)
No doc changes were needed: no existing docs page documented the removed "Contact Support" button in the K8s error empty state. The remaining "contact support" references in the repo are generic support/FAQ mentions unrelated to that UI.

### Notes / not yet resolved
- **Screenshots pending.** The callout only renders in a *not-ready* state. The demo cluster is fully configured (and lags the day-old PR), so the panel does not appear there and could not be captured. Screenshots to be added once a not-ready instance is available.
- **Open questions carried from the deliverable** (for reviewer @H4ad): exact `Learn here` link destinations (signoz.io/docs vs. external OTel docs), the precise "not fully configured" trigger threshold, whether Recheck is rate-limited, and whether the containers check type should be documented (no navigable Containers list view exists in the UI, so it is omitted).

Source PRs: SigNoz/signoz#12119

Auto-generated by docs-sync pipeline