### PR TITLE
docs: document fine-grained authorization for telemetry data

### DIFF
--- a/data/docs/dashboards/using-variables-in-queries.mdx
+++ b/data/docs/dashboards/using-variables-in-queries.mdx
@@ -1,11 +1,15 @@
 ---
-date: 2026-06-27
+date: 2026-07-17
 title: Using Variables in Queries
 description: Use dashboard variables in Query Builder, ClickHouse SQL, and PromQL queries in SigNoz.
 doc_type: howto
 ---
 
 Variables are referenced using `$var` syntax across all query types.
+
+<Admonition type="info">
+Dashboard variables are substituted **before** the authorization check. When a query filters on a variable (for example, `service.name = $service`), SigNoz evaluates permissions against the value the variable resolves to, not the variable name. A user with a [service-scoped role](https://signoz.io/docs/manage/administrator-guide/iam/roles/#scope-a-role-to-specific-telemetry) can use a dashboard whose variable resolves to a service they are allowed to query, but the query returns HTTP 403 if it resolves to a service outside their scope.
+</Admonition>
 
 ## Query Builder
 

--- a/data/docs/manage/administrator-guide/iam/overview.mdx
+++ b/data/docs/manage/administrator-guide/iam/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-26
+date: 2026-07-17
 title: Authorization Overview
 description: Understand how role-based access control works in SigNoz — principals, transactions, roles, and how they connect.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -55,6 +55,13 @@ The following resources are currently available for fine-grained access control:
 | `role` | `role` | Managed and custom roles |
 | `serviceaccount` | `serviceaccount` | Non-human identities for programmatic API access |
 | `metaresource` | `factor-api-key` | Authentication keys for service accounts |
+| `telemetryresource` | `logs` | Logs queried through `/api/v5/query_range` |
+| `telemetryresource` | `traces` | Traces queried through `/api/v5/query_range` |
+| `telemetryresource` | `metrics` | Metrics queried through `/api/v5/query_range` |
+| `telemetryresource` | `meter-metrics` | Meter (billing/usage) metrics |
+| `telemetryresource` | `audit-logs` | Audit-log data |
+
+Telemetry resources gate access to queried observability data. They support only the `read` relation and are enforced on the v5 query endpoints (`/api/v5/query_range` and its preview variant). See [Telemetry Resources](https://signoz.io/docs/manage/administrator-guide/iam/transactions/#telemetry-resources) for the default managed-role grants and selector format.
 
 For the full transactions reference for each resource, see the [Transactions Reference](https://signoz.io/docs/manage/administrator-guide/iam/transactions/).
 

--- a/data/docs/manage/administrator-guide/iam/roles.mdx
+++ b/data/docs/manage/administrator-guide/iam/roles.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-26
+date: 2026-07-17
 title: Roles
 description: Create and manage roles in SigNoz — managed roles, custom roles, and configuring transactions with the interactive or JSON editor.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -98,6 +98,48 @@ Each entry is a transaction group with an `objectGroup` (the resource and its se
 <Admonition type="info">
 If the JSON contains errors, switching back to Interactive mode prompts you to discard the invalid changes. Fix the errors first to keep your edits.
 </Admonition>
+
+## Scope a Role to Specific Telemetry
+
+Custom roles can restrict a user to querying data for specific services only. This is useful when a team should see telemetry for the services they own but not the rest of the platform. Telemetry access is enforced on the v5 query endpoints and is `read`-only.
+
+Telemetry selectors are qualified by query type and follow the form `<query-type>/service.name/<value>`. Grant `builder_query/service.name/<value>` to allow Query Builder queries filtered to a single service, `builder_query/*` for all services, or `*` for every query type against every service. For the full selector reference, see [Telemetry Resources](https://signoz.io/docs/manage/administrator-guide/iam/transactions/#telemetry-resources).
+
+The following JSON creates a `checkout-team` role that can query logs and traces only where `service.name = checkout`:
+
+```json
+[
+  {
+    "objectGroup": {
+      "resource": { "kind": "logs", "type": "telemetryresource" },
+      "selectors": ["builder_query/service.name/checkout"]
+    },
+    "relation": "read"
+  },
+  {
+    "objectGroup": {
+      "resource": { "kind": "traces", "type": "telemetryresource" },
+      "selectors": ["builder_query/service.name/checkout"]
+    },
+    "relation": "read"
+  }
+]
+```
+
+To build this in Interactive mode, open the telemetry resource card, set the `read` action to **Only selected**, and add the selector `builder_query/service.name/checkout`.
+
+<Admonition type="info">
+**ClickHouse SQL and PromQL are not covered by a service scope.** A `builder_query/service.name/<value>` grant does not authorize raw ClickHouse SQL or PromQL. If the role needs those, also grant `clickhouse_sql/*` (on each telemetry resource the query touches) and `promql/*` (on `metrics`). See [Telemetry Resources](https://signoz.io/docs/manage/administrator-guide/iam/transactions/#telemetry-selectors).
+</Admonition>
+
+<Admonition type="warning">
+**Current limitations of service-scoped roles**
+
+- A query that combines services with `OR` (for example, `service.name = A OR service.name = B`) is denied even when the role grants both `A` and `B` individually. Use separate dashboards or panels per service, or grant a broader selector.
+- Only `service.name` can be used to scope Query Builder telemetry access today.
+</Admonition>
+
+When a query requests a service the role does not cover, the endpoint returns **HTTP 403** (permission denied) and no data is returned.
 
 ## View a Role
 

--- a/data/docs/manage/administrator-guide/iam/transactions.mdx
+++ b/data/docs/manage/administrator-guide/iam/transactions.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-26
+date: 2026-07-17
 title: Transactions Reference
 description: Complete reference of transactions for each resource in SigNoz — relations, descriptions, and managed role access.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -19,7 +19,7 @@ A transaction is a single relation on a resource, optionally scoped to specific 
 For an explanation of relations and how access control works, see the [Authorization Overview](https://signoz.io/docs/manage/administrator-guide/iam/overview/).
 
 <Admonition type="info">
-This page currently covers IAM resources (roles, service accounts, API keys). Transactions for observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
+This page covers IAM resources (roles, service accounts, API keys) and telemetry query resources (logs, traces, metrics, meter-metrics, audit-logs). Transactions for other observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
 </Admonition>
 
 ## Role
@@ -64,6 +64,44 @@ Resource: `metaresource` | Kind: `factor-api-key` | Selector: API key ID
 | `update` | Modify API key metadata (for example, change the expiration date). | signoz-admin |
 | `delete` | Permanently revoke an API key. | signoz-admin |
 
+## Telemetry Resources
+
+Telemetry resources authorize the data returned by the v5 query endpoints (`/api/v5/query_range` and its preview variant). Access is enforced per telemetry type, and for Query Builder queries it can be scoped per service. Telemetry resources support only the `read` relation.
+
+Each telemetry type is a separate resource kind under the `telemetryresource` type. The type is derived from the query's signal and source: audit-logs is `signal=logs, source=audit`, and meter-metrics is `signal=metrics, source=meter`.
+
+| Resource | Kind | Source | Managed Role Access |
+|----------|------|--------|---------------------|
+| `telemetryresource` | `logs` | Application logs | signoz-admin, signoz-editor, signoz-viewer |
+| `telemetryresource` | `traces` | Distributed traces | signoz-admin, signoz-editor, signoz-viewer |
+| `telemetryresource` | `metrics` | Metrics | signoz-admin, signoz-editor, signoz-viewer |
+| `telemetryresource` | `meter-metrics` | Meter (billing/usage) metrics | signoz-admin, signoz-editor, signoz-viewer |
+| `telemetryresource` | `audit-logs` | Audit-log stream | signoz-admin |
+
+<Admonition type="warning">
+**Behavior change for upgraders:** audit-log queries are now restricted to `signoz-admin`. Under the previous flat check, any Viewer or Editor could query audit-log data. After upgrading, Editor and Viewer principals lose implicit access to audit-logs. See [Upgrade behavior](#upgrade-behavior) below.
+</Admonition>
+
+### Telemetry selectors
+
+Telemetry selectors are hierarchical and qualified by query type. A selector has the form `<query-type>/<key>/<value>`, where the query type is one of `builder_query` (Query Builder), `promql` (PromQL), or `clickhouse_sql` (ClickHouse SQL). The only key currently supported for scoping is `service.name`.
+
+| Selector | Grants |
+|----------|--------|
+| `*` | Every query type against every service for that telemetry resource. |
+| `builder_query/*` | All Query Builder queries against that resource, any service. |
+| `builder_query/service.name/<value>` | Query Builder queries filtered to `service.name = <value>` only (for example, `builder_query/service.name/checkout`). |
+| `promql/*` | All PromQL queries (applies to `metrics` only). |
+| `clickhouse_sql/*` | All ClickHouse SQL queries against that resource. |
+
+Selectors form a grant ladder: a broader selector covers everything below it. A query for `service.name = checkout` in the Query Builder is satisfied by any of `builder_query/service.name/checkout`, `builder_query/*`, or `*`.
+
+<Admonition type="info">
+**ClickHouse SQL and PromQL always require a wildcard grant.** A service-scoped `builder_query/service.name/<value>` selector does not cover raw ClickHouse SQL or PromQL, because those query types are not parsed for a `service.name` filter. To run ClickHouse SQL, the role also needs `clickhouse_sql/*` on each telemetry resource the query can touch (`logs`, `traces`, `metrics`, `meter-metrics`). To run PromQL, the role also needs `promql/*` on `metrics`.
+</Admonition>
+
+The managed roles are granted the wildcard selector (`*`) on the resources listed above, so their access is unrestricted for those telemetry types.
+
 ## Compound Transactions
 
 Some operations require transactions on multiple resources. Both transactions must be satisfied for the operation to succeed.
@@ -74,3 +112,14 @@ Some operations require transactions on multiple resources. Both transactions mu
 | Unassign a role from a service account | `serviceaccount:detach` AND `role:detach` |
 | Create an API key for a service account | `factor-api-key:create` AND `serviceaccount:attach` |
 | Revoke an API key from a service account | `factor-api-key:delete` AND `serviceaccount:detach` |
+
+## Upgrade behavior
+
+Telemetry read permissions are seeded automatically. On the first startup after upgrading, a database migration runs and grants the managed roles their default telemetry access, so standard deployments need no manual configuration:
+
+- **signoz-admin**: read on `logs`, `traces`, `metrics`, `meter-metrics`, and `audit-logs`.
+- **signoz-editor** and **signoz-viewer**: read on `logs`, `traces`, `metrics`, and `meter-metrics`.
+
+<Admonition type="warning">
+Editor and Viewer principals do **not** receive `audit-logs` access. If any Editor or Viewer users previously relied on the flat check to query audit-log data, they lose that access after the upgrade. Grant them `audit-logs` read through a custom role if they still need it.
+</Admonition>


### PR DESCRIPTION
## Summary

Documents FGA enforcement for telemetry query endpoints (`/api/v5/query_range` and preview) from source PR #12095.

- **Authorization Overview** (`iam/overview.mdx`): added the five telemetry resources (`logs`, `traces`, `metrics`, `meter-metrics`, `audit-logs`) to the Resources table, with a pointer to the selector reference.
- **Transactions Reference** (`iam/transactions.mdx`): new **Telemetry Resources** section covering the resource kinds, signal/source mapping, `read`-only relation, default managed-role grants, and the hierarchical selector format (`builder_query/service.name/<value>`, `builder_query/*`, `promql/*`, `clickhouse_sql/*`, `*`). Flagged the **audit-logs admin-only** change as a behavior change, and added an **Upgrade behavior** section documenting the automatic DB migration.
- **Roles** (`iam/roles.mdx`): new **Scope a Role to Specific Telemetry** section with a practical `checkout-team` JSON example, the ClickHouse SQL / PromQL wildcard requirement, the OR-condition limitation caveat, and the HTTP 403 behavior.
- **Using Variables in Queries** (`dashboards/using-variables-in-queries.mdx`): note that variable substitution happens before the authorization check; a scoped user is evaluated against the resolved value.
- Updated the `date` frontmatter to 2026-07-17 on all edited files.

## Notes / open items for reviewer
- **No screenshots**: PR #12095 is backend-only (no frontend diff); service-scoped role creation is API/JSON-editor only. Browser verification skipped as the demo lags a same-day-merged PR.
- **AUTHOR/legacy roles**: this doc tree uses the managed roles (signoz-admin/editor/viewer). No change to the legacy Admin/Editor/Viewer taxonomy.
- Confirm the `service.name`-only scoping key and the OR-condition limitation are intended as documented (both drawn from the source diff and integration tests).

Source PRs: #12095

Auto-generated by docs-sync pipeline