### PR TITLE
bugfix(open-in-ai): fix mobile alignment for open in ai dropdown

### DIFF
--- a/components/OpenInAI/OpenInAI.view.tsx
+++ b/components/OpenInAI/OpenInAI.view.tsx
@@ -53,25 +53,11 @@ function OpenInAI({
   const [copied, setCopied] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [open, setOpen] = useState(false)
-  const [menuAlignOffset, setMenuAlignOffset] = useState(0)
   const isCopyingRef = useRef(false)
-  const shellRef = useRef<HTMLDivElement>(null)
-  const chevronRef = useRef<HTMLButtonElement>(null)
   const logEvent = useLogEvent()
 
   const absolutePageUrl = useMemo(() => getAbsoluteUrl(pageUrl), [pageUrl])
   const canCopy = Boolean(markdownContent || getMarkdownContent)
-
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    if (nextOpen && shellRef.current && chevronRef.current) {
-      // Anchor the menu to the full split button, not just the chevron trigger.
-      setMenuAlignOffset(
-        shellRef.current.getBoundingClientRect().left -
-          chevronRef.current.getBoundingClientRect().left
-      )
-    }
-    setOpen(nextOpen)
-  }, [])
 
   const handleCopy = useCallback(async () => {
     if (!canCopy || isCopyingRef.current) return
@@ -126,7 +112,7 @@ function OpenInAI({
 
   return (
     <div className={cn('flex items-center', className)}>
-      <div ref={shellRef} className={cn(shellClass, 'relative')}>
+      <div className={cn(shellClass, 'relative')}>
         <button
           type="button"
           onClick={handleCopy}
@@ -147,10 +133,9 @@ function OpenInAI({
 
         <div className="w-px shrink-0 self-stretch bg-[var(--l1-border)]" aria-hidden="true" />
 
-        <DropdownMenu open={open} onOpenChange={handleOpenChange} modal={false}>
+        <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
           <DropdownMenuTrigger asChild>
             <button
-              ref={chevronRef}
               type="button"
               className={cn(segmentClass, segmentHoverClass, open && segmentActiveClass)}
               aria-label="More options"
@@ -168,10 +153,9 @@ function OpenInAI({
 
           <DropdownMenuContent
             side="bottom"
-            align="start"
+            align="end"
             sideOffset={4}
-            alignOffset={menuAlignOffset}
-            avoidCollisions={false}
+            collisionPadding={8}
             style={openInAIMenuVars}
             className="z-50 w-64 backdrop-blur-[20px]"
           >


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Fixes broken visibility for open in ai dropdown in mobile introduced in https://github.com/SigNoz/signoz.io/pull/3855

#### Screenshots / Screen Recordings (if applicable)

Before:
<img width="215" height="248" alt="Screenshot 2026-07-31 at 00 03 27" src="https://github.com/user-attachments/assets/9e4e8f02-d90b-4e0b-a898-4c2d5ab347c4" />

After:
<img width="424" height="229" alt="Screenshot 2026-07-31 at 00 03 51" src="https://github.com/user-attachments/assets/3dad8bd4-1bba-4d8d-90ea-16e52fbb0913" />

#### Issues closed by this PR
> NA.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> https://github.com/SigNoz/signoz.io/pull/3855 - changed DropdownMenuContent alignment from end to start, which broke on smaller screens 

#### Root Cause
> Regression

#### Fix Strategy
> Restored alignment end to copy markdown dropdown

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Open in ai modal only
- Potential regressions: None
- Rollback plan: NA


---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
