### PR TITLE
docs: note alert rule notification_settings round-trip fix

### DIFF
--- a/data/docs/alerts-management/terraform-provider-signoz.mdx
+++ b/data/docs/alerts-management/terraform-provider-signoz.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-12
+date: 2026-07-17
 
 title: Creating SigNoz Alerts with Terraform
 description: How to create SigNoz Alerts with Terraform, and problems faced during creation of terraform alerts.
@@ -186,6 +186,10 @@ This configuration defines:
 - notification_settings: Notification settings for the alerts.
 - renotify: Renotification settings for the alerts
 - evaluation: Evaluation settings for the alerts
+
+<Admonition type="info">
+Setting `use_policy = false`, an empty `group_by = []`, or an empty `alert_states = []` now round-trips correctly. Earlier SigNoz versions dropped these values from the alert rule GET response, so Terraform read them back as `null` and reported a persistent diff on every `plan` (for example, `usePolicy was false, but now null`). If you rely on any of these fields, upgrade to a SigNoz release published after v0.133.0. In the API schema, `groupBy` and `alertStates` are now nullable, so API clients and code generators should treat `null` (explicitly empty) and an absent field (never set) as distinct.
+</Admonition>
 
 ### Step 2: Check Correctness of Definition
 


### PR DESCRIPTION
## Summary
- Added an Admonition to the Terraform alerts provider page noting that `use_policy = false`, empty `group_by = []`, and empty `alert_states = []` now round-trip correctly through the alert rule API (previously dropped from the GET response, causing persistent Terraform diffs like `usePolicy was false, but now null`).
- Noted that `groupBy` and `alertStates` are now nullable in the OpenAPI schema, so clients/code generators should treat `null` (explicitly empty) and absent (never set) as distinct.
- Called out that the fix ships in SigNoz releases published after v0.133.0.
- Updated the frontmatter `date` on the edited file.

### Not changed (intentional)
- **API reference** renders dynamically from the product repo's `docs/api/openapi.yml` (the `nullable: true` additions for `groupBy`/`alertStates` from #12138 auto-surface on the next release tag), so no hand-authored reference MDX was added.
- No release-notes/changelog or separate Terraform provider changelog page exists in this repo, so no entry was added there.

Source PRs: #12138

Auto-generated by docs-sync pipeline