### PR TITLE
feat: DocCard updates

### DIFF
--- a/components/DocCard.tsx
+++ b/components/DocCard.tsx
@@ -1,20 +1,58 @@
 import React from 'react'
+import { ArrowRight } from 'lucide-react'
 import Link from '@/components/Link'
 
 interface CardProps {
   title: string
   description: string
   href: string
+  icon?: React.ReactNode
 }
 
-const DocCard: React.FC<CardProps> = ({ title, description, href }) => {
+const DocCard: React.FC<CardProps> = ({ title, description, href, icon }) => {
+  if (icon) {
+    return (
+      <Link
+        href={href}
+        className="block min-h-[152px] border border-dashed border-[var(--l1-border)] bg-transparent p-4 no-underline outline-none transition-colors hover:bg-[var(--l1-background-hover)] focus-visible:bg-[var(--l1-background-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--l1-border)] active:bg-[var(--l1-background-hover)]"
+      >
+        <div className="flex min-h-[120px] flex-col justify-between">
+          <div className="size-8 shrink-0 overflow-hidden rounded-[4px] text-[var(--l1-foreground)] [&_img]:size-full [&_img]:object-contain [&_svg]:size-full [&_svg]:fill-current [&_svg]:stroke-current">
+            {icon}
+          </div>
+          <div className="flex flex-col gap-3">
+            <div className="text-base font-semibold leading-none text-[var(--l1-foreground-hover)]">
+              {title}
+            </div>
+            <p className="m-0 text-[13px] leading-5 tracking-[-0.065px] text-[var(--l2-foreground)]">
+              {description}
+            </p>
+          </div>
+        </div>
+      </Link>
+    )
+  }
+
   return (
     <Link
       href={href}
-      className="block overflow-hidden rounded border  border-gray-700 bg-gray-900 p-6 no-underline shadow-lg transition-all duration-200 ease-in-out hover:border-blue-500 dark:bg-gray-800"
+      className="group block rounded border border-solid border-[var(--l1-border)] bg-[var(--l2-background)] p-4 no-underline outline-none transition-colors hover:bg-[var(--l1-background-hover)] focus-visible:bg-[var(--l1-background-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--l1-border)] active:bg-[var(--l1-background-hover)]"
     >
-      <div className="mb-2 text-xl font-bold text-white dark:text-gray-100">{title}</div>
-      <p className="text-base text-gray-400 dark:text-gray-300">{description}</p>
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-base font-medium leading-none text-[var(--l1-foreground)] transition-colors group-hover:text-[var(--l1-foreground-hover)] group-focus-visible:text-[var(--l1-foreground-hover)] group-active:text-[var(--l1-foreground-hover)]">
+            {title}
+          </div>
+          <ArrowRight
+            aria-hidden="true"
+            className="size-4 shrink-0 text-[var(--l2-foreground)] transition-colors group-hover:text-[var(--l1-foreground-hover)] group-focus-visible:text-[var(--l1-foreground-hover)] group-active:text-[var(--l1-foreground-hover)]"
+            strokeWidth={1.333}
+          />
+        </div>
+        <p className="m-0 text-[13px] leading-5 tracking-[-0.065px] text-[var(--l2-foreground)] transition-colors group-hover:text-[var(--l1-foreground-hover)] group-focus-visible:text-[var(--l1-foreground-hover)] group-active:text-[var(--l1-foreground-hover)]">
+          {description}
+        </p>
+      </div>
     </Link>
   )
 }

--- a/components/DocCard.tsx
+++ b/components/DocCard.tsx
@@ -6,33 +6,9 @@ interface CardProps {
   title: string
   description: string
   href: string
-  icon?: React.ReactNode
 }
 
-const DocCard: React.FC<CardProps> = ({ title, description, href, icon }) => {
-  if (icon) {
-    return (
-      <Link
-        href={href}
-        className="block min-h-[152px] border border-dashed border-[var(--l1-border)] bg-transparent p-4 no-underline outline-none transition-colors hover:bg-[var(--l1-background-hover)] focus-visible:bg-[var(--l1-background-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--l1-border)] active:bg-[var(--l1-background-hover)]"
-      >
-        <div className="flex min-h-[120px] flex-col justify-between">
-          <div className="size-8 shrink-0 overflow-hidden rounded-[4px] text-[var(--l1-foreground)] [&_img]:size-full [&_img]:object-contain [&_svg]:size-full [&_svg]:fill-current [&_svg]:stroke-current">
-            {icon}
-          </div>
-          <div className="flex flex-col gap-3">
-            <div className="text-base font-semibold leading-none text-[var(--l1-foreground-hover)]">
-              {title}
-            </div>
-            <p className="m-0 text-[13px] leading-5 tracking-[-0.065px] text-[var(--l2-foreground)]">
-              {description}
-            </p>
-          </div>
-        </div>
-      </Link>
-    )
-  }
-
+const DocCard: React.FC<CardProps> = ({ title, description, href }) => {
   return (
     <Link
       href={href}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Restyles docs `DocCard` to match the Docs-v2 design (title + arrow row, description below) and migrates colors/spacing to `@signozhq/design-tokens` semantic CSS variables (`--l1-*` / `--l2-*`).

This replaces the old hard-coded gray/blue/shadow card with a token-driven surface that supports hover, active, and focus-visible states consistently, while keeping the existing `title` / `description` / `href` API and `Link` behavior (onboarding rewrites, region params, external links).

#### Screenshots / Screen Recordings (if applicable)

Before:

<img width="870" height="537" alt="Screenshot 2026-07-31 at 14 38 35" src="https://github.com/user-attachments/assets/30f72da6-0a11-4865-b43a-2b2b49917842" />

After:
<img width="909" height="455" alt="Screenshot 2026-07-31 at 14 38 46" src="https://github.com/user-attachments/assets/6c8282ad-5019-4fbe-8991-f394f5cf9050" />

#### Issues closed by this PR

Closes https://github.com/SigNoz/growth-pod/issues/996

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---


### 🧪 Testing Strategy

- Tests added/updated: Not required (visual/styling-only change to `components/DocCard.tsx`; props API unchanged)
- Manual verification:
  - Docs pages using `<DocCard>` (default / hover / mouse-down active / keyboard focus-visible)
  - Link navigation still works for internal docs, absolute `signoz.io` docs URLs, and external links
- Edge cases covered: visited-link color overrides avoided by pinning title/description/arrow colors to semantic tokens; focus-visible outline for keyboard users

---

### ⚠️ Risk & Impact Assessment

- Blast radius: All MDX docs pages that render `<DocCard>` via `MDXComponents`
- Potential regressions: Visual density/spacing differences vs the old gray card; arrow affordance is new
- Rollback plan: Fix if any arises, reverting pr should be last resort

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers


---
