### PR TITLE
feat(pricing): add /pricing.md for agents

### DIFF
--- a/app/(site)/pricing.md/route.ts
+++ b/app/(site)/pricing.md/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { buildPricingMarkdown } from '@/utils/pricing/buildPricingMarkdown'
+import siteMetadata from '@/data/siteMetadata'
+
+const CACHE_CONTROL_HEADER = 'public, s-maxage=3600, stale-while-revalidate=86400'
+
+/**
+ * Markdown twin of /pricing. The HTML page prices usage through JS sliders,
+ * which agents cannot evaluate, so they get the rate tables directly here.
+ */
+export async function GET() {
+  const markdown = buildPricingMarkdown(siteMetadata.siteUrl)
+
+  return new NextResponse(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': CACHE_CONTROL_HEADER,
+      // Duplicate of /pricing; only the HTML page should rank.
+      'X-Robots-Tag': 'noindex',
+    },
+  })
+}

--- a/app/(site)/pricing/pricingv1/components/PricingCalculator/constants.ts
+++ b/app/(site)/pricing/pricingv1/components/PricingCalculator/constants.ts
@@ -6,26 +6,6 @@ export const MIN_VALUE = 0
 export const MAX_VALUE = 100000
 export const MIN_LOG_VALUE = 0.1
 
-export const TRACES_AND_LOGS_PRICES: Record<number, number> = {
-  15: 0.3,
-  30: 0.4,
-  90: 0.6,
-  180: 0.8,
-  365: 1.4,
-}
-
-export const METRICS_PRICES: Record<number, number> = {
-  1: 0.1,
-  3: 0.12,
-  6: 0.15,
-  13: 0.18,
-}
-
-const sortedRecordKeys = (record: Record<number, number>) =>
-  (Object.keys(record) as string[]).map(Number).sort((a, b) => a - b)
-
-/** Retention options are derived from price keys so tiers stay in sync. */
-export const RETENTION_PERIOD = {
-  TRACES_AND_LOGS: sortedRecordKeys(TRACES_AND_LOGS_PRICES).map((days) => ({ days })),
-  METRICS: sortedRecordKeys(METRICS_PRICES).map((months) => ({ months })),
-}
+// Rates live in @/constants/pricing so the pricing page, the overview card, and
+// /pricing.md all read the same numbers. Re-exported here for existing imports.
+export { TRACES_AND_LOGS_PRICES, METRICS_PRICES, RETENTION_PERIOD } from '@/constants/pricing'

--- a/app/(site)/pricing/pricingv1/components/SigNozCloudPricingOverview.tsx
+++ b/app/(site)/pricing/pricingv1/components/SigNozCloudPricingOverview.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { ArrowDownRight, ArrowRight, CheckCircle, Hash } from 'lucide-react'
 import Button from '@/components/ui/Button'
 import TrackingLink from '@/components/TrackingLink'
