### PR TITLE
docs: update Dashboard V2 schema and validation documentation

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-10
+date: 2026-07-27
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
 description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
 doc_type: howto
@@ -57,6 +57,10 @@ The full schema can be seen in the payload of the <a href="https://signoz.io/api
     }
 }
 ```
+
+<Admonition type="info">
+The spec has no `datasources` field. Any payload that still sets `datasources` has it ignored, so remove it from scripts, Terraform, and MCP integrations that build the dashboard spec. When a panel has the wrong number of queries, the validation error now reports the actual count it found, which makes API-level debugging easier.
+</Admonition>
 
 ### Dashboard APIs
 

--- a/data/docs/userguide/manage-dashboards.mdx
+++ b/data/docs/userguide/manage-dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to create, edit, delete, and manage dashboards and panels within SigNoz.
 title: Manage Dashboards in SigNoz
 doc_type: howto
@@ -61,10 +61,14 @@ Click the **...** (three-dot) menu at the top of any dashboard to access the fol
 - **Lock Dashboard** — Prevent accidental edits by locking the dashboard. When locked, panels cannot be added, removed, resized, or rearranged. Unlock the dashboard from the same menu to resume editing.
 - **Rename** — Quickly rename the dashboard without opening the full configuration drawer.
 - **Full screen** — View the dashboard in full-screen mode for presentations or wall displays.
-- **New section** — Add a section to organize panels into logical groups within the dashboard.
+- **New section** — Add a section to organize panels into logical groups within the dashboard. Section titles accept up to 256 characters.
 - **Export JSON** — Download the dashboard configuration as a JSON file for backup or sharing.
 - **Copy as JSON** — Copy the dashboard JSON to your clipboard.
 - **Delete dashboard** — Permanently delete the dashboard.
+
+<Admonition type="info">
+Section titles accept up to 256 characters. Dashboard names, panel names, and variable display names are limited to 128 characters.
+</Admonition>
 
 ## Update a Custom Dashboard
 

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Manage Variables in SigNoz
 description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
@@ -38,8 +38,12 @@ To add a variable to a dashboard, follow the steps below:
     3. **Type**: Pick the appropriate variable type (UI updates based on selection)
     4. _(Optional)_ **Sort**: Arrange values in ascending/descending order.
     5. _(Optional)_ **Enable multiple values to be checked**: Make dropdown multi-select
-    6. _(Optional)_ **Include an option for ALL values**: Show the `ALL` option which includes all options from the multi-select dropdown
+    6. _(Optional)_ **Include an option for ALL values**: Show the `ALL` option which includes all options from the multi-select dropdown. This toggle appears only when **Enable multiple values to be checked** is on.
 6. When you've finished, select the **Save** button.
+
+<Admonition type="info">
+**Include an option for ALL values** requires **Enable multiple values to be checked**. The editor shows the `ALL` toggle only after you enable multiple values, and the API rejects a variable that sets `allowAllValue` without `allowMultiple`.
+</Admonition>
 
 ## Supported Variable types:
 


### PR DESCRIPTION
## Summary
- Documented that **Include an option for ALL values** requires **Enable multiple values to be checked** for list variables (UI hides the toggle when multiple values is off; API rejects `allowAllValue` without `allowMultiple`) in `manage-variables.mdx`
- Documented the 256-character limit for dashboard section titles vs the 128-character limit for dashboard, panel, and variable display names in `manage-dashboards.mdx`
- Noted that the V2 dashboard spec has no `datasources` field (ignored if set; remove from scripts/Terraform/MCP tooling) and that panel query-count validation errors now report the actual count, in `dashboards-v2-api.mdx`
- Updated frontmatter dates on all edited files

### Notes
- No docs pages referenced the dashboard-spec `datasources` field, so nothing needed removal (resolves Open Question #3). The MCP server doc contains no dashboard-spec payload, so no edit was required.
- Verified on demo that the variable editor hides the ALL toggle when multiple values is off (resolves Open Question #1), so no screenshots were needed for this batch.

Source PRs: #12263

Auto-generated by docs-sync pipeline