### PR TITLE
docs: document Query Builder field context prefix autocomplete

### DIFF
--- a/data/docs/userguide/field-context-data-types.mdx
+++ b/data/docs/userguide/field-context-data-types.mdx
@@ -1,8 +1,9 @@
 ---
-date: 2025-11-20
+date: 2026-07-27
 
 title: Field Context and Data Types Guide
 description: Learn when to use explicit field contexts like resource. or attribute. in SigNoz queries. Understand data types, type specification syntax, and performance implications.
+doc_type: reference
 ---
 
 
@@ -92,6 +93,20 @@ span.duration > 1000
 log.severity_text = 'ERROR'
 log.body CONTAINS 'failed'
 ```
+
+**Log body:**
+```
+body.status = 'failed'
+```
+Use `body.` to scope to fields inside a structured (JSON) log body.
+
+**Metrics:**
+
+Use the `metric.` prefix to scope suggestions to metric fields when querying metric data.
+
+<Admonition type="tip">
+In the Query Builder filter bar, type any context prefix followed by a dot (`attribute.`, `resource.`, `span.`, `body.`, `log.`, `metric.`) to scope the autocomplete dropdown to keys in that context. A prefix also makes operator suggestions type-accurate for the resolved key. See [Query Builder filtering](https://signoz.io/docs/userguide/query-builder-v5/#filtering).
+</Admonition>
 
 ## Performance Considerations
 

--- a/data/docs/userguide/query-builder-v5.mdx
+++ b/data/docs/userguide/query-builder-v5.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-07-27
 
 title: Query Builder v5 - Advanced Querying Guide
 description: Master SigNoz Query Builder with filtering, aggregations, trace operators, multi-query formulas, and performance tips to analyze logs, traces, and metrics at scale.
@@ -70,6 +70,18 @@ Filtering is the foundation of every query. The Query Builder supports expressio
 
 <Admonition type="tip">
 Use the keyboard shortcut `CMD+ENTER` (Mac) or `CTRL+ENTER` (Windows/Linux) to quickly execute Stage & Run Query.
+</Admonition>
+
+#### Scope autocomplete with field context prefixes
+
+Every telemetry key belongs to a field context: `attribute.`, `resource.`, `span.`, `body.`, `log.`, or `metric.`. Type one of these prefixes followed by a dot in the filter bar to scope the key suggestions to that context. The dropdown then lists only keys from that context, each shown in its full prefixed form. For example, typing `attribute.` surfaces keys such as `attribute.status.code`.
+
+Prefixes also make operator suggestions type-accurate. The same key name can exist under more than one context or data type (for example, `status.code` stored as both a string and a number). Select or type it without a prefix and the operator dropdown offers every operator that applies across all of its types. Add a context prefix and the key resolves to a single variant, so the operator list narrows to the operators valid for that type. If `status.code` is string-only in the resource context, `resource.status.code` offers `LIKE` but hides numeric comparisons like `>`.
+
+Use a prefix when a bare key name is ambiguous, or when you want the operator list to match the exact variant you intend to filter on. For a full explanation of contexts, data types, and when a prefix is required, see [Field Context & Data Types](https://signoz.io/docs/userguide/field-context-data-types/).
+
+<Admonition type="info">
+The prefixed form (for example, `resource.status.code`) is valid filter syntax you can type directly into an expression, not only an autocomplete aid. Autocomplete inserts the same prefixed key it displays.
 </Admonition>
 
 For the full list of supported operators and syntax patterns, see the [Operators Reference](https://signoz.io/docs/userguide/operators-reference/) and [Search Syntax](https://signoz.io/docs/userguide/search-syntax/).


### PR DESCRIPTION
## Summary
- Added a "Scope autocomplete with field context prefixes" subsection to the Query Builder filtering docs (`query-builder-v5.mdx`): typing one of the six prefixes (`attribute.`, `resource.`, `span.`, `body.`, `log.`, `metric.`) followed by a dot scopes key suggestions to that context and shows keys in their full prefixed form.
- Documented that a prefix makes operator suggestions type-accurate (resolves an ambiguous key to a single variant, e.g. string-only `resource.status.code` shows `LIKE` but not `>`), and clarified the prefixed form is valid typeable filter syntax, not only an autocomplete aid.
- Extended `field-context-data-types.mdx` to cover the previously undocumented `body.` and `metric.` contexts, added a filter-bar autocomplete tip, and added the required `doc_type` frontmatter key.
- Updated frontmatter `date` to today on both edited files.

Notes:
- Prose-only. The prefix-scoping behavior is not yet live on the demo build (verified: typing `attribute.` still issues the pre-change `fields/keys` request with empty `fieldContext`), so screenshots are pending a demo refresh.

Source PRs: #12200

Auto-generated by docs-sync pipeline