### PR TITLE
docs: Dashboard V2 GA - list DSL filter, panel editor, variables, API validation

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,24 +1,33 @@
 ---
-date: 2026-07-10
+date: 2026-07-27
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
-description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
+description: "Use the SigNoz V2 Dashboards API: schema, endpoints, pagination, the query DSL, partial PATCH updates, and the validation rules for API and dashboard-as-code clients."
 doc_type: howto
 ---
 
-SigNoz is rolling out a redesigned **Dashboards** experience. Your existing dashboards, queries, variables, and panels continue to work exactly as they do now. This release keeps all of that intact and adds improvements that make dashboards easier to find, organize, and manage at scale.
+SigNoz **Dashboards** run on a redesigned, Perses-compatible schema. Your existing dashboards, queries, variables, and panels are migrated to it automatically. The new schema makes dashboards easier to find, organize, and manage at scale.
 
 - **Dashboards get easier to find and manage:** organize with key-value tags, personal pins, shared saved views, and quick cloning, plus a defined JSON/Terraform schema that enables direct editing, partial (token-efficient) updates, and reliable AI-driven changes.
 - **Panels get more expressive:** new styling controls (fill mode, line interpolation, disconnect lines, show points) and PNG/SVG export for sharing in reports and incident write-ups.
 
 ## What you need to know
 
-- Dashboards will be migrated in the week of 27th July.
-- Nothing breaks on the platform. Your existing dashboards keep working, and this rolls out alongside them.
-- If you don't use Terraform or don't have any scripts directly working with the SigNoz Dashboards APIs, no action is required from you today.
+- Existing dashboards are migrated to the V2 schema automatically when SigNoz starts up.
+- Dashboards used through the UI keep working with no action required.
+- If you have Terraform-managed dashboards or scripts calling the Dashboards APIs directly, migrate them to the V2 schema and endpoints. See the [v0.135.0 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-135/) for the migration path.
 
 ### If you have scripts that use the Dashboards API directly
 
 We suggest you migrate those scripts to use the new V2 Dashboards APIs. You can follow the examples in this guide below.
+
+<Admonition type="warning" title="Strict validation on the V2 spec">
+The V2 schema is strictly validated. Update API and dashboard-as-code (Terraform) clients for these rules:
+
+- **Empty enum strings are rejected.** Sending an explicit `""` for any enum field returns `400 Bad Request` with error code `dashboard_invalid_input`. Affected fields: `timePreference`, `legendPosition`, `legendMode`, `thresholdFormat`, `comparisonOperator`, `lineInterpolation`, `lineStyle`, `fillMode`, `precisionOption`, and `listVariableSort`. Omit the field to use its default instead of sending `""`.
+- **`links` is required and non-nullable.** Both dashboard-level and panel-level specs must include `links`. Send `"links": []` when there are none. Omitting the field or sending `null` is rejected.
+- **Dynamic-variable `signal` is required.** It accepts only `traces`, `logs`, `metrics`, or `all`. Clients that previously omitted it receive the `all` default on migration, but must send an explicit value going forward.
+- **List-variable `sort` always returns `none`.** When a list variable's sort is not set at creation, the response returns `"sort": "none"` explicitly instead of omitting the field.
+</Admonition>
 
 ### If you have dashboards synced via Terraform
 
@@ -319,7 +328,7 @@ curl --location --request PATCH '<YOUR-SIGNOZ-URL>/api/v2/dashboards/<ID>' \
                     "kind": "signoz/DynamicVariable",
                     "spec": {
                         "name": "http.route",
-                        "signal": ""
+                        "signal": "all"
                     }
                 }
             }

--- a/data/docs/dashboards/overview.mdx
+++ b/data/docs/dashboards/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Dashboards
 description: Build custom dashboards to visualize metrics, logs, and traces in SigNoz.
 doc_type: explanation
@@ -11,6 +11,10 @@ Dashboards in SigNoz let you build custom visualizations over any telemetry sign
   src="/img/docs/dashboards/overview/dashboards-overview.gif"
   alt="SigNoz dashboards — list, view, and configure panels"
 />
