### PR TITLE
docs: document Include variables toggle for dashboard share links

### DIFF
--- a/data/docs/dashboards/public-sharing.mdx
+++ b/data/docs/dashboards/public-sharing.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Public Sharing in Dashboards
-description: Share SigNoz dashboards publicly with a generated link and control the default time range available to viewers.
+description: Share SigNoz dashboards publicly with a generated link, include your current variable selections, and control the default time range for viewers.
 doc_type: howto
 ---
 
@@ -12,6 +12,25 @@ Use public sharing when you want to make a dashboard available with a link outsi
   alt="Share page link option in SigNoz dashboard"
   caption="Share the current page link with your team members."
 />
+
+## Share a Link with Variable Selections
+
+When you share a dashboard's page link with another SigNoz user, you can include your current variable selections so the recipient opens the dashboard with the same values already applied. This works with the authenticated **Share page link** dialog, not the public dashboard URLs described below.
+
+1. Open a Dashboard V2 that has at least one variable defined.
+2. Set the variable values you want to share using the variable selectors at the top of the dashboard.
+3. Click the **Share** button in the dashboard header.
+4. Turn on the **Include variables** toggle, then click **Copy page link**.
+
+<Admonition type="info">
+  The **Include variables** toggle appears only when the dashboard has at least one variable, and it is off by default. Leave it off to share a plain link that opens with each viewer's own variable selections.
+</Admonition>
+
+When the recipient opens the link, SigNoz applies your variable selections and keeps them for subsequent refreshes, then removes the encoded parameter from the URL so the address stays clean. See [Manage Variables](https://signoz.io/docs/userguide/manage-variables/#share-variable-selections) for how variable selections are stored.
+
+<Admonition type="info">
+  **Include variables** works only with private, authenticated share links. The public dashboard URLs created through the **Publish** flow below do not support variables.
+</Admonition>
 
 ## Enable Public Sharing
 

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Manage Variables in SigNoz
-description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
+description: Learn how to create, use, and share dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
 ---
 
@@ -166,6 +166,20 @@ If you have a specific use case where dynamic variables don't work:
 2. Or reach out to support for assistance
 
 We're actively working on dynamic variables and all feedback is welcome.
+
+## Share variable selections
+
+Variable selections are tied to your dashboard session, not to the dashboard URL. Changing a variable no longer writes the value into the address bar, so copying the URL from your browser does not carry your selections to another user.
+
+To share a link that reproduces your current selections, use the **Include variables** toggle in the dashboard's share dialog:
+
+1. Set the variable values you want to share.
+2. Click **Share** in the Dashboard V2 header.
+3. Turn on **Include variables** (shown only when the dashboard has at least one variable, off by default), then click **Copy page link**.
+
+The generated link carries your selections in an encoded `?variables=` query parameter. When the recipient opens it, SigNoz applies the selections and keeps them for subsequent refreshes, then removes the parameter from the URL. Because the values persist after the parameter is cleared, a plain bookmark of the cleaned URL will not restore the shared selections. Reshare with **Include variables** enabled when you want to hand off a specific set of values.
+
+For the full sharing flow, see [Public Sharing in Dashboards](https://signoz.io/docs/dashboards/public-sharing/#share-a-link-with-variable-selections).
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Added a "Share a Link with Variable Selections" section to `dashboards/public-sharing.mdx` covering the new **Include variables** toggle: opt-in (off by default), shown only when the dashboard has at least one variable, and the seed-then-clear `?variables=` URL behavior for recipients.
- Clarified that **Include variables** works only with private/authenticated share links, not the public "Publish" dashboard URLs (which do not support variables).
- Added a "Share variable selections" section to `userguide/manage-variables.mdx` describing where selections are stored (session, not URL) and the Share toggle as the mechanism for generating a seeded link, including the bookmarked-URL caveat.
- Cross-linked the two pages.
- Updated frontmatter `date` to 2026-07-27 on both edited files.

## Screenshots
- None. The demo build (demo.in.signoz.cloud) still serves the older Share dialog (only "Copy page link", no **Include variables** or time-range toggle), so the new toggle is not screenshottable yet. Prose-only; screenshots pending the demo deploy.

Source PRs: #12198 (author @AshwinBhatkal, merged 2026-07-21)

Auto-generated by docs-sync pipeline