### PR TITLE
docs: document traces missing-key fallback behavior

### DIFF
--- a/data/docs/apm-and-distributed-tracing/querying-traces.mdx
+++ b/data/docs/apm-and-distributed-tracing/querying-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-07-16
 title: Querying Traces
 description: Query traces in SigNoz using the Query Builder in Trace Explorer and Dashboards, with ClickHouse SQL available in Dashboards.
 doc_type: reference
@@ -25,6 +25,23 @@ Use the **Filter** field to narrow down spans using attributes. Supported operat
 
 Combine filters with `AND` / `OR` for complex queries. See the [Search Syntax](https://signoz.io/docs/userguide/search-syntax/) guide and [Operators Reference](https://signoz.io/docs/userguide/operators-reference/) for the full list of operators and syntax details.
 
+#### Missing attribute keys
+
+If a filter, selected field, group-by, or aggregation references an attribute key that is not found in field metadata (because of indexing lag, TTL eviction, or a typo), the trace query no longer fails. SigNoz runs the query against the raw span data stored in ClickHouse and returns results with a warning in the query response:
+
+```
+key `<name>` not found in metadata; querying the underlying data directly. If this is unexpected, check the key name for typos.
+```
+
+Key resolution follows these rules:
+
+- A qualified key such as `resource.service.name` or `mykey:string` is honored exactly. The context and data type you specify are used as-is, and the same fallback applies if the key is absent from metadata.
+- A bare key name defaults to the attribute context, with its data type inferred from the filter value you provide (`mykey = 'a'` is treated as a string, `mykey > 5` as a number).
+
+<Admonition type="info">
+This graceful fallback applies to traces only. Queries on logs, metrics, and other signals still return a `key not found` error when a referenced key is absent from metadata.
+</Admonition>
+
 ### Aggregation (Time Series & Table views)
 
 Trace queries support a full set of [aggregation functions](https://signoz.io/docs/querying/aggregation-grouping/) in the **Time Series** and **Table** views:
@@ -36,6 +53,12 @@ Trace queries support a full set of [aggregation functions](https://signoz.io/do
 ### Group By (Time Series & Table views)
 
 Segment results by one or more attributes in the **Time Series** and **Table** views. For example, grouping by `service.name` and `operation` produces a separate series for each service-operation pair. Useful for comparing latency or error rates across services, endpoints, or status codes.
+
+When you group by an attribute key that is not present on every span, spans missing that key now appear in a `null` group instead of an empty-string (`''`) group.
+
+<Admonition type="warning">
+If you have dashboards or alert rules that match or compare against the empty-string group-by bucket for traces, update them to match `null` instead. After this change, matching on `''` silently returns no rows for spans that lack the grouped key.
+</Admonition>
 
 ### Having
 

--- a/data/docs/userguide/search-troubleshooting.mdx
+++ b/data/docs/userguide/search-troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-07-16
 title: Search Query Troubleshooting Guide
 description: Diagnose and fix common SigNoz search query errors including syntax errors, ambiguous fields, missing keys, and function-related issues with clear examples.
 ---
@@ -81,6 +81,10 @@ searching for AND operator
 ### Q. I'm getting `key '<fieldname>' not found` — why can't it find my field?
 
 A. The field you referenced does not exist in the selected signal. This is usually a typo, a missing `body.` prefix, or using a field that belongs to a different signal type.
+
+<Admonition type="info">
+This error no longer applies to **traces**. A trace query that references a key missing from field metadata runs against the raw span data and returns a warning instead of failing. See [Querying Traces](https://signoz.io/docs/apm-and-distributed-tracing/querying-traces/#missing-attribute-keys). This entry applies to logs, metrics, and other signals, which still return `key not found`. If a trace query returns no rows, a typo in the key name is still a likely cause, so check the fixes below.
+</Admonition>
 
 <details>
 


### PR DESCRIPTION
## Summary
- **Querying Traces** (`apm-and-distributed-tracing/querying-traces.mdx`): added a *Missing attribute keys* note under Filtering explaining that a trace query referencing a key absent from field metadata (indexing lag, TTL eviction, or a typo) now runs against raw span data and returns a warning instead of failing. Documented qualified vs. bare key resolution and that the fallback is traces-only (logs/metrics still error).
- **Querying Traces — Group By**: documented that spans missing a grouped-by key now land in a `null` bucket instead of an empty-string (`''`) bucket, with a warning to update dashboards/alert rules that match on `''`.
- **Search Query Troubleshooting** (`userguide/search-troubleshooting.mdx`): added a note to the `key '<fieldname>' not found` entry clarifying the error no longer applies to traces, while logs/metrics behavior is unchanged.
- Updated frontmatter `date` to 2026-07-16 on both edited files.

### Notes / open items
- **No UI changes.** The warning surfaces in the API response body only; no new Traces Explorer UI element was introduced by the source PR, so no screenshots were taken. UI exposure of the warning is unconfirmed.
- **Release notes / changelog:** no docs changelog/release-notes page exists in `data/docs`, so the 400 → 200 API behavior change is not recorded there. Flagging for a maintainer to add wherever API breaking changes are tracked.
- Qualified-key open question resolved from source: a qualified key (e.g. `mykey:string`) is honored as-is and the same fallback still applies when it is absent from metadata.

Source PRs: #12091

Auto-generated by docs-sync pipeline