### PR TITLE
docs: pre-filled alert condition when creating alerts from dashboard panels

### DIFF
--- a/data/docs/alerts-management/metrics-based-alerts.mdx
+++ b/data/docs/alerts-management/metrics-based-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: 2026-07-17
 title: Metrics based alerts
 description: Learn how to create metrics-based alerts in SigNoz by defining alert conditions, configuring notification settings, and using practical examples for memory usage, error rate, and latency monitoring.
 doc_type: reference
@@ -8,6 +8,10 @@ doc_type: reference
 A Metric-based alert in SigNoz allows you to define conditions based on metric data and trigger alerts when these conditions are met. You can define your metric query using **Query Builder**, **ClickHouse queries**, or **PromQL**.
 
 This page covers the configuration options available for Metric-based alerts — from defining the metric query to setting conditions and notification preferences.
+
+<Admonition type="info">
+If you start from a dashboard panel using [**Create Alerts**](https://signoz.io/docs/dashboards/interactivity/#create-an-alert-from-a-panel), the alert opens with the panel's query loaded and the condition partly pre-filled from the panel's Reduce To setting and thresholds. Review and complete the remaining fields below before saving.
+</Admonition>
 
 At the top of the alert creation page, you can set:
 

--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-17
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -278,3 +278,56 @@ You can toggle individual series on and off through the chart legend. Hidden ser
 - If every matching series in the receiver is hidden, the receiver tooltip disappears entirely the next time you move the cursor on the source.
 
 This makes it easy to focus comparison on a specific subset by hiding the rest.
+
+## Create an alert from a panel
+
+You can turn any panel into an alert without rebuilding its query. When you create an alert from a panel, SigNoz carries the panel's query into the alert builder and seeds the alert **condition** from the panel's **Reduce To** setting and its **thresholds**, so the condition arrives partly filled in.
+
+**Create Alerts** is available on **Time Series**, **Bar**, **Value** (Number), and **Histogram** panels. Table, List, and Pie panels do not offer it.
+
+### Create the alert
+
+1. Hover over the panel and open its actions menu (the **...** menu in the panel header). You can also open the same action from the panel editor.
+2. Select **Create Alerts**. SigNoz opens the alert builder in a new tab with the panel's query already loaded.
+3. Review the pre-filled condition, adjust anything you need, and save the alert.
+
+The alert condition reads as a sentence: *Send a notification when `<query>` is `<operator>` the threshold(s) `<occurrence>` during the `<evaluation window>`*. The **operator** and **occurrence** parts are the fields seeded from the panel.
+
+### Occurrence from Reduce To
+
+For **Value** (Number) panels, the panel's **Reduce To** setting maps to the alert occurrence:
+
+| Panel Reduce To | Alert occurrence |
+| --- | --- |
+| Sum | `IN TOTAL` |
+| Avg | `ON AVERAGE` |
+| Max, Min, or Latest | Default (left unchanged) |
+
+Time Series, Bar, and Histogram panels do not expose a Reduce To that maps to occurrence, so their occurrence stays at the alert builder's default.
+
+<Admonition type="info">
+For panels built from multiple queries or a formula, the occurrence is pre-filled only when **every** query uses the same Reduce To. If the queries use different Reduce To settings, the default occurrence is preserved and you should set it manually after the alert opens.
+</Admonition>
+
+### Operator and value from thresholds
+
+When the panel has thresholds configured, SigNoz picks the **most dangerous threshold** and copies its value (and unit) into the alert. Danger is ranked by threshold color:
+
+`red` > `orange` > `green` > `blue` > any other color
+
+For **Value** (Number) panels, the threshold's comparison operator is copied as well:
+
+| Panel threshold operator | Alert operator |
+| --- | --- |
+| Above (>) or Above or equal (≥) | `ABOVE` |
+| Below (<) or Below or equal (≤) | `BELOW` |
+| Equal (=) | `EQUAL TO` |
+| Not equal (≠) | `NOT EQUAL TO` |
+
+<Admonition type="warning">
+The alert operators do not include an "or equal" boundary, so **Above or equal (≥)** and **Below or equal (≤)** panel thresholds map to the closest available operators, `ABOVE` and `BELOW`. If you set a boundary threshold, confirm the operator after the alert opens.
+</Admonition>
+
+**Time Series** and **Bar** panels pre-fill the threshold **value** and **unit**, but the operator stays at the default: these panels store thresholds as value markers without a comparison operator. **Histogram** panels do not pass thresholds, so nothing threshold-related is seeded.
+
+Everything SigNoz fills in is a starting point. Review the condition and complete the remaining fields before saving. For the full list of condition options, see [Metrics based alerts](https://signoz.io/docs/alerts-management/metrics-based-alerts/#step-2-define-alert-conditions).


### PR DESCRIPTION
## Summary
- Added a new **Create an alert from a panel** section to the Dashboards Interactivity page documenting how clicking **Create Alerts** on a V2 panel pre-fills the alert condition.
- Documented the **Reduce To → occurrence** mapping (Value panels: Sum→`IN TOTAL`, Avg→`ON AVERAGE`; Max/Min/Latest→default), including the multi-query/formula rule (occurrence pre-filled only when all queries share the same Reduce To).
- Documented the **threshold → operator/value** mapping, the most-dangerous-threshold color order (red > orange > green > blue > other), and the panel-operator → alert-operator table, with a warning that `Above or equal (≥)` / `Below or equal (≤)` map to `ABOVE` / `BELOW`.
- Noted per-panel-type behavior: Time Series and Bar pre-fill threshold value/unit only (operator stays default); Histogram passes no thresholds; only Time Series, Bar, Value, and Histogram panels offer Create Alerts.
- Added a cross-reference Admonition on the **Metrics based alerts** page pointing to the panel section.
- Updated frontmatter `date` to 2026-07-17 on both edited files.

Screenshots: pending. PR #12137 merged 2026-07-17 and the demo build lags same-day merges, so the pre-fill flow was not yet reproducible on the demo for capture.

Source PRs: #12137

Auto-generated by docs-sync pipeline