### PR TITLE
docs: add inclusive threshold operators to alert condition docs

### DIFF
--- a/data/docs/alerts-management/metrics-based-alerts.mdx
+++ b/data/docs/alerts-management/metrics-based-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-01
 title: Metrics based alerts
 description: Learn how to create metrics-based alerts in SigNoz by defining alert conditions, configuring notification settings, and using practical examples for memory usage, error rate, and latency monitoring.
 doc_type: reference
@@ -76,8 +76,16 @@ The condition configuration of an alert in SigNoz consists of 5 core parts:
    | --- | --- | --- |
    | `Above` | Triggers if the value is greater than | CPU usage `Above 90` (%) |
    | `Below` | Triggers if the value is less than | Apdex score `Below 0.8` |
+   | `Above or equal to` (≥) | Triggers if the value is greater than or equal to | CPU usage `Above or equal to 90` (%) |
+   | `Below or equal to` (≤) | Triggers if the value is less than or equal to | Apdex score `Below or equal to 0.8` |
    | `Equal to` | Triggers if the value is exactly equal | Request count `Equal to 0` |
    | `Not equal to` | Triggers if the value is not equal | Instance status `Not Equal to 1` |
+
+   When you select `Above or equal to` or `Below or equal to`, the threshold row shows the **≥** or **≤** symbol next to the value, and the match-type tooltips describe the inclusive boundary ("equal or exceed" / "equal or fall below").
+
+   <Admonition type="info">
+   `Above or equal to` (≥) and `Below or equal to` (≤) are available in the default alert experience. The classic (v1) experience, reached through **Switch to Classic Experience**, offers only `Above`, `Below`, `Equal to`, and `Not equal to`.
+   </Admonition>
 
 ### Match Type
     

--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-08-01
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -391,14 +391,14 @@ For **Value** (Number) panels, the threshold's comparison operator is copied as 
 
 | Panel threshold operator | Alert operator |
 | --- | --- |
-| Above (`>`) or Above or equal (`≥`) | `ABOVE` |
-| Below (`<`) or Below or equal (`≤`) | `BELOW` |
+| Above (`>`) | `ABOVE` |
+| Below (`<`) | `BELOW` |
+| Above or equal (`≥`) | `ABOVE OR EQUAL TO` |
+| Below or equal (`≤`) | `BELOW OR EQUAL TO` |
 | Equal (`=`) | `EQUAL TO` |
 | Not equal (`≠`) | `NOT EQUAL TO` |
 
-<Admonition type="warning">
-The alert operators do not include an "or equal" boundary, so **Above or equal (≥)** and **Below or equal (≤)** panel thresholds map to the closest available operators, `ABOVE` and `BELOW`. If you set a boundary threshold, confirm the operator after the alert opens.
-</Admonition>
+The inclusive boundary operators are preserved exactly. A panel threshold set to **Above or equal (≥)** or **Below or equal (≤)** now carries over to `ABOVE OR EQUAL TO` or `BELOW OR EQUAL TO` in the alert condition instead of collapsing onto the strict `ABOVE` or `BELOW` variant.
 
 **Time Series** and **Bar** panels pre-fill the threshold **value** and **unit**, but the operator stays at the default, because these panels store thresholds as value markers without a comparison operator. **Histogram** panels do not pass thresholds, so nothing threshold-related is seeded.
 


### PR DESCRIPTION
## Summary
- Added `ABOVE OR EQUAL TO` (≥) and `BELOW OR EQUAL TO` (≤) to the threshold operator reference table in **Metrics based alerts** (Step 2 → Condition), with a note that they are available in the default (v2) alert experience but not in the classic (v1) experience.
- Updated the **Interactivity in dashboards** → *Create Alert from panel* operator-mapping table so ≥ and ≤ panel thresholds now map to `ABOVE OR EQUAL TO` / `BELOW OR EQUAL TO` instead of collapsing onto strict `ABOVE`/`BELOW`, and removed the now-obsolete warning about the missing boundary operators.
- Updated frontmatter `date` to 2026-08-01 on both edited files.

## Notes
- **Screenshots deferred:** the demo build (demo.in.signoz.cloud) still lags PR #12360 (merged today) — the operator dropdown currently shows only ABOVE / BELOW / EQUAL TO / NOT EQUAL TO, so the new operators are not screenshottable yet. Prose-only for now; screenshots pending demo catch-up.
- **API reference / CompareOperator:** no hand-authored docs enumerate the `CompareOperator` enum; the API reference auto-generates from the OpenAPI spec (which now includes `above_or_equal`/`below_or_equal`), so no manual change is needed.
- **Terraform provider:** the SigNoz Terraform doc is dashboards-only and points to the Terraform Registry (schema-generated) for canonical reference; no alert-operator enumeration exists to update.

Source PRs: #12360

Auto-generated by docs-sync pipeline