### PR TITLE
chore(docs-nav): move Langflow dashboard entry to alphabetical position

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -2390,11 +2390,6 @@
             ]
           },
           {
-            "type": "doc",
-            "route": "/docs/dashboards/dashboard-templates/langflow-dashboard",
-            "label": "Langflow"
-          },
-          {
             "label": "LiteLLM",
             "type": "category",
             "isExpanded": false,
@@ -2664,6 +2659,11 @@
             "type": "doc",
             "route": "/docs/dashboards/dashboard-templates/kong-gateway",
             "label": "Kong Gateway"
+          },
+          {
+            "type": "doc",
+            "route": "/docs/dashboards/dashboard-templates/langflow-dashboard",
+            "label": "Langflow"
           },
           {
             "type": "doc",


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
The Langflow entry under Dashboards → Out of Box Dashboards in the docs side nav was placed among the category groups (between the Kubernetes and LiteLLM categories) instead of in the flat alphabetical list of dashboard template docs. This PR moves it to its correct alphabetical position, between "Kong Gateway" and "LiveKit".

The other Langflow entry (`/docs/langflow-observability` in the LLM section) was checked and is already correctly ordered.

#### Screenshots / Screen Recordings (if applicable)
N/A (nav ordering change only)

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
The Langflow dashboard nav entry was inserted at the wrong spot when it was added, landing among the category groups rather than in the alphabetical doc list.

#### Fix Strategy
Move the existing entry (unchanged) to its alphabetical position in `data/docs-side-nav/main.json`.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A (data-only change)
- Manual verification: JSON validated; `yarn check:docs-metadata`, `yarn test:docs-metadata`, `yarn check:doc-redirects`, and `yarn test:doc-redirects` all pass
- Edge cases covered: verified the second Langflow nav entry in the LLM section is already correctly ordered

---

### ⚠️ Risk & Impact Assessment

- Blast radius: docs sidebar ordering only; no routes or content changed
- Potential regressions: none expected
- Rollback plan: revert the commit

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The diff only moves the existing Langflow entry; no labels or routes were modified.

---