### PR TITLE
docs: document self-service dashboard migration retry

### DIFF
--- a/data/docs/dashboards/dashboards-v2-api.mdx
+++ b/data/docs/dashboards/dashboards-v2-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-05
 title: "Dashboards V2 API - Schema, Endpoints & PATCH Updates"
 description: "Migrate to the redesigned SigNoz Dashboards experience and learn the V2 Dashboards API: schema, endpoints, pagination, the query DSL, and partial PATCH updates."
 doc_type: howto
@@ -102,6 +102,18 @@ Locking and unlocking a dashboard get new endpoints:
 PUT    /api/v2/dashboards/{id}/lock  -- Lock a Dashboard
 DELETE /api/v2/dashboards/{id}/lock  -- Unlock a Dashboard
 ```
+
+### Retry a dashboard migration
+
+A dashboard whose stored data could not be converted during the upgrade stays on the V1 schema and is flagged **Legacy**. Re-run the V1 to V2 migration for a single dashboard with:
+
+```
+POST /api/v2/dashboards/{id}/migrate  -- Retry the V1 to V2 migration
+```
+
+The call requires the **Editor** role. It is idempotent: a dashboard already on the V2 schema is returned unchanged, in the same shape as `GET /api/v2/dashboards/{id}` (a `status` string and the V2 dashboard under `data`). Migration also coerces numeric fields that were stored as strings, such as a `limit` or `offset` saved as `"5"`, so those dashboards convert without manual edits.
+
+In the product, this endpoint backs the **Retry migration** button in the legacy dashboard dialog. See [Recover a legacy dashboard](https://signoz.io/docs/operate/migration/upgrade-0-135/#recover-a-legacy-dashboard) in the upgrade guide for the UI flow. Full request and response details are in the <a href="https://signoz.io/api-reference/" target="_blank" rel="noopener noreferrer nofollow">API Reference</a>.
 
 ### Migrating from the V1 dashboard APIs
 

--- a/data/docs/operate/migration/upgrade-0-135.mdx
+++ b/data/docs/operate/migration/upgrade-0-135.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-05
 title: Upgrade SigNoz to v0.135.0 with Dashboards V2 Schema
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
 description: Upgrade self-hosted SigNoz to v0.135.0. Dashboards convert to the V2 schema automatically, and the retired V1 dashboard APIs need script and Terraform changes.
@@ -81,14 +81,33 @@ helm -n signoz upgrade signoz signoz/signoz
 1. Pods and containers are healthy (`kubectl get pods -n signoz`, `docker compose ps`, or `systemctl status 'signoz-*'`).
 2. SigNoz reports v0.135.0 under **Settings**.
 3. Open **Dashboards**: the redesigned list page loads, and your existing dashboards render with data.
-4. Scan the list for rows marked **Legacy**. The conversion runs per dashboard, and a dashboard whose stored data cannot be converted is left on the old schema and flagged rather than failing the upgrade. Legacy dashboards are listed but cannot be opened in the new experience. Open the row's dialog to copy the dashboard ID and share it with support.
+4. Scan the list for rows marked **Legacy**. The conversion runs per dashboard, and a dashboard whose stored data cannot be converted is left on the old schema and flagged rather than failing the upgrade. Legacy dashboards are listed but cannot be opened in the new experience. If you have edit access, you can [re-run the migration yourself](#recover-a-legacy-dashboard); otherwise copy the dashboard ID from the row's dialog and share it with support.
 
 ## What changes after migration
 
 - **Automatic conversion.** Existing dashboards, inbuilt dashboards, and templates convert to the new schema when the server starts. SVG dashboard icons stored as percent-encoded inline data URIs are preserved during conversion.
-- **Dashboards that can't be converted stay on the legacy format.** A dashboard whose stored data cannot be converted is logged and left in the V1 format instead of blocking startup. It is listed and flagged as **Legacy**, and cannot be opened in the new experience. Copy the dashboard ID from the row's dialog and share it with support.
+- **Dashboards that can't be converted stay on the legacy format.** A dashboard whose stored data cannot be converted is logged and left in the V1 format instead of blocking startup. It is listed and flagged as **Legacy**, and cannot be opened in the new experience. Editors can [re-run the migration from the list](#recover-a-legacy-dashboard); viewers copy the dashboard ID from the row's dialog and share it with support.
 - **Saved list-filter URLs no longer apply filters.** The dashboards list page now filters with a query expression. The old URL parameters (`search`, `createdBy`, `updated`, and `tags`) no longer apply filters, so bookmarks or shared links using them open the list unfiltered. See [Find and filter dashboards](https://signoz.io/docs/userguide/manage-dashboards/#find-and-filter-dashboards).
 - **Layouts are validated on write.** Programmatic creates and updates must satisfy the grid rules. See [Dashboard layout constraints](https://signoz.io/docs/userguide/manage-dashboards/#dashboard-layout-constraints).
+
+## Recover a legacy dashboard
+
+If the automatic conversion left a dashboard on the old schema, it is flagged **Legacy** and cannot be opened in the new experience. You can re-run the migration for that dashboard in place from the list, without contacting support.
+
+<Admonition type="info">
+Retrying needs edit access. Editors and admins see a **Retry migration** button in the legacy dashboard dialog. Viewers see only the Contact Support path.
+</Admonition>
+
+To retry as an Editor:
+
+1. Open **Dashboards** and find the row flagged **Legacy**.
+2. Click the row to open the legacy dashboard dialog.
+3. Click **Retry migration**. While the migration runs, the button shows a spinner and the dialog's **Close** button is disabled.
+4. On success, a **Dashboard migrated to the new experience** toast appears and the list refreshes automatically. Open the dashboard to confirm it renders in the new experience.
+
+Retrying often succeeds once the case that blocked the first attempt is handled. For example, dashboards that stored the numeric `limit` or `offset` fields as strings (such as `"5"`) now migrate cleanly on retry with no manual edits. If the retry still fails, copy the dashboard ID from the dialog and share it with support.
+
+You can also trigger this migration programmatically with `POST /api/v2/dashboards/{id}/migrate`. See [Retry a dashboard migration](https://signoz.io/docs/dashboards/dashboards-v2-api/#retry-a-dashboard-migration) in the Dashboards V2 API guide.
 
 ## Migrate API scripts to the V2 Dashboards APIs
 


### PR DESCRIPTION
## Summary
- Added a **Recover a legacy dashboard** section to the v0.135.0 upgrade guide covering the self-service retry flow: who sees it (Editors vs Viewers), how to trigger it, the loading and success states ("Dashboard migrated to the new experience" toast + auto list refresh), and the string-coercion fix for numeric `limit`/`offset` stored as strings (features 1-6).
- Updated the two existing legacy-dashboard mentions in the upgrade guide (Step 3 verify + "What changes after migration") to point Editors at the new retry path and keep the Contact Support fallback for Viewers.
- Documented `POST /api/v2/dashboards/{id}/migrate` in the Dashboards V2 API guide: required Editor role, idempotency guarantee, response shape, and cross-links to the upgrade guide and auto-generated API Reference (feature 7).
- Updated frontmatter `date` to 2026-08-05 on both edited files.

### Notes
- **Not EE-only / no flag gate.** The `ee/` change only delegates to the core `pkg/modules/dashboard` `MigrateV2` logic; the endpoint is registered in the OSS package with no feature flag. Documented as universally available.
- **API Reference auto-generates.** The endpoint is in `openapi.yml`, so the API Reference page renders it automatically. The hand-authored guide entry only summarizes it and links out, per repo convention.
- **Prose-only, screenshots pending.** The retry flow requires a dashboard in the failed-migration ("Legacy") state, which does not exist on the healthy demo environment. Screenshots (legacy row, Editor dialog with Retry button, loading state, success toast, Viewer-only Contact Support) need a seeded legacy dashboard on a pre-production environment.

Source PRs: #12387

Auto-generated by docs-sync pipeline