### PR TITLE
docs: update Infrastructure Monitoring V2 documentation

### DIFF
--- a/data/docs/infrastructure-monitoring/host-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/host-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-05
 title: Host Monitoring
 description: Monitor host performance in SigNoz, covering CPU, memory, disk, and network metrics with correlated traces and logs.
 doc_type: explanation
@@ -25,9 +25,13 @@ The main screen displays a list of all monitored hosts along with key metrics. T
 - **Search Filter** bar to query hosts by any attribute
 - **Group By** dropdown to group hosts by a selected attribute
 - **Columns selector** to choose which columns are visible in the table
-- **Sortable columns**: click any column header to sort
+- **Sortable columns**: click a column header to sort. The **Hostname** column and the metric columns (CPU Usage, Memory Usage, Disk Usage, and so on) all toggle ascending/descending order
 - **Total count** displayed at the bottom (e.g., "Showing 1 - 4 of 4 Hosts")
 - **Paginated results** with configurable page size
+
+<Admonition type="info">
+The **CPU Usage**, **Memory Usage (WSS)**, and **Disk Usage** column headers each show an info icon. Hover it to see a color-coded threshold legend that explains what each progress-bar color means: **green** for healthy usage, **amber** for elevated usage, and **red** for critical usage. The exact bands per column are described under [Host List Page Columns](#host-list-page-columns). The Memory Usage (WSS) legend also notes that the value excludes cache memory.
+</Admonition>
 
 ### Group By
 

--- a/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-05
 title: Kubernetes Monitoring - Pods, Nodes & Workloads
 description: Monitor Kubernetes pods, nodes, and workloads in SigNoz with resource utilization and correlated traces, logs, and events for every cluster resource type.
 doc_type: explanation
@@ -51,6 +51,8 @@ The search bar at the top lets you query entities by any attribute using the que
 
 Use the **Group By** dropdown to group entities by an attribute such as `k8s.node.name`, `k8s.namespace.name`, `k8s.deployment.name`, or `k8s.cluster.name`. When a group is selected, the table displays group header rows that you can expand to see individual entities within each group.
 
+If a name column is the active sort when you change the Group By selection, that sort is cleared automatically, since row order inside groups is defined by the grouping.
+
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-group-by.webp"
   alt="Kubernetes Pods grouped by k8s.node.name showing group header rows"
@@ -68,6 +70,14 @@ Click the columns icon in the toolbar to open the **Columns** panel. It shows th
   caption="Columns selector for customizing table columns"
   className="box-shadowed-image"
 />
+
+### Sorting
+
+Click a column header to sort ascending or descending. Name columns (**Pod Name**, **Node Name**, **Namespace Name**, **Cluster Name**, **Deployment Name**, **DaemonSet Name**, **StatefulSet Name**, **Job Name**, and **PVC Name**) and utilization columns both support sorting.
+
+### Column header legends
+
+Utilization columns show an info icon in their header. Hover it to see a color-coded threshold legend that maps each progress-bar color to a health band, with a short description of what the band means. Request columns (**CPU Req Usage (%)**, **Mem Req Usage (%)**) and limit columns (**CPU Limit Usage (%)**, **Mem Limit Usage (%)**) use request- and limit-specific bands. These utilization columns and their legends appear on the [Pods](https://signoz.io/docs/infrastructure-monitoring/kubernetes/pods/), [Deployments](https://signoz.io/docs/infrastructure-monitoring/kubernetes/deployments/), [DaemonSets](https://signoz.io/docs/infrastructure-monitoring/kubernetes/daemonsets/), [Jobs](https://signoz.io/docs/infrastructure-monitoring/kubernetes/jobs/), and [StatefulSets](https://signoz.io/docs/infrastructure-monitoring/kubernetes/statefulsets/) views. See each view's column reference for the exact band ranges.
 
 ### Detail Page
 


### PR DESCRIPTION
## Summary
- Host Monitoring: documented the color-coded threshold legend tooltips added to the **CPU Usage**, **Memory Usage (WSS)**, and **Disk Usage** column headers, and clarified that the **Hostname** column is now sortable (PR #12402).
- Kubernetes Monitoring: added a **Column header legends** section describing the request/limit threshold legends on the Pods, Deployments, DaemonSets, Jobs, and StatefulSets utilization columns; added a **Sorting** section listing the sortable name columns; and documented that changing **Group By** clears an active name-column sort (PR #12402).
- Updated frontmatter dates on all edited files.

### Notes
- Infrastructure Monitoring V2 GA / `use_infra_monitoring_v2` flag removal (PR #12398) is a docs no-op: no opt-in or flag language exists anywhere in the section, and the docs already describe V2 as the current interface.
- Prose-only: the demo build lags #12402 (Hosts still show "Memory Usage" instead of "Memory Usage (WSS)", the Hostname column is not yet sortable, and CPU/Disk headers lack the new info icons), so the new tooltip legends are not yet screenshottable. Screenshots pending demo catch-up.
- The per-entity pages (e.g. Pods) already document the exact color-band ranges, so the new sections point readers there rather than duplicating them.

Source PRs: #12398, #12402

Auto-generated by docs-sync pipeline