### PR TITLE
docs(llm): embed YouTube walkthrough in Firecrawl monitoring doc

### DIFF
--- a/data/docs/firecrawl-monitoring.mdx
+++ b/data/docs/firecrawl-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-15
+date: 2026-07-19
 title: Firecrawl Monitoring with OpenTelemetry and SigNoz
 description: Set up Firecrawl monitoring with OpenTelemetry and SigNoz. Track scrape, crawl, search, and map calls with traces and metrics for latency and credits.
 doc_type: howto
@@ -10,6 +10,8 @@ doc_type: howto
 Firecrawl monitoring gives you real-time visibility into your web scraping and crawling workloads by collecting traces and metrics using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a>. Firecrawl does not emit OpenTelemetry itself, so this guide uses <a href="https://pypi.org/project/firecrawl-otel/" target="_blank" rel="noopener noreferrer nofollow">firecrawl-otel</a>, a client-side instrumentation package that wraps the Firecrawl Python SDK. It traces every `scrape`, `crawl`, `search`, `map`, `extract`, and `batch_scrape` call without any changes to your call sites, and records metrics for call counts, latency, credits consumed, and results returned.
 
 With full Firecrawl observability in SigNoz, you can trace every scraping call end to end, see which operations are slow or failing, track credit consumption against your Firecrawl plan, set alerts on latency and error rates, and continuously improve the reliability of your scraping pipelines.
+
+<YouTube id="UxrBRLFdLKA" mute="false" />
 
 ## Prerequisites
 


### PR DESCRIPTION
https://staging.signoz.io/docs/firecrawl-monitoring/

## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Adds a YouTube walkthrough video to the Firecrawl Monitoring doc so readers get a visual overview of the setup before diving into the written steps. The video is embedded with the shared `<YouTube />` component and placed right after the intro paragraphs (before `## Prerequisites`), matching the pattern already used in the Cohere and Langflow docs. The doc `date` was bumped to reflect the update.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

N/A — single video embed; renders via the existing `<YouTube />` component.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
- [x] 📚 Docs

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No new tests required for a docs content change
- Manual verification: Ran `yarn check:docs-metadata`, `yarn test:docs-metadata`, and `yarn check:doc-redirects` — all pass. Pre-commit hooks (metadata, redirects, stale URLs, CMS assets) also pass.
- Edge cases covered: Confirmed the embed uses the same `<YouTube id="..." mute="false" />` component and placement as the Cohere/Langflow docs

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: A single docs page (`data/docs/firecrawl-monitoring.mdx`)
- Potential regressions: None expected; only adds a video embed and updates the doc date
- Rollback plan: Revert the commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | N/A (docs site) |
| Change Type | Maintenance |
| Description | Add a YouTube walkthrough to the Firecrawl monitoring doc |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

The embed follows the exact pattern introduced for the Cohere and Langflow docs in commit `bc10dfe77`.

---
