### PR TITLE
docs: update V2 pie legend and table empty-cell behavior

### DIFF
--- a/data/docs/dashboards/panel-types/pie.mdx
+++ b/data/docs/dashboards/panel-types/pie.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Pie Chart Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Pie Chart panel type in SigNoz dashboards to visualize proportional data.
 doc_type: reference
 ---
@@ -50,7 +50,13 @@ The following graph shows the distribution of the service requests over the serv
 
 #### Legend
 
-Customize the legend position and series colors.
+Customize the legend position and series colors. When you group by an attribute, legend and slice labels use the `{key="value"}` format (for example, `{service.name="frontend"}`), matching the time series, bar, and histogram panels. Positioning the legend on the right keeps the full donut visible without clipping.
+
+Series colors are keyed by this label, so a custom color override applies only when its key matches the label exactly.
+
+<Admonition type="warning" title="Re-save custom colors set before this change">
+Earlier V2 pie panels showed group-by legends as bare values (for example, `frontend` instead of `{service.name="frontend"}`). If you set custom colors for a V2 pie panel using those bare-value keys, the overrides no longer match the new labels. Open the panel, re-apply the colors against the new `{key="value"}` entries, and save.
+</Admonition>
 
 #### Context Links
 

--- a/data/docs/dashboards/panel-types/table.mdx
+++ b/data/docs/dashboards/panel-types/table.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: Table Panel Type
-date: 2026-05-13
+date: 2026-07-27
 description: Learn how to use the Table panel type in SigNoz dashboards to display and analyze metrics data in tabular format.
 doc_type: reference
 ---
@@ -55,6 +55,13 @@ Add context links to enable click-through navigation from the panel to other das
 #### Thresholds
 
 Thresholds are used to draw a line on the y-axis to highlight the value. The thresholds are defined as a list of tuples. Each tuple contains the value and the color. The color is optional and if not provided, the default color will be used.
+
+#### Empty cells
+
+A cell with a missing or null metric value displays `n/a` instead of `0`. These cells:
+
+- take no threshold background color, so a `0` threshold does not color them.
+- sort to the bottom of the column whether you sort ascending or descending, rather than sorting as the value `0`.
 
 
 ### Get Help


### PR DESCRIPTION
## Summary

Documents three V2 dashboard panel bug fixes from product PR #12282 (merged 2026-07-26).

**Pie chart panel** (`pie.mdx`)
- Documents the group-by legend/slice label format `{key="value"}` (e.g. `{service.name="frontend"}`), matching V1 and the other panel types.
- Notes that right-positioned legends keep the donut fully visible (clipping fix).
- Adds a warning `Admonition`: users who set custom colors on V2 pie panels using the old bare-value keys must re-save the overrides against the new `{key="value"}` keys.

**Table panel** (`table.mdx`)
- Adds an *Empty cells* section: missing/null metric values render as `n/a`, take no threshold background color, and sort to the bottom of the column.

- Updated frontmatter `date` on both edited files.

## Screenshots
Prose-only. The demo build (demo.in.signoz.cloud) still renders the old bare-value pie labels (verified: slice labels show `espresso`/`latte`, not `{...}`), so the new `{key="value"}` legend format is not yet capturable. The existing `pie-chart.webp` shows the pre-fix bare-value legend and should be refreshed once the demo picks up #12282.

Source PRs: #12282

Auto-generated by docs-sync pipeline