+
+<Admonition type="info" title="Dashboards run on the V2 schema">
+Dashboards use the redesigned, Perses-compatible schema. Existing dashboards are converted automatically when SigNoz starts up, so no manual action is needed for dashboards used through the UI. If you call the Dashboards API directly or manage dashboards with Terraform, see the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) and the [v0.135.0 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-135/).
+</Admonition>
 
 ## Key capabilities
 

--- a/data/docs/dashboards/panel-types/table.mdx
+++ b/data/docs/dashboards/panel-types/table.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Table Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Table panel type in SigNoz dashboards to display and analyze metrics data in tabular format.
 doc_type: reference
 ---
@@ -46,7 +46,9 @@ The following graph shows the average requests per second (req/s) for a service 
 #### Formatting & Units
 
 - **Decimal Precision** — Number of decimal places to display. The default is `2 decimals`.
-- **Column Units** — Set the unit for each column (for example, query `A`) to format values in human-readable format (for example, `Bytes`, `Percent`, `Milliseconds`).
+- **Column Units** — Set the unit for each column (for example, query `A`) to format values in human-readable format (for example, `Bytes`, `Percent`, `Milliseconds`). If a column's selected unit differs from the underlying metric's unit, the column unit selector shows a mismatch warning so you can confirm the conversion is intended.
+
+When you switch a panel that had a panel-wide unit to the Table visualization, that unit is applied automatically to every value column in the table.
 
 #### Context Links
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-24
+date: 2026-07-27
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
 description: SigNoz v0.135.0 rolls out the redesigned, Perses-compatible Dashboards V2. Existing dashboards migrate automatically; API scripts and Terraform need migration.
@@ -36,7 +36,11 @@ For the full release scope, see <a href="https://github.com/SigNoz/signoz/issues
 
 ### Step 1: Back up your data
 
-Dashboards live in the SigNoz Metastore (SQLite or Postgres) and are converted to the new schema during the rollout. Back up the Metastore before upgrading. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops (v0.131 requires a ClickHouse upgrade) before jumping to v0.135.0.
+Dashboards live in the SigNoz Metastore (SQLite or Postgres) and are converted to the new schema automatically when the server starts up. Back up the Metastore before upgrading. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops (v0.131 requires a ClickHouse upgrade) before jumping to v0.135.0.
+
+<Admonition type="warning" title="Dashboard names must be unique per organization">
+V2 enforces a unique dashboard name within each organization. Before upgrading, rename any dashboards that share a name in the same organization. A dashboard with a duplicate name may not migrate and is left in the legacy format.
+</Admonition>
 
 ### Step 2: Upgrade SigNoz
 
@@ -73,6 +77,12 @@ helm -n signoz upgrade signoz signoz/signoz
 2. SigNoz reports v0.135.0 under **Settings**.
 3. Open **Dashboards**: the redesigned list page loads, and your existing dashboards render with data.
 