+import { TRACES_AND_LOGS_PRICES, METRICS_PRICES } from '@/constants/pricing'
 
 interface SigNozCloudPricingOverviewProps {
   className?: string
@@ -22,20 +23,17 @@ interface MetricsRetention {
 const SigNozCloudPricingOverview: React.FC<SigNozCloudPricingOverviewProps> = ({
   className = '',
 }) => {
+  // Derived from the shared rate tables so this card cannot drift from the
+  // calculator or /pricing.md.
   const RETENTION_PERIOD = {
-    TRACES_AND_LOGS: [
-      { days: 15, price: 0.3 },
-      { days: 30, price: 0.4 },
-      { days: 90, price: 0.6 },
-      { days: 180, price: 0.8 },
-      { days: 365, price: 1.4 },
-    ] as TracesAndLogsRetention[],
-    METRICS: [
-      { months: 1, price: 0.1 },
-      { months: 3, price: 0.12 },
-      { months: 6, price: 0.15 },
-      { months: 13, price: 0.18 },
-    ] as MetricsRetention[],
+    TRACES_AND_LOGS: Object.keys(TRACES_AND_LOGS_PRICES)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((days) => ({ days, price: TRACES_AND_LOGS_PRICES[days] })) as TracesAndLogsRetention[],
+    METRICS: Object.keys(METRICS_PRICES)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((months) => ({ months, price: METRICS_PRICES[months] })) as MetricsRetention[],
   }
 
   const formatTracesAndLogsRetentionLabel = (days: number) =>

--- a/constants/pricing.ts
+++ b/constants/pricing.ts
@@ -1,0 +1,38 @@
+/**
+ * Single source of truth for SigNoz Cloud rates.
+ *
+ * Consumed by the pricing calculator, the pricing overview card, and the
+ * agent-facing /pricing.md route. Update rates here only.
+ */
+
+/** USD per GB ingested, keyed by retention in days. */
+export const TRACES_AND_LOGS_PRICES: Record<number, number> = {
+  15: 0.3,
+  30: 0.4,
+  90: 0.6,
+  180: 0.8,
+  365: 1.4,
+}
+
+/** USD per million samples, keyed by retention in months. */
+export const METRICS_PRICES: Record<number, number> = {
+  1: 0.1,
+  3: 0.12,
+  6: 0.15,
+  13: 0.18,
+}
+
+export const TEAMS_BASE_PRICE_USD = 49
+export const TEAMS_LIST_PRICE_USD = 199
+export const STARTUP_PRICE_USD = 19
+export const ENTERPRISE_FLOOR_USD = 4000
+export const DEDICATED_SUPPORT_THRESHOLD_USD = 999
+
+const sortedRecordKeys = (record: Record<number, number>) =>
+  (Object.keys(record) as string[]).map(Number).sort((a, b) => a - b)
+
+/** Retention options are derived from price keys so tiers stay in sync. */
+export const RETENTION_PERIOD = {
+  TRACES_AND_LOGS: sortedRecordKeys(TRACES_AND_LOGS_PRICES).map((days) => ({ days })),
+  METRICS: sortedRecordKeys(METRICS_PRICES).map((months) => ({ months })),
+}

--- a/tests/pricing-markdown.test.js
+++ b/tests/pricing-markdown.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { buildPricingMarkdown } = loadTsModule('utils/pricing/buildPricingMarkdown.ts')
+const {
+  TRACES_AND_LOGS_PRICES,
+  METRICS_PRICES,
+  TEAMS_BASE_PRICE_USD,
+  ENTERPRISE_FLOOR_USD,
+  STARTUP_PRICE_USD,
+} = loadTsModule('constants/pricing.ts')
+
+const SITE_URL = 'https://signoz.io'
+const markdown = buildPricingMarkdown(SITE_URL)
+
+test('pricing markdown lists every traces/logs retention tier from the calculator constants', () => {
+  for (const [days, price] of Object.entries(TRACES_AND_LOGS_PRICES)) {
+    const label = Number(days) === 365 ? '1 year' : `${days} days`
+    const expected = `| ${label} | $${Number(price).toFixed(2)} |`
+    assert.ok(
+      markdown.includes(expected),
+      `expected traces/logs row for ${label} at $${price}, got:\n${markdown}`
+    )
+  }
+})
+
+test('pricing markdown lists every metrics retention tier from the calculator constants', () => {
+  for (const [months, price] of Object.entries(METRICS_PRICES)) {
+    const label = `${months} month${Number(months) > 1 ? 's' : ''}`
+    const expected = `| ${label} | $${Number(price).toFixed(2)} |`
+    assert.ok(
+      markdown.includes(expected),
+      `expected metrics row for ${label} at $${price}, got:\n${markdown}`
+    )
+  }
+})
+
+test('pricing markdown has no more rate rows than the constants define', () => {
+  const tableRowCount = (markdown.match(/^\| (?:\d+ days|1 year|\d+ months?) \| \$/gm) || []).length
+  const expected = Object.keys(TRACES_AND_LOGS_PRICES).length + Object.keys(METRICS_PRICES).length
+  assert.equal(tableRowCount, expected)
+})
+
+test('pricing markdown states the plan prices', () => {
+  assert.match(markdown, new RegExp(`from \\$${TEAMS_BASE_PRICE_USD}/month`))
+  assert.match(markdown, new RegExp(`from \\$${ENTERPRISE_FLOOR_USD}/month`))
+  assert.match(markdown, new RegExp(`\\$${STARTUP_PRICE_USD}/month`))
+})
+
+test('pricing markdown covers the plan and policy sections agents ask about', () => {
+  assert.match(markdown, /^# SigNoz Pricing$/m)
+  assert.match(markdown, /^## Plans$/m)
+  assert.match(markdown, /^## Ingestion rates$/m)
+  assert.match(markdown, /^## Teams plan$/m)
+  assert.match(markdown, /^## Enterprise plan$/m)
+  assert.match(markdown, /^## Startup program$/m)
+  assert.match(markdown, /^## How metrics samples are counted$/m)
+  // The differentiators agents most often get wrong.
+  assert.match(markdown, /no per-user pricing/i)
+  assert.match(markdown, /no surcharge for custom metrics/i)
+})
+
+test('pricing markdown references llms.txt', () => {
+  assert.match(markdown, /Agent guide: \/llms\.txt/)
+})
+
+test('pricing markdown builds absolute URLs from the passed site URL', () => {
+  assert.match(markdown, new RegExp(`${SITE_URL}/pricing/`))
+  assert.match(markdown, new RegExp(`${SITE_URL}/startups/`))
+  // No site-relative links that would break when pasted into an agent context.
+  assert.doesNotMatch(markdown, /\]\(\/(?!\/)/)
+})
+
+test('pricing markdown derives included usage from the cheapest tier', () => {
+  const cheapestGbPrice = Math.min(...Object.values(TRACES_AND_LOGS_PRICES))
+  const expectedGb = Math.floor(TEAMS_BASE_PRICE_USD / cheapestGbPrice)
+  assert.match(markdown, new RegExp(`${expectedGb} GB of logs/traces`))
+})

--- a/utils/pricing/buildPricingMarkdown.ts
+++ b/utils/pricing/buildPricingMarkdown.ts
@@ -1,0 +1,156 @@
+import {
+  TRACES_AND_LOGS_PRICES,
+  METRICS_PRICES,
+  TEAMS_BASE_PRICE_USD,
+  TEAMS_LIST_PRICE_USD,
+  STARTUP_PRICE_USD,
+  ENTERPRISE_FLOOR_USD,
+  DEDICATED_SUPPORT_THRESHOLD_USD,
+} from '@/constants/pricing'
+
+/**
+ * Agent-facing markdown rendering of /pricing.
+ *
+ * Rates and plan prices are imported from @/constants/pricing rather than
+ * restated here, so this page cannot drift from what the calculator charges.
+ * Prose describing inclusions and eligibility is declared below and must be
+ * updated alongside the pricing components.
+ */
+
+const formatUsd = (value: number): string =>
+  Number.isInteger(value) ? `$${value}` : `$${value.toFixed(2)}`
+
+const sortedEntries = (record: Record<number, number>): [number, number][] =>
+  Object.keys(record)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map((key) => [key, record[key]])
+
+const retentionLabel = (days: number): string => (days === 365 ? '1 year' : `${days} days`)
+
+const buildTracesAndLogsTable = (): string => {
+  const rows = sortedEntries(TRACES_AND_LOGS_PRICES).map(
+    ([days, price]) => `| ${retentionLabel(days)} | ${formatUsd(price)} |`
+  )
+
+  return ['| Retention | Price per GB ingested |', '| --- | --- |', ...rows].join('\n')
+}
+
+const buildMetricsTable = (): string => {
+  const rows = sortedEntries(METRICS_PRICES).map(
+    ([months, price]) => `| ${months} month${months > 1 ? 's' : ''} | ${formatUsd(price)} |`
+  )
+
+  return ['| Retention | Price per million samples |', '| --- | --- |', ...rows].join('\n')
+}
+
+const cheapestTracesAndLogsPrice = (): number => sortedEntries(TRACES_AND_LOGS_PRICES)[0][1]
+const cheapestMetricsPrice = (): number => sortedEntries(METRICS_PRICES)[0][1]
+
+/** Usage the $49 base covers at the lowest retention tier. */
+const includedUsageSummary = (): string => {
+  const gb = Math.floor(TEAMS_BASE_PRICE_USD / cheapestTracesAndLogsPrice())
+  const samples = Math.round(TEAMS_BASE_PRICE_USD / cheapestMetricsPrice())
+  return `${gb} GB of logs/traces at 15 days retention, or ${samples} million metric samples at 1 month retention`
+}
+
+export const buildPricingMarkdown = (siteUrl: string): string => {
+  const lines: string[] = [
+    '# SigNoz Pricing',
+    '',
+    'SigNoz is an open-source, OpenTelemetry-native observability platform for logs, traces, and metrics.',
+    '',
+    'Pricing is usage-based only. There is no per-user pricing, no per-host/container/node pricing, and no surcharge for custom metrics. You add unlimited teammates and monitor any number of hosts on every paid plan.',
+    '',
+    '## Plans',
+    '',
+    '| Plan | Price | Best for |',
+    '| --- | --- | --- |',
+    '| Community Edition | Free, self-hosted | Teams with DevOps expertise who want full control |',
+    `| Teams (Cloud) | from ${formatUsd(TEAMS_BASE_PRICE_USD)}/month | Teams who want zero operational overhead |`,
+    `| Enterprise | Custom, from ${formatUsd(ENTERPRISE_FLOOR_USD)}/month | Orgs needing data residency, compliance, and support |`,
+    '',
+    `The Teams list price is ${formatUsd(TEAMS_LIST_PRICE_USD)}/month, currently offered at ${formatUsd(TEAMS_BASE_PRICE_USD)}/month.`,
+    '',
+    '## Ingestion rates',
+    '',
+    'Rates depend on how long you retain the data. You pick retention per signal.',
+    '',
+    '### Logs and traces',
+    '',
+    buildTracesAndLogsTable(),
+    '',
+    '### Metrics',
+    '',
+    buildMetricsTable(),
+    '',
+    'Metrics are billed per million samples, not per time series or per custom metric.',
+    '',
+    '## Teams plan',
+    '',
+    `The ${formatUsd(TEAMS_BASE_PRICE_USD)}/month base includes usage worth ${formatUsd(TEAMS_BASE_PRICE_USD)} — roughly ${includedUsageSummary()}. Beyond that you pay only for what exceeds the base, at the rates above.`,
+    '',
+    'Included in the Teams plan:',
+    '',
+    '- Access to all product features',
+    '- Any mix of logs, traces, and metrics',
+    '- Unlimited teammates; any number of hosts',
+    '- Access to the MCP Server and Noz, the SigNoz AI teammate',
+    '- Support via in-product chat and email',
+    `- Dedicated Slack channel on spends above ${formatUsd(DEDICATED_SUPPORT_THRESHOLD_USD)}/month`,
+    `- Datadog dashboard migration support on spends above ${formatUsd(DEDICATED_SUPPORT_THRESHOLD_USD)}/month`,
+    '- SOC 2 Type II and HIPAA compliant (BAA agreement available as an add-on)',
+    '- Data centers in the US, EU, and India',
+    '',
+    '## Enterprise plan',
+    '',
+    `Custom pricing, starting at ${formatUsd(ENTERPRISE_FLOOR_USD)}/month. Choose one of:`,
+    '',
+    `- A dedicated environment on SigNoz Cloud (includes monthly ingestion usage up to ${formatUsd(ENTERPRISE_FLOOR_USD)})`,
+    '- Bring your own cloud, managed by SigNoz in your cloud account',
+    '- Self-hosted with a support contract',
+    '',
+    'Enterprise adds volume discounts and annual contracts, HIPAA/BAA and other certifications, dedicated Slack plus email and in-product support, guided migration, ongoing professional services, team training, and an SLA with downtime developer pairing. Enterprise-only features include SSO, SAML, audit logs, multi-tenancy, finer RBAC with custom roles, and per-source custom log retention.',
+    '',
+    '## Startup program',
+    '',
+    `50% off standard pricing — ${formatUsd(STARTUP_PRICE_USD)}/month instead of ${formatUsd(TEAMS_BASE_PRICE_USD)}/month. Eligibility:`,
+    '',
+    '- Less than 3 years old',
+    '- Fewer than 30 employees',
+    '- Raised less than $6 million',
+    '',
+    `Apply at ${siteUrl}/startups/`,
+    '',
+    '## How metrics samples are counted',
+    '',
+    'A sample is one data point from one time series. A time series reporting every 30 seconds produces 2 samples per minute.',
+    '',
+    `Worked example: 10,000 time series at a 30-second interval is 20,000 samples/minute, about 864 million samples/month. At ${formatUsd(cheapestMetricsPrice())} per million samples (1 month retention) that is about ${formatUsd(Math.round(864 * cheapestMetricsPrice() * 100) / 100)}/month.`,
+    '',
+    `Detailed walkthrough: ${siteUrl}/pricing/metrics-cost-estimation/`,
+    '',
+    '## Community Edition vs Teams',
+    '',
+    'The Community Edition is free and self-managed. SigNoz Cloud (Teams) removes cluster management and adds features not in the community build, including SSO and SAML support, plus help with initial dashboard and alert configuration.',
+    '',
+    '## Product areas covered on all plans',
+    '',
+    'APM and distributed tracing, log management, infrastructure monitoring, cloud monitoring, CI/CD observability, data exploration, exceptions monitoring, frontend and mobile monitoring, LLM monitoring, alerts management, pre-built integrations and dashboards, OpenTelemetry-native messaging queue monitoring, correlation of signals, and service dependency visualization.',
+    '',
+    '## Links',
+    '',
+    `- Pricing page: ${siteUrl}/pricing/`,
+    `- Start a free trial: ${siteUrl}/teams/`,
+    `- Contact sales: ${siteUrl}/contact-us/`,
+    `- Metrics cost estimation: ${siteUrl}/pricing/metrics-cost-estimation/`,
+    `- Cost comparison vs Datadog, New Relic, Grafana: ${siteUrl}/blog/pricing-comparison-signoz-vs-datadog-vs-newrelic-vs-grafana/`,
+    `- Datadog migration tool: ${siteUrl}/datadog-migration-tool/`,
+    `- Docs: ${siteUrl}/docs/introduction/`,
+    '',
+    'Agent guide: /llms.txt',
+    '',
+  ]
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Problem

`/pricing` prices usage through JS sliders (`PricingCalculator/`). Agents can't evaluate those — they scrape component markup and get no rates. This is the exact failure Resend described when they shipped `resend.com/pricing.md`.

## Changes

**`/pricing.md`** — full pricing story as markdown (4.4 KB): plans table, per-retention ingestion rates for logs/traces and metrics, what the $49 base includes, Enterprise options and benefits, Startup program eligibility, how metric samples are counted with a worked example, Community vs Teams, and links.

**Rates are imported, not restated.** `utils/pricing/buildPricingMarkdown.ts` pulls from `@/constants/pricing`, so both the rate tables and the derived "included usage" figure follow the calculator automatically.

**Consolidates duplicated rate tables.** They were hardcoded in two places:
- `PricingCalculator/constants.ts`
- `SigNozCloudPricingOverview.tsx:25-39` — its own separate copy of the same 5 traces/logs tiers and 4 metrics tiers

Both now read `@/constants/pricing`. The calculator's constants module re-exports them so existing imports are unchanged. This was a live drift risk: someone updating a rate in one file would have left the other stale.

`X-Robots-Tag: noindex` so it doesn't compete with `/pricing` in search.

## Why the constants moved to `constants/`

Rates couldn't be imported from the pricing component directly — there is **no `@/app/*` path alias** in `tsconfig.json`, so `@/` cannot resolve through the `(site)` route group. The first attempt failed at runtime with `Module not found`. Worth knowing for any future util that needs to read from `app/`.

## Verification

Drift protection was verified live, not just asserted — temporarily changing the 15-day rate from `0.3` to `0.35` propagated to both the table (`| 15 days | $0.35 |`) **and** the derived included-usage figure (163 GB → 140 GB) with no other edits. Constant restored.

Against a local dev server:

| Request | Result |
|---|---|
| `/pricing.md` | 200 `text/markdown`, `noindex`, 4,425 bytes |
| `/pricing/` | 200 `text/html` (unchanged) |

- `tests/pricing-markdown.test.js` — 8 new tests: every tier row matches the constants, row count matches the constants (catches stale extra rows), plan prices, required sections, no site-relative links, llms.txt reference, derived usage math
- `yarn test` — 56 passed
- `node --test tests/*.test.js` — full sweep clean
- `yarn check:stale-urls` — pass
- `yarn lint` — 0 errors
- `yarn build` — exit 0, `/pricing.md` registered as a route

## Review notes

- Prose (inclusions, eligibility, support thresholds) is hand-written and **must be updated alongside the pricing components** — only the numbers are coupled. Flagged in a comment at the top of the builder.
- Figures cross-checked against the components: $49 base / $199 list, $4000 Enterprise floor, $19 startup, $999 dedicated-support threshold, and the $86.40 metrics example (matches the pricing FAQ verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)