### PR TITLE
docs: document hasToken single-token constraint

### DIFF
--- a/data/docs/userguide/functions-reference.mdx
+++ b/data/docs/userguide/functions-reference.mdx
@@ -1,8 +1,9 @@
 ---
-date: 2026-05-18
+date: 2026-07-27
 
 title: Functions Reference Guide
 description: Reference guide for SigNoz query functions for arrays and token matching. Learn syntax and usage examples.
+doc_type: reference
 ---
 
 This guide covers functions available for querying array fields in SigNoz.
@@ -15,21 +16,33 @@ Functions are currently supported only for JSON body searches.
 
 ### hasToken() Function
 
-Check if a token is present in a string.
+Check if a whole token is present in a string.
 
-The search term must be a single token—meaning a sequence of alphanumeric characters (A-Z, a-z, 0-9) that appears in the text separated by spaces, punctuation, or at the start/end of the string.
-hasToken will only match the term as a whole word, not as a substring inside another word (e.g., matches uuid123 but not abcuuid123xyz)
+The needle must be a single token: one uninterrupted run of ASCII letters and digits (`A-Z`, `a-z`, `0-9`) with no separator characters. `hasToken` matches the needle only as a complete word, never as a substring inside another word (for example, it matches `uuid123` but not `abcuuid123xyz`).
 
 **Syntax:**
 ```
-has(field, value)
+hasToken(field, value)
 ```
 
 **Examples:**
 ```
-has(body, "john@test.com")
-has(body, "e8ff7fe2-6f6a-4795-bd7f-d07f8e49d764")
+# Valid: the needle is a single alphanumeric token
+hasToken(body, 'uuid123')
+hasToken(body, 'timeout')
 ```
+
+<Admonition type="warning">
+The needle must be a single whole token. If it contains any character that is not an ASCII letter or digit (for example `_`, `-`, `.`, `@`, `/`, `:`, or a space), the query fails with an HTTP 400 error that names the offending separator. To search across separators, use a substring filter with `CONTAINS` instead.
+
+```
+# Invalid: the needle contains separators (@ and .), returns HTTP 400
+hasToken(body, 'john@test.com')
+
+# Correct: CONTAINS matches across separators
+body CONTAINS 'john@test.com'
+```
+</Admonition>
 
 ### has() Function
 

--- a/data/docs/userguide/search-troubleshooting.mdx
+++ b/data/docs/userguide/search-troubleshooting.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2026-05-18
+date: 2026-07-27
 title: Search Query Troubleshooting Guide
 description: Diagnose and fix common SigNoz search query errors including syntax errors, ambiguous fields, missing keys, and function-related issues with clear examples.
+doc_type: howto
 ---
 
 This page covers common error messages from the SigNoz filter bar (used in Logs Explorer, Traces Explorer, alert rules, and dashboards) and how to fix them.
@@ -253,6 +254,26 @@ If you need to check for a value in a non-body array field, use a standard opera
 ```
 attribute.tags CONTAINS 'prod'
 ```
+
+</details>
+
+### Q. I'm getting `hasToken ... contains the separator` — why does my token search fail?
+
+A. `hasToken()` matches a single whole token, so the needle must be one uninterrupted run of ASCII letters and digits. If it contains any other character (for example `_`, `-`, `.`, `@`, `/`, `:`, or a space), the query fails with an HTTP 400 error naming the offending separator. Use a substring filter with `CONTAINS` to search across separators.
+
+<details>
+
+<summary>Show causes and fixes</summary>
+
+```
+# Wrong — needle contains separators (@ and .)
+hasToken(body, 'john@test.com')
+
+# Correct — use CONTAINS to match across separators
+body CONTAINS 'john@test.com'
+```
+
+See the [hasToken function reference](https://signoz.io/docs/userguide/functions-reference/#hastoken-function) for the full token rules.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Fixed the `hasToken()` section in the Functions Reference: corrected the syntax to `hasToken(field, value)` (was `has(...)`) and replaced the old examples (`john@test.com`, a UUID) whose needles contain separators and now return HTTP 400.
- Documented the single-token constraint: the needle must be one run of ASCII letters/digits; any non-alphanumeric separator (`_ - . @ / :`, space, etc.) returns a 400 error naming the separator, with a `CONTAINS` remediation. This is the page the product's 400 error message links to (`/docs/userguide/functions-reference/#hastoken-function`).
- Added a matching troubleshooting Q&A on the Search Query Troubleshooting page for the new error string.
- Updated `date` frontmatter to 2026-07-27 on both edited files; added missing `doc_type` keys.

## Notes on the deliverable's open questions
- The hasToken reference page **exists** and the anchor (`#hastoken-function`) matches the URL hardcoded in the product error message.
- Separators recognized: **any** character that is not an ASCII letter or digit (verified in `firstTokenSeparator`), not just `_ - .` and space.
- The hasAny/hasAll big-integer fix (feature #3) needs **no docs change** — no large-integer limitation was ever documented, so there is nothing to update.
- No screenshots: backend error-message / query-result behavior only, no UI element.

Source PRs: #12261

Auto-generated by docs-sync pipeline