### PR TITLE
docs: document Kubernetes pod status & restarts

### DIFF
--- a/data/docs/infrastructure-monitoring/overview.mdx
+++ b/data/docs/infrastructure-monitoring/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-07-16
 title: Infrastructure Monitoring - Hosts & K8s Overview
 description: Discover how SigNoz Infrastructure Monitoring provides a unified view of host and Kubernetes performance. Monitor CPU, memory, disk, and network with correlated traces and logs.
 
@@ -165,6 +165,8 @@ The **Pods View** provides real-time visibility into pod resource utilization, e
 #### Table Columns
 
 - **Pod Name**: Name of the Kubernetes pod.
+- **Status**: The pod's current runtime status, shown as a colored badge (for example `Running`, `Pending`, `CrashLoopBackOff`, or `OOMKilled`). See [Pod status](#pod-status).
+- **Restarts**: Total container restart count for the pod. This column is sortable. When restart data is unavailable, it shows a dash (`-`) with a "No data" tooltip.
 - **Available**: Number of available pod replicas.
 - **Desired**: Desired number of pod replicas.
 - **CPU Request Usage (%)**: Percentage of requested CPU being utilized.
@@ -179,6 +181,30 @@ The **Pods View** provides real-time visibility into pod resource utilization, e
 - **Search & Filtering**: Quickly locate specific pods using various filters.
 - **Group By Attribute**: Group pods by Namespace, Node, or Deployment.
 - **Sortable Metrics**: Sort columns for better trend analysis.
+
+### Pod status
+
+The **Status** column reports each pod's runtime status rather than its raw Kubernetes phase field, so container-level problems (such as image pull failures or crash loops) surface directly in the list. SigNoz recognizes the following pod statuses:
+
+`Running`, `Pending`, `Unknown`, `Failed`, `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `CreateContainerConfigError`, `ContainerCreating`, `OOMKilled`, `Error`, `ContainerCannotRun`, `Evicted`, `NodeAffinity`, `NodeLost`, `Shutdown`, and `UnexpectedAdmissionError`.
+
+<Admonition type="info">
+The **Status** column and the grouped **Pod Status** counts replace the earlier **Phase** column and **Pod Phases** counts. The status reflects the pod's observed runtime state instead of the native Kubernetes phase field.
+</Admonition>
+
+#### Pod status counts
+
+Every Kubernetes entity table (Pods, Clusters, Nodes, Namespaces, Deployments, Jobs, DaemonSets, and StatefulSets) shows a grouped **Pod Status** count bar. It rolls the individual statuses into five display categories:
+
+| Category | Meaning |
+| --- | --- |
+| **Running** | Pods that are currently running. |
+| **Completed** | Pods that finished successfully. This is the SigNoz label for what Kubernetes calls the `Succeeded` phase. |
+| **Pending** | Pods waiting to be scheduled or to start. |
+| **Unknown** | Pods whose status could not be determined. |
+| **Error Status** | A single aggregated count of all error-type statuses. Hover the count to see a breakdown of each error state and its count. |
+
+**Error Status** always aggregates the same fixed set of states: `Failed`, `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `CreateContainerConfigError`, `ContainerCreating`, `OOMKilled`, `Error`, `ContainerCannotRun`, `Evicted`, `NodeAffinity`, `NodeLost`, `Shutdown`, and `UnexpectedAdmissionError`.
 
 ### Filtering and Selection Panel
 


### PR DESCRIPTION
## Summary

Documents the pod health changes from product PR #12127 (Phase → Status rename, new **Restarts** column, expanded status taxonomy, and regrouped pod-count categories) in the Kubernetes section of `infrastructure-monitoring/overview.mdx`.

- Added **Status** and **Restarts** columns to the Pods table reference (Restarts is sortable; dash + "No data" tooltip when unavailable).
- Added a **Pod status** section listing all ~18 recognized statuses.
- Added a **Pod status counts** table for the five display categories (Running / Completed / Pending / Unknown / Error Status), with the exact fixed set of 14 states that Error Status aggregates and the hover-breakdown behavior.
- Added an Admonition noting the Phase → Status / Pod Phases → Pod Status rename.
- Updated the `date` frontmatter to 2026-07-16.

## Open questions from the deliverable — resolved from product source
- **Error Status aggregation rule**: Fixed set of 14 states (`ERROR_STATUS_LABELS` in `commonUtils.tsx`). Documented in full.
- **Completed vs Succeeded**: `completed` is a distinct count field; documented as the SigNoz label for Kubernetes' `Succeeded` phase.
- **Restarts visibility**: Regular default-visible, sortable column (not part of the hideable "additional columns").

## ⚠️ Scope note for reviewer (@H4ad)
The deliverable lists eight pages to edit under `/infrastructure-monitoring/kubernetes/*` (pods, clusters, nodes, etc.). **Those pages do not exist in the docs repo** — the only Kubernetes doc is `infrastructure-monitoring/overview.mdx`, so this PR documents the change there.

Separately, the product's V2 K8s tables deep-link (`docPath`) to **9 entity pages / 91 distinct anchors** (e.g. `/infrastructure-monitoring/kubernetes/pods#pod-status`, `#restarts`, `#pod-counts-by-status`). None of those pages/anchors exist, so **all 91 in-product help-links currently 404** — a pre-existing gap, not introduced by #12127. Building out that per-entity reference tree is a larger effort tracked outside this batch.

Not documented: feature #10 (dash instead of `N/A` for empty HTTP method / status code cells in the entity Traces panel) — cosmetic placeholder change with no corresponding existing doc content.

## Screenshots
None. The SigNoz demo lags PR #12127 — the Pods table still shows the old columns (no Status/Restarts), so the feature isn't screenshottable yet. Screenshots pending a demo refresh.

Source PRs: #12127

Auto-generated by docs-sync pipeline