### PR TITLE
bugfix: url encode in canonical urls

### DIFF
--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -15,7 +15,10 @@ export async function generateMetadata(props: {
   params: Promise<{ slug: string[] }>
 }): Promise<Metadata | undefined> {
   const params = await props.params
-  const slug = decodeURI(params.slug.join('/'))
+  const slug = params.slug
+    .map((segment) => decodeURIComponent(segment))
+    .filter(Boolean)
+    .join('/')
   const post = await fetchDocBySlug(slug)
 
   if (!post) {
@@ -24,17 +27,21 @@ export async function generateMetadata(props: {
 
   const seoTitle = post?.meta_title || post?.title
   const fullTitle = seoTitle ? `${seoTitle} | SigNoz Docs` : 'SigNoz Docs'
+  const pageUrl = `${siteMetadata.siteUrl}/docs/${slug}/`
 
   return {
     title: seoTitle,
     description: post.description,
+    alternates: {
+      canonical: pageUrl,
+    },
     openGraph: {
       title: fullTitle,
       description: post.description,
       siteName: siteMetadata.title,
       locale: 'en_US',
       type: 'article',
-      url: './',
+      url: pageUrl,
     },
     twitter: {
       card: 'summary_large_image',
@@ -49,7 +56,10 @@ export const generateStaticParams = async () => {
 
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
   const params = await props.params
-  const slug = decodeURI(params.slug.join('/'))
+  const slug = params.slug
+    .map((segment) => decodeURIComponent(segment))
+    .filter(Boolean)
+    .join('/')
   const post = await fetchDocBySlug(slug)
 
   if (!post) {

--- a/app/(site)/docs/(main-docs)/[...slug]/page.tsx
+++ b/app/(site)/docs/(main-docs)/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import JsonLdScript from '@/components/JsonLdScript'
 import { buildBreadcrumbSchema, getDocsBreadcrumbs } from '@/utils/breadcrumbSchema'
 import { fetchDocBySlug } from '@/utils/cachedData'
 import { compileMdxSource } from '@/utils/compileMdx'
+import { slugFromParams } from '@/utils/docs/markdownRouting'
 
 export const revalidate = 86400
 export const dynamicParams = true
@@ -15,10 +16,7 @@ export async function generateMetadata(props: {
   params: Promise<{ slug: string[] }>
 }): Promise<Metadata | undefined> {
   const params = await props.params
-  const slug = params.slug
-    .map((segment) => decodeURIComponent(segment))
-    .filter(Boolean)
-    .join('/')
+  const slug = slugFromParams(params.slug)
   const post = await fetchDocBySlug(slug)
 
   if (!post) {
@@ -27,6 +25,8 @@ export async function generateMetadata(props: {
 
   const seoTitle = post?.meta_title || post?.title
   const fullTitle = seoTitle ? `${seoTitle} | SigNoz Docs` : 'SigNoz Docs'
+  // Absolute URLs — relative "./" makes Next encode nested catch-all slugs as %2F
+  // (e.g. /docs/ai%2Fsignoz-mcp-server/) in canonical and og:url.
   const pageUrl = `${siteMetadata.siteUrl}/docs/${slug}/`
 
   return {
@@ -56,10 +56,7 @@ export const generateStaticParams = async () => {
 
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
   const params = await props.params
-  const slug = params.slug
-    .map((segment) => decodeURIComponent(segment))
-    .filter(Boolean)
-    .join('/')
+  const slug = slugFromParams(params.slug)
   const post = await fetchDocBySlug(slug)
 
   if (!post) {

--- a/app/docs-onboarding/[...slug]/page.tsx
+++ b/app/docs-onboarding/[...slug]/page.tsx
@@ -1,34 +1,12 @@
-import { Metadata } from 'next'
-import { generateMetadata as docsGenerateMetadata } from '../../(site)/docs/(main-docs)/[...slug]/page'
-import siteMetadata from '@/data/siteMetadata'
-
 // Inlined as literal because Next 15's segment-config static analyzer doesn't
 // follow re-exports. Keep in sync with ../../(site)/docs/(main-docs)/[...slug]/page.tsx
 export const revalidate = 86400
 export const dynamicParams = true
 
-export { default, generateStaticParams } from '../../(site)/docs/(main-docs)/[...slug]/page'
-
-export async function generateMetadata(props: {
-  params: Promise<{ slug: string[] }>
-}): Promise<Metadata | undefined> {
-  const params = await props.params
-  const metadata = await docsGenerateMetadata({ params: Promise.resolve(params) })
-
-  const slug = params.slug
-    .map((segment) => decodeURIComponent(segment))
-    .filter(Boolean)
-    .join('/')
-  const canonicalUrl = `${siteMetadata.siteUrl}/docs/${slug}/`
-
-  return {
-    ...metadata,
-    alternates: {
-      canonical: canonicalUrl,
-    },
-    openGraph: {
-      ...metadata?.openGraph,
-      url: canonicalUrl,
-    },
-  }
-}
+// generateMetadata is re-exported: main docs already emits absolute
+// https://signoz.io/docs/${slug}/ canonical + og:url (not relative to /docs-onboarding).
+export {
+  default,
+  generateStaticParams,
+  generateMetadata,
+} from '../../(site)/docs/(main-docs)/[...slug]/page'

--- a/app/docs-onboarding/[...slug]/page.tsx
+++ b/app/docs-onboarding/[...slug]/page.tsx
@@ -15,13 +15,20 @@ export async function generateMetadata(props: {
   const params = await props.params
   const metadata = await docsGenerateMetadata({ params: Promise.resolve(params) })
 
-  const slug = decodeURI(params.slug.join('/'))
+  const slug = params.slug
+    .map((segment) => decodeURIComponent(segment))
+    .filter(Boolean)
+    .join('/')
   const canonicalUrl = `${siteMetadata.siteUrl}/docs/${slug}/`
 
   return {
     ...metadata,
     alternates: {
       canonical: canonicalUrl,
+    },
+    openGraph: {
+      ...metadata?.openGraph,
+      url: canonicalUrl,
     },
   }
 }

--- a/tests/docs-markdown-routing.test.js
+++ b/tests/docs-markdown-routing.test.js
@@ -7,6 +7,7 @@ const {
   normalizeDocsSlugFromPathname,
   buildDocsMarkdownRewritePath,
   resolveDocsMarkdownSlug,
+  slugFromParams,
 } = loadTsModule('utils/docs/markdownRouting.ts')
 
 test('shouldRewriteDocsToMarkdown rewrites docs paths when markdown is preferred', async () => {
@@ -55,4 +56,13 @@ test('resolveDocsMarkdownSlug resolves slug from route segments', async () => {
     'metrics-management/overview'
   )
   assert.equal(resolveDocsMarkdownSlug(['logs%2Fmanagement']), 'logs/management')
+})
+
+test('slugFromParams decodes catch-all segments without defaulting', async () => {
+  assert.equal(slugFromParams([]), '')
+  assert.equal(slugFromParams(['ai', 'signoz-mcp-server']), 'ai/signoz-mcp-server')
+  assert.equal(slugFromParams(['ai%2Fsignoz-mcp-server']), 'ai/signoz-mcp-server')
+  assert.equal(slugFromParams(['install', 'docker']), 'install/docker')
+  // Malformed percent-encoding should not throw
+  assert.equal(slugFromParams(['foo%zz']), 'foo%zz')
 })

--- a/utils/docs/markdownRouting.ts
+++ b/utils/docs/markdownRouting.ts
@@ -20,15 +20,29 @@ export const buildDocsMarkdownRewritePath = (pathname: string): string => {
   return docsSlug ? `/api/docs-markdown/${docsSlug}` : '/api/docs-markdown'
 }
 
+/**
+ * Normalize catch-all `[...slug]` params into a docs path.
+ * Decodes per segment so a single encoded segment like `ai%2Fsignoz-mcp-server`
+ * becomes `ai/signoz-mcp-server` (decodeURI leaves `%2F` intact).
+ */
+export const slugFromParams = (slug: string[]): string =>
+  slug
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment).trim()
+      } catch {
+        // Malformed percent-encoding — keep the raw segment so content lookup
+        // 404s instead of throwing URIError from generateMetadata.
+        return segment.trim()
+      }
+    })
+    .filter(Boolean)
+    .join('/')
+
 export const resolveDocsMarkdownSlug = (segments?: string[]): string => {
   if (!segments || segments.length === 0) {
     return 'introduction'
   }
 
-  const joined = segments
-    .map((segment) => decodeURIComponent(segment).trim())
-    .filter(Boolean)
-    .join('/')
-
-  return joined || 'introduction'
+  return slugFromParams(segments) || 'introduction'
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Nested docs pages were emitting **`%2F`-encoded paths** in `<link rel="canonical">` and `og:url`, e.g.:

- Bad: `https://signoz.io/docs/ai%2Fsignoz-mcp-server/`
- Good: `https://signoz.io/docs/ai/signoz-mcp-server/`

This happened because main docs `generateMetadata` relied on relative metadata (`openGraph.url: './'`) plus the root layout’s `alternates.canonical: './'`. For multi-segment `[...slug]` routes, Next.js resolves that relative path into a URL where path separators inside the catch-all param are percent-encoded as `%2F`. Crawlers then discover and index both forms (the encoded variant still returns 200).

**Fix:** set absolute `alternates.canonical` and `openGraph.url` from the decoded slug (same approach already used by `/docs-onboarding`). Also decode slug segments with `decodeURIComponent` so a single encoded catch-all segment still resolves correctly.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

**Before**
```html
<link rel="canonical" href="https://signoz.io/docs/ai%2Fsignoz-mcp-server/"/>
```
<img width="1920" height="269" alt="Screenshot 2026-08-04 at 12 14 00" src="https://github.com/user-attachments/assets/1326d0ad-bf91-4bf5-9283-9a5d22db5c1f" />

**After**
```html
<link rel="canonical" href="https://signoz.io/docs/ai/signoz-mcp-server/"/>
```
<img width="1918" height="289" alt="Screenshot 2026-08-04 at 12 15 15" src="https://github.com/user-attachments/assets/2622ff81-7c75-4805-a335-a8b244536d61" />


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?
> Regression, faulty assumption, edge case, refactor, etc.

Relative metadata URLs (`canonical: './'`, `og:url: './'`) on nested docs catch-all routes. Next.js resolves `./` against the current route; for multi-segment `[...slug]` params it can serialize the path with `%2F` instead of real `/` separators.

This is a known class of catch-all / encoded-slash behavior in Next.js App Router:

- [vercel/next.js#53682 — Catch-all params encoding (`b%2Fc`)](https://github.com/vercel/next.js/issues/53682)
- [vercel/next.js#53849 — Catch-all `[...slug]` as one URL-encoded string](https://github.com/vercel/next.js/issues/53849)
- [vercel/next.js#49646 — App dir treats `%2F` in params as `/`](https://github.com/vercel/next.js/issues/49646)
- [vercel/next.js#24775 — Encoded slashes in catch-all routes](https://github.com/vercel/next.js/issues/24775)
- [Discussion #67421 — Catch-all encoded slash resolution](https://github.com/vercel/next.js/discussions/67421)

#### Fix Strategy
> How does this PR address the root cause?

1. Build an absolute page URL: `` `${siteMetadata.siteUrl}/docs/${slug}/` ``
2. Set `alternates.canonical` and `openGraph.url` to that absolute URL in main docs `generateMetadata`
3. Keep docs-onboarding in sync (canonical + `og:url` both point at `/docs/...`)
4. Decode each slug segment with `decodeURIComponent` before joining

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Not required (metadata URL construction only)
- Manual verification:
  - View source / curl nested docs pages (`/docs/ai/signoz-mcp-server/`, `/docs/install/docker/`, `/docs/instrumentation/opentelemetry-python/`)
  - Confirm canonical and `og:url` have no `%2F`
  - Confirm single-segment pages (e.g. `/docs/introduction/`) still look correct
  - Confirm `/docs-onboarding/...` still canonicalizes to `/docs/...`
- Edge cases covered:
  - Multi-segment nested docs
  - Encoded incoming path segments (`%2F`) still resolve via `decodeURIComponent`

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Docs SEO metadata only (`canonical` / `og:url` on `/docs/[...slug]` and `/docs-onboarding/[...slug]`)
- Potential regressions: Incorrect canonical if slug decoding is wrong (mitigated by joining decoded segments the same way content lookup already works)
- Rollback plan: Revert the commit

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- Sitemap / sidebar / JSON-LD were already correct; only Next metadata resolution was wrong.
