### PR TITLE
docs(llm): build internal link graph across the 46 LLM observability guides

### DIFF
--- a/data/docs/agno-monitoring.mdx
+++ b/data/docs/agno-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: Agno Monitoring and Observability with OpenTelemetry
 description: Learn how to monitor Agno agents with OpenTelemetry and SigNoz. Track traces, logs, and metrics for real-time visibility into latency, errors, and usage.
 doc_type: howto
@@ -384,9 +383,14 @@ You can also check out our custom Agno dashboard [here](https://signoz.io/docs/
   caption="Agno Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
 
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+- [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
+- [Mastra observability with OpenTelemetry](https://signoz.io/docs/mastra-observability/) - trace Mastra agents, workflows, and tool calls
+- [LiveKit observability with OpenTelemetry](https://signoz.io/docs/livekit-observability/) - trace voice agent sessions, turn latency, and STT and TTS calls
+- [Monitor Pipecat voice agents with OpenTelemetry](https://signoz.io/docs/pipecat-monitoring/) - trace pipeline latency across the STT, LLM, and TTS stages
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/amazon-bedrock-monitoring.mdx
+++ b/data/docs/amazon-bedrock-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: Amazon Bedrock Monitoring and Observability with OpenTelemetry
 description: Setup Amazon Bedrock monitoring using OpenTelemetry and SigNoz. Track model performance, latency, error rates, and usage across foundation models.
 ---
@@ -421,3 +420,15 @@ You can also check out our custom Amazon Bedrock dashboard [here](https://signo
   alt="Bedrock Dashboard"
   caption="Amazon Bedrock Dashboard Template"
 />
+
+## Related integrations
+
+Trace what sits on either side of your gateway, from the providers behind it to the apps in front:
+
+- [Monitor Azure OpenAI with OpenTelemetry](https://signoz.io/docs/azure-openai-monitoring/) - track deployment latency, token consumption, and quota errors
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [OpenRouter observability with OpenTelemetry](https://signoz.io/docs/openrouter-observability/) - trace routed model calls and compare cost across providers
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+- [Monitor n8n workflows with OpenTelemetry](https://signoz.io/docs/n8n-monitoring/) - trace workflow executions and pinpoint node-level failures
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/anthropic-monitoring.mdx
+++ b/data/docs/anthropic-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: Anthropic Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Anthropic API calls using OpenTelemetry and SigNoz. Track latency, errors, and usage trends for better AI observability.
 doc_type: howto
@@ -365,3 +364,15 @@ You can also check out our custom Anthropic API dashboard [here](https://signoz
   alt="Anthropic API Dashboard"
   caption="Anthropic API dashboard template"
 />
+
+## Related integrations
+
+Send telemetry from the rest of your model providers to the same backend:
+
+- [Monitor Google Gemini with OpenTelemetry](https://signoz.io/docs/google-gemini-monitoring/) - track Gemini model latency, token counts, and safety-block errors
+- [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
+- [Monitor Cohere with OpenTelemetry](https://signoz.io/docs/cohere-monitoring/) - trace Chat, Embed, and Rerank calls with per-call token usage
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+- [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/autogen-observability.mdx
+++ b/data/docs/autogen-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: AutoGen Observability & Monitoring with OpenTelemetry
 description: Setup AutoGen observability with OpenTelemetry and SigNoz. Monitor multi-agent workflows, track performance, and debug issues in real time.
 ---
@@ -487,7 +486,6 @@ If you don't see your telemetry data:
 4. **Try a console exporter** — Enable a console exporter locally to confirm that your application is generating telemetry data before it’s sent to SigNoz
 
 
-
 ## Next Steps
 
 You can also check out our custom AutoGen dashboard [here](https://signoz.io/docs/dashboards/dashboard-templates/autogen-dashboard/) which provides specialized visualizations for monitoring your AutoGen usage in applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
@@ -498,9 +496,14 @@ You can also check out our custom AutoGen dashboard [here](https://signoz.io/do
   caption="AutoGen Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
 
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+- [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
+- [Monitor Pipecat voice agents with OpenTelemetry](https://signoz.io/docs/pipecat-monitoring/) - trace pipeline latency across the STT, LLM, and TTS stages
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/azure-openai-monitoring.mdx
+++ b/data/docs/azure-openai-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: Azure OpenAI Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Azure OpenAI API using OpenTelemetry and SigNoz. Track model latency, error rates, and usage for enterprise AI workloads.
 ---
@@ -623,3 +622,15 @@ You can also check out our custom Azure OpenAI API dashboard [here](https://sig
   alt="Azure OpenAI Dashboard"
   caption="Azure OpenAI API Dashboard Template"
 />
+
+## Related integrations
+
+Trace what sits on either side of your gateway, from the providers behind it to the apps in front:
+
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [OpenRouter observability with OpenTelemetry](https://signoz.io/docs/openrouter-observability/) - trace routed model calls and compare cost across providers
+- [Monitor Amazon Bedrock with OpenTelemetry](https://signoz.io/docs/amazon-bedrock-monitoring/) - track invocation latency, token usage, and error rates across Bedrock foundation models
+- [Monitor Cohere with OpenTelemetry](https://signoz.io/docs/cohere-monitoring/) - trace Chat, Embed, and Rerank calls with per-call token usage
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/baseten-monitoring.mdx
+++ b/data/docs/baseten-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Baseten Monitoring & Observability with OpenTelemetry
 description: Setup Baseten monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Baseten LLM applications and model usage.
 doc_type: howto
@@ -410,9 +410,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your self-hosted inference stack:
 
+- [Monitor Open WebUI with OpenTelemetry](https://signoz.io/docs/open-webui-monitoring/) - trace chat requests, database queries, and model token usage
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+- [Hugging Face observability with OpenTelemetry](https://signoz.io/docs/huggingface-observability/) - trace inference API calls and local pipeline runs
+- [Monitor Haystack pipelines with OpenTelemetry](https://signoz.io/docs/haystack-monitoring/) - trace RAG pipelines, retrievers, and generator nodes
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/claude-agent-monitoring.mdx
+++ b/data/docs/claude-agent-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-09
-
+date: 2026-08-03
 title: Claude Agent SDK Monitoring & Observability with OpenTelemetry
 description: Setup Claude Agent SDK monitoring with OpenTelemetry and SigNoz. Track agent workflows, latency, and errors with correlated traces and metrics.
 doc_type: howto
@@ -164,9 +163,14 @@ You can also check out our custom Claude Agent SDK dashboard [here](https://sig
   caption="Claude Agent SDK Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
 
+- [CrewAI observability with OpenTelemetry](https://signoz.io/docs/crewai-observability/) - trace crews, agents, tasks, and tool calls end to end
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+- [Monitor xAI Grok with OpenTelemetry](https://signoz.io/docs/grok-monitoring/) - trace Grok API calls with latency and token usage
+- [Monitor Google Gemini with OpenTelemetry](https://signoz.io/docs/google-gemini-monitoring/) - track Gemini model latency, token counts, and safety-block errors
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -350,7 +350,7 @@ Instrument the other AI agents and assistants you run, using the same OpenTeleme
 
 - [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
 - [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
-- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace gateway sessions, tool calls, and model usage across your messaging channels
 - [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
 - [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
 

--- a/data/docs/claude-code-monitoring.mdx
+++ b/data/docs/claude-code-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-25
-
+date: 2026-08-03
 title: Claude Code Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Claude Code sessions using OpenTelemetry and SigNoz. Track token usage, costs, API performance, and session activity across your engineering team.
 doc_type: howto
@@ -344,3 +343,15 @@ A. Metrics (like `claude_code.token.usage` and `claude_code.cost.usage`) are num
 />
 
 </DocCardContainer>
+
+## Related integrations
+
+Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
+
+- [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
+- [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+- [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/codex-monitoring.mdx
+++ b/data/docs/codex-monitoring.mdx
@@ -196,8 +196,8 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
 
 - [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
-- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
-- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace gateway sessions, tool calls, and model usage across your messaging channels
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace long-running agent sessions, skill execution, and subagent runs
 - [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
 - [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
 

--- a/data/docs/codex-monitoring.mdx
+++ b/data/docs/codex-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: OpenAI Codex Observability & Monitoring with OpenTelemetry
 description: Learn how to monitor OpenAI Codex usage with OpenTelemetry and SigNoz. Track coding assistant traces, logs, and performance metrics.
 doc_type: howto
@@ -191,9 +191,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
 
+- [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/cohere-monitoring.mdx
+++ b/data/docs/cohere-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-16
+date: 2026-08-03
 title: Cohere Monitoring & Observability with OpenTelemetry
 description: Set up Cohere monitoring with OpenTelemetry and SigNoz. Track Chat, Embed, and Rerank traces, model calls, latency, and token usage from your Cohere apps.
 doc_type: howto
@@ -169,7 +169,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Send telemetry from the rest of your model providers to the same backend:
+
+- [Monitor DeepSeek with OpenTelemetry](https://signoz.io/docs/deepseek-monitoring/) - track DeepSeek model latency, token usage, and error rates
+- [Monitor xAI Grok with OpenTelemetry](https://signoz.io/docs/grok-monitoring/) - trace Grok API calls with latency and token usage
+- [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
+- [Monitor Azure OpenAI with OpenTelemetry](https://signoz.io/docs/azure-openai-monitoring/) - track deployment latency, token consumption, and quota errors
+- [Monitor Amazon Bedrock with OpenTelemetry](https://signoz.io/docs/amazon-bedrock-monitoring/) - track invocation latency, token usage, and error rates across Bedrock foundation models
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/crewai-observability.mdx
+++ b/data/docs/crewai-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: CrewAI Observability & Monitoring with OpenTelemetry
 description: Set up CrewAI observability with OpenTelemetry and SigNoz for full CrewAI monitoring. Track agent, tool, and model performance with traces, logs, and metrics.
 doc_type: howto
@@ -477,3 +476,15 @@ The [CrewAI Monitoring Dashboard](https://signoz.io/docs/dashboards/dashboard-te
   alt="CrewAI Dashboard"
   caption="CrewAI Dashboard Template"
 />
+
+## Related integrations
+
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
+
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+- [LiveKit observability with OpenTelemetry](https://signoz.io/docs/livekit-observability/) - trace voice agent sessions, turn latency, and STT and TTS calls
+- [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/deepseek-monitoring.mdx
+++ b/data/docs/deepseek-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: DeepSeek Monitoring & Observability with OpenTelemetry
 description: Set up DeepSeek monitoring with OpenTelemetry and SigNoz to track latency, error rates, and token usage for full DeepSeek observability.
 doc_type: howto
@@ -648,3 +647,15 @@ The [DeepSeek API dashboard template](https://signoz.io/docs/dashboards/dashboar
   alt="DeepSeek Dashboard"
   caption="DeepSeek API Dashboard Template"
 />
+
+## Related integrations
+
+Send telemetry from the rest of your model providers to the same backend:
+
+- [Monitor xAI Grok with OpenTelemetry](https://signoz.io/docs/grok-monitoring/) - trace Grok API calls with latency and token usage
+- [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
+- [Groq observability with OpenTelemetry](https://signoz.io/docs/groq-observability/) - trace Groq inference calls and measure time to first token
+- [Monitor Baseten with OpenTelemetry](https://signoz.io/docs/baseten-monitoring/) - trace model deployments and inference calls running on Baseten
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/dify-observability.mdx
+++ b/data/docs/dify-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: 2026-08-03
 title: Dify Observability & Monitoring with OpenTelemetry
 description: Observability and monitoring for Dify usage and performance with OpenTelemetry instrumentation to send traces and metrics to SigNoz
 doc_type: howto
@@ -166,9 +166,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your AI workflow and agent-building stack:
 
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+- [Monitor Inkeep with OpenTelemetry](https://signoz.io/docs/inkeep-monitoring/) - trace Inkeep assistant queries and the retrieval behind them
+- [Monitor n8n workflows with OpenTelemetry](https://signoz.io/docs/n8n-monitoring/) - trace workflow executions and pinpoint node-level failures
+- [Hugging Face observability with OpenTelemetry](https://signoz.io/docs/huggingface-observability/) - trace inference API calls and local pipeline runs
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/dspy-observability.mdx
+++ b/data/docs/dspy-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-21
+date: 2026-08-03
 title: DSPy Observability & Monitoring with OpenTelemetry
 description: Set up DSPy observability with OpenTelemetry and SigNoz. Trace module, chain, and tool calls, model requests, latency, and errors from your DSPy programs.
 doc_type: howto
@@ -239,7 +239,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Trace the rest of your LLM application and retrieval stack:
+
+- [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+- [LlamaIndex observability with OpenTelemetry](https://signoz.io/docs/llamaindex-observability/) - trace RAG queries, retrievers, and index operations
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+- [Monitor Inkeep with OpenTelemetry](https://signoz.io/docs/inkeep-monitoring/) - trace Inkeep assistant queries and the retrieval behind them
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/firecrawl-monitoring.mdx
+++ b/data/docs/firecrawl-monitoring.mdx
@@ -172,7 +172,7 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 Trace the agents and applications running on top of this infrastructure:
 
 - [Temporal observability with OpenTelemetry](https://signoz.io/docs/temporal-observability/) - trace workflows, activities, and long-running agent execution
-- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace gateway sessions, tool calls, and model usage across your messaging channels
 - [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
 - [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
 - [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance

--- a/data/docs/firecrawl-monitoring.mdx
+++ b/data/docs/firecrawl-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-19
+date: 2026-08-03
 title: Firecrawl Monitoring with OpenTelemetry and SigNoz
 description: Set up Firecrawl monitoring with OpenTelemetry and SigNoz. Track scrape, crawl, search, and map calls with traces and metrics for latency and credits.
 doc_type: howto
@@ -167,7 +167,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Trace the agents and applications running on top of this infrastructure:
+
+- [Temporal observability with OpenTelemetry](https://signoz.io/docs/temporal-observability/) - trace workflows, activities, and long-running agent execution
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/google-adk-observability.mdx
+++ b/data/docs/google-adk-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-01
+date: 2026-08-03
 title: Google ADK Observability & Monitoring with OpenTelemetry
 description: Set up Google ADK observability with OpenTelemetry and SigNoz. Monitor AI agents, track LLM traces, logs, and metrics, and debug issues fast.
 doc_type: howto
@@ -97,7 +97,6 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry import trace
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor 
 import os
-
 
 
 resource = Resource.create({"service.name": "<service_name>"})
@@ -339,9 +338,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
 
+- [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
+- [Mastra observability with OpenTelemetry](https://signoz.io/docs/mastra-observability/) - trace Mastra agents, workflows, and tool calls
+- [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
+- [Monitor Pipecat voice agents with OpenTelemetry](https://signoz.io/docs/pipecat-monitoring/) - trace pipeline latency across the STT, LLM, and TTS stages
+- [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/google-gemini-monitoring.mdx
+++ b/data/docs/google-gemini-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: Google Gemini Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Google Gemini API with OpenTelemetry and SigNoz. Track model performance, latency, and usage trends for your AI applications.
 ---
@@ -362,3 +361,15 @@ You can also check out our custom Google Gemini dashboard [here](https://signoz
   alt="Gemini Dashboard"
   caption="Google Gemini Dashboard Template"
 />
+
+## Related integrations
+
+Send telemetry from the rest of your model providers to the same backend:
+
+- [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
+- [Monitor Cohere with OpenTelemetry](https://signoz.io/docs/cohere-monitoring/) - trace Chat, Embed, and Rerank calls with per-call token usage
+- [Monitor DeepSeek with OpenTelemetry](https://signoz.io/docs/deepseek-monitoring/) - track DeepSeek model latency, token usage, and error rates
+- [Monitor Amazon Bedrock with OpenTelemetry](https://signoz.io/docs/amazon-bedrock-monitoring/) - track invocation latency, token usage, and error rates across Bedrock foundation models
+- [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/grok-monitoring.mdx
+++ b/data/docs/grok-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-29
+date: 2026-08-03
 title: xAI Grok Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor xAI Grok using OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Grok LLM applications with real-time dashboards.
 doc_type: howto
@@ -345,9 +345,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Send telemetry from the rest of your model providers to the same backend:
 
+- [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
+- [Groq observability with OpenTelemetry](https://signoz.io/docs/groq-observability/) - trace Groq inference calls and measure time to first token
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+- [Monitor Azure OpenAI with OpenTelemetry](https://signoz.io/docs/azure-openai-monitoring/) - track deployment latency, token consumption, and quota errors
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/groq-observability.mdx
+++ b/data/docs/groq-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Groq Observability & Monitoring with OpenTelemetry
 description: Learn how to set up observability and monitoring for Groq applications using OpenTelemetry. Export traces, logs, and metrics to SigNoz to monitor LLM usage and optimize your AI workflows.
 doc_type: howto
@@ -435,9 +435,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Send telemetry from the rest of your model providers to the same backend:
 
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+- [Monitor Google Gemini with OpenTelemetry](https://signoz.io/docs/google-gemini-monitoring/) - track Gemini model latency, token counts, and safety-block errors
+- [DSPy observability with OpenTelemetry](https://signoz.io/docs/dspy-observability/) - trace modules, chains, and optimizer runs
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/haystack-monitoring.mdx
+++ b/data/docs/haystack-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Haystack Observability & Monitoring with OpenTelemetry
 description: Learn how to monitor Haystack AI pipelines using OpenTelemetry and SigNoz. Track RAG workflows, model performance, and latency in real time.
 doc_type: howto
@@ -409,9 +409,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Trace the rest of your LLM application and retrieval stack:
 
+- [DSPy observability with OpenTelemetry](https://signoz.io/docs/dspy-observability/) - trace modules, chains, and optimizer runs
+- [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+- [Monitor Inkeep with OpenTelemetry](https://signoz.io/docs/inkeep-monitoring/) - trace Inkeep assistant queries and the retrieval behind them
+- [Groq observability with OpenTelemetry](https://signoz.io/docs/groq-observability/) - trace Groq inference calls and measure time to first token
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/hermes-monitoring.mdx
+++ b/data/docs/hermes-monitoring.mdx
@@ -1,15 +1,19 @@
 ---
 date: 2026-08-03
 title: Hermes Monitoring and Observability with OpenTelemetry
-description: Set up Hermes monitoring and observability with OpenTelemetry to send traces, logs, and metrics to SigNoz for full visibility into agent usage
+description: Set up Hermes Agent monitoring with OpenTelemetry and SigNoz. Trace long-running agent sessions, skill execution, subagent runs, and model calls.
 doc_type: howto
 ---
 
 ## What is Hermes Monitoring?
 
-Hermes monitoring gives you full visibility into your AI coding agent's behavior. This guide walks you through setting up Hermes monitoring and observability using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces, metrics, and logs to SigNoz. With this integration, you can observe and track your Hermes AI agent sessions, LLM calls, tool invocations, and more.
+<a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener noreferrer nofollow">Hermes Agent</a> is an open source autonomous AI assistant from Nous Research. It keeps memory across sessions, generates its own skills from experience, spawns subagents for parallel work, and runs scheduled tasks unattended. You reach it from a terminal or from Telegram, Discord, Slack, WhatsApp, Signal, and email.
 
-With full Hermes monitoring in SigNoz, you can correlate traces, logs, and metrics in unified dashboards, set alerts on latency and errors, and improve the reliability of your AI coding workflows. This end to end Hermes observability gives you actionable insight into every agent session, LLM call, and tool invocation.
+That design is what makes Hermes hard to follow without telemetry: sessions are long-lived, the skill set changes underneath you, subagents run out of sight, and scheduled jobs fire when nobody is watching.
+
+This guide walks you through setting up Hermes monitoring and observability using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> and exporting traces, metrics, and logs to SigNoz. With this integration, you can observe agent sessions, LLM calls, tool invocations, skill execution, and subagent runs.
+
+With full Hermes monitoring in SigNoz, you can correlate traces, logs, and metrics in unified dashboards, set alerts on latency and errors, and see which models, skills, and tools are driving your cost and failures.
 
 ## Prerequisites
 

--- a/data/docs/hermes-monitoring.mdx
+++ b/data/docs/hermes-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-23
+date: 2026-08-03
 title: Hermes Monitoring and Observability with OpenTelemetry
 description: Set up Hermes monitoring and observability with OpenTelemetry to send traces, logs, and metrics to SigNoz for full visibility into agent usage
 doc_type: howto
@@ -353,7 +353,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
+
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+- [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
+- [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
+- [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/huggingface-observability.mdx
+++ b/data/docs/huggingface-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Hugging Face Observability & Monitoring with OpenTelemetry
 description: Setup Hugging Face observability with OpenTelemetry and SigNoz. Monitor model inference, track traces, and analyze LLM usage with unified dashboards.
 doc_type: howto
@@ -395,9 +395,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your self-hosted inference stack:
 
+- [Monitor Baseten with OpenTelemetry](https://signoz.io/docs/baseten-monitoring/) - trace model deployments and inference calls running on Baseten
+- [Monitor Open WebUI with OpenTelemetry](https://signoz.io/docs/open-webui-monitoring/) - trace chat requests, database queries, and model token usage
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+- [Monitor Haystack pipelines with OpenTelemetry](https://signoz.io/docs/haystack-monitoring/) - trace RAG pipelines, retrievers, and generator nodes
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/inkeep-monitoring.mdx
+++ b/data/docs/inkeep-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: Inkeep Monitoring & Observability with OpenTelemetry
 description: Monitoring and observability for Inkeep usage and performance with OpenTelemetry instrumentation to send traces, logs, and metrics to SigNoz
 doc_type: howto
@@ -109,7 +108,6 @@ SIGNOZ_API_KEY=<your-signoz-api-key>
 </Tabs>
 
 
-
 ### Step 4: Run the setup script
 Ensure Docker Desktop (or Docker daemon) is running before running the setup script.
 
@@ -177,7 +175,14 @@ You can also check out our custom Inkeep dashboard [here](https://signoz.io/doc
   caption="Inkeep Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Instrument the rest of your AI workflow and agent-building stack:
+
+- [Monitor n8n workflows with OpenTelemetry](https://signoz.io/docs/n8n-monitoring/) - trace workflow executions and pinpoint node-level failures
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+- [OpenRouter observability with OpenTelemetry](https://signoz.io/docs/openrouter-observability/) - trace routed model calls and compare cost across providers
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/langchain-observability.mdx
+++ b/data/docs/langchain-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: LangChain & LangGraph Observability with OpenTelemetry
 description: Set up LangChain and LangGraph observability with OpenTelemetry and SigNoz. Monitor agent reasoning, tool calls, and chain execution with real-time traces.
 doc_type: howto
@@ -233,10 +232,21 @@ You can instrument your LangChain/LangGraph applications in JavaScript using the
 
 For detailed guidance on instrumenting JavaScript applications with OpenTelemetry and connecting them to SigNoz, see the [SigNoz OpenTelemetry JavaScript instrumentation docs](https://signoz.io/docs/instrumentation/javascript/opentelemetry-nodejs/).
 
-Additional resources:
+## Related integrations
+
+Trace the rest of your LLM application and retrieval stack:
+
+- [LlamaIndex observability with OpenTelemetry](https://signoz.io/docs/llamaindex-observability/) - trace RAG queries, retrievers, and index operations
+- [Monitor Haystack pipelines with OpenTelemetry](https://signoz.io/docs/haystack-monitoring/) - trace RAG pipelines, retrievers, and generator nodes
+- [DSPy observability with OpenTelemetry](https://signoz.io/docs/dspy-observability/) - trace modules, chains, and optimizer runs
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+- [Monitor Firecrawl with OpenTelemetry](https://signoz.io/docs/firecrawl-monitoring/) - trace scrape, crawl, search, and map calls alongside credit usage
+
+Further reading:
+
 - Watch the <a href="https://youtu.be/yQezobnHzeg" target="_blank" rel="noopener noreferrer nofollow">LangGraph observability walkthrough</a>
 - Watch the <a href="https://youtu.be/fS9TN558UQY" target="_blank" rel="noopener noreferrer nofollow">LangChain agent monitoring walkthrough</a>
 - Read [LangChain Observability with OpenTelemetry](https://signoz.io/blog/langchain-observability-with-opentelemetry/)
 - Read [Monitoring a LangChain Agent that uses the SigNoz MCP](https://signoz.io/blog/monitoring-langchain-agent-querying-signoz-mcp-server/)
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/langflow-observability.mdx
+++ b/data/docs/langflow-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-16
+date: 2026-08-03
 title: Langflow Observability & Monitoring with OpenTelemetry
 description: Set up Langflow observability with OpenTelemetry and SigNoz. Track flow and LLM traces, model calls, prompts, and token usage from your Langflow apps.
 doc_type: howto
@@ -160,7 +160,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
+
+Instrument the rest of your AI workflow and agent-building stack:
+
+- [Monitor Inkeep with OpenTelemetry](https://signoz.io/docs/inkeep-monitoring/) - trace Inkeep assistant queries and the retrieval behind them
+- [Monitor n8n workflows with OpenTelemetry](https://signoz.io/docs/n8n-monitoring/) - trace workflow executions and pinpoint node-level failures
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [Hugging Face observability with OpenTelemetry](https://signoz.io/docs/huggingface-observability/) - trace inference API calls and local pipeline runs
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/langtrace.mdx
+++ b/data/docs/langtrace.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-08-03
 title: LLM Monitoring with Langtrace - Setup Guide
 description: Learn how to integrate Langtrace with SigNoz for LLM observability. Monitor and analyze AI application traces with specialized instrumentation.
 doc_type: howto
@@ -143,9 +143,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Use the same OpenTelemetry pipeline for the frameworks and providers you instrument:
 
+- [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
+- [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/langtrace.mdx
+++ b/data/docs/langtrace.mdx
@@ -150,7 +150,7 @@ Use the same OpenTelemetry pipeline for the frameworks and providers you instrum
 - [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
 - [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
 - [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
-- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace gateway sessions, tool calls, and model usage across your messaging channels
 - [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
 
 Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/litellm-observability.mdx
+++ b/data/docs/litellm-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: LiteLLM Observability & Monitoring with OpenTelemetry
 description: Configure LiteLLM observability with OpenTelemetry to export traces, logs, and metrics to SigNoz for real-time LiteLLM monitoring of SDK and Proxy.
 doc_type: howto
@@ -455,3 +454,15 @@ The [LiteLLM Proxy Dashboard](https://signoz.io/docs/dashboards/dashboard-templa
 
 </TabItem>
 </Tabs>
+
+## Related integrations
+
+Trace what sits on either side of your gateway, from the providers behind it to the apps in front:
+
+- [OpenRouter observability with OpenTelemetry](https://signoz.io/docs/openrouter-observability/) - trace routed model calls and compare cost across providers
+- [Monitor Amazon Bedrock with OpenTelemetry](https://signoz.io/docs/amazon-bedrock-monitoring/) - track invocation latency, token usage, and error rates across Bedrock foundation models
+- [Monitor Azure OpenAI with OpenTelemetry](https://signoz.io/docs/azure-openai-monitoring/) - track deployment latency, token consumption, and quota errors
+- [Monitor DeepSeek with OpenTelemetry](https://signoz.io/docs/deepseek-monitoring/) - track DeepSeek model latency, token usage, and error rates
+- [Monitor Cohere with OpenTelemetry](https://signoz.io/docs/cohere-monitoring/) - trace Chat, Embed, and Rerank calls with per-call token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/livekit-observability.mdx
+++ b/data/docs/livekit-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: LiveKit Observability & Monitoring with OpenTelemetry
 description: Learn how to instrument LiveKit voice agents with OpenTelemetry and export traces, logs, and metrics to SigNoz to monitor latency and errors.
 doc_type: howto
@@ -525,7 +524,6 @@ If you don't see your telemetry data:
 4. **Try a console exporter** — Enable a console exporter locally to confirm that your application is generating telemetry data before it’s sent to SigNoz
 
 
-
 ## Next Steps
 
 You can also check out our custom LiveKit dashboard [here](https://signoz.io/docs/dashboards/dashboard-templates/livekit-dashboard/) which provides specialized visualizations for monitoring your LiveKit usage in applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
@@ -536,9 +534,14 @@ You can also check out our custom LiveKit dashboard [here](https://signoz.io/do
   caption="LiveKit Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Trace the rest of the stack behind your voice agents:
 
+- [Monitor Pipecat voice agents with OpenTelemetry](https://signoz.io/docs/pipecat-monitoring/) - trace pipeline latency across the STT, LLM, and TTS stages
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+- [Mastra observability with OpenTelemetry](https://signoz.io/docs/mastra-observability/) - trace Mastra agents, workflows, and tool calls
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [Temporal observability with OpenTelemetry](https://signoz.io/docs/temporal-observability/) - trace workflows, activities, and long-running agent execution
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/llamaindex-observability.mdx
+++ b/data/docs/llamaindex-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: LlamaIndex Observability & Monitoring with OpenTelemetry
 description: Learn how to instrument LlamaIndex RAG workflows with OpenTelemetry and OpenInference, and stream traces to SigNoz for end-to-end visibility.
 ---
@@ -201,8 +200,18 @@ When you click on a trace ID in SigNoz, you'll see a detailed view of the trace,
   </figcaption>
 </figure>
 
-## Additional Resources
+## Related integrations
+
+Trace the rest of your LLM application and retrieval stack:
+
+- [Monitor Haystack pipelines with OpenTelemetry](https://signoz.io/docs/haystack-monitoring/) - trace RAG pipelines, retrievers, and generator nodes
+- [DSPy observability with OpenTelemetry](https://signoz.io/docs/dspy-observability/) - trace modules, chains, and optimizer runs
+- [Vercel AI SDK observability with OpenTelemetry](https://signoz.io/docs/vercel-ai-sdk-observability/) - trace generateText, streamText, and tool calls inside Next.js
+- [Monitor Firecrawl with OpenTelemetry](https://signoz.io/docs/firecrawl-monitoring/) - trace scrape, crawl, search, and map calls alongside credit usage
+- [Google ADK observability with OpenTelemetry](https://signoz.io/docs/google-adk-observability/) - trace ADK agents, tools, and the model calls they make
+
+Further reading:
 
 - Read [Observing LlamaIndex Apps with OpenTelemetry + SigNoz](https://signoz.io/blog/opentelemetry-llamaindex/)
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/mastra-observability.mdx
+++ b/data/docs/mastra-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Mastra Observability & Monitoring with OpenTelemetry
 description: Set up Mastra observability with OpenTelemetry and SigNoz. Track traces for Mastra monitoring - model performance, latency, and error rates.
 doc_type: howto
@@ -144,3 +144,15 @@ When you click on a trace in SigNoz, you'll see a detailed view of the trace, in
 You can also check out our [Mastra Dashboard](https://signoz.io/docs/dashboards/dashboard-templates/mastra-dashboard/) which provides specialized visualizations for Mastra monitoring in your applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
 
 <Figure src="/img/docs/llm/mastra/mastra-dashboard.webp" alt="Mastra Dashboard" caption="Mastra Dashboard Template" />
+
+## Related integrations
+
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
+
+- [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+- [CrewAI observability with OpenTelemetry](https://signoz.io/docs/crewai-observability/) - trace crews, agents, tasks, and tool calls end to end
+- [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/mistral-observability.mdx
+++ b/data/docs/mistral-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Mistral AI Observability & Monitoring with OpenTelemetry
 description: Setup Mistral AI observability with OpenTelemetry and SigNoz. Monitor LLM performance, track traces, logs, and metrics in unified dashboards.
 doc_type: howto
@@ -393,9 +393,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Send telemetry from the rest of your model providers to the same backend:
 
+- [Monitor Cohere with OpenTelemetry](https://signoz.io/docs/cohere-monitoring/) - trace Chat, Embed, and Rerank calls with per-call token usage
+- [Monitor DeepSeek with OpenTelemetry](https://signoz.io/docs/deepseek-monitoring/) - track DeepSeek model latency, token usage, and error rates
+- [Monitor xAI Grok with OpenTelemetry](https://signoz.io/docs/grok-monitoring/) - trace Grok API calls with latency and token usage
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+- [Monitor Agno agents with OpenTelemetry](https://signoz.io/docs/agno-monitoring/) - trace agent runs, tool calls, and model requests across Agno teams and workflows
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/n8n-monitoring.mdx
+++ b/data/docs/n8n-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-08-03
 title: n8n Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor n8n Cloud workflows with OpenTelemetry and SigNoz. Track execution traces, set up alerts, and debug workflow issues.
 doc_type: howto
@@ -72,7 +72,6 @@ MAX_RETRIES=5
 <KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).
 </KeyPointCallout>
-
 
 
 ### Step 3: Launch with Docker
@@ -189,9 +188,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your AI workflow and agent-building stack:
 
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+- [Monitor Inkeep with OpenTelemetry](https://signoz.io/docs/inkeep-monitoring/) - trace Inkeep assistant queries and the retrieval behind them
+- [OpenRouter observability with OpenTelemetry](https://signoz.io/docs/openrouter-observability/) - trace routed model calls and compare cost across providers
+- [Monitor Open WebUI with OpenTelemetry](https://signoz.io/docs/open-webui-monitoring/) - trace chat requests, database queries, and model token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/ollama-monitoring.mdx
+++ b/data/docs/ollama-monitoring.mdx
@@ -166,7 +166,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry import trace
-from opentelemetry.instrumentation.ollama import OllamaInstrumentor().instrument()
+from opentelemetry.instrumentation.ollama import OllamaInstrumentor
 import os
 
 

--- a/data/docs/ollama-monitoring.mdx
+++ b/data/docs/ollama-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Ollama Monitoring & Observability with OpenTelemetry
 description: Set up Ollama monitoring and observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for full LLM visibility in real-time.
 doc_type: howto
@@ -415,9 +415,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your self-hosted inference stack:
 
+- [Hugging Face observability with OpenTelemetry](https://signoz.io/docs/huggingface-observability/) - trace inference API calls and local pipeline runs
+- [Monitor Baseten with OpenTelemetry](https://signoz.io/docs/baseten-monitoring/) - trace model deployments and inference calls running on Baseten
+- [Monitor Open WebUI with OpenTelemetry](https://signoz.io/docs/open-webui-monitoring/) - trace chat requests, database queries, and model token usage
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/open-webui-monitoring.mdx
+++ b/data/docs/open-webui-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-23
+date: 2026-08-03
 title: Open WebUI Observability & Monitoring with OpenTelemetry
 description: Set up Open WebUI monitoring with OpenTelemetry and SigNoz. Track API and LLM traces, database queries, token usage, cost, and model latency.
 doc_type: howto
@@ -330,8 +330,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-## Additional resources
+## Related integrations
 
-- [Set up alerts on traces and metrics](https://signoz.io/docs/alerts-management/trace-based-alerts/)
-- [Query and filter traces](https://signoz.io/docs/userguide/query-builder-v5/)
-- [Correlate logs with traces](https://signoz.io/docs/traces-management/guides/correlate-traces-and-logs/)
+Instrument the rest of your self-hosted inference stack:
+
+- [Monitor Ollama with OpenTelemetry](https://signoz.io/docs/ollama-monitoring/) - track local model inference latency, tokens, and resource usage
+- [Hugging Face observability with OpenTelemetry](https://signoz.io/docs/huggingface-observability/) - trace inference API calls and local pipeline runs
+- [Monitor Baseten with OpenTelemetry](https://signoz.io/docs/baseten-monitoring/) - trace model deployments and inference calls running on Baseten
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openai-monitoring.mdx
+++ b/data/docs/openai-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: OpenAI Monitoring with OpenTelemetry
 description: Set up OpenAI monitoring and observability with SigNoz. Track token usage, model latency, request traces, and error rates across your LLM apps in real time.
 doc_type: howto
@@ -617,3 +616,15 @@ If you don't see your telemetry data:
 You can also check out our custom OpenAI dashboard [here](https://signoz.io/docs/dashboards/dashboard-templates/openai-dashboard/) which provides specialized visualizations for monitoring your OpenAI usage in applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
 
 <Figure src="/img/docs/llm/openai/openai-dashboard.webp" alt="OpenAI monitoring dashboard in SigNoz with pre-built LLM charts" caption="OpenAI monitoring dashboard in SigNoz" />
+
+## Related integrations
+
+Send telemetry from the rest of your model providers to the same backend:
+
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+- [Monitor Google Gemini with OpenTelemetry](https://signoz.io/docs/google-gemini-monitoring/) - track Gemini model latency, token counts, and safety-block errors
+- [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
+- [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
+- [Monitor Open WebUI with OpenTelemetry](https://signoz.io/docs/open-webui-monitoring/) - trace chat requests, database queries, and model token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openclaw-observability.mdx
+++ b/data/docs/openclaw-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-08-03
 title: OpenClaw Observability & Monitoring with OpenTelemetry
 description: Set up OpenClaw observability and monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics from LLM applications to optimize performance.
 doc_type: howto
@@ -251,10 +251,18 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
+## Related integrations
+
+Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
+
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+- [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
+- [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
+- [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
+
+Further reading:
+
 - Read [Monitoring OpenClaw with OpenTelemetry](https://signoz.io/blog/monitoring-openclaw-with-opentelemetry/)
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
 
-
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openclaw-observability.mdx
+++ b/data/docs/openclaw-observability.mdx
@@ -1,15 +1,19 @@
 ---
 date: 2026-08-03
 title: OpenClaw Observability & Monitoring with OpenTelemetry
-description: Set up OpenClaw observability and monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics from LLM applications to optimize performance.
+description: Set up OpenClaw observability with OpenTelemetry and SigNoz. Trace gateway sessions, tool calls, scheduled jobs, and model usage across messaging channels.
 doc_type: howto
 ---
 
 ## What is OpenClaw Observability?
 
-OpenClaw observability gives you real-time visibility into your LLM applications and AI workflows by collecting traces, logs, and metrics using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a>. This guide shows you how to instrument OpenClaw and send telemetry data to SigNoz, so you can monitor performance, debug issues, and optimize your AI workflows.
+<a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer nofollow">OpenClaw</a> is an open source personal AI assistant that runs on your own devices and reaches you through the messaging apps you already use, including WhatsApp, Telegram, Slack, Discord, and Signal. A local gateway process acts as its control plane, handling sessions, scheduled jobs, and tool execution.
 
-With full OpenClaw observability in SigNoz, you can correlate traces, logs, and metrics in a single dashboard, set up alerts for error rates or high latency, and analyze LLM usage patterns over time to continuously improve reliability and efficiency.
+Because it runs locally and acts on a schedule without being prompted, telemetry is often the only way to see what OpenClaw did while you were away: which models it called, which tools ran, and what a session cost.
+
+OpenClaw observability gives you that visibility by collecting traces, logs, and metrics using <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a>. This guide shows you how to instrument OpenClaw and send telemetry data to SigNoz, so you can monitor performance, debug failures, and understand model usage.
+
+With full OpenClaw observability in SigNoz, you can correlate traces, logs, and metrics in a single dashboard, set up alerts for error rates or high latency, and analyze usage patterns across channels over time.
 
 <YouTube id="2DS1Y-h6GdE" mute="false" />
 
@@ -255,7 +259,7 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
 
-- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace long-running agent sessions, skill execution, and subagent runs
 - [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
 - [Monitor OpenAI Codex with OpenTelemetry](https://signoz.io/docs/codex-monitoring/) - track Codex CLI sessions, token spend, and command-level traces
 - [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz

--- a/data/docs/opencode-observability.mdx
+++ b/data/docs/opencode-observability.mdx
@@ -175,8 +175,8 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
 
-- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
-- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace gateway sessions, tool calls, and model usage across your messaging channels
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace long-running agent sessions, skill execution, and subagent runs
 - [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
 - [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
 - [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage

--- a/data/docs/opencode-observability.mdx
+++ b/data/docs/opencode-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-05-26
-
+date: 2026-08-03
 title: OpenCode Observability & Monitoring with OpenTelemetry
 description: Learn how to set up OpenCode observability and monitoring with OpenTelemetry and SigNoz. Track traces, logs, and metrics from AI coding sessions.
 doc_type: howto
@@ -172,8 +171,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the other AI agents and assistants you run, using the same OpenTelemetry pipeline:
+
+- [OpenClaw observability with OpenTelemetry](https://signoz.io/docs/openclaw-observability/) - trace OpenClaw routing, caching, and token accounting
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openlit.mdx
+++ b/data/docs/openlit.mdx
@@ -165,7 +165,7 @@ Use the same OpenTelemetry pipeline for the frameworks and providers you instrum
 - [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
 - [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
 - [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
-- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace long-running agent sessions, skill execution, and subagent runs
 - [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
 
 Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openlit.mdx
+++ b/data/docs/openlit.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-08-03
 title: OpenLIT Observability - Monitor LLMs & GenAI Apps
 description: Learn how to integrate OpenLIT with SigNoz for LLM observability. Monitor AI application traces and metrics with specialized instrumentation.
 doc_type: howto
@@ -158,9 +158,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Use the same OpenTelemetry pipeline for the frameworks and providers you instrument:
 
+- [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
+- [Instrument LLM apps with Traceloop OpenLLMetry](https://signoz.io/docs/traceloop/) - an OpenTelemetry SDK that auto-instruments 20+ LLM providers
+- [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Semantic Kernel observability with OpenTelemetry](https://signoz.io/docs/semantic-kernel-observability/) - trace plugins, planners, and kernel function calls
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/openrouter-observability.mdx
+++ b/data/docs/openrouter-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: OpenRouter Observability & Monitoring with OpenTelemetry
 description: Set up OpenRouter observability and monitoring with OpenTelemetry and SigNoz. Track traces, monitor LLM API routing, and analyze usage across models.
 doc_type: howto
@@ -45,7 +45,6 @@ Click 'Add Destination +' next to the OpenTelemetry Collector entry
   alt="OTel Collector Add Destination"
   caption="OpenTelemetry Collector Add Destination"
 />
-
 
 
 and enter:
@@ -222,9 +221,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Trace what sits on either side of your gateway, from the providers behind it to the apps in front:
 
+- [Monitor Amazon Bedrock with OpenTelemetry](https://signoz.io/docs/amazon-bedrock-monitoring/) - track invocation latency, token usage, and error rates across Bedrock foundation models
+- [Monitor Azure OpenAI with OpenTelemetry](https://signoz.io/docs/azure-openai-monitoring/) - track deployment latency, token consumption, and quota errors
+- [LiteLLM observability with OpenTelemetry](https://signoz.io/docs/litellm-observability/) - trace calls across 100+ models through either the SDK or the proxy
+- [Dify observability with OpenTelemetry](https://signoz.io/docs/dify-observability/) - trace Dify app workflows and LLM node execution
+- [CrewAI observability with OpenTelemetry](https://signoz.io/docs/crewai-observability/) - trace crews, agents, tasks, and tool calls end to end
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/pipecat-monitoring.mdx
+++ b/data/docs/pipecat-monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-11
-
+date: 2026-08-03
 title: Pipecat Monitoring & Observability with OpenTelemetry
 description: Learn how to monitor Pipecat voice agents with OpenTelemetry and SigNoz. Track latency, errors, and model performance in real-time dashboards.
 doc_type: tutorial
@@ -134,8 +133,6 @@ from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
-
-
 
 
 logger.info("✅ All components loaded successfully!")
@@ -492,7 +489,6 @@ from pipecat.transports.daily.transport import DailyParams
 from pipecat.utils.tracing.setup import setup_tracing 
 
 
-
 logger.info("✅ All components loaded successfully!")
 
 load_dotenv(override=True)
@@ -685,7 +681,6 @@ If you don't see your telemetry data:
 </details>
 
 
-
 ## Next Steps
 
 You can also check out our custom Pipecat dashboard [here](https://signoz.io/docs/dashboards/dashboard-templates/pipecat-dashboard/) which provides specialized visualizations for monitoring your Pipecat usage in applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
@@ -696,9 +691,14 @@ You can also check out our custom Pipecat dashboard [here](https://signoz.io/do
   caption="Pipecat Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Trace the rest of the stack behind your voice agents:
 
+- [LiveKit observability with OpenTelemetry](https://signoz.io/docs/livekit-observability/) - trace voice agent sessions, turn latency, and STT and TTS calls
+- [Mastra observability with OpenTelemetry](https://signoz.io/docs/mastra-observability/) - trace Mastra agents, workflows, and tool calls
+- [LlamaIndex observability with OpenTelemetry](https://signoz.io/docs/llamaindex-observability/) - trace RAG queries, retrievers, and index operations
+- [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/pydantic-ai-observability.mdx
+++ b/data/docs/pydantic-ai-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-29
+date: 2026-08-03
 tags: [SigNoz Cloud]
 title: Pydantic AI Observability & Monitoring with OpenTelemetry
 description: Setup Pydantic AI observability with OpenTelemetry and SigNoz. Monitor agent and model performance, track latency, and debug AI workflows.
@@ -403,3 +403,15 @@ You can also check out our custom Pydantic AI dashboard [here](https://signoz.i
   alt="Pydantic Dashboard"
   caption="Pydantic AI Dashboard Template"
 />
+
+## Related integrations
+
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
+
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+- [CrewAI observability with OpenTelemetry](https://signoz.io/docs/crewai-observability/) - trace crews, agents, tasks, and tool calls end to end
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+- [Monitor Google Gemini with OpenTelemetry](https://signoz.io/docs/google-gemini-monitoring/) - track Gemini model latency, token counts, and safety-block errors
+- [DSPy observability with OpenTelemetry](https://signoz.io/docs/dspy-observability/) - trace modules, chains, and optimizer runs
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/qwen-observability.mdx
+++ b/data/docs/qwen-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 title: Qwen Observability & Monitoring with OpenTelemetry
 description: Setup Qwen observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Qwen LLM applications with unified dashboards.
 doc_type: howto
@@ -410,9 +410,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Send telemetry from the rest of your model providers to the same backend:
 
+- [Groq observability with OpenTelemetry](https://signoz.io/docs/groq-observability/) - trace Groq inference calls and measure time to first token
+- [Monitor the OpenAI API with OpenTelemetry](https://signoz.io/docs/openai-monitoring/) - track token usage, model latency, and error rates across every call
+- [Monitor the Anthropic API with OpenTelemetry](https://signoz.io/docs/anthropic-monitoring/) - trace Claude requests and break down input, output, and cache token usage
+- [CrewAI observability with OpenTelemetry](https://signoz.io/docs/crewai-observability/) - trace crews, agents, tasks, and tool calls end to end
+- [Monitor Baseten with OpenTelemetry](https://signoz.io/docs/baseten-monitoring/) - trace model deployments and inference calls running on Baseten
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/semantic-kernel-observability.mdx
+++ b/data/docs/semantic-kernel-observability.mdx
@@ -1,6 +1,5 @@
 ---
-date: 2026-06-29
-
+date: 2026-08-03
 title: Semantic Kernel Observability - Monitor AI Orchestration
 description: Setup Semantic Kernel observability with OpenTelemetry and SigNoz. Monitor AI model performance, traces, and metrics for better debugging.
 doc_type: howto
@@ -75,7 +74,6 @@ import logging
 
 
 import os
-
 
 
 async def main():
@@ -336,7 +334,6 @@ import logging
 import os
 
 
-
 async def main():
 
     kernel = Kernel()
@@ -455,7 +452,6 @@ If you don't see your telemetry data:
 4. **Try a console exporter** — Enable a console exporter locally to confirm that your application is generating telemetry data before it’s sent to SigNoz
 
 
-
 ## Next Steps
 
 You can also check out our custom Semantic Kernel dashboard [here](https://signoz.io/docs/dashboards/dashboard-templates/semantic-kernel-dashboard/) which provides specialized visualizations for monitoring your Semantic-kernel usage in applications. The dashboard includes pre-built charts specifically tailored for LLM usage, along with import instructions to get started quickly.
@@ -466,9 +462,14 @@ You can also check out our custom Semantic Kernel dashboard [here](https://sign
   caption="Semantic Kernel Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Instrument the rest of your agent stack with the same OpenTelemetry pipeline:
 
+- [Mastra observability with OpenTelemetry](https://signoz.io/docs/mastra-observability/) - trace Mastra agents, workflows, and tool calls
+- [Pydantic AI observability with OpenTelemetry](https://signoz.io/docs/pydantic-ai-observability/) - trace agent runs, output validation, and model calls
+- [Monitor the Claude Agent SDK with OpenTelemetry](https://signoz.io/docs/claude-agent-monitoring/) - trace agent loops, tool use, and the model calls behind them
+- [Monitor Claude Code with OpenTelemetry](https://signoz.io/docs/claude-code-monitoring/) - track session token usage, cost per task, and API performance
+- [Monitor DeepSeek with OpenTelemetry](https://signoz.io/docs/deepseek-monitoring/) - track DeepSeek model latency, token usage, and error rates
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/temporal-observability.mdx
+++ b/data/docs/temporal-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-03
 tags: [SigNoz Cloud, Self-Host]
 title: Temporal Observability & Monitoring with OpenTelemetry
 description: Set up Temporal observability and monitoring with OpenTelemetry and SigNoz. Trace workflows, agent execution, and debug performance issues in real time.
@@ -538,9 +538,14 @@ The [Temporal dashboard template](https://signoz.io/docs/dashboards/dashboard-te
   caption="Temporal Dashboard Template"
 />
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Trace the agents and applications running on top of this infrastructure:
 
+- [Monitor Firecrawl with OpenTelemetry](https://signoz.io/docs/firecrawl-monitoring/) - trace scrape, crawl, search, and map calls alongside credit usage
+- [LiveKit observability with OpenTelemetry](https://signoz.io/docs/livekit-observability/) - trace voice agent sessions, turn latency, and STT and TTS calls
+- [OpenCode observability with OpenTelemetry](https://signoz.io/docs/opencode-observability/) - trace OpenCode sessions, tool calls, and per-message cost
+- [Monitor Pipecat voice agents with OpenTelemetry](https://signoz.io/docs/pipecat-monitoring/) - trace pipeline latency across the STT, LLM, and TTS stages
+- [AutoGen observability with OpenTelemetry](https://signoz.io/docs/autogen-observability/) - trace multi-agent conversations, group chats, and tool execution
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/traceloop.mdx
+++ b/data/docs/traceloop.mdx
@@ -146,7 +146,7 @@ Use the same OpenTelemetry pipeline for the frameworks and providers you instrum
 
 - [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
 - [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
-- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace long-running agent sessions, skill execution, and subagent runs
 - [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
 - [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
 

--- a/data/docs/traceloop.mdx
+++ b/data/docs/traceloop.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-08-03
 title: Traceloop Observability - Monitor LLM Usage
 description: Learn how to integrate Traceloop OpenLLMetry with SigNoz for LLM observability. Monitor AI application traces with specialized instrumentation.
 doc_type: howto
@@ -140,9 +140,14 @@ For more details, see [Why use the OpenTelemetry Collector?](https://signoz.io/d
 
 </details>
 
-Additional resources:
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
-- Explore [log correlation](https://signoz.io/docs/userguide/logs_query_builder/)
+## Related integrations
 
+Use the same OpenTelemetry pipeline for the frameworks and providers you instrument:
 
+- [Instrument LLM apps with OpenLIT](https://signoz.io/docs/openlit/) - a one-line OpenTelemetry SDK covering GenAI, vector DB, and GPU telemetry
+- [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
+- [Monitor Hermes with OpenTelemetry](https://signoz.io/docs/hermes-monitoring/) - trace Hermes agent runs and the model calls behind them
+- [Monitor Mistral AI with OpenTelemetry](https://signoz.io/docs/mistral-observability/) - track Mistral model latency, token usage, and error rates
+- [Qwen observability with OpenTelemetry](https://signoz.io/docs/qwen-observability/) - trace Qwen model calls with latency and token usage
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.

--- a/data/docs/vercel-ai-sdk-observability.mdx
+++ b/data/docs/vercel-ai-sdk-observability.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-09
+date: 2026-08-03
 title: Vercel AI SDK Observability & Monitoring with OpenTelemetry
 description: Set up Vercel AI SDK observability with OpenTelemetry and SigNoz. Monitor AI function calls, trace requests end-to-end in your Next.js app.
 doc_type: howto
@@ -204,8 +204,18 @@ The [Vercel AI SDK Observability Dashboard](https://signoz.io/docs/dashboards/da
   </figcaption>
 </figure>
 
-## Additional Resources
+## Related integrations
+
+Trace the rest of your LLM application and retrieval stack:
+
+- [LangChain and LangGraph observability with OpenTelemetry](https://signoz.io/docs/langchain-observability/) - trace chains, agents, graph nodes, and tool calls
+- [LlamaIndex observability with OpenTelemetry](https://signoz.io/docs/llamaindex-observability/) - trace RAG queries, retrievers, and index operations
+- [Monitor Haystack pipelines with OpenTelemetry](https://signoz.io/docs/haystack-monitoring/) - trace RAG pipelines, retrievers, and generator nodes
+- [Instrument LLM apps with Langtrace](https://signoz.io/docs/langtrace/) - an OpenTelemetry-native SDK that exports LLM spans straight to SigNoz
+- [Langflow observability with OpenTelemetry](https://signoz.io/docs/langflow-observability/) - trace Langflow flows, components, and model calls
+
+Further reading:
 
 - Read [Observing Vercel AI SDK with OpenTelemetry + SigNoz](https://signoz.io/blog/opentelemetry-vercel-ai-sdk/)
-- Set up [alerts](https://signoz.io/docs/alerts/) for high latency or error rates
-- Learn more about [querying traces](https://signoz.io/docs/userguide/traces/)
+
+Browse [all LLM observability integrations](https://signoz.io/docs/llm-observability/) to instrument the rest of your stack.


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The 46 LLM observability guides had **no internal link graph at all**. A scripted check over all of them found:

- **0** of 2,070 possible directed sibling links
- **0** of 46 pages linking to the `/docs/llm-observability` hub
- **39** of 46 with two or fewer inbound references anywhere in the repo
- **3** pages (traceloop, openlit, langtrace) with exactly zero inbound links from anything

Forty-six pages of accumulated authority sitting in forty-six sealed silos. Every page also carried an identical "Additional Resources" block pointing at the same three generic alerts/traces/logs pages, which added no topical signal and crowded out real cross-links.

This PR replaces that boilerplate with a `## Related integrations` section on every guide: five siblings plus the hub, with descriptive query-shaped anchor text rather than the brand-name-only form the listicle grid uses.

Pages are grouped into ten clusters by **what each technology actually does**, verified against upstream sources rather than the SigNoz doc copy. That verification caught two factual errors in the docs themselves, fixed here:

- **Hermes** was described as an AI coding agent. It is an autonomous personal assistant with persistent memory, reachable over Telegram and Discord.
- **OpenClaw** was described in terms of routing, caching and token accounting. It is a general-purpose personal AI assistant you talk to through WhatsApp, Telegram and Discord.

Also fixes a Python `SyntaxError` in the Ollama guide, where an import statement had swallowed the instrumentor call:

```diff
- from opentelemetry.instrumentation.ollama import OllamaInstrumentor().instrument()
+ from opentelemetry.instrumentation.ollama import OllamaInstrumentor
```

The `OllamaInstrumentor().instrument(tracer_provider=provider)` call already existed correctly further down the snippet, so this line was pure corruption. All 46 guides now have zero Python syntax errors.

#### Resulting link graph

| | Before | After |
|---|---|---|
| Directed sibling links | 0 of 2,070 | **230** |
| Pages linking to the hub | 0 / 46 | **46 / 46** |
| Orphan pages | 3 | **0** |
| Inbound links per page | 0 to 2 | **4 to 6** |

Distribution was balanced deliberately: an early pass had LiteLLM at 16 inbound and LiveKit at 1, so cross-cluster picks were rebalanced globally.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Three separate issues:

1. **No link graph.** The guides were authored individually from a shared template, and the template's trailing section pointed at generic product docs rather than at sibling integrations. Nothing in the authoring process created cross-links, so none ever appeared.
2. **Hermes and OpenClaw mischaracterized.** Both docs described the tool based on surrounding template language rather than on what the project actually is. Verified against upstream sources during the clustering work.
3. **Ollama snippet.** An editing artifact merged the import line with the `.instrument()` call, producing code that cannot execute.

#### Fix Strategy

Added a related integration section to each LLM docs that link to other LLM docs that readers might want to click in relation to the current doc.
---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. This is content-only; no code paths change.
- **Manual verification:**
  - `yarn check:docs-metadata` passes on all 46
  - `yarn check:doc-redirects` passes
  - `yarn test:doc-redirects` passes 13/13
  - All 46 files compile through `@mdx-js/mdx`
  - Link graph extracted from the committed MDX rather than the build script, confirming 230 edges and 46/46 hub links
  - All 46 code blocks pass `py_compile`
- **Edge cases covered:** verified no empty `##` sections were left behind after boilerplate removal, and confirmed the apparent hits were false positives from an H2 immediately followed by an H3.

**Known pre-existing failure, unrelated to this PR:** `yarn test:docs-metadata` fails one assertion, `should allow date exactly 7 days in the past` (`tests/docs-metadata.test.js:262`). This is a boundary test of the checker's own logic against fixtures, not against docs content. Reproduced identically on `main` (29 pass / 1 fail), and this branch touches nothing under `tests/` or `scripts/`.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** 46 MDX files under `data/docs/`. No code, no routing, no redirects. All added links are internal and point to existing published URLs.
- **Potential regressions:** the main risk is an editorially odd pairing surfacing an unrelated integration. Cross-cluster picks were reviewed by hand for this. A secondary risk is that removing "Additional Resources" drops a link someone relied on; the generic alerts/traces/logs targets remain reachable from the sidebar and from the hub.
- **Rollback plan:** revert the three commits. Content-only, so no migration or cache concerns.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Maintenance |
| Description | LLM observability guides now cross-link to related integrations and the hub. Corrected the descriptions of Hermes and OpenClaw, and fixed a broken Python snippet in the Ollama guide. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The `date:` frontmatter is bumped on all 46 per the repo's documented freshness convention for edited docs. That inflates the diff but is intentional.

Diff size is 539 insertions against 223 deletions across 46 files. The deletions are the removed resource blocks; the insertions are the new sections plus the two content corrections.

Worth a second opinion on the ten-cluster grouping, since it drives which pages link to which. The grouping principle was "what would this reader also be instrumenting," which mostly coincides with a strict taxonomy but diverges in a few places where intent was chosen over category.
