### PR TITLE
feat(dashboards): offer V2 dashboard template JSON and deprecate V1

### DIFF
--- a/components/Dashboards/DashboardActions.tsx
+++ b/components/Dashboards/DashboardActions.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import React, { useCallback, useMemo, useRef, useState } from 'react'
-import { Check, Copy, Download, TriangleAlert } from 'lucide-react'
+import { Check, Copy, Download } from 'lucide-react'
+import Admonition from '../Admonition/Admonition'
 import Button from '../ui/Button'
 
 export const V2_MIN_SIGNOZ_VERSION = 'v0.135.0'
@@ -64,11 +65,20 @@ const TAB_CLASS = [
 
 // `not-prose` drops the docs anchor styling, so links carry it themselves.
 const LINK_CLASS = 'text-[var(--accent-primary)] underline underline-offset-2'
+// The raw JSON lives on GitHub, so following it leaves the docs site.
+const EXTERNAL_LINK_PROPS = {
+  target: '_blank',
+  rel: 'noopener noreferrer nofollow',
+} as const
 
-const V1_NOTICE_CLASS = [
-  'mb-4 flex gap-2 rounded-[4px] p-3 text-sm leading-6 text-[var(--l2-foreground)]',
-  'border border-[color-mix(in_srgb,var(--accent-amber)_35%,transparent)]',
-  'bg-[color-mix(in_srgb,var(--accent-amber)_8%,transparent)]',
+/**
+ * Low-emphasis action styling for the deprecated version. The `secondary` Button
+ * variant hardcodes dark ink/vanilla colors, so it stayed dark on a light ground;
+ * these semantic tokens flip with the theme like the rest of the card.
+ */
+const V1_BUTTON_CLASS = [
+  'border border-[var(--l1-border)] bg-transparent text-[var(--l2-foreground)]',
+  'hover:bg-[var(--l3-background)] hover:text-[var(--l1-foreground)]',
 ].join(' ')
 
 const DashboardActions: React.FC<DashboardActionsProps> = ({
@@ -192,22 +202,14 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
 
       <div className="px-4 py-4">
         {isV1 ? (
-          <p className={V1_NOTICE_CLASS}>
-            <TriangleAlert
-              aria-hidden
-              className="mt-1 h-4 w-4 shrink-0 text-[var(--accent-amber)]"
-            />
-            <span>
-              <strong className="font-semibold text-[var(--l1-foreground)]">Deprecated.</strong> Use
-              V1 only on SigNoz older than {V2_MIN_SIGNOZ_VERSION}. From {V2_MIN_SIGNOZ_VERSION}{' '}
-              onwards, import the V2 JSON — V1 imports still work through a temporary compatibility
-              path that will be removed. See the{' '}
-              <a className={LINK_CLASS} href={UPGRADE_GUIDE_URL}>
-                {V2_MIN_SIGNOZ_VERSION} upgrade guide
-              </a>
-              .
-            </span>
-          </p>
+          // Admonition already carries the warning tone in both themes, so the
+          // notice does not hand-roll its own amber surface.
+          <Admonition type="warning" variant="sm" title="V1 is deprecated" className="mt-0">
+            Use V1 only on SigNoz older than {V2_MIN_SIGNOZ_VERSION}. From {V2_MIN_SIGNOZ_VERSION}{' '}
+            onwards, import the V2 JSON — V1 imports still work through a temporary compatibility
+            path that will be removed. See the{' '}
+            <a href={UPGRADE_GUIDE_URL}>{V2_MIN_SIGNOZ_VERSION} upgrade guide</a>.
+          </Admonition>
         ) : (
           <p className="mb-4 text-sm leading-6 text-[var(--l2-foreground)]">
             Recommended. Uses the{' '}
@@ -221,7 +223,8 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
         <div className="flex flex-wrap gap-3">
           <Button
             // The deprecated version should not carry the primary CTA weight.
-            variant={isV1 ? 'secondary' : 'default'}
+            variant={isV1 ? 'ghost' : 'default'}
+            className={isV1 ? V1_BUTTON_CLASS : undefined}
             rounded="default"
             isButton={true}
             onClick={handleDownload}
@@ -232,7 +235,8 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
           </Button>
 
           <Button
-            variant="tertiary"
+            variant={isV1 ? 'ghost' : 'tertiary'}
+            className={isV1 ? V1_BUTTON_CLASS : undefined}
             rounded="default"
             isButton={true}
             onClick={handleCopy}
@@ -259,7 +263,11 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
         {error && (
           <p className="mt-3 text-sm leading-6 text-[var(--accent-cherry)]">
             {error}{' '}
-            <a className="underline underline-offset-2" href={activeUrl}>
+            <a
+              className="text-[var(--accent-cherry)] underline underline-offset-2"
+              href={activeUrl}
+              {...EXTERNAL_LINK_PROPS}
+            >
               Open the raw JSON
             </a>{' '}
             instead.

--- a/components/Dashboards/DashboardActions.tsx
+++ b/components/Dashboards/DashboardActions.tsx
@@ -1,112 +1,276 @@
 'use client'
 
-import React, { useState } from 'react'
-import { Download, Copy, CheckCircle } from 'lucide-react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { Check, Copy, Download, TriangleAlert } from 'lucide-react'
 import Button from '../ui/Button'
 
-interface DashboardActionsProps {
-  dashboardJsonUrl: string
-  dashboardName: string
+export const V2_MIN_SIGNOZ_VERSION = 'v0.135.0'
+const DASHBOARDS_V2_DOC_URL = 'https://signoz.io/docs/dashboards/dashboards-v2-api/'
+const UPGRADE_GUIDE_URL = 'https://signoz.io/docs/operate/migration/upgrade-0-135/'
+const IMPORT_DOC_URL = 'https://signoz.io/docs/dashboards/import-dashboard/'
+
+export type DashboardSchemaVersion = 'v2' | 'v1'
+
+type PendingAction = 'download' | 'copy' | null
+
+export interface DashboardActionsProps {
+  /** V2 (Perses) dashboard JSON. The default and recommended version. */
+  dashboardJsonV2Url?: string
+  /**
+   * Legacy V1 dashboard JSON. Omit when the dashboard has no V1 file — the
+   * version switch is then hidden and only V2 is offered.
+   */
+  dashboardJsonV1Url?: string
+  /**
+   * Legacy alias for `dashboardJsonV2Url`, kept so docs written before the V2
+   * rollout keep rendering.
+   *
+   * @deprecated Use `dashboardJsonV2Url`.
+   */
+  dashboardJsonUrl?: string
+  dashboardName?: string
   className?: string
 }
 
-const DashboardActions: React.FC<DashboardActionsProps> = ({ 
-  dashboardJsonUrl, 
-  dashboardName,
-  className = ""
+const VERSION_LABELS: Record<DashboardSchemaVersion, string> = {
+  v2: 'V2',
+  v1: 'V1 (legacy)',
+}
+
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+/** Falls back to the JSON file name when a doc does not pass `dashboardName`. */
+const getFileNameBase = (dashboardName: string, url: string): string => {
+  const fromName = slugify(dashboardName)
+  if (fromName) return fromName
+
+  const fileName = url.split('?')[0].split('/').pop() || ''
+  return slugify(fileName.replace(/\.json$/i, '')) || 'signoz-dashboard'
+}
+
+const CARD_CLASS = [
+  'not-prose my-6 w-full rounded-[6px] border text-left',
+  'border-[var(--l1-border)] bg-[var(--card,var(--l2-background))]',
+].join(' ')
+
+const TAB_CLASS = [
+  'rounded-[4px] px-2.5 py-1 text-xs font-medium leading-5 transition-colors',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]',
+].join(' ')
+
+// `not-prose` drops the docs anchor styling, so links carry it themselves.
+const LINK_CLASS = 'text-[var(--accent-primary)] underline underline-offset-2'
+
+const V1_NOTICE_CLASS = [
+  'mb-4 flex gap-2 rounded-[4px] p-3 text-sm leading-6 text-[var(--l2-foreground)]',
+  'border border-[color-mix(in_srgb,var(--accent-amber)_35%,transparent)]',
+  'bg-[color-mix(in_srgb,var(--accent-amber)_8%,transparent)]',
+].join(' ')
+
+const DashboardActions: React.FC<DashboardActionsProps> = ({
+  dashboardJsonV2Url,
+  dashboardJsonV1Url,
+  dashboardJsonUrl,
+  dashboardName = '',
+  className = '',
 }) => {
-  const [isDownloading, setIsDownloading] = useState(false)
-  const [isCopying, setIsCopying] = useState(false)
+  const v2Url = dashboardJsonV2Url || dashboardJsonUrl || ''
+  const v1Url = dashboardJsonV1Url || ''
+
+  const versions = useMemo<DashboardSchemaVersion[]>(
+    () => [...(v2Url ? (['v2'] as const) : []), ...(v1Url ? (['v1'] as const) : [])],
+    [v2Url, v1Url]
+  )
+
+  const [activeVersion, setActiveVersion] = useState<DashboardSchemaVersion>(v2Url ? 'v2' : 'v1')
+  const [pending, setPending] = useState<PendingAction>(null)
   const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Copying after downloading the same version should not refetch.
+  const jsonCache = useRef(new Map<string, string>())
+
+  const isV1 = activeVersion === 'v1'
+  const activeUrl = isV1 ? v1Url : v2Url
+  const shortLabel = activeVersion.toUpperCase()
+
+  const fetchJson = useCallback(async (url: string): Promise<string> => {
+    const cached = jsonCache.current.get(url)
+    if (cached) return cached
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch dashboard JSON: ${response.status}`)
+    }
+
+    const formatted = JSON.stringify(await response.json(), null, 2)
+    jsonCache.current.set(url, formatted)
+    return formatted
+  }, [])
+
+  const selectVersion = (version: DashboardSchemaVersion) => {
+    setActiveVersion(version)
+    setCopied(false)
+    setError(null)
+  }
 
   const handleDownload = async () => {
-    setIsDownloading(true)
+    setPending('download')
+    setError(null)
     try {
-      const response = await fetch(dashboardJsonUrl)
-      if (!response.ok) {
-        throw new Error('Failed to fetch dashboard JSON')
-      }
-      
-      const dashboardData = await response.json()
-      const blob = new Blob([JSON.stringify(dashboardData, null, 2)], { 
-        type: 'application/json' 
-      })
-      
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `${dashboardName.toLowerCase().replace(/\s+/g, '-')}.json`
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
-      URL.revokeObjectURL(url)
-    } catch (error) {
-      console.error('Error downloading dashboard:', error)
-      alert('Failed to download dashboard. Please try again.')
+      const json = await fetchJson(activeUrl)
+      const objectUrl = URL.createObjectURL(new Blob([json], { type: 'application/json' }))
+      const anchor = document.createElement('a')
+      anchor.href = objectUrl
+      anchor.download = `${getFileNameBase(dashboardName, activeUrl)}-${activeVersion}.json`
+      document.body.appendChild(anchor)
+      anchor.click()
+      document.body.removeChild(anchor)
+      URL.revokeObjectURL(objectUrl)
+    } catch (downloadError) {
+      console.error('Error downloading dashboard:', downloadError)
+      setError('Could not download the dashboard JSON.')
     } finally {
-      setIsDownloading(false)
+      setPending(null)
     }
   }
 
   const handleCopy = async () => {
-    setIsCopying(true)
+    setPending('copy')
+    setError(null)
     try {
-      const response = await fetch(dashboardJsonUrl)
-      if (!response.ok) {
-        throw new Error('Failed to fetch dashboard JSON')
-      }
-      
-      const dashboardData = await response.json()
-      await navigator.clipboard.writeText(JSON.stringify(dashboardData, null, 2))
-      
+      await navigator.clipboard.writeText(await fetchJson(activeUrl))
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    } catch (error) {
-      console.error('Error copying dashboard:', error)
-      alert('Failed to copy dashboard. Please try again.')
+    } catch (copyError) {
+      console.error('Error copying dashboard:', copyError)
+      setError('Could not copy the dashboard JSON.')
     } finally {
-      setIsCopying(false)
+      setPending(null)
     }
   }
 
+  if (!activeUrl) return null
+
   return (
-    <div className={`flex flex-col items-center ${className}`}>
-      <div className="flex gap-3 my-6">
-        <Button
-          variant="default"
-          rounded='default'
-          isButton={true}
-          onClick={handleDownload}
-          disabled={isDownloading}
-        >
-          <Download className="w-3.5 h-3.5 mr-1.5" />
-          {isDownloading ? 'Downloading...' : 'Download JSON'}
-        </Button>
-        
-        <Button 
-          variant={"tertiary"} 
-          rounded={"default"} 
-          isButton={true}
-          onClick={handleCopy}
-          disabled={isCopying}
-        >
-          {copied ? (
-            <>
-              <CheckCircle className="w-3.5 h-3.5 mr-1.5 text-green-600" />
-              <span className="text-green-600">Copied!</span>
-            </>
-          ) : (
-            <>
-              <Copy className="w-3.5 h-3.5 mr-1.5" />
-              {isCopying ? 'Copying...' : 'Copy JSON'}
-            </>
-          )}
-        </Button>
+    <div className={`${CARD_CLASS} ${className}`.trim()}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--l1-border)] px-4 py-3">
+        <span className="text-sm font-medium text-[var(--l1-foreground)]">Dashboard JSON</span>
+
+        {versions.length > 1 && (
+          <div
+            role="tablist"
+            aria-label="Dashboard JSON schema version"
+            className="flex items-center gap-1 rounded-[6px] bg-[var(--l3-background)] p-1"
+          >
+            {versions.map((version) => {
+              const selected = version === activeVersion
+              return (
+                <button
+                  key={version}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  onClick={() => selectVersion(version)}
+                  className={[
+                    TAB_CLASS,
+                    selected
+                      ? 'bg-[var(--card,var(--l2-background))] text-[var(--l1-foreground)] shadow-sm'
+                      : 'text-[var(--l3-foreground)] hover:text-[var(--l1-foreground)]',
+                  ].join(' ')}
+                >
+                  {VERSION_LABELS[version]}
+                </button>
+              )
+            })}
+          </div>
+        )}
       </div>
-      
-      <div className="text-sm text-gray-600 mt-2">
-        <p className="text-center">
-          <span className="font-bold italic">Dashboards → + New dashboard → Import JSON</span>
+
+      <div className="px-4 py-4">
+        {isV1 ? (
+          <p className={V1_NOTICE_CLASS}>
+            <TriangleAlert
+              aria-hidden
+              className="mt-1 h-4 w-4 shrink-0 text-[var(--accent-amber)]"
+            />
+            <span>
+              <strong className="font-semibold text-[var(--l1-foreground)]">Deprecated.</strong> Use
+              V1 only on SigNoz older than {V2_MIN_SIGNOZ_VERSION}. From {V2_MIN_SIGNOZ_VERSION}{' '}
+              onwards, import the V2 JSON — V1 imports still work through a temporary compatibility
+              path that will be removed. See the{' '}
+              <a className={LINK_CLASS} href={UPGRADE_GUIDE_URL}>
+                {V2_MIN_SIGNOZ_VERSION} upgrade guide
+              </a>
+              .
+            </span>
+          </p>
+        ) : (
+          <p className="mb-4 text-sm leading-6 text-[var(--l2-foreground)]">
+            Recommended. Uses the{' '}
+            <a className={LINK_CLASS} href={DASHBOARDS_V2_DOC_URL}>
+              V2 dashboard schema
+            </a>{' '}
+            and needs SigNoz {V2_MIN_SIGNOZ_VERSION} or newer.
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            // The deprecated version should not carry the primary CTA weight.
+            variant={isV1 ? 'secondary' : 'default'}
+            rounded="default"
+            isButton={true}
+            onClick={handleDownload}
+            disabled={pending !== null}
+          >
+            <Download aria-hidden className="mr-1.5 h-3.5 w-3.5" />
+            {pending === 'download' ? 'Downloading...' : `Download ${shortLabel} JSON`}
+          </Button>
+
+          <Button
+            variant="tertiary"
+            rounded="default"
+            isButton={true}
+            onClick={handleCopy}
+            disabled={pending !== null}
+          >
+            {copied ? (
+              <>
+                <Check aria-hidden className="mr-1.5 h-3.5 w-3.5" />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Copy aria-hidden className="mr-1.5 h-3.5 w-3.5" />
+                {pending === 'copy' ? 'Copying...' : `Copy ${shortLabel} JSON`}
+              </>
+            )}
+          </Button>
+        </div>
+
+        <p aria-live="polite" className="sr-only">
+          {copied ? `${shortLabel} dashboard JSON copied` : ''}
+        </p>
+
+        {error && (
+          <p className="mt-3 text-sm leading-6 text-[var(--accent-cherry)]">
+            {error}{' '}
+            <a className="underline underline-offset-2" href={activeUrl}>
+              Open the raw JSON
+            </a>{' '}
+            instead.
+          </p>
+        )}
+
+        <p className="mt-4 text-xs leading-5 text-[var(--l3-foreground)]">
+          Import it in SigNoz with <strong>Dashboards → + New dashboard → Import JSON</strong>.{' '}
+          <a className={LINK_CLASS} href={IMPORT_DOC_URL}>
+            Import guide
+          </a>
         </p>
       </div>
     </div>

--- a/components/Dashboards/DashboardActions.tsx
+++ b/components/Dashboards/DashboardActions.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { Check, Copy, Download } from 'lucide-react'
 import Admonition from '../Admonition/Admonition'
+import Link from '../Link'
 import Button from '../ui/Button'
 
 export const V2_MIN_SIGNOZ_VERSION = 'v0.135.0'
@@ -65,21 +66,6 @@ const TAB_CLASS = [
 
 // `not-prose` drops the docs anchor styling, so links carry it themselves.
 const LINK_CLASS = 'text-[var(--accent-primary)] underline underline-offset-2'
-// The raw JSON lives on GitHub, so following it leaves the docs site.
-const EXTERNAL_LINK_PROPS = {
-  target: '_blank',
-  rel: 'noopener noreferrer nofollow',
-} as const
-
-/**
- * Low-emphasis action styling for the deprecated version. The `secondary` Button
- * variant hardcodes dark ink/vanilla colors, so it stayed dark on a light ground;
- * these semantic tokens flip with the theme like the rest of the card.
- */
-const V1_BUTTON_CLASS = [
-  'border border-[var(--l1-border)] bg-transparent text-[var(--l2-foreground)]',
-  'hover:bg-[var(--l3-background)] hover:text-[var(--l1-foreground)]',
-].join(' ')
 
 const DashboardActions: React.FC<DashboardActionsProps> = ({
   dashboardJsonV2Url,
@@ -202,29 +188,25 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
 
       <div className="px-4 py-4">
         {isV1 ? (
-          // Admonition already carries the warning tone in both themes, so the
-          // notice does not hand-roll its own amber surface.
           <Admonition type="warning" variant="sm" title="V1 is deprecated" className="mt-0">
             Use V1 only on SigNoz older than {V2_MIN_SIGNOZ_VERSION}. From {V2_MIN_SIGNOZ_VERSION}{' '}
             onwards, import the V2 JSON — V1 imports still work through a temporary compatibility
             path that will be removed. See the{' '}
-            <a href={UPGRADE_GUIDE_URL}>{V2_MIN_SIGNOZ_VERSION} upgrade guide</a>.
+            <Link href={UPGRADE_GUIDE_URL}>{V2_MIN_SIGNOZ_VERSION} upgrade guide</Link>.
           </Admonition>
         ) : (
           <p className="mb-4 text-sm leading-6 text-[var(--l2-foreground)]">
             Recommended. Uses the{' '}
-            <a className={LINK_CLASS} href={DASHBOARDS_V2_DOC_URL}>
+            <Link className={LINK_CLASS} href={DASHBOARDS_V2_DOC_URL}>
               V2 dashboard schema
-            </a>{' '}
+            </Link>{' '}
             and needs SigNoz {V2_MIN_SIGNOZ_VERSION} or newer.
           </p>
         )}
 
         <div className="flex flex-wrap gap-3">
           <Button
-            // The deprecated version should not carry the primary CTA weight.
-            variant={isV1 ? 'ghost' : 'default'}
-            className={isV1 ? V1_BUTTON_CLASS : undefined}
+            variant="default"
             rounded="default"
             isButton={true}
             onClick={handleDownload}
@@ -235,8 +217,7 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
           </Button>
 
           <Button
-            variant={isV1 ? 'ghost' : 'tertiary'}
-            className={isV1 ? V1_BUTTON_CLASS : undefined}
+            variant="tertiary"
             rounded="default"
             isButton={true}
             onClick={handleCopy}
@@ -263,22 +244,21 @@ const DashboardActions: React.FC<DashboardActionsProps> = ({
         {error && (
           <p className="mt-3 text-sm leading-6 text-[var(--accent-cherry)]">
             {error}{' '}
-            <a
+            <Link
               className="text-[var(--accent-cherry)] underline underline-offset-2"
               href={activeUrl}
-              {...EXTERNAL_LINK_PROPS}
             >
               Open the raw JSON
-            </a>{' '}
+            </Link>{' '}
             instead.
           </p>
         )}
 
         <p className="mt-4 text-xs leading-5 text-[var(--l3-foreground)]">
           Import it in SigNoz with <strong>Dashboards → + New dashboard → Import JSON</strong>.{' '}
-          <a className={LINK_CLASS} href={IMPORT_DOC_URL}>
+          <Link className={LINK_CLASS} href={IMPORT_DOC_URL}>
             Import guide
-          </a>
+          </Link>
         </p>
       </div>
     </div>

--- a/contributing/docs-authoring.md
+++ b/contributing/docs-authoring.md
@@ -227,8 +227,26 @@ Use the template in [templates/send-data-doc.md](templates/send-data-doc.md).
 
 - Link to the relevant telemetry setup doc near the top.
 - Include a dashboard preview screenshot.
-- Provide import instructions using `DashboardActions`.
+- Provide copy/download actions using `DashboardActions`. Do not wrap it in a layout `div` — it renders as a full-width card.
 - Include sections for what the dashboard monitors, metrics included, and next steps.
+
+`DashboardActions` props:
+
+| Prop | Required | Notes |
+|---|---|---|
+| `dashboardJsonV2Url` | Yes | Raw URL of the V2 (Perses) JSON — the root path in the <a href="https://github.com/SigNoz/dashboards" target="_blank" rel="noopener noreferrer nofollow">dashboards repo</a>. |
+| `dashboardJsonV1Url` | No | Raw URL of the deprecated V1 JSON, which lives in the `v1/` subdirectory next to the V2 file. Omit it when the dashboard has no `v1/` copy; the version switch is then hidden. |
+| `dashboardName` | No | Used for the downloaded file name. Falls back to the JSON file name. |
+
+```mdx
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/v1/nginx.json"
+  dashboardName="NGINX"
+/>
+```
+
+The component labels V2 as recommended (SigNoz v0.135.0 and newer) and V1 as deprecated, so pages do not need their own version admonition.
 
 ### Troubleshooting Docs
 

--- a/data/docs/dashboards/dashboard-templates/agno-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/agno-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-10
+date: 2026-07-31
 
 title: Agno Dashboard
 description: Monitor Agno usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into Agno usage and performance. It highlight
   caption="Agno Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/agno/agno-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/agno/agno-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/agno/v1/agno-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/amazon-bedrock-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/amazon-bedrock-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Amazon Bedrock Dashboard
 description: Monitor Amazon Bedrock usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/bedrock-dashboard.webp" alt="Bedrock Dashboard" caption="Amazon Bedrock Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/bedrock/bedrock-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/bedrock/bedrock-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Anthropic API Dashboard
 description: Monitor Anthropic/Claude API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,10 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/anthropic-api-dashboard.webp" alt="Anthropic Dashboard" caption="Anthropic API Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/anthropic/anthropic-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/anthropic/anthropic-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/anthropic/v1/anthropic-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/apache-druid-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/apache-druid-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-20
+date: 2026-07-31
 title: Apache Druid Dashboard
 description: Monitor Apache Druid broker and coordinator health - query performance, JVM heap, GC activity, and Jetty thread pool saturation.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard covers broker and coordinator nodes: query latency, CPU cost, JVM
   caption="Apache Druid Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-druid/apache-druid-dashboard.json"
-    dashboardName="Apache Druid"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-druid/apache-druid-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-druid/v1/apache-druid-dashboard.json"
+  dashboardName="Apache Druid"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/apache-web-server.mdx
+++ b/data/docs/dashboards/dashboard-templates/apache-web-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-24
+date: 2026-07-31
 title: Apache Web Server Dashboard
 description: Monitor comprehensive Apache HTTP Server performance including request handling, CPU utilization, worker processes, traffic patterns, and server load for optimal web server management.
 doc_type: explanation
@@ -18,12 +18,11 @@ To populate this dashboard, collect Apache metrics with the OpenTelemetry Collec
     <figcaption><i>Apache Web Server Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-web-server/apache.json"
-    dashboardName="Apache Web Server"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-web-server/apache.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apache-web-server/v1/apache.json"
+  dashboardName="Apache Web Server"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/apm-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/apm-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: APM Metrics Dashboard
 description: Monitor comprehensive application performance metrics including latency, request rates, error rates, and external calls for your applications and services.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the opentelemetry instrumentation and 
     <figcaption><i>APM Metrics Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/apm-metrics.json"
-    dashboardName="APM Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/apm-metrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/v1/apm-metrics.json"
+  dashboardName="APM Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/argocd-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/argocd-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-23
+date: 2026-07-31
 title: ArgoCD Dashboard
 description: Monitor ArgoCD applications and operations with comprehensive metrics including application health, sync status, controller performance, cluster stats, and repository server activity.
 doc_type: explanation
@@ -17,12 +17,11 @@ This dashboard provides comprehensive monitoring of ArgoCD application health an
   caption="ArgoCD Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/argocd/argocd.json"
-    dashboardName="ArgoCD Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/argocd/argocd.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/argocd/v1/argocd.json"
+  dashboardName="ArgoCD Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/aspnet-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/aspnet-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-16
+date: 2026-07-31
 title: ASP.NET Core Metrics Dashboard
 description: Monitor ASP.NET Core application performance including HTTP request latency, Kestrel connections, GC and memory, thread pool health, and routing metrics.
 doc_type: explanation
@@ -17,12 +17,11 @@ Monitor ASP.NET Core application performance across five areas: HTTP request thr
   caption="ASP.NET Core Metrics Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aspnetcore/aspnetcore-otlp-v1.json"
-    dashboardName="ASP.NET Core Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aspnetcore/aspnetcore-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aspnetcore/v1/aspnetcore-otlp-v1.json"
+  dashboardName="ASP.NET Core Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/autogen-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/autogen-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Autogen Dashboard
 description: Monitor Autogen usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -20,12 +20,9 @@ This dashboard offers a clear view into Autogen usage and performance. It highli
   caption="Autogen Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/autogen/autogen-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/autogen/autogen-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/aws-elasticache-redis.mdx
+++ b/data/docs/dashboards/dashboard-templates/aws-elasticache-redis.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: AWS ElastiCache Redis Dashboard
 description: Monitor AWS ElastiCache Redis instances with comprehensive CloudWatch metrics including CPU utilization, memory usage, network traffic, cache performance, and replication metrics.
@@ -12,12 +12,11 @@ This dashboard provides comprehensive monitoring of AWS ElastiCache Redis perfor
 To use this dashboard, you need to set up the data source and send telemetry to SigNoz. Follow the [AWS ElastiCache Redis Integration](https://signoz.io/docs/integrations/aws-elasticache-redis/) guide to get started.
 </Admonition>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-elasticache/redis/overview.json"
-    dashboardName="AWS ElastiCache Redis Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-elasticache/redis/overview.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-elasticache/redis/v1/overview.json"
+  dashboardName="AWS ElastiCache Redis Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/aws-sqs-prometheus.mdx
+++ b/data/docs/dashboards/dashboard-templates/aws-sqs-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-30
+date: 2026-07-31
 title: AWS SQS Prometheus Dashboard
 description: Monitor AWS Simple Queue Service (SQS) using Prometheus metrics with comprehensive queue status tracking, message counts, and processing states across different environments and regions.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides comprehensive monitoring of AWS Simple Queue Service (SQ
   caption="AWS SQS Prometheus Dashboard" 
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-sqs-prometheus/aws-sqs-prometheus.json"
-    dashboardName="AWS SQS Prometheus Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-sqs-prometheus/aws-sqs-prometheus.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/aws-sqs-prometheus/v1/aws-sqs-prometheus.json"
+  dashboardName="AWS SQS Prometheus Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/azure-openai-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/azure-openai-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Azure OpenAI API Dashboard
 description: Monitor Azure OpenAI API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/azure-openai-dashboard.webp" alt="Azure OpenAI Dashboard" caption="Azure OpenAI API Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/azure-openai/azure-openai-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/azure-openai/azure-openai-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/baseten-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/baseten-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-08
+date: 2026-07-31
 title: Baseten Dashboard
 description: Monitor Baseten usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -19,12 +19,10 @@ This dashboard offers a clear view into Baseten usage and performance. It highli
   caption="Baseten Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/baseten/baseten-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/baseten/baseten-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/baseten/v1/baseten-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/cert-manager-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/cert-manager-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-25
+date: 2026-07-31
 title: Cert-Manager Dashboard
 description: Monitor cert-manager certificate health, expiration, issuer status, controller performance, ACME operations, webhook health, and component resource usage.
 doc_type: explanation
@@ -19,12 +19,11 @@ Use this dashboard to track certificate readiness, expiry, controller activity, 
   alt="cert-manager Dashboard - Overview"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cert-manager/cert-manager-dashboard.json"
-    dashboardName="Cert-Manager Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cert-manager/cert-manager-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cert-manager/v1/cert-manager-dashboard.json"
+  dashboardName="Cert-Manager Dashboard"
+/>
 
 ## Dashboard Variables
 

--- a/data/docs/dashboards/dashboard-templates/cicd.mdx
+++ b/data/docs/dashboards/dashboard-templates/cicd.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: CI/CD Dashboard
 description: Monitor comprehensive CI/CD pipeline performance including repository metrics, change management, pipeline duration, and deployment status across any VCS provider with semantic metrics support.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>CI/CD Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cicd/cicd.json"
-    dashboardName="CI/CD"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cicd/cicd.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cicd/v1/cicd.json"
+  dashboardName="CI/CD"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/claude-agent-sdk-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/claude-agent-sdk-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-06
+date: 2026-07-31
 title: Claude Agent SDK Dashboard
 description: Monitor Claude Agent SDK usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -20,12 +20,10 @@ This dashboard offers a clear view into Claude Agent SDK usage and performance. 
   caption="Claude Agent SDK Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-agent-sdk/claude-agent-sdk-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-agent-sdk/claude-agent-sdk-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-agent-sdk/v1/claude-agent-sdk-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/claude-code-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/claude-code-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-08
+date: 2026-07-31
 
 title: Claude Code Dashboard
 description: Track Claude Code usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, costs, success rates, and developer engagement across your AI-assisted development workflows.
@@ -19,12 +19,10 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Claude Code Dashboard - Credit: <a href="https://github.com/mikelane">Mike Lane</a></i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-code/claude-code-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-code/claude-code-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/claude-code/v1/claude-code-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/clickhouse-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/clickhouse-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: ClickHouse Monitoring Dashboard
 description: Monitor ClickHouse database performance with comprehensive metrics including query execution, resource utilization, connection metrics, replication health, and storage operations.
@@ -12,12 +12,11 @@ This dashboard provides comprehensive monitoring of ClickHouse database performa
 To use this dashboard, you need to set up the data source and send telemetry to SigNoz. Follow the [ClickHouse Integration](https://signoz.io/docs/integrations/clickhouse/) guide to get started.
 </Admonition>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/clickhouse/clickhouse-overview.json"
-    dashboardName="ClickHouse Monitoring Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/clickhouse/clickhouse-overview.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/clickhouse/v1/clickhouse-overview.json"
+  dashboardName="ClickHouse Monitoring Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/cloudnative-pg-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/cloudnative-pg-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-24
+date: 2026-07-31
 title: CloudNativePG Metrics Dashboard for Kubernetes Clusters
 description: Monitor CloudNativePG cluster health in SigNoz including connections, throughput, cache, replication, WAL and archiving, checkpoints, and storage.
 doc_type: explanation
@@ -19,12 +19,11 @@ Set up the data source and send telemetry to SigNoz before you import this dashb
   caption="CloudNativePG Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cloudnative-pg/cloudnative-pg-dashboard.json"
-    dashboardName="CloudNativePG"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cloudnative-pg/cloudnative-pg-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cloudnative-pg/v1/cloudnative-pg-dashboard.json"
+  dashboardName="CloudNativePG"
+/>
 
 ## Dashboard Coverage
 

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-23
+date: 2026-07-31
 title: OpenAI Codex Dashboard
 description: Track OpenAI Codex usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, costs, success rates, and developer engagement across your AI-assisted development workflows.
 doc_type: explanation
@@ -18,12 +18,10 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>OpenAI Codex Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/codex/codex-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/codex/codex-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/codex/v1/codex-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/cohere-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/cohere-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-11
+date: 2026-07-31
 title: Cohere Dashboard
 description: Monitor Cohere LLM operations with a focus on request volume, errors, token usage, latency, model adoption, and individual spans.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides a comprehensive view of the `cohere-otel` service using 
   caption="Cohere Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cohere/cohere-dashboard.json"
-    dashboardName="Cohere"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cohere/cohere-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/cohere/v1/cohere-dashboard.json"
+  dashboardName="Cohere"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/cost-meter.mdx
+++ b/data/docs/dashboards/dashboard-templates/cost-meter.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-31
 
 title: Cost Meter Dashboard
 description: Visualize and control your observability data usage and costs with granular, real-time insights across logs, metrics, and traces—empowering proactive spend management and telemetry governance.
@@ -16,12 +16,11 @@ Gain complete transparency into your observability platform’s data consumption
   caption="Cost Meter Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/meter/meter.json"
-    dashboardName="Cost Meter Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/meter/meter.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/meter/v1/meter.json"
+  dashboardName="Cost Meter Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/couchdb.mdx
+++ b/data/docs/dashboards/dashboard-templates/couchdb.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: CouchDB Dashboard
 description: Monitor essential CouchDB database performance including HTTP requests, response times, database operations, and resource utilization for optimal NoSQL database management.
@@ -19,12 +19,11 @@ To use this dashboard, you need to configure the <a href="https://github.com/ope
     <figcaption><i>CouchDB Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/couchdb/couchdb.json"
-    dashboardName="CouchDB"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/couchdb/couchdb.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/couchdb/v1/couchdb.json"
+  dashboardName="CouchDB"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/crewai-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/crewai-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Crew AI Dashboard
 description: Monitor Crew AI workflows and performance including token consumption, crew and agent execution times, task distribution, and per-tool performance trends for optimal AI agent observability.
@@ -16,12 +16,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/crew-dashboard.webp" alt="Crew AI Dashboard" caption="Crew AI Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/crewai/crewai-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/crewai/crewai-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/db-calls-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/db-calls-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-07-31
 
 title: DB Calls Monitoring Dashboard
 description: Monitor comprehensive database operations including transaction rates, top DB statements, error rates, and slowest database calls for performance optimization.
@@ -19,12 +19,11 @@ To use this dashboard, you need to instrument your application and send traces t
     <figcaption><i>DB Calls Monitoring Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/db-calls-monitoring.json"
-    dashboardName="DB Calls Monitoring"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/db-calls-monitoring.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/v1/db-calls-monitoring.json"
+  dashboardName="DB Calls Monitoring"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/deepseek-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/deepseek-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: DeepSeek API Dashboard
 description: Monitor DeepSeek API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,10 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/deepseek-dashboard.webp" alt="DeepSeek Dashboard" caption="DeepSeek API Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/deepseek/deepseek-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/deepseek/deepseek-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/deepseek/v1/deepseek-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/dify-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/dify-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: 2026-07-31
 title: Dify Dashboard
 description: Monitor Dify LLM agent workflows including token consumption, workflow execution volumes, error rates, latency trends, and model usage distribution for optimal AI application observability.
 doc_type: explanation
@@ -19,12 +19,9 @@ This dashboard provides a comprehensive view of the `langgenius/dify` service us
   caption="Dify Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/dify/dify-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/dify/dify-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/docker-container-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/docker-container-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Docker Container Metrics Dashboard
 description: Monitor comprehensive container performance including CPU utilization, memory usage, network traffic, and storage I/O metrics for Docker containers and orchestrated environments.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Docker Container Metrics Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/container-metrics-by-host.json"
-    dashboardName="Docker Container Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/container-metrics-by-host.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/v1/container-metrics-by-host.json"
+  dashboardName="Docker Container Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/dspy-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/dspy-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-21
+date: 2026-07-31
 title: DSPy Dashboard
 description: Monitor DSPy programs with module, chain, and tool activity, LLM call volume, per-model usage, latency percentiles, and errors using OpenTelemetry traces.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides a comprehensive view of your `DSPy` programs using trace
   caption="DSPy Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/dspy/dspy-dashboard.json"
-    dashboardName="DSPy"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/dspy/dspy-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/dspy/v1/dspy-dashboard.json"
+  dashboardName="DSPy"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/elasticsearch-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/elasticsearch-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-20
+date: 2026-07-31
 title: Elasticsearch Metrics Dashboard for Cluster Monitoring
 description: Monitor Elasticsearch cluster health, node resources, index operations, search performance, JVM, cache, circuit breakers, and thread pools in SigNoz.
 doc_type: explanation
@@ -19,12 +19,11 @@ Set up the data source and send telemetry to SigNoz before you import this dashb
   caption="Elasticsearch Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/elasticsearch/elasticsearch-dashboard-detailed.json"
-    dashboardName="Elasticsearch"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/elasticsearch/elasticsearch-dashboard-detailed.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/elasticsearch/v1/elasticsearch-dashboard-detailed.json"
+  dashboardName="Elasticsearch"
+/>
 
 ## Dashboard Coverage
 

--- a/data/docs/dashboards/dashboard-templates/envoy-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/envoy-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-14
+date: 2026-07-31
 title: Envoy Proxy Dashboard
 description: Monitor Envoy Proxy performance using OpenTelemetry metrics.
 doc_type: explanation
@@ -19,12 +19,11 @@ To use this dashboard, you need to configure Envoy to send metrics to SigNoz. Fo
   caption="Envoy Dashboard - General Overview and Request Metrics"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/envoy/envoy-otlp-v1.json"
-    dashboardName="Envoy Proxy"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/envoy/envoy-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/envoy/v1/envoy-otlp-v1.json"
+  dashboardName="Envoy Proxy"
+/>
 
 ## Dashboard Variables
 

--- a/data/docs/dashboards/dashboard-templates/firecrawl-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/firecrawl-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-15
+date: 2026-07-31
 title: Firecrawl Dashboard
 description: Monitor Firecrawl SDK usage with call volume, error rate, latency percentiles, credits consumed, and results returned, broken down per operation.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides a comprehensive view of Firecrawl SDK usage using trace 
   caption="Firecrawl Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/firecrawl/firecrawl-dashboard.json"
-    dashboardName="Firecrawl"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/firecrawl/firecrawl-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/firecrawl/v1/firecrawl-dashboard.json"
+  dashboardName="Firecrawl"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/flask-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/flask-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 title: Flask Monitoring Dashboard
 description: Monitor Flask web application performance with comprehensive metrics including request rates, response times, error tracking, and latency analysis built on Prometheus Flask metrics.
 doc_type: explanation
@@ -11,12 +11,11 @@ This dashboard provides comprehensive monitoring of Flask web application perfor
 To use this dashboard, you need to instrument your Flask application using [prometheus-flask-exporter](https://github.com/rycus86/prometheus_flask_exporter). You can collect these metrics using the **Prometheus** receiver. Follow the [Prometheus Metrics](https://signoz.io/docs/userguide/prometheus-metrics/) guide to get started.
 </Admonition>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/flask-monitoring/flask-monitoring.json"
-    dashboardName="Flask Monitoring Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/flask-monitoring/flask-monitoring.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/flask-monitoring/v1/flask-monitoring.json"
+  dashboardName="Flask Monitoring Dashboard"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/fluxcd-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/fluxcd-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-02
+date: 2026-07-31
 title: FluxCD Metrics Dashboard
 description: Monitor Flux controller health including reconciliation throughput, errors, duration, workqueues, runtime resource usage, and Kubernetes API traffic.
 doc_type: explanation
@@ -17,12 +17,11 @@ Use this dashboard to monitor your Flux control plane across reconciliation thro
   caption="FluxCD Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fluxcd/fluxcd.json"
-    dashboardName="FluxCD Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fluxcd/fluxcd.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fluxcd/v1/fluxcd.json"
+  dashboardName="FluxCD Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/fly-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/fly-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-07-31
 title: Fly.io Dashboard
 description: Monitor Fly.io application and infrastructure metrics including CPU usage, memory consumption, network throughput, and instance health.
 doc_type: explanation
@@ -19,12 +19,11 @@ To use this dashboard, you need to configure Fly.io metrics collection in SigNoz
   caption="Fly.io Dashboard - CPU, Memory, and Network Metrics"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
-    dashboardName="Fly.io (Prometheus)"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/v1/fly-prometheus-v1.json"
+  dashboardName="Fly.io (Prometheus)"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/frontend-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/frontend-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-11
+date: 2026-07-31
 title: Frontend Monitoring Dashboards
 description: Monitor your website's performance and user experience with Core Web Vitals metrics using OpenTelemetry.
 
@@ -21,12 +21,11 @@ We provide two dashboard templates based on how you choose to export your web vi
 
 ### Web Vitals with Metrics
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/web-vitals-monitoring-with-metrics.json"
-    dashboardName="Web Vitals Metrics Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/web-vitals-monitoring-with-metrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/v1/web-vitals-monitoring-with-metrics.json"
+  dashboardName="Web Vitals Metrics Dashboard"
+/>
 
 **Best for**: Large-scale deployments requiring sampling and aggregated statistical analysis
 
@@ -34,12 +33,11 @@ We provide two dashboard templates based on how you choose to export your web vi
 
 ### Web Vitals with Traces
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/web-vitals-monitoring-with-traces.json"
-    dashboardName="Web Vitals Traces Dashboard"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/web-vitals-monitoring-with-traces.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/web-vitals-monitoring/v1/web-vitals-monitoring-with-traces.json"
+  dashboardName="Web Vitals Traces Dashboard"
+/>
 
 **Best for**: Debugging specific user issues and detailed performance analysis
 

--- a/data/docs/dashboards/dashboard-templates/go-runtime-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/go-runtime-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-02
+date: 2026-07-31
 
 title: Go Runtime Metrics Dashboard
 description: Monitor comprehensive Go runtime performance including memory usage, goroutine count, garbage collection, processor limits, and heap allocation for optimal Go application performance.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Go Runtime Metrics Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/go-runtime/go-runtime-metrics.json"
-    dashboardName="Go Runtime Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/go-runtime/go-runtime-metrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/go-runtime/v1/go-runtime-metrics.json"
+  dashboardName="Go Runtime Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/google-adk-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/google-adk-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-16
+date: 2026-07-31
 title: Google ADK Dashboard
 description: Monitor Google ADK usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -19,12 +19,9 @@ This dashboard offers a clear view into Google ADK usage and agent performance. 
   caption="Google ADK Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/google-adk/google-adk-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/google-adk/google-adk-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/google-gemini-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/google-gemini-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Google Gemini Dashboard
 description: Monitor Google Gemini API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/gemini-dashboard.webp" alt="Google Gemini Dashboard" caption="Google Gemini Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/google-gemini/google-gemini-template.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/google-gemini/google-gemini-template.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/grok-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/grok-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-30
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: xAi Grok Dashboard
 description: Monitor Grok usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,9 @@ This dashboard offers a clear view into Grok usage and performance. It highlight
   caption="Grok Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/grok/grok-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/grok/grok-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/groq-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/groq-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-27
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: Groq Dashboard
 description: Monitor Groq usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,9 @@ This dashboard offers a clear view into Groq usage and performance. It highlight
   caption="Groq Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/groq/groq-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/groq/groq-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/haproxy-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/haproxy-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-25
+date: 2026-07-31
 
 title: HAProxy Monitoring Dashboard
 description: Monitor comprehensive HAProxy load balancer operations including network traffic, request/response metrics, connection statistics, session data, and error rates for performance optimization.
@@ -20,12 +20,11 @@ To populate this dashboard, collect HAProxy metrics with the OpenTelemetry Colle
     <figcaption><i>HAProxy Monitoring Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haproxy/haproxy.json"
-    dashboardName="HAProxy Monitoring"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haproxy/haproxy.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haproxy/v1/haproxy.json"
+  dashboardName="HAProxy Monitoring"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/haystack-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/haystack-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-17
+date: 2026-07-31
 title: Haystack Dashboard
 description: Monitor Haystack usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -20,12 +20,10 @@ This dashboard offers a clear view into Haystack usage and performance. It highl
   caption="Haystack Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haystack/haystack-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haystack/haystack-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/haystack/v1/haystack-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/hermes-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/hermes-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-07-31
 title: Hermes Agent Dashboard
 description: Monitor Hermes coding agent sessions, LLM API calls and token usage, tool-call activity, latency, and errors using OTel traces for complete AI agent observability.
 doc_type: explanation
@@ -20,12 +20,9 @@ This dashboard offers a clear view into Hermes coding agent behavior and perform
   caption="Hermes Agent Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hermes/hermes-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hermes/hermes-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/hostmetrics-k8s.mdx
+++ b/data/docs/dashboards/dashboard-templates/hostmetrics-k8s.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-16
+date: 2026-07-31
 title: Host Metrics K8s Dashboard
 description: Monitor comprehensive host system metrics for Kubernetes environments including CPU, memory, disk, network and filesystem usage across cluster nodes.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides comprehensive monitoring of host-level system metrics fo
   caption="Host Metrics K8s Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/hostmetrics-k8s.json"
-    dashboardName="Host Metrics K8s"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/hostmetrics-k8s.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/v1/hostmetrics-k8s.json"
+  dashboardName="Host Metrics K8s"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/hostmetrics-vm.mdx
+++ b/data/docs/dashboards/dashboard-templates/hostmetrics-vm.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-19
+date: 2026-07-31
 title: Host Metrics VM Dashboard
 description: Monitor comprehensive host system metrics for VM environments including CPU, memory, disk, network and filesystem usage.
 doc_type: explanation
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
   caption="Host Metrics VM Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/hostmetrics.json"
-    dashboardName="Host Metrics VM"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/hostmetrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/hostmetrics/v1/hostmetrics.json"
+  dashboardName="Host Metrics VM"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/http-api-monitoring.mdx
+++ b/data/docs/dashboards/dashboard-templates/http-api-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: HTTP API Monitoring Dashboard
 description: Monitor HTTP API performance with comprehensive metrics including endpoint latency, status code distribution, external API calls, and request patterns built on OpenTelemetry HTTP attributes.
@@ -12,12 +12,11 @@ This dashboard provides comprehensive monitoring of HTTP API performance, offeri
 To use this dashboard, you need to instrument your application and send traces to SigNoz. Follow the [Instrumentation](https://signoz.io/docs/instrumentation/) guide to get started.
 </Admonition>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/http-api-monitoring.json"
-    dashboardName="HTTP API Monitoring"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/http-api-monitoring.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/apm/v1/http-api-monitoring.json"
+  dashboardName="HTTP API Monitoring"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/huggingface-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/huggingface-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-02
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: Hugging Face Dashboard
 description: Monitor Hugging Face usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into Hugging Face usage and performance. It h
   caption="Hugging Face Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/huggingface/huggingface-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/huggingface/huggingface-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/huggingface/v1/huggingface-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/inkeep-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/inkeep-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-17
+date: 2026-07-31
 
 title: Inkeep Dashboard
 description: Monitor Inkeep usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -20,12 +20,9 @@ This dashboard offers a clear view into Inkeep usage and performance. It highlig
   caption="Inkeep Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/inkeep/inkeep-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/inkeep/inkeep-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/istio-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/istio-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-17
+date: 2026-07-31
 title: Istio Metrics Dashboard
 description: Monitor Istio service mesh performance including request rates, latency, error rates, TCP throughput, control plane health, and mTLS security metrics.
 doc_type: explanation
@@ -17,12 +17,11 @@ Monitor your Istio service mesh across seven areas: request traffic, latency and
   caption="Istio Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/istio/istio-prometheus-v1.json"
-    dashboardName="Istio Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/istio/istio-prometheus-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/istio/v1/istio-prometheus-v1.json"
+  dashboardName="Istio Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/jvm-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/jvm-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: JVM Metrics Dashboard
 description: Monitor comprehensive JVM runtime performance including CPU utilization, memory management, garbage collection, thread states, and class loading for optimal Java application performance.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>JVM Metrics Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/jvm/jvm-metrics-by-service.json"
-    dashboardName="JVM Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/jvm/jvm-metrics-by-service.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/jvm/v1/jvm-metrics-by-service.json"
+  dashboardName="JVM Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kafka-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/kafka-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-21
+date: 2026-07-31
 title: Kafka Monitoring Dashboard
 description: Monitor Kafka brokers, topics, partitions, and consumer groups using OpenTelemetry kafkametricsreceiver.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides comprehensive monitoring for your Kafka cluster, includi
   caption="Kafka Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/main/kafka/kafka-dashboard.json"
-    dashboardName="Kafka Monitoring"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/kafka/kafka-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/kafka/v1/kafka-dashboard.json"
+  dashboardName="Kafka Monitoring"
+/>
 
 ## Dashboard Variables
 

--- a/data/docs/dashboards/dashboard-templates/keda.mdx
+++ b/data/docs/dashboards/dashboard-templates/keda.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-02
+date: 2026-07-31
 title: Monitor KEDA Autoscaling Health with SigNoz Dashboard
 description: Monitor KEDA autoscaling health in SigNoz, including scaling loop latency, scaler errors, active triggers, and registered resources.
 doc_type: explanation
@@ -18,12 +18,11 @@ To use this dashboard, configure KEDA to send OpenTelemetry metrics to SigNoz fi
     <figcaption><i>KEDA Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/keda/keda-otlp-v1.json"
-    dashboardName="KEDA"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/keda/keda-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/keda/v1/keda-otlp-v1.json"
+  dashboardName="KEDA"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/key-operations.mdx
+++ b/data/docs/dashboards/dashboard-templates/key-operations.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Key Operations Dashboard
 description: Monitor critical application operations and endpoints with comprehensive latency, error rate, and throughput metrics for performance optimization.
@@ -19,12 +19,11 @@ To use this dashboard, you need to instrument your application and send traces t
     <figcaption><i>Key Operations Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/key-operations/key-operations.json"
-    dashboardName="Key Operations"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/key-operations/key-operations.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/key-operations/v1/key-operations.json"
+  dashboardName="Key Operations"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kong-gateway.mdx
+++ b/data/docs/dashboards/dashboard-templates/kong-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-23
+date: 2026-07-31
 title: Kong Gateway Dashboard
 description: Monitor Kong Gateway performance, latency, and error rates using OpenTelemetry.
 doc_type: explanation
@@ -19,12 +19,11 @@ Monitor Kong Gateway performance and connection management. Track request proces
   caption="Kong Gateway Dashboard - Overview"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/kong-gateway/kong-gateway-dashboard.json"
-    dashboardName="Kong Gateway"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/kong-gateway/kong-gateway-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/kong-gateway/v1/kong-gateway-dashboard.json"
+  dashboardName="Kong Gateway"
+/>
 
 After import, the Total Requests and Active Connections panels should populate immediately if Kong is sending metrics to SigNoz.
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-cluster-metrics.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-cluster-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-19
+date: 2026-07-31
 title: Kubernetes Cluster Metrics Dashboard
 
 description: Monitor Kubernetes metrics for running pods for deployments, daemonsets, statefulset, replicasets and pods count by phase.
@@ -26,12 +26,11 @@ This dashboard provides an overview for the Kubernetes pods for deployments, dae
   </figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-cluster-metrics.json"
-    dashboardName="Kubernetes Cluster Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-cluster-metrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-cluster-metrics.json"
+  dashboardName="Kubernetes Cluster Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-cronjobs.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-cronjobs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-27
+date: 2026-07-31
 title: Kubernetes CronJobs Dashboard
 description: Monitor Kubernetes CronJobs and their Job runs in SigNoz, including active CronJobs, success and failure counts, and per-Job pod state.
 doc_type: explanation
@@ -18,12 +18,11 @@ To use this dashboard, install K8s Infra in your cluster so the cluster collecto
     <figcaption><i>Kubernetes CronJobs Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-cronjobs.json"
-    dashboardName="Kubernetes CronJobs"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-cronjobs.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-cronjobs.json"
+  dashboardName="Kubernetes CronJobs"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-events.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-events.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-16
+date: 2026-07-31
 title: Kubernetes Events Dashboard
 description: This dashboard displays specific event and object kind counts, as well as their respective time-series charts, allowing the viewer to understand what's happening inside a cluster at a glance.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard displays specific event and object kind counts, as well as their 
   caption="Kubernetes Events Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/k8s-events-receiver.json"
-    dashboardName="Kubernetes Events"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/k8s-events-receiver.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/k8s-events-receiver.json"
+  dashboardName="Kubernetes Events"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-node-metrics-detailed.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-node-metrics-detailed.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-19
+date: 2026-07-31
 
 title: Kubernetes Node Metrics - Detailed Dashboard
 description: Monitor comprehensive Kubernetes node metrics including CPU, memory, filesystem, and network performance across your cluster nodes.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Kubernetes Node Metrics (Detailed) Dashboard </i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-node-metrics-detailed.json"
-    dashboardName="Kubernetes Node Metrics Detailed"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-node-metrics-detailed.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-node-metrics-detailed.json"
+  dashboardName="Kubernetes Node Metrics Detailed"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-node-metrics-overall.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-node-metrics-overall.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-19
+date: 2026-07-31
 title: Kubernetes Node Metrics - Overall
 description: A high-level dashboard to monitor overall Kubernetes Node metrics like CPU, memory, filesystem usage, and network IO.
 doc_type: explanation
@@ -19,12 +19,11 @@ Monitor your Kubernetes cluster nodes at a high level. This dashboard provides a
   caption="Kubernetes Node Metrics - Overall Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-node-metrics-overall.json"
-    dashboardName="Kubernetes Node Metrics - Overall"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-node-metrics-overall.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-node-metrics-overall.json"
+  dashboardName="Kubernetes Node Metrics - Overall"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-pod-metrics-detailed.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-pod-metrics-detailed.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Kubernetes Pod Metrics - Detailed Dashboard
 description: Monitor comprehensive Kubernetes pod metrics including CPU, memory, and filesystem performance for individual pods in your cluster.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Kubernetes Pod Metrics (Detailed) Dashboard </i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pod-metrics-detailed.json"
-    dashboardName="Kubernetes Pod Metrics Detailed"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pod-metrics-detailed.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-pod-metrics-detailed.json"
+  dashboardName="Kubernetes Pod Metrics Detailed"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-pod-metrics-overall.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-pod-metrics-overall.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-19
+date: 2026-07-31
 title: Kubernetes Pod Metrics - Overall
 description: A high-level dashboard to monitor overall Kubernetes Pod metrics like CPU, memory, filesystem usage, and network IO.
 doc_type: explanation
@@ -19,12 +19,11 @@ Monitor your Kubernetes pods at a high level. This dashboard provides a simplifi
   caption="Kubernetes Pod Metrics - Overall Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pod-metrics-overall.json"
-    dashboardName="Kubernetes Pod Metrics - Overall"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pod-metrics-overall.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-pod-metrics-overall.json"
+  dashboardName="Kubernetes Pod Metrics - Overall"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/kubernetes-pvc.mdx
+++ b/data/docs/dashboards/dashboard-templates/kubernetes-pvc.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-16
+date: 2026-07-31
 title: Kubernetes PVC Metrics Dashboard
 description: Monitor Kubernetes Persistent Volume Claim (PVC) metrics for capacity and usage.
 doc_type: explanation
@@ -33,12 +33,11 @@ The kubeletstats receiver will collect volume metrics from all pods in your clus
   caption="Kubernetes PVC Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pvc-metrics.json"
-    dashboardName="Kubernetes PVC Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/kubernetes-pvc-metrics.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/k8s-infra-metrics/v1/kubernetes-pvc-metrics.json"
+  dashboardName="Kubernetes PVC Metrics"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/langflow-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/langflow-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-08
+date: 2026-07-31
 title: Langflow Dashboard
 description: Monitor Langflow flows and agents with a focus on LLM usage such as token consumption, per-model breakdown, call latency, tool calls, and errors.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides a comprehensive view of the `Langflow` service using tra
   caption="Langflow Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/langflow/langflow-dashboard.json"
-    dashboardName="Langflow"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/langflow/langflow-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/langflow/v1/langflow-dashboard.json"
+  dashboardName="Langflow"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/litellm-proxy-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/litellm-proxy-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: LiteLLM Proxy Dashboard
 description: Monitor LiteLLM Proxy usage and performance including token consumption, model details and info, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -20,12 +20,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
   caption="LiteLLM Proxy Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/litellm/litellm-proxy-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/litellm/litellm-proxy-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/litellm-sdk-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/litellm-sdk-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: LiteLLM SDK Dashboard
 description: Monitor LiteLLM SDK usage and performance including token consumption, model details and info, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -20,12 +20,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
   caption="LiteLLM SDK Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/litellm/litellm-sdk-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/litellm/litellm-sdk-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/livekit-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/livekit-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: LiveKit Dashboard
 description: Monitor LiveKit usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into LiveKit usage and performance. It highli
   caption="LiveKit Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/livekit/livekit-dashboard.json"
-    dashboardName="LiveKit"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/livekit/livekit-dashboard.json"
+  dashboardName="LiveKit"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/mastra-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/mastra-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Mastra Dashboard
 description: Monitor Mastra usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -16,12 +16,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 <Figure src="/img/docs/dashboards/dashboard-templates/mastra-dashboard.webp" alt="Mastra Dashboard" caption="Mastra Dashboard Template" />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mastra/mastra-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mastra/mastra-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/memcached.mdx
+++ b/data/docs/dashboards/dashboard-templates/memcached.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Memcached Dashboard
 description: Monitor comprehensive Memcached performance including cache operations, memory utilization, connection management, and resource usage for optimal caching system performance.
@@ -19,12 +19,11 @@ To use this dashboard, you need to configure the <a href="https://github.com/ope
     <figcaption><i>Memcached Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/memcached/memcached.json"
-    dashboardName="Memcached"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/memcached/memcached.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/memcached/v1/memcached.json"
+  dashboardName="Memcached"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/mistral-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/mistral-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-16
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: Mistral Dashboard
 description: Monitor Mistral usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into Mistral usage and performance. It highli
   caption="Mistral Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mistral/mistral-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mistral/mistral-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mistral/v1/mistral-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/mysql.mdx
+++ b/data/docs/dashboards/dashboard-templates/mysql.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-22
+date: 2026-07-31
 title: MySQL Dashboard
 description: Monitor comprehensive MySQL database performance including connections, locks, buffer pool usage, table I/O operations, and resource utilization for database optimization.
 doc_type: explanation
@@ -18,12 +18,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>MySQL Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/mysql-otlp-v1.json"
-    dashboardName="MySQL"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/mysql-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/v1/mysql-otlp-v1.json"
+  dashboardName="MySQL"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/n8n-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/n8n-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-30
+date: 2026-07-31
 title: n8n Dashboard
 description: Monitor n8n workflow executions including workflow error rates, node error rates, execution volumes, and latency trends for optimal automation observability.
 doc_type: explanation
@@ -20,12 +20,10 @@ This dashboard offers a clear view into n8n Cloud usage and performance. It high
   caption="n8n Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/n8n/n8n-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/n8n/n8n-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/n8n/v1/n8n-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/nginx-ingress-controller-overview.mdx
+++ b/data/docs/dashboards/dashboard-templates/nginx-ingress-controller-overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-30
+date: 2026-07-31
 title: Ingress Nginx - Controller Overview Dashboard
 description: Monitor NGINX Ingress Controller health including request volume, connections, config reloads, CPU and memory usage, and per-ingress success rates in SigNoz.
 doc_type: explanation
@@ -17,12 +17,11 @@ Track NGINX Ingress Controller health: request volume, active connections, confi
   caption="Ingress Nginx - Controller Overview Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/ingress-nginx-controller.json"
-    dashboardName="Ingress Nginx - Controller Overview"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/ingress-nginx-controller.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/v1/ingress-nginx-controller.json"
+  dashboardName="Ingress Nginx - Controller Overview"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/nginx-ingress-request-handling-performance.mdx
+++ b/data/docs/dashboards/dashboard-templates/nginx-ingress-request-handling-performance.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-30
+date: 2026-07-31
 title: Ingress Nginx - Request Handling Performance Dashboard
 description: Monitor nginx-ingress-controller request latency, upstream response time, error rates, and throughput in Kubernetes with a pre-built SigNoz dashboard.
 doc_type: explanation
@@ -17,12 +17,11 @@ Monitor per-ingress request latency, error ratios, upstream response times, and 
   caption="Ingress Nginx - Request Handling Performance Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx-ingress-request-handling-performance.json"
-    dashboardName="Ingress Nginx - Request Handling Performance"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx-ingress-request-handling-performance.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/v1/nginx-ingress-request-handling-performance.json"
+  dashboardName="Ingress Nginx - Request Handling Performance"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/nginx.mdx
+++ b/data/docs/dashboards/dashboard-templates/nginx.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: NGINX Dashboard
 description: Monitor comprehensive NGINX web server performance including request handling, connection management, and server states using OpenTelemetry metrics for optimal web server monitoring.
@@ -19,12 +19,11 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>NGINX Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json"
-    dashboardName="NGINX"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/v1/nginx.json"
+  dashboardName="NGINX"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/ollama-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/ollama-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-09
+date: 2026-07-31
 title: Ollama Dashboard
 description: Monitor Ollama usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -20,12 +20,9 @@ This dashboard offers a clear view into Ollama usage and performance. It highlig
   caption="Ollama Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/ollama/ollama-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/ollama/ollama-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/open-webui-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/open-webui-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-23
+date: 2026-07-31
 title: Open WebUI Dashboard
 description: Monitor Open WebUI with request throughput, latency percentiles, error rates, database query performance, and LLM token usage, cost, and latency by model.
 doc_type: explanation
@@ -19,12 +19,11 @@ This dashboard provides a comprehensive view of your `Open WebUI` deployment usi
   caption="Open WebUI Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/open-webui/open-webui-dashboard.json"
-    dashboardName="Open WebUI"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/open-webui/open-webui-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/open-webui/v1/open-webui-dashboard.json"
+  dashboardName="Open WebUI"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/openai-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/openai-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-05
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: OpenAI Dashboard
 description: Monitor OpenAI usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,9 @@ This dashboard offers a clear view into OpenAI usage and performance. It highlig
   caption="OpenAI Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openai/openai-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openai/openai-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/openclaw-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/openclaw-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-10
+date: 2026-07-31
 tags: [SigNoz Cloud, Self-Host]
 title: OpenClaw Dashboard
 description: Monitor OpenClaw usage and performance including token consumption, model distribution, request volumes, latency trends, and agent run errors for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into OpenClaw usage and performance. It highl
   caption="OpenClaw Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openclaw/openclaw-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openclaw/openclaw-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openclaw/v1/openclaw-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/opencode-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/opencode-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-15
+date: 2026-07-31
 
 title: OpenCode Dashboard
 description: Track OpenCode usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, costs, success rates, and developer engagement across your AI-assisted development workflows.
@@ -19,12 +19,9 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>OpenCode Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/opencode/opencode-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/opencode/opencode-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/openrouter-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/openrouter-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-20
+date: 2026-07-31
 title: OpenRouter Dashboard
 description: Monitor OpenRouter usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -20,12 +20,10 @@ This dashboard offers a clear view into OpenRouter usage and performance. It hig
   caption="OpenRouter Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openrouter/openrouter-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openrouter/openrouter-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openrouter/v1/openrouter-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/opentelemetry-collector-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/opentelemetry-collector-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-23
+date: 2026-07-31
 title: OpenTelemetry Collector Pipeline Health Dashboard Template
 description: Monitor OTel Collector receiver throughput, processor drops, exporter delivery, queue depth, and process resource usage.
 doc_type: explanation
@@ -17,12 +17,11 @@ Use this dashboard to monitor your OpenTelemetry Collector instances across rece
   caption="OpenTelemetry Collector Pipeline Health Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/opentelemetry-collector/opentelemetry-collector-dashboard.json"
-    dashboardName="OpenTelemetry Collector"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/opentelemetry-collector/opentelemetry-collector-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/opentelemetry-collector/v1/opentelemetry-collector-dashboard.json"
+  dashboardName="OpenTelemetry Collector"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/overview.mdx
+++ b/data/docs/dashboards/dashboard-templates/overview.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-10
+date: 2026-07-31
 
 title: Dashboard Templates
 description: A collection of pre-built SigNoz dashboard templates for monitoring popular services and infrastructure components.
@@ -7,6 +7,19 @@ doc_type: explanation
 ---
 
 Browse our collection of pre-built SigNoz dashboard templates designed to help you monitor and gain insights about your infrastructure and applications. These templates are ready to import and can be customized to fit your specific monitoring requirements.
+
+## Dashboard JSON versions
+
+Every template page offers its JSON in two schema versions. Pick the one that matches your SigNoz version:
+
+- **V2 (recommended)**: Use it on SigNoz **v0.135.0 or newer**, including SigNoz Cloud. It uses the [V2 dashboard schema](https://signoz.io/docs/dashboards/dashboards-v2-api/).
+- **V1 (deprecated)**: Use it only on SigNoz **older than v0.135.0**.
+
+<Admonition type="warning" title="V1 dashboard JSON is deprecated">
+From SigNoz v0.135.0 onwards, use the V2 JSON only. V1 imports still succeed through a temporary compatibility path that converts the payload on the server, but that path will be removed in a future release, and V1 templates are no longer updated. If you are on an older self-hosted version, follow the [v0.135.0 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-135/) to move over.
+</Admonition>
+
+Not every template has a V1 copy — newer templates ship as V2 only, and those pages offer a single download.
 
 ## Available Dashboard Templates
 
@@ -16,15 +29,16 @@ Browse our collection of pre-built SigNoz dashboard templates designed to help y
 
 1. **Browse Templates**: Explore our collection of pre-built dashboard templates above
 2. **View Details**: Click on any template to see detailed information, preview images, and metrics description
-3. **Download JSON**: Use the download button to get the dashboard JSON file
-4. **Import to SigNoz**: Follow our [dashboard import guide](https://signoz.io/docs/dashboards/import-dashboard/) to import the JSON into your SigNoz instance
-5. **Customize**: Modify the dashboard to match your specific monitoring requirements
+3. **Pick a Version**: Use **V2** on SigNoz v0.135.0 or newer, and **V1** only on older versions
+4. **Copy or Download JSON**: Use the copy or download button to get the dashboard JSON
+5. **Import to SigNoz**: Follow our [dashboard import guide](https://signoz.io/docs/dashboards/import-dashboard/) to import the JSON into your SigNoz instance
+6. **Customize**: Modify the dashboard to match your specific monitoring requirements
 
 ## What's Included
 
 Each dashboard template includes:
 
-- **Dashboard JSON**: Ready-to-import configuration file
+- **Dashboard JSON**: Ready-to-import configuration file, in the V2 schema and — where available — the deprecated V1 schema
 - **Preview Images**: Screenshots showing the dashboard in action
 - **Metrics Documentation**: Detailed description of all metrics and panels
 - **Variables**: Pre-configured template variables for filtering and customization

--- a/data/docs/dashboards/dashboard-templates/pgbouncer-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/pgbouncer-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-23
+date: 2026-07-31
 title: PgBouncer Metrics Dashboard
 description: Monitor PgBouncer connection-pool health in SigNoz, covering pool states, query throughput, client wait times, and per-database connections.
 doc_type: explanation
@@ -19,12 +19,11 @@ Set up the data source and send telemetry to SigNoz before you import this dashb
   caption="PgBouncer Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pgbouncer/pgbouncer-dashboard.json"
-    dashboardName="PgBouncer"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pgbouncer/pgbouncer-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pgbouncer/v1/pgbouncer-dashboard.json"
+  dashboardName="PgBouncer"
+/>
 
 ## Dashboard Coverage
 

--- a/data/docs/dashboards/dashboard-templates/pipecat-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/pipecat-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-02
+date: 2026-07-31
 
 title: Pipecat Dashboard
 description: Monitor Pipecat usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,10 @@ This dashboard offers a clear view into Pipecat usage and performance. It highli
   caption="Pipecat Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pipecat/pipecat-dashboard.json"
-    dashboardName="Pipecat"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pipecat/pipecat-dashboard.json"
+  dashboardName="Pipecat"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/planetscale-postgres-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/planetscale-postgres-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-20
+date: 2026-07-31
 title: PlanetScale PostgreSQL Metrics Dashboard
 description: Monitor PlanetScale Postgres connections, session states, PgBouncer pools, commits, locks, WAL archiving, storage, and pod resources. Filter by branch and role.
 doc_type: explanation
@@ -17,12 +17,11 @@ Use this dashboard to monitor your PlanetScale Postgres branches across connecti
   caption="PlanetScale PostgreSQL Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/planetscale-postgres.json"
-    dashboardName="PlanetScale PostgreSQL"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/planetscale-postgres.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/v1/planetscale-postgres.json"
+  dashboardName="PlanetScale PostgreSQL"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/planetscale-vitess-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/planetscale-vitess-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-20
+date: 2026-07-31
 title: PlanetScale Vitess (MySQL) Metrics Dashboard
 description: Monitor PlanetScale Vitess query rate, latency, pools, MySQL internals, replication lag, VTOrc, storage, and pod resources. Filter by branch, keyspace, and tablet type.
 doc_type: explanation
@@ -17,12 +17,11 @@ Use this dashboard to monitor your PlanetScale Vitess (MySQL) branches across vt
   caption="PlanetScale Vitess (MySQL) Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/planetscale-vitess.json"
-    dashboardName="PlanetScale Vitess (MySQL)"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/planetscale-vitess.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/planetscale/v1/planetscale-vitess.json"
+  dashboardName="PlanetScale Vitess (MySQL)"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/postgresql.mdx
+++ b/data/docs/dashboards/dashboard-templates/postgresql.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: PostgreSQL Dashboard
 description: This dashboard provides comprehensive monitoring of PostgreSQL database performance and health, offering detailed visibility into connections, transactions, locks, and query performance for optimal database monitoring.
@@ -19,12 +19,11 @@ This dashboard provides a high-level overview of your PostgreSQL databases, incl
     <figcaption><i>PostgreSQL Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/postgresql/postgresql.json"
-    dashboardName="PostgreSQL"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/postgresql/postgresql.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/postgresql/v1/postgresql.json"
+  dashboardName="PostgreSQL"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/pydantic-ai-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/pydantic-ai-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-17
+date: 2026-07-31
 
 title: Pydantic AI Dashboard
 description: Monitor Pydantic AI usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -19,12 +19,9 @@ This dashboard offers a clear view into Pydantic AI usage and performance. It hi
   caption="Pydantic AI Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pydantic-ai/pydantic-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/pydantic-ai/pydantic-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/qwen-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/qwen-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-01
+date: 2026-07-31
 title: Qwen Dashboard
 description: Monitor Qwen usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
@@ -20,12 +20,10 @@ This dashboard offers a clear view into Qwen usage and performance. It highlight
   caption="Qwen Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/qwen/qwen-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/qwen/qwen-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/qwen/v1/qwen-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/rabbitmq.mdx
+++ b/data/docs/dashboards/dashboard-templates/rabbitmq.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-22
+date: 2026-07-31
 title: RabbitMQ Dashboard
 description: Monitor comprehensive RabbitMQ message queue performance including message publishing, delivery, acknowledgments, and queue status using OpenTelemetry metrics for optimal message broker management.
 doc_type: explanation
@@ -18,12 +18,11 @@ To use this dashboard, configure the <a href="https://github.com/open-telemetry/
     <figcaption><i>RabbitMQ Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/rabbitmq/rabbitmq.json"
-    dashboardName="RabbitMQ"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/rabbitmq/rabbitmq.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/rabbitmq/v1/rabbitmq.json"
+  dashboardName="RabbitMQ"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/render-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/render-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-08
+date: 2026-07-31
 title: Render Dashboard
 description: Monitor Render service performance including CPU usage, memory consumption, and network throughput using Render Metrics Streams.
 doc_type: explanation
@@ -19,12 +19,11 @@ To use this dashboard, you need to configure Render to send metrics to SigNoz. F
   caption="Render Dashboard - CPU, Memory, and Network Metrics"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/render/render-dashboard.json"
-    dashboardName="Render"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/render/render-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/render/v1/render-dashboard.json"
+  dashboardName="Render"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/semantic-kernel-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/semantic-kernel-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-18
+date: 2026-07-31
 
 title: Semantic Kernel Dashboard
 description: Monitor Semantic Kernel usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
@@ -21,12 +21,9 @@ This dashboard offers a clear view into Semantic Kernel usage and performance. I
   caption="Semantic Kernel Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/semantic-kernel/semantic-kernel-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/semantic-kernel/semantic-kernel-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/signoz-ingestion-analysis.mdx
+++ b/data/docs/dashboards/dashboard-templates/signoz-ingestion-analysis.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-01-03
+date: 2026-07-31
 
 title: SigNoz Ingestion Analysis Dashboard
 description: Monitor and analyze the volume of metrics, traces, and logs ingested into SigNoz for cost optimization and capacity planning.
@@ -14,12 +14,11 @@ This dashboard provides comprehensive monitoring of data ingestion volumes into 
     <figcaption><i>SigNoz Ingestion Analysis Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-ingestion-analysis/signoz-ingestion-analysis-v2.json"
-    dashboardName="SigNoz Ingestion Analysis"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-ingestion-analysis/signoz-ingestion-analysis-v2.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-ingestion-analysis/v1/signoz-ingestion-analysis-v2.json"
+  dashboardName="SigNoz Ingestion Analysis"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/signoz-mcp-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/signoz-mcp-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-29
+date: 2026-07-31
 title: SigNoz MCP Server Dashboard
 description: Monitor the SigNoz MCP server's tool-call rate, error rate, MCP method usage, and execute_tool span latency broken down per tool.
 doc_type: explanation
@@ -19,12 +19,10 @@ This dashboard provides operational visibility into the SigNoz MCP server. It tr
   caption="SigNoz MCP Server Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-mcp/signoz-mcp-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-mcp/signoz-mcp-dashboard.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/signoz-mcp/v1/signoz-mcp-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/snowflake.mdx
+++ b/data/docs/dashboards/dashboard-templates/snowflake.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-21
+date: 2026-07-31
 title: Snowflake Metrics Dashboard
 description: Monitor your Snowflake performance, storage usage, and query execution metrics in SigNoz.
 doc_type: explanation
@@ -19,12 +19,11 @@ Monitor the performance, storage, and cost of your Snowflake environment. This d
   caption="Snowflake Billing and Credit Usage Metrics"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/snowflake/snowflake-otlp-v1.json"
-    dashboardName="Snowflake Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/snowflake/snowflake-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/snowflake/v1/snowflake-otlp-v1.json"
+  dashboardName="Snowflake Metrics"
+/>
 
 ## Dashboard Variables
 

--- a/data/docs/dashboards/dashboard-templates/supabase.mdx
+++ b/data/docs/dashboards/dashboard-templates/supabase.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-02-18
+date: 2026-07-31
 title: Supabase Monitoring Dashboard
 description: Monitor Supabase, PgBouncer, and Postgres performance using OpenTelemetry.
 doc_type: explanation
@@ -25,12 +25,11 @@ To use this dashboard, you need to configure Supabase to send metrics to SigNoz.
   caption="Supabase Dashboard - Database Performance"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/main/supabase/supabase-dashboard-detailed.json"
-    dashboardName="Supabase Monitoring"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/supabase/supabase-dashboard-detailed.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/supabase/v1/supabase-dashboard-detailed.json"
+  dashboardName="Supabase Monitoring"
+/>
 
 ## Dashboard Variables
 

--- a/data/docs/dashboards/dashboard-templates/temporal-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/temporal-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-23
+date: 2026-07-31
 title: Temporal AI Agents Dashboard
 description: Monitor AI agent workloads running on Temporal, including LLM token consumption, model distribution, agent performance, error rates, request volumes, and infrastructure metrics for optimal agentic AI observability.
 doc_type: explanation
@@ -19,12 +19,9 @@ This dashboard provides visibility into AI agent workloads running on Temporal. 
   caption="Temporal Dashboard Template"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/temporal-agents/temporal-dashboard.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/temporal-agents/temporal-dashboard.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/dashboard-templates/vercel-ai-sdk-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/vercel-ai-sdk-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-25
+date: 2026-07-31
 
 title: Vercel AI SDK Dashboard
 description: Monitor Vercel AI SDK performance using OpenTelemetry metrics with comprehensive visibility into latency, token usage, generation rates, and latent request tracking.
@@ -19,12 +19,10 @@ To use this dashboard, you need to set up the data source and send telemetry to 
     <figcaption><i>Vercel AI SDK Dashboard</i></figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/vercel-ai-sdk/vercel-ai-sdk-template.json"
-    dashboardName=""
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/vercel-ai-sdk/vercel-ai-sdk-template.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/vercel-ai-sdk/v1/vercel-ai-sdk-template.json"
+/>
 
 ## What This Dashboard Monitors
 

--- a/data/docs/dashboards/import-dashboard.mdx
+++ b/data/docs/dashboards/import-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-07-31
 title: Import Dashboard in SigNoz
 description: Import pre-built JSON dashboard templates into SigNoz to quickly set up monitoring views for your infrastructure and applications.
 doc_type: howto
@@ -17,6 +17,8 @@ various services like databases, web servers, and more.
 ### Step 2: Copy/Download the dashboard JSON
 
 You can choose any dashboard you’d like to use. For instance, to monitor a MySQL database, click the [MySQL dashboard](https://signoz.io/docs/dashboards/dashboard-templates/mysql/) icon. On that page, you’ll see options to copy or download the dashboard JSON file.
+
+Templates offer the JSON in two schema versions. Select **V2** if you run SigNoz v0.135.0 or newer, including SigNoz Cloud. Select **V1** only if you run an older self-hosted version — V1 is deprecated, and templates that ship as V2 only offer a single download. See [Dashboard JSON versions](https://signoz.io/docs/dashboards/dashboard-templates/overview/#dashboard-json-versions) for details.
 
 ### Step 3: Import the dashboard in SigNoz
 

--- a/data/docs/integrations/outposts/flyio.mdx
+++ b/data/docs/integrations/outposts/flyio.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-07-31
 title: Monitor Fly.io with SigNoz
 description: Ship logs and metrics from your Fly.io apps to SigNoz — forward logs via fly-log-shipper and scrape metrics through Fly's Prometheus federation endpoint.
 doc_type: howto
@@ -364,12 +364,11 @@ You should see lines like `fly_instance_cpu_user_seconds_total`, `fly_instance_m
 
 A pre-built Fly.io Prometheus dashboard is available to import directly into SigNoz:
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
-    dashboardName="Fly.io (Prometheus)"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/v1/fly-prometheus-v1.json"
+  dashboardName="Fly.io (Prometheus)"
+/>
 
 <figure data-zoomable align="center">
   <img src="/img/docs/dashboards/dashboard-templates/fly-dashboard.webp" alt="Fly.io pre-built Prometheus dashboard in SigNoz" />

--- a/data/docs/metrics-management/docker-container-metrics.mdx
+++ b/data/docs/metrics-management/docker-container-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-13
+date: 2026-07-31
 title: Docker Container Metrics
 description: Monitor Docker container metrics using the OpenTelemetry Collector and SigNoz.
 doc_type: howto
@@ -139,12 +139,11 @@ You can use the pre-configured dashboard for Docker metrics or [create your own 
   caption="Docker Container Metrics Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/container-metrics-by-host.json"
-    dashboardName="Docker Container Metrics"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/container-metrics-by-host.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/container-metrics/docker/v1/container-metrics-by-host.json"
+  dashboardName="Docker Container Metrics"
+/>
 
 The pre-defined `Container Metrics` enables you to select the Docker host from a dropdown list and visualize the following groups of metrics:
 

--- a/data/docs/metrics-management/fly-metrics.mdx
+++ b/data/docs/metrics-management/fly-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-12
+date: 2026-07-31
 title: Fly.io Metrics
 description: Monitor Fly.io application metrics in SigNoz
 
@@ -401,10 +401,9 @@ You should see lines like `fly_instance_cpu_user_seconds_total`, `fly_instance_m
   </figcaption>
 </figure>
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
-    dashboardName="Fly.io (Prometheus)"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/fly-prometheus-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/fly/v1/fly-prometheus-v1.json"
+  dashboardName="Fly.io (Prometheus)"
+/>
 

--- a/data/docs/metrics-management/mysql-metrics.mdx
+++ b/data/docs/metrics-management/mysql-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-22
+date: 2026-07-31
 title: MySQL metrics
 description: Monitor MySQL metrics in SigNoz using OpenTelemetry Collector and ready-made dashboards.
 doc_type: howto
@@ -102,12 +102,11 @@ You can also use the pre-configured [MySQL dashboard](https://signoz.io/docs/das
   caption="MySQL Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/mysql-otlp-v1.json"
-    dashboardName="MySQL"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/mysql-otlp-v1.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/mysql/v1/mysql-otlp-v1.json"
+  dashboardName="MySQL"
+/>
 
 ## Monitoring Multiple MySQL Instances
 

--- a/data/docs/metrics-management/nginx-metrics.mdx
+++ b/data/docs/metrics-management/nginx-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-07-31
 title: Monitor NGINX Metrics with OpenTelemetry and SigNoz
 description: Learn how to collect NGINX metrics with the OpenTelemetry Collector's nginx receiver and monitor them in SigNoz using a ready-made dashboard.
 doc_type: howto
@@ -120,12 +120,11 @@ You can also import the pre-configured [NGINX dashboard](https://signoz.io/docs/
   caption="NGINX Dashboard"
 />
 
-<div className="flex justify-center">
-  <DashboardActions
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json"
-    dashboardName="NGINX"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/v1/nginx.json"
+  dashboardName="NGINX"
+/>
 
 ## Troubleshooting
 

--- a/data/docs/metrics-management/nvidia-dcgm-metrics.mdx
+++ b/data/docs/metrics-management/nvidia-dcgm-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-03
+date: 2026-07-31
 title: NVIDIA GPU metrics with DCGM Exporter
 doc_type: howto
 description: Collect NVIDIA GPU metrics using DCGM Exporter and SigNoz OpenTelemetry Collector Prometheus receiver.
@@ -86,12 +86,11 @@ Once configured, verify ingestion in the [Metrics Explorer](https://signoz.io/do
 
 You can use the pre-configured NVIDIA DCGM dashboard to monitor your GPUs:
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nvidia-dcgm/nvidia-dcgm.json"
-    dashboardName="NVIDIA DCGM"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nvidia-dcgm/nvidia-dcgm.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nvidia-dcgm/v1/nvidia-dcgm.json"
+  dashboardName="NVIDIA DCGM"
+/>
 
 ## Troubleshooting
 

--- a/data/docs/metrics-management/slurm-metrics.mdx
+++ b/data/docs/metrics-management/slurm-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-03
+date: 2026-07-31
 title: SLURM metrics
 doc_type: howto
 description: Collect SLURM cluster metrics using a Prometheus SLURM exporter and the SigNoz OpenTelemetry Collector Prometheus receiver.
@@ -64,12 +64,11 @@ Once configured, verify ingestion in the [Metrics Explorer](https://signoz.io/do
 
 You can use the pre-configured SLURM dashboard to monitor your cluster:
 
-<div className="flex justify-center">
-  <DashboardActions 
-    dashboardJsonUrl="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/slurm/slurm.json"
-    dashboardName="SLURM"
-  />
-</div>
+<DashboardActions
+  dashboardJsonV2Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/slurm/slurm.json"
+  dashboardJsonV1Url="https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/slurm/v1/slurm.json"
+  dashboardName="SLURM"
+/>
 
 ## Troubleshooting
 

--- a/tests/agent-markdown-stubs.test.js
+++ b/tests/agent-markdown-stubs.test.js
@@ -131,6 +131,58 @@ test('RegionTable stub renders a placeholder for the endpoint table', async () =
   assert.doesNotMatch(html, /Component: RegionTable/)
 })
 
+test('DashboardActions stub renders both schema versions with their URLs', async () => {
+  const v2Url =
+    'https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/agno/agno-dashboard.json'
+  const v1Url =
+    'https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/agno/v1/agno-dashboard.json'
+  const doc = createDoc(
+    `<DashboardActions dashboardJsonV2Url="${v2Url}" dashboardJsonV1Url="${v1Url}" />`
+  )
+  const components = await buildAgentMdxComponentsForDoc(doc)
+  const html = renderToStaticMarkup(
+    React.createElement(components.DashboardActions, {
+      dashboardJsonV2Url: v2Url,
+      dashboardJsonV1Url: v1Url,
+    })
+  )
+
+  assert.match(html, /V2 dashboard JSON \(recommended, requires SigNoz v0\.135\.0 or newer\)/)
+  assert.match(html, /V1 dashboard JSON \(deprecated, only for SigNoz older than v0\.135\.0\)/)
+  assert.match(html, /agno\/agno-dashboard\.json/)
+  assert.match(html, /agno\/v1\/agno-dashboard\.json/)
+  assert.match(html, /New dashboard → Import JSON/)
+  assert.doesNotMatch(html, /Component: DashboardActions/)
+})
+
+test('DashboardActions stub omits V1 when a dashboard is V2 only', async () => {
+  const v2Url =
+    'https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/openai/openai-dashboard.json'
+  const doc = createDoc(`<DashboardActions dashboardJsonV2Url="${v2Url}" />`)
+  const components = await buildAgentMdxComponentsForDoc(doc)
+  const html = renderToStaticMarkup(
+    React.createElement(components.DashboardActions, { dashboardJsonV2Url: v2Url })
+  )
+
+  assert.match(html, /V2 dashboard JSON/)
+  assert.doesNotMatch(html, /V1 dashboard JSON/)
+})
+
+test('DashboardActions stub still handles the legacy dashboardJsonUrl prop', async () => {
+  const url = 'https://raw.githubusercontent.com/SigNoz/dashboards/refs/heads/main/nginx/nginx.json'
+  const doc = createDoc(`<DashboardActions dashboardJsonUrl="${url}" dashboardName="NGINX" />`)
+  const components = await buildAgentMdxComponentsForDoc(doc)
+  const html = renderToStaticMarkup(
+    React.createElement(components.DashboardActions, {
+      dashboardJsonUrl: url,
+      dashboardName: 'NGINX',
+    })
+  )
+
+  assert.match(html, /V2 dashboard JSON/)
+  assert.match(html, /nginx\/nginx\.json/)
+})
+
 test('MCPInstallButton stub renders child text with client context', async () => {
   const doc = createDoc('<MCPInstallButton client="cursor">Add to Cursor</MCPInstallButton>')
   const components = await buildAgentMdxComponentsForDoc(doc)

--- a/utils/docs/agentMarkdownStubs.ts
+++ b/utils/docs/agentMarkdownStubs.ts
@@ -34,6 +34,7 @@ type AgentMdxComponentPolicy = 'custom-stub' | 'reviewed-fallback'
 
 export const KNOWN_AGENT_MDX_COMPONENT_NAMES = [
   'Admonition',
+  'DashboardActions',
   'DocCard',
   'DocCardContainer',
   'Figure',
@@ -51,7 +52,6 @@ export const KNOWN_AGENT_MDX_COMPONENT_NAMES = [
 export const REVIEWED_FALLBACK_AGENT_MDX_COMPONENT_NAMES = [
   'CHClientWithOutput',
   'CommonPrerequisites',
-  'DashboardActions',
   'DSConfigIntro',
   'DSConfigOss',
   'DSSendDataEc2',
@@ -118,6 +118,10 @@ const formatLabel = (value: string): string =>
     .join(' ')
 
 const MCP_INSTALL_REGIONS = ['us', 'eu', 'in', 'us2', 'eu2', 'in2'] as const
+
+const V2_MIN_SIGNOZ_VERSION = 'v0.135.0'
+const DASHBOARD_IMPORT_HINT =
+  'Import it in SigNoz with Dashboards → + New dashboard → Import JSON (https://signoz.io/docs/dashboards/import-dashboard/).'
 
 const buildMcpInstallLink = (client: string, region: string): string | null => {
   const mcpUrl = `https://mcp.${region}.signoz.cloud/mcp`
@@ -239,6 +243,49 @@ const createKnownComponentStubs = (
       null,
       React.createElement('img', { src, alt }),
       caption ? React.createElement('figcaption', null, caption) : null
+    )
+  },
+  DashboardActions: (props) => {
+    const v2Url =
+      getStringProp(props, 'dashboardJsonV2Url') || getStringProp(props, 'dashboardJsonUrl')
+    const v1Url = getStringProp(props, 'dashboardJsonV1Url')
+
+    if (!v2Url && !v1Url) {
+      const UnknownDashboardActions = createUnknownComponentStub('DashboardActions')
+      return React.createElement(UnknownDashboardActions, props)
+    }
+
+    const entries: Array<[string, string]> = []
+    if (v2Url) {
+      entries.push([
+        `V2 dashboard JSON (recommended, requires SigNoz ${V2_MIN_SIGNOZ_VERSION} or newer)`,
+        v2Url,
+      ])
+    }
+    if (v1Url) {
+      entries.push([
+        `V1 dashboard JSON (deprecated, only for SigNoz older than ${V2_MIN_SIGNOZ_VERSION})`,
+        v1Url,
+      ])
+    }
+
+    return React.createElement(
+      'section',
+      null,
+      React.createElement('p', null, React.createElement('strong', null, 'Dashboard JSON')),
+      React.createElement(
+        'ul',
+        null,
+        ...entries.map(([label, href]) =>
+          React.createElement(
+            'li',
+            { key: href },
+            `${label}: `,
+            React.createElement('a', { href }, href)
+          )
+        )
+      ),
+      React.createElement('p', null, DASHBOARD_IMPORT_HINT)
     )
   },
   DocCard: (props) => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

[SigNoz/dashboards#396](https://github.com/SigNoz/dashboards/pull/396) introduces a V2 (Perses) JSON for every dashboard: the V2 file takes the existing root path, and the legacy V1 copy moves into a `v1/` subdirectory. Template pages currently expose exactly one download and say nothing about versions, so after that PR merges every page would silently hand out V2 JSON — which fails to import on SigNoz older than v0.135.0 — with no way to reach V1 and no warning either way.

This makes the version explicit and steers readers to V2.

`DashboardActions` becomes a **"Dashboard JSON" card** with a version segmented control. Version is a *mode*, not an action, so it is a tab pair rather than four buttons — there are still only copy and download. The deprecation warning appears only while V1 is selected, i.e. exactly when the reader is considering it, instead of sitting on every page as permanent noise. The V1 download also drops from primary to secondary so the visual weight matches the recommendation.

The V1 tab stays visible rather than hidden behind a disclosure: users on older self-hosted SigNoz genuinely need it and should not have to hunt. It is labelled `V1 (legacy)` and de-emphasized instead. Templates with no V1 file render with no version chrome at all.

Wording is precise about both directions of incompatibility: V2 **requires** v0.135.0+, while V1 still imports on newer versions through the temporary server-side conversion shim that will be removed.

#### Screenshots / Screen Recordings (if applicable)

https://github.com/user-attachments/assets/d7cdca65-4f66-4d28-94f4-4c854c2844e3

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

Three pre-existing `DashboardActions` bugs are fixed alongside the main change, since it rewrites the same code paths.

#### Root Cause

- `dashboardName=""` was passed by 36 pages. The download name was built as `` `${dashboardName.toLowerCase()...}.json` ``, so an empty name produced a bare `.json` — a hidden dotfile.
- Fetch failures called `alert()`, which is jarring and offers no recovery path.
- Copy and download each refetched the JSON independently, so copy-after-download hit the network twice.

#### Fix Strategy

File names fall back to the JSON basename and carry a version suffix (`nginx-v2.json`, `agno-dashboard-v2.json`). Failures render an inline error with a link to the raw JSON. Fetched JSON is cached per URL for the component's lifetime.

---

### 🧪 Testing Strategy

- **Tests added/updated:** three cases in `tests/agent-markdown-stubs.test.js` covering the new `DashboardActions` agent stub — both versions present, V2-only, and the legacy `dashboardJsonUrl` alias.
- **Manual verification:** drove the real pages in Chromium against `yarn dev`, with the dashboards-repo requests stubbed so the assertions do not depend on the unmerged PR:
  - V2 download → `nginx-v2.json` with V2 content; V2 copy → V2 content on the clipboard
  - switch to V1 → deprecation notice renders, download → `nginx-v1.json` with V1 content, copy → V1 content
  - no-name page (`agno-dashboard`) → `agno-dashboard-v2.json`, confirming the dotfile fix
  - forced 404 → inline error with the raw-JSON fallback link, no `alert()`
  - V2-only page (`openai-dashboard`) → zero version tabs
  - narrow viewport (380px) → header and buttons wrap without horizontal overflow
- **Content verification against the dashboards PR branch:** all 84 generated V1 URLs return 200 on `nv/perses-dashboards`, and all 101 V2 URLs carry `schemaVersion: "v6"`.
- **Repo checks:** `check:docs-metadata`, `test:docs-metadata`, `check:doc-redirects`, `test:doc-redirects`, `check:stale-urls`, `test:stale-urls`, `yarn lint` (0 errors; 180 pre-existing warnings, none in touched files), `yarn build`, `yarn test` (56 passing).
- **Edge cases covered:** V2-only templates, V1-only (component falls back to V1 as the active version), the deprecated `dashboardJsonUrl` alias, empty `dashboardName`, fetch failure, clipboard failure.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** 105 dashboard template docs plus the templates overview and import guide. One component, used only by these pages. No routes, slugs, or redirects change.
- **Potential regressions:** low. The component keeps accepting `dashboardJsonUrl` as a V2 alias, so any page that still passes it renders normally. The main risk is ordering, not correctness — see the blocking note below.
- **Rollback plan:** revert the PR. Nothing is stateful and no URLs move.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Dashboard template pages now offer both V2 and V1 dashboard JSON, defaulting to V2 and marking V1 as deprecated for SigNoz v0.135.0 and newer. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**🚧 Do not merge before [SigNoz/dashboards#396](https://github.com/SigNoz/dashboards/pull/396).** That PR is what makes the root paths serve V2 and creates the `v1/` copies. Until it lands, every URL labelled "V2" here still serves V1 content and all 84 V1 URLs 404. This is purely a sequencing constraint — I verified against the `nv/perses-dashboards` branch that all the URLs resolve and carry the expected schema.

**⚠️ dashboards#396 drops V1 for 22 dashboards.** These are modified in place with no `v1/` copy preserved:

`autogen`, `azure-openai`, `bedrock`, `crewai`, `dify`, `google-adk`, `google-gemini`, `grok`, `groq`, `hermes`, `inkeep`, `litellm` (proxy + sdk), `livekit`, `mastra`, `ollama`, `openai`, `opencode`, `pipecat`, `pydantic-ai`, `semantic-kernel`, `temporal-agents`

I have shipped those pages as V2-only, which is right if it is intentional. If it is an oversight, those users lose their V1 fallback and it is worth raising on that PR — the URLs get picked up automatically once the files exist.

**Two related surfaces left alone, flagged for a call:**

- `data/docs/integrations/temporal-cloud-metrics.mdx:258` links a raw dashboard JSON directly in prose, so it will silently become V2 with no version note. Out of scope here, but easy to fold in if you want it.
- Several `constants/listicles/dashboard-templates.json` entries link to GitHub tree pages instead of doc pages (`aws-rds`, `ecs-infra-metrics`, `jenkins`, `jmx`, and others). Readers there will now see both a `v1/` directory and the V2 file with no guidance.

**Review pointers:**

- The 105 MDX files were migrated by script and are mechanically identical: prop rename, V1 URL added where a `v1/` copy exists, wrapper `div` dropped. `data/docs/dashboards/dashboard-templates/nginx.mdx` is representative — the rest follow the same shape.
- The `date:` frontmatter bump across all 107 docs is required by `check:docs-metadata`, which rejects a modified doc whose date is more than 7 days old.
- Commits are split by concern: component → agent markdown → docs.
