### PR TITLE
fix: url encode in not found suggestions

### DIFF
--- a/components/not-found/suggestions.ts
+++ b/components/not-found/suggestions.ts
@@ -9,8 +9,8 @@ import type { AlgoliaHit, SuggestedDoc } from './types'
 export const hasAlgoliaConfig = (): boolean => {
   return Boolean(
     process.env.NEXT_PUBLIC_ALGOLIA_APP_ID &&
-      (process.env.ALGOLIA_SEARCH_API_KEY || process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY) &&
-      process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME
+    (process.env.ALGOLIA_SEARCH_API_KEY || process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY) &&
+    process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME
   )
 }
 
@@ -41,10 +41,11 @@ const getTitleFromHit = (hit: AlgoliaHit): string | null => {
 const toDocsHref = (url: string): string | null => {
   try {
     const parsed = new URL(url, 'https://signoz.io')
-    if (!parsed.pathname.startsWith('/docs/')) {
+    const pathname = decodeURIComponent(parsed.pathname)
+    if (!pathname.startsWith('/docs/')) {
       return null
     }
-    return `${parsed.pathname}${parsed.hash}`
+    return `${pathname}${parsed.hash}`
   } catch {
     return null
   }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> 404 page recommendation links redirect to URLs with encoded slashes (`%2F`) instead of actual slashes (`/`).
>
> For example, clicking a suggestion link navigates to `https://signoz.io/docs/ai%2Foverview/` instead of `https://signoz.io/docs/ai/overview/`
>
> The root cause is that `new URL().pathname` preserves percent-encoded characters from Algolia hit URLs. Adding `decodeURIComponent` on the pathname ensures slashes are properly decoded before being passed to the `<Link>` component.
>
> This is the same kind of issue fixed in https://github.com/SigNoz/signoz.io/pull/3712, which addressed encoded slashes in a different area. This PR applies the same fix to the 404 suggestion links.

#### Screenshots / Screen Recordings (if applicable)

**Before:** Hovering over a 404 suggestion shows `https://signoz.io/docs/ai%2Foverview/` - clicking leads to the correct page though.
<img width="1892" height="967" alt="Screenshot 2026-07-17 at 15 41 03" src="https://github.com/user-attachments/assets/61392b1a-9f57-44f2-b984-5321c4824ece" />
<img width="1735" height="423" alt="Screenshot 2026-07-17 at 15 41 16" src="https://github.com/user-attachments/assets/81a7a4d8-957c-4c69-81d7-f25603c01b7c" />

**After:** Links use proper slashes and navigate correctly.
<img width="1902" height="972" alt="Screenshot 2026-07-17 at 15 41 57" src="https://github.com/user-attachments/assets/0992ca72-1118-458c-89e1-440da8679c3e" />


#### Issues closed by this PR

NA, bugfix 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> `toDocsHref` in `components/not-found/suggestions.ts` uses `new URL(url).pathname` to extract the path from Algolia hit URLs. The WHATWG URL spec preserves `%2F` in pathnames rather than decoding it to `/`. When Algolia returns URLs with encoded slashes, the encoded form is passed through to the `<Link href>`.

#### Fix Strategy
> Apply `decodeURIComponent()` to the parsed pathname before using it, ensuring all percent-encoded path separators are decoded to slashes.

---

### 🧪 Testing Strategy
> How was this change validated?


- Tests added/updated: N/A
- Manual verification: Visited a 404 docs page, confirmed suggestion links now use proper slashes and navigate to the correct pages.
- Edge cases covered: Paths without encoding are unaffected (`decodeURIComponent('/')` returns `/`).

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Minimal - only affects 404 page suggestion link URLs.
- Potential regressions: None expected. `decodeURIComponent` is a no-op on already-decoded paths.
- Rollback plan: Revert the PR

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Same pattern as https://github.com/SigNoz/signoz.io/pull/3712.

---
