### PR TITLE
docs: update Dashboard V2 Number and Pie panel documentation

### DIFF
--- a/data/docs/dashboards/panel-types/pie.mdx
+++ b/data/docs/dashboards/panel-types/pie.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Pie Chart Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Pie Chart panel type in SigNoz dashboards to visualize proportional data.
 doc_type: reference
 ---
@@ -50,7 +50,7 @@ The following graph shows the distribution of the service requests over the serv
 
 #### Legend
 
-Customize the legend position and series colors.
+Customize the legend position and series colors. When the legend is positioned to the right, its column auto-sizes to fit the longest series name (up to 40% of the panel width, between 150 px and 320 px) so long labels are not truncated.
 
 #### Context Links
 

--- a/data/docs/dashboards/panel-types/value.mdx
+++ b/data/docs/dashboards/panel-types/value.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Number Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Number panel type in SigNoz dashboards to display single aggregated metric values.
 doc_type: reference
 ---
@@ -38,6 +38,10 @@ The following graph shows the combined average requests per second (req/s) for a
     - Log: see the [Logs query builder documentation](https://signoz.io/docs/userguide/query-builder-v5/#logs-and-traces-query-builder) to configure log query
     - Trace: see the [Traces query builder documentation](https://signoz.io/docs/userguide/query-builder-v5/#logs-and-traces-query-builder) to configure trace query
 - Reduce: choose the function to reduce the data (e.g. `avg`, `sum`, `max`, `min`, or `latest`). This step aggregates the data over the selected time period and returns a single value. For example, if you have a request rate over a period of time, the `avg` function will return the average of per-minute request rate over the period.
+
+<Admonition type="warning">
+A Number panel shows a single value, so it renders only the first enabled query. If more than one query is enabled, an amber warning icon appears on the panel, in both the editor preview and the rendered dashboard tile. Hovering the icon shows: "This panel shows a single value, but more than one query is enabled. Disable the queries you don't want to display, keeping only the one whose value you want to show." Disable the extra queries to clear the warning.
+</Admonition>
 
 ### Configuration Options
 


### PR DESCRIPTION
## Summary
- **Number panel** (`panel-types/value.mdx`): documented that a Number panel renders only the first enabled query, and described the amber multi-query warning (when it appears, its exact hover text, and how to clear it by disabling extra queries). Covers feature 1.
- **Pie chart** (`panel-types/pie.mdx`): noted that a right-positioned legend now auto-sizes to fit the longest series name (up to 40% of panel width, 150–320 px) instead of truncating. Covers feature 2.
- Updated frontmatter `date` to 2026-07-27 on both edited files.

### Not changed (verified no doc impact)
- **Feature 3 (escaped single-quote round-trip in Create Alert flow):** no Create Alert from Panel section exists in `interactivity.mdx` on main, and no walkthrough carries a double-backslash caveat. Nothing to fix.
- **Feature 4 (`%`/`+` literals in explorer-to-dashboard export):** no existing export walkthrough documents a `%`/`+` filter caveat. Nothing to remove.

### Screenshots
Prose-only. The demo build lags PR #12246 (merged 2026-07-23): the amber warning icon does not yet render in the Number panel editor preview, and long-label pie legends could not be reproduced. Screenshots pending once the demo picks up the build.

Source PRs: #12246

Auto-generated by docs-sync pipeline