### PR TITLE
fix(docs): correct v1 dashboard API status in the v0.135.0 upgrade guide

### DIFF
--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -2,7 +2,7 @@
 date: 2026-07-24
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
-description: SigNoz v0.135.0 rolls out the redesigned, Perses-compatible Dashboards V2. Existing dashboards migrate automatically; the V1 dashboard APIs are retired, so API scripts and Terraform need migration.
+description: Upgrade self-hosted SigNoz to v0.135.0. Dashboards convert to the V2 schema automatically, and the retired V1 dashboard APIs need script and Terraform changes.
 doc_type: howto
 ---
 
@@ -32,8 +32,8 @@ For the full release scope, see <a href="https://github.com/SigNoz/signoz/issues
 
 | If you | Then |
 | --- | --- |
-| Use dashboards only through the UI | Nothing: dashboards are migrated automatically. Check afterwards for any dashboard marked `legacy` |
-| Have scripts calling `/api/v1/dashboards` | [Migrate them to the V2 APIs](#migrate-api-scripts-to-the-v2-dashboards-apis) **before upgrading** — the V1 endpoints stop responding |
+| Use dashboards only through the UI | Nothing: dashboards are migrated automatically. Check afterwards for any dashboard marked **Legacy** |
+| Have scripts calling `/api/v1/dashboards` | [Migrate them to the V2 APIs](#migrate-api-scripts-to-the-v2-dashboards-apis) **before upgrading**: the V1 endpoints stop responding |
 | Manage dashboards with the Terraform provider | [Upgrade the provider and migrate resources](#migrate-terraform-managed-dashboards) |
 
 ## Upgrade self-hosted SigNoz
@@ -76,7 +76,7 @@ helm -n signoz upgrade signoz signoz/signoz
 1. Pods and containers are healthy (`kubectl get pods -n signoz`, `docker compose ps`, or `systemctl status 'signoz-*'`).
 2. SigNoz reports v0.135.0 under **Settings**.
 3. Open **Dashboards**: the redesigned list page loads, and your existing dashboards render with data.
-4. Scan the list for rows marked **Legacy**. The conversion runs per dashboard, and a dashboard whose stored data cannot be converted is left on the old schema and flagged rather than failing the upgrade. Legacy dashboards are listed but cannot be opened in the new experience — open the row's dialog to copy the dashboard ID and share it with support.
+4. Scan the list for rows marked **Legacy**. The conversion runs per dashboard, and a dashboard whose stored data cannot be converted is left on the old schema and flagged rather than failing the upgrade. Legacy dashboards are listed but cannot be opened in the new experience. Open the row's dialog to copy the dashboard ID and share it with support.
 
 ## Migrate API scripts to the V2 Dashboards APIs
 
@@ -93,7 +93,7 @@ The V1 dashboard endpoints are retired in v0.135.0. They respond with `501 Not I
 
 The public sharing routes (`/api/v1/dashboards/{id}/public` and `/api/v1/public/dashboards/{id}`) are not affected and keep working.
 
-One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload — a body carrying `version` and no `schemaVersion` — and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
+One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload (a body carrying `version` and no `schemaVersion`) and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -2,11 +2,15 @@
 date: 2026-07-24
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
-description: SigNoz v0.135.0 rolls out the redesigned, Perses-compatible Dashboards V2. Existing dashboards migrate automatically; API scripts and Terraform need migration.
+description: SigNoz v0.135.0 rolls out the redesigned, Perses-compatible Dashboards V2. Existing dashboards migrate automatically; the V1 dashboard APIs are retired, so API scripts and Terraform need migration.
 doc_type: howto
 ---
 
-SigNoz v0.135.0 rolls out the redesigned [Dashboards](https://signoz.io/docs/dashboards/dashboards-v2-api/) experience and the new Dashboards V2 APIs. Your existing dashboards, queries, variables, and panels are migrated to the new Perses-compatible schema automatically. You only need to act if you have scripts calling the Dashboards API directly, or manage dashboards with the Terraform provider.
+SigNoz v0.135.0 rolls out the redesigned [Dashboards](https://signoz.io/docs/dashboards/dashboards-v2-api/) experience and the new Dashboards V2 APIs. Your existing dashboards, queries, variables, and panels are migrated to the new Perses-compatible schema automatically, so no action is needed if you only use dashboards through the UI.
+
+<Admonition type="warning" title="The V1 dashboard endpoints stop responding in v0.135.0">
+`/api/v1/dashboards` and its sub-routes return `501 Not Implemented` after this upgrade. If you have scripts calling the Dashboards API directly, or manage dashboards with the Terraform provider, [migrate them](#migrate-api-scripts-to-the-v2-dashboards-apis) before you upgrade.
+</Admonition>
 
 <Admonition type="info" title="What changed in v0.135" defaultCollapsed="true">
 Dashboards move to a strictly validated schema based on the <a href="https://perses.dev/" target="_blank" rel="noopener noreferrer nofollow">Perses</a> dashboard-as-code standard.
@@ -15,11 +19,11 @@ Key changes:
 
 - **Schema & APIs**: V2 CRUD APIs with Perses validation, `PATCH` for granular panel and metadata updates, and list APIs with pagination, sorting, and a query DSL
 - **Editing**: optimistic updates; panels and query changes save without "Stage & Run"
-- **Variables**: inline creation with `ALL` support and paginated options
-- **List page & panels**: tags, pins, saved views, and sorting; panel copy, drilldown, CSV/PNG/SVG export, and alerts from a panel
+- **Variables**: inline creation, `ALL` support, orchestrated refetch with correct load ordering, and `$variable` suggestions in queries
+- **List page & panels**: tags, pins, saved views, and sorting; panel and section cloning, drilldown, CSV/PNG/SVG export, and alerts from a panel
 - **Performance**: only on-screen panels refetch on time-range change and auto-refresh
 - **Ecosystem**: public dashboards on the V2 API, MCP server support, and a typed schema for GitOps and Terraform
-- **Migration**: existing dashboards, inbuilt dashboards, and templates migrate to the new schema automatically
+- **Migration**: existing dashboards and inbuilt dashboards are converted to the new schema in place during the upgrade; the V1 dashboard APIs are retired
 
 For the full release scope, see <a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>; for the schema and API details, see the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/).
 </Admonition>
@@ -28,8 +32,8 @@ For the full release scope, see <a href="https://github.com/SigNoz/signoz/issues
 
 | If you | Then |
 | --- | --- |
-| Use dashboards only through the UI | Nothing: dashboards are migrated automatically |
-| Have scripts calling `/api/v1/dashboards` | [Migrate them to the V2 APIs](#migrate-api-scripts-to-the-v2-dashboards-apis) |
+| Use dashboards only through the UI | Nothing: dashboards are migrated automatically. Check afterwards for any dashboard marked `legacy` |
+| Have scripts calling `/api/v1/dashboards` | [Migrate them to the V2 APIs](#migrate-api-scripts-to-the-v2-dashboards-apis) **before upgrading** — the V1 endpoints stop responding |
 | Manage dashboards with the Terraform provider | [Upgrade the provider and migrate resources](#migrate-terraform-managed-dashboards) |
 
 ## Upgrade self-hosted SigNoz
@@ -72,18 +76,24 @@ helm -n signoz upgrade signoz signoz/signoz
 1. Pods and containers are healthy (`kubectl get pods -n signoz`, `docker compose ps`, or `systemctl status 'signoz-*'`).
 2. SigNoz reports v0.135.0 under **Settings**.
 3. Open **Dashboards**: the redesigned list page loads, and your existing dashboards render with data.
+4. Scan the list for rows marked **Legacy**. The conversion runs per dashboard, and a dashboard whose stored data cannot be converted is left on the old schema and flagged rather than failing the upgrade. Legacy dashboards are listed but cannot be opened in the new experience — open the row's dialog to copy the dashboard ID and share it with support.
 
 ## Migrate API scripts to the V2 Dashboards APIs
 
-Existing scripts keep working during the rollout: the V2 Create and Update APIs accept V1 payloads, and the V2 list API marks not-yet-migrated dashboards as `legacy` instead of erroring. This backward compatibility will be deprecated in an upcoming release (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>), so move your scripts to the V2 endpoints:
+The V1 dashboard endpoints are retired in v0.135.0. They respond with `501 Not Implemented`, the error code `dashboard_deprecated`, and a message naming the V2 replacement. Move your scripts to the V2 endpoints before you upgrade:
 
-| V1 endpoint | V2 endpoint |
+| V1 endpoint (now `501`) | V2 endpoint |
 | --- | --- |
 | `GET /api/v1/dashboards` | `GET /api/v2/dashboards` |
 | `POST /api/v1/dashboards` | `POST /api/v2/dashboards` |
 | `GET /api/v1/dashboards/{id}` | `GET /api/v2/dashboards/{id}` |
 | `PUT /api/v1/dashboards/{id}` | `PUT /api/v2/dashboards/{id}` |
 | `DELETE /api/v1/dashboards/{id}` | `DELETE /api/v2/dashboards/{id}` |
+| `PUT /api/v1/dashboards/{id}/lock` | `PUT /api/v2/dashboards/{id}/lock`, `DELETE /api/v2/dashboards/{id}/lock` |
+
+The public sharing routes (`/api/v1/dashboards/{id}/public` and `/api/v1/public/dashboards/{id}`) are not affected and keep working.
+
+One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload — a body carrying `version` and no `schemaVersion` — and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -35,6 +35,7 @@ For the full release scope, see <a href="https://github.com/SigNoz/signoz/issues
 | Use dashboards only through the UI | Nothing: dashboards are migrated automatically. Check afterwards for any dashboard marked **Legacy** |
 | Have scripts calling `/api/v1/dashboards` | [Migrate them to the V2 APIs](#migrate-api-scripts-to-the-v2-dashboards-apis) **before upgrading**: the V1 endpoints stop responding |
 | Manage dashboards with the Terraform provider | [Upgrade the provider and migrate resources](#migrate-terraform-managed-dashboards) |
+| Use the SigNoz MCP server with an AI assistant | [Upgrade it to v0.10.0](#upgrade-the-signoz-mcp-server) |
 
 ## Upgrade self-hosted SigNoz
 
@@ -96,6 +97,21 @@ The public sharing routes (`/api/v1/dashboards/{id}/public` and `/api/v1/public/
 One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload (a body carrying `version` and no `schemaVersion`) and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
+
+## Upgrade the SigNoz MCP server
+
+The MCP server's dashboard tools moved to the V2 APIs in **v0.10.0**, so the two upgrades are coupled. On SigNoz Cloud's hosted MCP endpoint this happens for you; self-hosted MCP deployments need the version bump.
+
+| signoz-mcp-server | SigNoz | Result |
+| --- | --- | --- |
+| v0.9.x or older | v0.134.x or older | Works on the V1 dashboard API |
+| v0.9.x or older | v0.135.0 or newer | Dashboard tools fail: they call the retired V1 routes |
+| v0.10.0 | v0.134.x or older | Dashboard tools fail: the V2 routes do not exist yet |
+| v0.10.0 | v0.135.0 or newer | Supported |
+
+Only the dashboard tools are affected. The metrics, traces, logs, alerts, services, and docs tools work across both versions. Tool names are unchanged, so MCP client configs need no edits beyond the version bump. v0.10.0 also adds `signoz_patch_dashboard`, which applies an RFC 6902 JSON Patch so an assistant can edit one panel without resending the whole dashboard.
+
+For the full list of changes and known limitations, see <a href="https://github.com/SigNoz/signoz-mcp-server/issues/262" target="_blank" rel="noopener noreferrer nofollow">signoz-mcp-server#262</a>.
 
 ## Migrate Terraform-managed dashboards
 


### PR DESCRIPTION
## Why

The [v0.135.0 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-135/) tells readers their existing V1 dashboard scripts keep working through the rollout. Verified against the code in `SigNoz/signoz`, they do not - the guide would send operators into a broken upgrade.

## What's wrong

**1. The V1 dashboard endpoints are retired, not deprecated-but-working.**

Every V1 dashboard CRUD route returns **`501 Not Implemented`** with error code `dashboard_deprecated`:

- `pkg/modules/dashboard/impldashboard/handler.go` — `Create`, `Update`, `LockUnlock`, `Delete`
- `pkg/query-service/app/http_handler.go` — `Get`, `List`
- Asserted in `tests/integration/tests/dashboard/01_dashboard.py::test_v1_dashboard_endpoints_are_deprecated`

The guide's "Existing scripts keep working during the rollout" told people they could migrate after upgrading. They have to migrate before.

**2. Only Create accepts V1 payloads, not Update.**

`CreateV2` has a V1 fallback (`version` present, `schemaVersion` absent → `ConvertV1ToV2`). `UpdateV2` binds straight to `UpdatableDashboardV2`, whose `Validate()` rejects anything but `schemaVersion: "v6"`.

## Also corrected

| Claim | Reality |
| --- | --- |
| Variables have "paginated options" | Not shipped — `useFetchedVariableOptions.ts` resolves the full option set per fetch cycle |
| "panel copy" | Panels clone within a dashboard and move between sections; there is no cross-dashboard copy |
| "templates migrate to the new schema automatically" | Built-in and integration dashboards do; the in-product Templates tab links out to the docs template library |
| Legacy dashboards | The guide implied they degrade gracefully. They are listed with a **Legacy** badge but cannot be opened — the UI shows a contact-support dialog. Added a verification step for this |

## Changes

- New warning admonition up top: the V1 endpoints stop responding, migrate before upgrading
- Rewrote the "Migrate API scripts" intro; added the `/lock` row and a note that the public sharing routes are unaffected
- Documented the create-only V1 payload shim explicitly, including that Update does not accept V1
- Added a step 4 to "Verify the upgrade" covering Legacy-flagged dashboards
- Fixed the feature bullets and the frontmatter description

Context: SigNoz/signoz#12177 (the tracking issue has been corrected the same way).