### PR TITLE
docs: update Dashboards V2 scalar reduceTo and v1 import behavior

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-10
+date: 2026-07-27
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
 description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
 doc_type: howto
@@ -57,6 +57,36 @@ The full schema can be seen in the payload of the <a href="https://signoz.io/api
     }
 }
 ```
+
+### Scalar panels require `reduceTo` on metric queries
+
+Value (number) panels, pie charts, and tables render a single value per query, so they issue a **scalar** request. A metric query produces a time series, so a scalar request must say how to collapse that series to one number. Set `reduceTo` on each metric aggregation in these panels.
+
+Valid values are: `sum`, `count`, `avg`, `min`, `max`, `last`, `median`.
+
+```json
+"aggregations": [
+    {
+        "metricName": "system.cpu.time",
+        "timeAggregation": "rate",
+        "spaceAggregation": "sum",
+        "reduceTo": "sum"
+    }
+]
+```
+
+The visual query builder sets `reduceTo` for you, so this only affects requests you construct programmatically. A scalar metric query that omits it, or uses an unsupported value, is rejected at query time with `400 Bad Request` and the `invalid_input` error code:
+
+```json
+{
+    "error": {
+        "code": "invalid_input",
+        "message": "reduceTo is required for aggregation #1 in query 'A' for the scalar request type"
+    }
+}
+```
+
+Existing V1 dashboards do not need edits: their scalar metric queries have `reduceTo` derived automatically during migration (rate and increase map to `sum`, percentile aggregations map to `avg`, other gauge aggregations map to `last`).
 
 ### Dashboard APIs
 

--- a/data/docs/dashboards/import-dashboard.mdx
+++ b/data/docs/dashboards/import-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-27
 title: Import Dashboard in SigNoz
 description: Import pre-built JSON dashboard templates into SigNoz to quickly set up monitoring views for your infrastructure and applications.
 doc_type: howto
@@ -36,4 +36,8 @@ You can either paste the JSON that you copied or upload the JSON file that you d
   caption="Paste or Upload Dashboard JSON"
 />
 
-Once the JSON is imported, you will see the new dashboard on your dashboards page. 
+Once the JSON is imported, you will see the new dashboard on your dashboards page.
+
+<Admonition type="info" title="Importing a legacy dashboard export">
+Dashboards exported from an older SigNoz version use the legacy V1 JSON format. You can import that JSON directly here. SigNoz detects the V1 format and converts it to the current Dashboards V2 schema on the server, so no manual reshaping is needed before import.
+</Admonition>

--- a/data/docs/dashboards/panel-types/value.mdx
+++ b/data/docs/dashboards/panel-types/value.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Number Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Number panel type in SigNoz dashboards to display single aggregated metric values.
 doc_type: reference
 ---
@@ -38,6 +38,10 @@ The following graph shows the combined average requests per second (req/s) for a
     - Log: see the [Logs query builder documentation](https://signoz.io/docs/userguide/query-builder-v5/#logs-and-traces-query-builder) to configure log query
     - Trace: see the [Traces query builder documentation](https://signoz.io/docs/userguide/query-builder-v5/#logs-and-traces-query-builder) to configure trace query
 - Reduce: choose the function to reduce the data (e.g. `avg`, `sum`, `max`, `min`, or `latest`). This step aggregates the data over the selected time period and returns a single value. For example, if you have a request rate over a period of time, the `avg` function will return the average of per-minute request rate over the period.
+
+<Admonition type="info" title="PromQL queries on Number panels">
+A Number panel backed by a PromQL query reduces the resulting series to its **last** data point and displays that single value. For rate-style expressions such as `rate(...)`, "last" is the most recent evaluated point, not an average over the window. If you want a different aggregate, wrap the expression in a range function such as `avg_over_time(...)` so the query itself returns the value you want to display.
+</Admonition>
 
 ### Configuration Options
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-24
+date: 2026-07-27
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
 description: Upgrade self-hosted SigNoz to v0.135.0. Dashboards convert to the V2 schema automatically, and the retired V1 dashboard APIs need script and Terraform changes.
@@ -97,6 +97,10 @@ The public sharing routes (`/api/v1/dashboards/{id}/public` and `/api/v1/public/
 One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload (a body carrying `version` and no `schemaVersion`) and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
+
+<Admonition type="info" title="Scalar metric queries now require reduceTo">
+Value (number) panels, pie charts, and tables issue scalar requests, and a scalar metric query must now set `reduceTo` to collapse its time series to a single value. Valid values are `sum`, `count`, `avg`, `min`, `max`, `last`, and `median`. The visual query builder sets this automatically, and your existing dashboards have `reduceTo` derived for them during migration (rate and increase map to `sum`, percentile aggregations to `avg`, other gauge aggregations to `last`), so no action is needed for dashboards built in the UI. If you construct scalar queries programmatically, add `reduceTo` to each metric aggregation: a query that omits it is rejected with `400 Bad Request`. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/#scalar-panels-require-reduceto-on-metric-queries) for details.
+</Admonition>
 
 ## Upgrade the SigNoz MCP server
 


### PR DESCRIPTION
## Summary

Documents the three fixes shipped in [SigNoz #12276](https://github.com/SigNoz/signoz/pull/12276) for Dashboards V2:

- **`import-dashboard.mdx`** — added an Admonition noting that legacy V1 dashboard JSON can be imported directly and is migrated to the V2 schema server-side (feature 1).
- **`dashboards-v2-api.mdx`** — new "Scalar panels require `reduceTo`" section: value/pie/table metric queries must set `reduceTo` (valid values `sum`, `count`, `avg`, `min`, `max`, `last`, `median`), documented the `400 invalid_input` error shape, and the V1→V2 auto-derivation rules (features 2–4).
- **`operate/migration/upgrade-0-135.mdx`** — Admonition in the API-migration section summarizing the `reduceTo` requirement, builder auto-population, and migration auto-derivation (features 2–4).
- **`panel-types/value.mdx`** — note that PromQL-backed Number panels reduce the series to its last data point, with a wrap-in-`avg_over_time(...)` alternative for rate-style queries (feature 5).
- Updated the `date` frontmatter to 2026-07-27 on all four edited files.

Prose-only: all three changes are error-path validation, internal migration logic, or a fix to a previously broken flow, so no screenshots are required (existing Import Dashboard screenshots remain accurate).

Source PRs: #12276

Auto-generated by docs-sync pipeline