### PR TITLE
docs: document required Dashboards V2 spec fields

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-04
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
 description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
 doc_type: howto
@@ -162,6 +162,34 @@ The visual query builder sets `reduceTo` for you, so this only affects requests 
 ```
 
 Existing V1 dashboards do not need edits: their scalar metric queries have `reduceTo` derived automatically during migration (rate and increase map to `sum`, percentile aggregations map to `avg`, other gauge aggregations map to `last`).
+
+### Required spec fields
+
+Every create (`POST`), update (`PUT`), and partial-update (`PATCH`) request must send three `spec` fields: `variables`, `panels`, and `layouts`. Each is required and non-nullable. Omit one, or send `null`, and the request is rejected with `400 Bad Request` and the error code `dashboard_invalid_input`. Send the empty collection when a dashboard has none:
+
+- `variables`: an array. Use `[]` for a dashboard with no variables.
+- `panels`: an object. Use `{}` for a dashboard with no panels.
+- `layouts`: an array. Use `[]` for a dashboard with no layout entries.
+
+The minimum valid spec is therefore:
+
+```json
+{
+    "variables": [],
+    "panels": {},
+    "layouts": []
+}
+```
+
+A bare `{}` spec is no longer accepted at the API layer. Each missing field returns its own message:
+
+```
+spec.variables: is required and must not be null; use [] for a dashboard with no variables
+spec.panels: is required and must not be null; use {} for a dashboard with no panels
+spec.layouts: is required and must not be null; use [] for a dashboard with no layouts
+```
+
+This only affects specs you build programmatically. Existing dashboards need no edits: a one-time migration on startup back-fills any stored dashboard missing these fields with the empty collection, so dashboards created through the UI are unaffected.
 
 Users can now personally pin any dashboard, so there's a special List API to get dashboards that takes pins into account:
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-04
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
 description: Upgrade self-hosted SigNoz to v0.135.0. Dashboards convert to the V2 schema automatically, and the retired V1 dashboard APIs need script and Terraform changes.
@@ -108,6 +108,10 @@ The public sharing routes (`/api/v1/dashboards/{id}/public` and `/api/v1/public/
 One compatibility shim remains, on create only: `POST /api/v2/dashboards` still accepts a V1 payload (a body carrying `version` and no `schemaVersion`) and converts it to V2, so import flows and existing create automation keep working during the rollout window. This shim will be removed in a few releases (<a href="https://github.com/SigNoz/signoz/issues/12177" target="_blank" rel="noopener noreferrer nofollow">signoz#12177</a>). `PUT /api/v2/dashboards/{id}` does **not** accept V1 payloads; it requires `schemaVersion: "v6"`.
 
 The V2 APIs also add a `PATCH` endpoint for partial updates, split lock and unlock endpoints, a pin-aware per-user listing, and pagination, sorting, and a query DSL on the list endpoint. The payload changes shape too, from flat JSON to a Perses `spec` tree. See the [Dashboards V2 API guide](https://signoz.io/docs/dashboards/dashboards-v2-api/) for the full endpoint list, schema, and `PATCH` examples.
+
+<Admonition type="warning" title="The minimum dashboard spec expanded">
+`spec.variables`, `spec.panels`, and `spec.layouts` are now required and non-nullable on every create, update, and patch. A script that sent a bare `{}` spec, or omitted any of the three, is rejected with `400 Bad Request` and error code `dashboard_invalid_input`. Send the empty collection for each instead: `{"variables": [], "panels": {}, "layouts": []}`. Stored dashboards missing these fields are back-filled automatically during the upgrade, so only scripts that build specs from scratch need changes. See [Required spec fields](https://signoz.io/docs/dashboards/dashboards-v2-api/#required-spec-fields).
+</Admonition>
 
 ## Upgrade the SigNoz MCP server
 


### PR DESCRIPTION
## Summary
- Added a **Required spec fields** section to `dashboards-v2-api.mdx`: `variables`, `panels`, and `layouts` are now required and non-nullable on every create/update/patch. Documents the minimum valid spec (`{"variables": [], "panels": {}, "layouts": []}`), the three exact 400 validation messages, error code `dashboard_invalid_input`, and the startup back-fill for existing dashboards.
- Added a warning callout to the "Migrate API scripts" section of `upgrade-0-135.mdx` noting the expanded minimum spec body for scripts that previously sent `{}`.
- Audited existing spec examples on the API page: the schema overview already includes all three fields, and PATCH examples are JSON Patch arrays (not full specs), so no example fixes were needed.
- The auto-generated API Reference already marks these fields `required`/non-nullable (struct tags in source), so no reference action is needed.
- Updated frontmatter dates on all edited files.

Source PRs: #12381

Auto-generated by docs-sync pipeline