+## What changes after migration
+
+- **Automatic conversion.** Existing dashboards, inbuilt dashboards, and templates convert to the V2 schema when the server starts. SVG dashboard icons stored as percent-encoded inline data URIs are preserved during conversion.
+- **Dashboards that can't be converted stay on the legacy format.** A dashboard that fails conversion (for example, one with a duplicate name in its organization) is logged and left in the V1 format instead of blocking startup. These dashboards keep working. Resolve the underlying issue, such as a duplicate name, so the dashboard can migrate.
+- **Saved list-filter URLs no longer apply filters.** The Dashboards list page now filters with a query expression. The old URL parameters (`search`, `createdBy`, `updated`, and `tags`) no longer apply filters, so bookmarks or shared links using them open the list unfiltered. See [Find and filter dashboards](https://signoz.io/docs/userguide/manage-dashboards/#find-and-filter-dashboards).
+
 ## Migrate API scripts to the V2 Dashboards APIs
 
 Existing scripts keep working during the rollout: the V2 Create and Update APIs accept V1 payloads, and the V2 list API marks not-yet-migrated dashboards as `legacy` instead of erroring. This backward compatibility will be deprecated in an upcoming release (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>), so move your scripts to the V2 endpoints:
@@ -86,6 +96,8 @@ Existing scripts keep working during the rollout: the V2 Create and Update APIs 
 | `DELETE /api/v1/dashboards/{id}` | `DELETE /api/v2/dashboards/{id}` |
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
+
+The V2 schema is strictly validated. Before migrating scripts, note that empty enum strings are rejected (omit the field for the default), `links` is required and non-nullable (send `[]` when there are none), and a dynamic variable's `signal` must be one of `traces`, `logs`, `metrics`, or `all`. See [Strict validation on the V2 spec](https://signoz.io/docs/dashboards/dashboards-v2-api/#if-you-have-scripts-that-use-the-dashboards-api-directly) in the API guide for the complete list.
 
 ## Migrate Terraform-managed dashboards
 

--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,11 +1,11 @@
 ---
-date: 2026-05-13
-description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
+date: 2026-07-27
+description: Learn how to create, edit, delete, filter, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
 ---
 
-This section shows how you can create, update, and remove dashboards and panels.
+This section shows how you can create, update, filter, and remove dashboards and panels.
 
 <Figure
   src="/img/docs/userguide/manage-dashboards/dashboards-page.webp"
@@ -19,6 +19,62 @@ From the Dashboards page, you can:
 - **New Dashboard** — Create a dashboard from scratch by entering a name and selecting **+ New Dashboard**.
 - **Import JSON** — Import a dashboard from a JSON file or a Grafana export.
 - **View templates** — Quickly jump to the templates library to import a pre-built dashboard.
+
+## Find and filter dashboards
+
+The Dashboards list page has a single query box that filters the list using a structured expression language (DSL). Build a query from keys, operators, values, and `AND` / `OR` connectors. The **Created by** and **Updated** dropdowns next to the box write their conditions into the same query.
+
+### Filter keys
+
+Reserved fields appear as **field** pills in the autocomplete list:
+
+| Key | Type | Operators | Example |
+| --- | --- | --- | --- |
+| `name` | string | `=` `!=` `CONTAINS` `NOT CONTAINS` `LIKE` `NOT LIKE` `ILIKE` `NOT ILIKE` `IN` `NOT IN` | `name CONTAINS 'prod'` |
+| `description` | string | Same as `name` | `description ILIKE '%latency%'` |
+| `created_by` | string | Same as `name` | `created_by = 'me@example.com'` |
+| `created_at` | timestamp | `=` `!=` `<` `<=` `>` `>=` `BETWEEN` `NOT BETWEEN` | `created_at >= '2026-07-01T00:00:00Z'` |
+| `updated_at` | timestamp | Same as `created_at` | `updated_at >= '2026-07-20T00:00:00Z'` |
+| `locked` | boolean | `=` `!=` | `locked = true` |
+
+Any key that is not a reserved field is treated as an organization **tag** key and appears as a **tag** pill. Tag keys use the string operators plus `EXISTS` and `NOT EXISTS`:
+
+```text
+env = 'prod' AND team = 'core'
+owner EXISTS
+```
+
+Value formats:
+
+- String values are quoted: `name = 'API latency'`.
+- `IN` / `NOT IN` take a bracketed list: `created_by IN ['a@example.com', 'b@example.com']`.
+- Boolean values are unquoted: `locked = true`.
+- Timestamps use RFC3339: `updated_at >= '2026-07-20T00:00:00Z'`.
+- `EXISTS` / `NOT EXISTS` take no value.
+
+### Autocomplete
+
+Click into the query box, or start typing, to open the suggestions popup. It guides you one stage at a time: **keys → operators → values → connectors** (`AND` / `OR`). Use ↑/↓ to move through suggestions, Enter to apply the highlighted one, and Esc to dismiss the popup. Typed expressions are color-highlighted so keys, operators, `AND` / `OR` keywords, quoted strings, and bare values are easy to tell apart.
+
+### Draft-and-run model
+
+The query box uses a draft model: typing does not run a search. Apply the filter with **Cmd/Ctrl + Enter** or the **Run** button. A blue dot appears on **Run** whenever there are typed changes that have not been applied yet.
+
+### Created by and Updated dropdowns
+
+- **Created by** is a multi-select dropdown with a checkbox per creator, inline search, and a clear-all control. It writes a `created_by` condition into the query and runs the filter when the dropdown closes, not on each individual pick.
+- **Updated** is a single-select dropdown. Choosing a time window adds the matching `updated_at` condition to the query and applies it immediately.
+
+Editing a simple top-level condition in the query box is reflected back into these dropdowns.
+
+### List behavior
+
+- The list header (title and filter bar) stays pinned to the top of the viewport as the list scrolls.
+- Deleting the last dashboard on a page other than the first steps back to the previous page instead of showing an empty result.
+
+<Admonition type="warning" title="Saved and shared list URLs">
+The old list URL parameters (`search`, `createdBy`, `updated`, and `tags`) no longer apply filters. Bookmarks or shared links that use them open the list unfiltered. Re-create the filter in the query box and re-share the URL.
+</Admonition>
 
 ## Prerequisites
 
@@ -131,6 +187,27 @@ Note the following about panels:
 2. Find the dashboard in which you created the panel you wish to update, and then select the pencil icon located at the top right corner of your panel.
 3. Make the changes.
 4. When you've finished, select the **Save** button.
+
+## Panel editor behavior
+
+The full-page panel editor keeps your in-progress work as you move around:
+
+- **Switching to view mode keeps unsaved changes.** All pending configuration (thresholds, units, table and list columns, legend, axes, and formatting) carries into **Switch to View Mode** along with the query.
+- **Query edits survive a browser refresh.** In-progress builder edits are restored on reload. Configuration changes such as title, thresholds, and units are not currently retained across a hard refresh.
+- **The Save button reflects state.** **Save** is enabled when there are unsaved changes and disabled when there are none, including after a refresh or after switching from the View modal to the full editor.
+- **New queries do not auto-run.** Adding a query does not trigger a preview fetch. The preview runs after you select **Run Query**.
+- **Query-builder dropdowns render fully.** Group-by, order-by, having, filter, metric name, aggregator, and unit menus are no longer clipped by the resizable editor pane.
+- **A custom time range is preserved.** A time range picked in the editor's time picker is kept when you navigate back to the dashboard.
+- **Variables seed on direct load.** Opening the editor from a pasted link or a hard refresh seeds all variable values into the query preview.
+- **Visualization-type switches carry settings forward.** Changing the panel type (for example Time Series to Table) carries over axes soft min/max, log scale, time preference, stacking, fill spans, legend position and mode, and chart appearance instead of resetting them to defaults.
+- **Context links with a literal `%`** (for example `?search=95%`) open correctly.
+
+The **Switch to Edit Mode** button in a panel's View modal appears only when you have edit permission on an unlocked dashboard.
+
+## Arrange panels
+
+- After you save a panel, clone a panel, or add a section, the dashboard scrolls to reveal the new or affected item.
+- New panels are placed in an open grid position without overlapping tall panels that extend into the lower rows.
 
 ## Next Steps
 

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Manage Variables in SigNoz
 description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
@@ -41,6 +41,18 @@ To add a variable to a dashboard, follow the steps below:
     6. _(Optional)_ **Include an option for ALL values**: Show the `ALL` option which includes all options from the multi-select dropdown
 6. When you've finished, select the **Save** button.
 
+## Multi-select variable behavior
+
+When a variable has **Enable multiple values to be checked** turned on, it appears in the variables bar as a multi-select dropdown:
+
+- **Selections commit when the dropdown closes.** Dependent panels and variables update once, after you close the dropdown, instead of cascading on every individual checkbox click.
+- **Only button.** Hovering an option row shows an **Only** button. Selecting it keeps that single value and deselects all others.
+- **Clearing resets to the default.** Clearing the selection with the × button falls back to the variable's configured default instead of leaving it empty.
+- **Overflow chip.** When more than one value is selected, the variable pill shows the first selected value plus a **+N** chip for the remaining selections.
+- **Stable defaults.** Re-running the variable's query no longer clears the default when it returns the same option set. The default is reset only when the option set changes and no longer contains the current default.
+
+Variable selections are preserved when you move between the dashboard and the panel editor, including across a hard refresh of the editor.
+
 ## Supported Variable types:
 
 SigNoz supports four ways of creating variables: dynamic, query, custom, and textbox.
@@ -51,7 +63,7 @@ Dynamic variables automatically retrieve attribute values without requiring manu
 
 1. Field - either an OTEL telemetry intrinsic field (like span name or log severity_text) or a custom <a href="https://opentelemetry.io/docs/concepts/glossary/#attribute" target="_blank" rel="noopener noreferrer nofollow">attribute</a> from logs, traces, or metrics
 
-2. Source: Pick where to search - it checks logs, traces, and metrics by default, but choosing just one source makes it faster. Some of the fields have identical values across signals (e.g., k8s.pod.name is the same whether from logs or traces), so one source is sufficient. Use 'All sources' only when the same field contains distinct values across different signal types.
+2. Signal: Pick where to search. The options are **All**, **Logs**, **Traces**, and **Metrics**. **All** (the default) queries traces, logs, and metrics at the same time; choosing a single signal makes the lookup faster. Some fields have identical values across signals (for example, `k8s.pod.name` is the same whether it comes from logs or traces), so a single signal is sufficient. Use **All** only when the same field contains distinct values across different signal types.
 
     ![Dynamic Variable](/img/docs/dashboards/variables/dynamic-variable.png)
 


### PR DESCRIPTION
## Summary

Documents the Dashboard V2 General Availability batch. All changes are prose-only: the demo still serves the intermediate V2 build (old single search box on the list page, old variables bar), so the new filter bar and multi-select UI are not screenshottable yet. Screenshots pending a demo deploy.

### Changes
- **dashboards/overview.mdx** — Added an info admonition that dashboards run on the V2 schema and migrate automatically on startup (features 1-5).
- **userguide/manage-dashboards.mdx** — New "Find and filter dashboards" section documenting the DSL query box (reserved keys + per-type operator sets, tag keys, autocomplete stages, draft/run model, dirty dot, Created by / Updated dropdowns, sticky header, page step-back, and the URL-parameter breaking change). New "Panel editor behavior" and "Arrange panels" sections (features 6-32).
- **dashboards/panel-types/table.mdx** — Column unit mismatch warning and unit fan-out when switching to Table (features 29-30).
- **userguide/manage-variables.mdx** — New "Multi-select variable behavior" section (commit-on-close, Only button, clear-to-default, +N overflow chip, stable defaults, selection preservation) and the dynamic-variable `all` signal option (features 33-39).
- **dashboards/dashboards-v2-api.mdx** — Moved to present-tense GA; added a strict-validation admonition (empty-enum rejection, required non-nullable `links`, required `signal` enum, `sort: none` response); fixed the dynamic-variable example `signal` value (features 40-43).
- **operate/migration/upgrade-0-135.mdx** — Name-uniqueness warning, "What changes after migration" section (automatic conversion, SVG icon preservation, legacy fallback, broken filter URLs), and an API strict-validation summary (features 1, 2, 5, 18, 40-44).

Notes: The V2 API Reference auto-generates from the product `openapi.yml`, so features 40-43 are surfaced as a scoped admonition on the how-to guide rather than duplicated. Open Question #5 (DSL operators) resolved from `dslGrammar.ts`.

Source PRs: #12041, #12046, #12049, #12146, #12197, #12201, #12249, #12254, #12274

Auto-generated by docs-sync pipeline