### PR TITLE
feat: update the signup flow for verification ttl

### DIFF
--- a/app/(site)/teams/TeamsPage.tsx
+++ b/app/(site)/teams/TeamsPage.tsx
@@ -97,7 +97,7 @@ const SignupFormIsolated: React.FC<SignupFormIsolatedProps> = ({
 }) => {
   const [formState, setFormState] = useState({
     workEmail: '',
-    dataRegion: 'us',
+    dataRegion: 'us2',
     termsOfServiceAccepted: true,
   })
   const emailInputRef = useRef<HTMLInputElement>(null)

--- a/app/(site)/workspace-setup/VerificationFailed.tsx
+++ b/app/(site)/workspace-setup/VerificationFailed.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import React from 'react'
+import { ArrowRight, CheckCircleIcon, Frown, Loader2, MailWarning } from 'lucide-react'
+import TrackingButton from '@/components/TrackingButton'
+import TrackingLink from '@/components/TrackingLink'
+import './workspace-setup.styles.css'
+
+interface VerificationFailedProps {
+  variant: 'expired' | 'error'
+  email: string
+  errorMessage: string | null
+  resendStatus: 'idle' | 'sending' | 'sent' | 'failed'
+  canResend: boolean
+  onResend: () => void
+}
+
+function VerificationFailed({
+  variant,
+  email,
+  errorMessage,
+  resendStatus,
+  canResend,
+  onResend,
+}: VerificationFailedProps) {
+  const isExpired = variant === 'expired'
+  const isSending = resendStatus === 'sending'
+
+  return (
+    <div className="welcome-container mx-auto flex min-h-[96vh] max-w-[520px] flex-col items-center justify-center py-32">
+      <MailWarning className="text-signoz_robin-500" size={56} />
+
+      <div className="mt-[28px] text-center text-xl">
+        {isExpired ? 'Your verification link has expired' : "We couldn't verify your email"}
+      </div>
+
+      <div className="mt-[28px] w-full rounded-[6px] border border-[#1D212D] bg-signoz_ink-300 p-[24px] text-sm">
+        {isExpired
+          ? 'This verification link has expired or is no longer valid. Request a new verification email to continue setting up your workspace.'
+          : errorMessage ||
+            'Something went wrong while verifying your email. Please try again later or contact support for assistance.'}
+      </div>
+
+      {resendStatus === 'sent' && (
+        <div className="mt-[28px] flex w-full items-center justify-center gap-2 text-center text-xs text-signoz_forest-500">
+          <CheckCircleIcon size={16} /> New verification email sent{email ? ` to ${email}` : ''} —
+          check your inbox (and spam folder).
+        </div>
+      )}
+
+      {resendStatus === 'failed' && (
+        <div className="mt-[28px] flex w-full items-center justify-center gap-2 text-center text-xs text-signoz_cherry-500">
+          <Frown size={16} /> We couldn't resend the verification email. Please try again or contact
+          support for assistance.
+        </div>
+      )}
+
+      <div className="flex w-full flex-col">
+        {isExpired && canResend && resendStatus !== 'sent' && (
+          <TrackingButton
+            type="submit"
+            className={`mt-[28px] flex h-[40px] w-full items-center justify-center gap-4 rounded-full bg-signoz_robin-500 px-[16px] py-[8px] text-sm font-medium ${
+              isSending ? 'cursor-not-allowed opacity-50' : ''
+            }`}
+            onClick={onResend}
+            disabled={isSending}
+            clickType="Primary CTA"
+            clickName="Resend Verification Email"
+            clickLocation="Workspace Setup Verification Failed"
+            clickText="Resend verification email"
+          >
+            <span className="flex text-xs leading-5">Resend verification email</span>
+            {isSending ? <Loader2 size={14} className="animate-spin" /> : <ArrowRight size={14} />}
+          </TrackingButton>
+        )}
+
+        <TrackingLink
+          href="mailto:cloud-support@signoz.io"
+          className="mt-[12px] flex h-[40px] w-full items-center justify-center gap-4 rounded-full bg-signoz_ink-300 px-[16px] py-[8px] text-sm font-medium"
+          clickType="Support Link"
+          clickName="Contact Support Link"
+          clickLocation="Workspace Setup Verification Failed"
+          clickText="Contact cloud support"
+        >
+          <span className="flex text-xs leading-5">Contact cloud support</span>
+          <ArrowRight size={14} />
+        </TrackingLink>
+      </div>
+    </div>
+  )
+}
+
+export default VerificationFailed

--- a/app/(site)/workspace-setup/VerificationFailed.tsx
+++ b/app/(site)/workspace-setup/VerificationFailed.tsx
@@ -8,7 +8,6 @@ import './workspace-setup.styles.css'
 
 interface VerificationFailedProps {
   variant: 'expired' | 'error'
-  email: string
   errorMessage: string | null
   resendStatus: 'idle' | 'sending' | 'sent' | 'failed'
   canResend: boolean
@@ -17,7 +16,6 @@ interface VerificationFailedProps {
 
 function VerificationFailed({
   variant,
-  email,
   errorMessage,
   resendStatus,
   canResend,
@@ -43,15 +41,15 @@ function VerificationFailed({
 
       {resendStatus === 'sent' && (
         <div className="mt-[28px] flex w-full items-center justify-center gap-2 text-center text-xs text-signoz_forest-500">
-          <CheckCircleIcon size={16} /> New verification email sent{email ? ` to ${email}` : ''} —
-          check your inbox (and spam folder).
+          <CheckCircleIcon size={16} className="shrink-0" /> Verification email sent! Please check
+          your inbox.
         </div>
       )}
 
       {resendStatus === 'failed' && (
         <div className="mt-[28px] flex w-full items-center justify-center gap-2 text-center text-xs text-signoz_cherry-500">
-          <Frown size={16} /> We couldn't resend the verification email. Please try again or contact
-          support for assistance.
+          <Frown size={16} className="shrink-0" /> Couldn't send the email. Please try again or
+          contact support.
         </div>
       )}
 

--- a/app/(site)/workspace-setup/WorkspaceSetup.tsx
+++ b/app/(site)/workspace-setup/WorkspaceSetup.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react'
 import { useLogEvent } from '@/hooks/useLogEvent'
 import './workspace-setup.styles.css'
 
-function WorkspaceSetup({ isWorkspaceSetupDelayed, email, workspaceData }) {
+function WorkspaceSetup({ isEmailVerified, isWorkspaceSetupDelayed, email, workspaceData }) {
   const logEvent = useLogEvent()
   const pathname = usePathname()
 
@@ -78,17 +78,27 @@ function WorkspaceSetup({ isWorkspaceSetupDelayed, email, workspaceData }) {
 
       <div className="text-md mt-[28px] w-full rounded-[6px] border border-[#1D212D] bg-signoz_ink-300 p-[24px]">
         <div className="flex items-center gap-4 text-sm">
-          <CheckCircleIcon size={24} /> Email verified! Looking good.
+          {isEmailVerified ? (
+            <>
+              <CheckCircleIcon size={24} /> Email verified! Looking good.
+            </>
+          ) : (
+            <>
+              <Loader2 size={24} className="animate-spin" /> Verifying your email ...
+            </>
+          )}
         </div>
 
-        <div
-          className={`mt-[28px] flex items-center gap-4 text-sm ${
-            isWorkspaceSetupDelayed ? 'text-signoz_amber-500' : ''
-          }`}
-        >
-          <Loader2 size={24} className="animate-spin" /> Preparing your cloud workspace, This may
-          take a few minutes ...
-        </div>
+        {isEmailVerified && (
+          <div
+            className={`mt-[28px] flex items-center gap-4 text-sm ${
+              isWorkspaceSetupDelayed ? 'text-signoz_amber-500' : ''
+            }`}
+          >
+            <Loader2 size={24} className="animate-spin" /> Preparing your cloud workspace, This may
+            take a few minutes ...
+          </div>
+        )}
       </div>
 
       {isWorkspaceSetupDelayed && (

--- a/app/(site)/workspace-setup/WorkspaceSetup.tsx
+++ b/app/(site)/workspace-setup/WorkspaceSetup.tsx
@@ -95,7 +95,7 @@ function WorkspaceSetup({ isEmailVerified, isWorkspaceSetupDelayed, email, works
               isWorkspaceSetupDelayed ? 'text-signoz_amber-500' : ''
             }`}
           >
-            <Loader2 size={24} className="animate-spin" /> Preparing your cloud workspace, This may
+            <Loader2 size={24} className="animate-spin" /> Preparing your cloud workspace. This may
             take a few minutes ...
           </div>
         )}

--- a/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
+++ b/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
@@ -140,11 +140,7 @@ function WorkspaceSetupHome() {
       return
     }
 
-    // encode params: searchParams.get() returns decoded values, so characters
-    // like `+` in the email would otherwise be read as a space by the backend
-    const verifyWorkSpaceSetupURL = `${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/deployments/cesearch?code=${encodeURIComponent(
-      code
-    )}&email=${encodeURIComponent(email)}`
+    const verifyWorkSpaceSetupURL = `${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/deployments/cesearch?code=${code}&email=${email}`
 
     try {
       const res = await fetch(verifyWorkSpaceSetupURL)

--- a/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
+++ b/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
@@ -5,13 +5,18 @@ import { useSearchParams } from 'next/navigation'
 import { useLogEvent } from '@/hooks/useLogEvent'
 import WorkspaceReady from './WorkspaceReady'
 import WorkspaceSetup from './WorkspaceSetup'
+import VerificationFailed from './VerificationFailed'
+
+type VerificationState = 'verifying' | 'verified' | 'expired' | 'error'
+type ResendStatus = 'idle' | 'sending' | 'sent' | 'failed'
 
 function WorkspaceSetupHome() {
   const [isWorkspaceReady, setIsWorkspaceReady] = useState(false)
   const [isWorkspaceSetupDelayed, setIsWorkspaceSetupDelayed] = useState(false)
-  const [isPollingEnabled, setIsPollingEnabled] = useState(false)
-  const [pollingInterval, setPollingInterval] = useState(3000) // initial polling interval - 3 seconds
-  const [isEmailVerified, setIsEmailVerified] = useState(false)
+  const [verificationState, setVerificationState] = useState<VerificationState>('verifying')
+  const [verificationError, setVerificationError] = useState<string | null>(null)
+  const [resendStatus, setResendStatus] = useState<ResendStatus>('idle')
+  const [storedRegion, setStoredRegion] = useState<string | null>(null)
   const [retryCount, setRetryCount] = useState(1)
   const [workspaceData, setWorkspaceData] = useState(null)
   const searchParams = useSearchParams()
@@ -20,65 +25,111 @@ function WorkspaceSetupHome() {
   const code = searchParams.get('code')
   const email = searchParams.get('email')
   const region = searchParams.get('region')
+  const decodedEmail = decodeURIComponent(email || '')
+
+  // Region for resend: URL param first (email links carry it), localStorage fallback
+  const resendRegion = region || storedRegion
+  const canResend = Boolean(email && resendRegion)
 
   const verifyEmail = async () => {
     logEvent({
       eventName: 'Email Verification Started',
       eventType: 'track',
       attributes: {
-        email: decodeURIComponent(email || ''),
+        email: decodedEmail,
         region: region,
       },
     })
 
-    const res = await fetch(`${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/users/verify`, {
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'PUT',
-      body: JSON.stringify({
-        code: code,
-        email: decodeURIComponent(email || ''),
-        region: {
-          name: region,
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/users/verify`, {
+        cache: 'no-store',
+        headers: {
+          'Content-Type': 'application/json',
         },
-      }),
-    })
+        method: 'PUT',
+        body: JSON.stringify({
+          code: code,
+          email: decodedEmail,
+          region: {
+            name: region,
+          },
+        }),
+      })
 
-    const data = await res.json()
+      if (res.ok) {
+        // Success is 204 No Content — there is no body to parse
+        setVerificationState('verified')
+        logEvent({
+          eventName: 'Email Verified',
+          eventType: 'track',
+          attributes: {
+            status: 'success',
+            email: decodedEmail,
+          },
+        })
+        return
+      }
 
-    if (data.status === 'error' && data.type !== 'already-exists') {
-      setIsEmailVerified(false)
+      let data: { type?: string; error?: string } = {}
+      try {
+        data = await res.json()
+      } catch {
+        // non-JSON error body — handled by the generic error branch below
+      }
+
+      if (data.type === 'already-exists') {
+        // Already verified (page refresh or social signup) — continue provisioning
+        setVerificationState('verified')
+        logEvent({
+          eventName: 'Email Verified',
+          eventType: 'track',
+          attributes: {
+            status: 'already-exists',
+            email: decodedEmail,
+          },
+        })
+        return
+      }
+
+      if (
+        (res.status === 400 && data.type === 'invalid-input') ||
+        (res.status === 404 && data.type === 'not-found')
+      ) {
+        // Expired code (400) or stale/regenerated code (404) — offer resend
+        setVerificationState('expired')
+        logEvent({
+          eventName: 'Email Verification Link Expired',
+          eventType: 'track',
+          attributes: {
+            status: res.status,
+            type: data.type,
+            email: decodedEmail,
+          },
+        })
+        return
+      }
+
+      setVerificationState('error')
+      setVerificationError(data.error || null)
       logEvent({
         eventName: 'Email Verification Failed',
         eventType: 'track',
         attributes: {
+          status: res.status,
           error: data.error,
           type: data.type,
-          email: decodeURIComponent(email || ''),
+          email: decodedEmail,
         },
       })
-    } else if (data.status === 'success') {
-      setIsEmailVerified(true)
-      setIsPollingEnabled(true)
+    } catch (error) {
+      setVerificationState('error')
       logEvent({
-        eventName: 'Email Verified',
+        eventName: 'Email Verification Failed',
         eventType: 'track',
         attributes: {
-          status: 'success',
-          email: decodeURIComponent(email || ''),
-        },
-      })
-    } else if (data.status === 'error' && data.type === 'already-exists') {
-      setIsEmailVerified(true)
-      setIsPollingEnabled(true)
-      logEvent({
-        eventName: 'Email Verified',
-        eventType: 'track',
-        attributes: {
-          status: 'already-exists',
-          email: decodeURIComponent(email || ''),
+          error: 'network-error',
+          email: decodedEmail,
         },
       })
     }
@@ -91,38 +142,139 @@ function WorkspaceSetupHome() {
 
     const verifyWorkSpaceSetupURL = `${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/deployments/cesearch?code=${code}&email=${email}`
 
-    const res = await fetch(verifyWorkSpaceSetupURL)
-    const data = await res.json()
+    try {
+      const res = await fetch(verifyWorkSpaceSetupURL)
+      const data = await res.json()
 
-    if (data.status === 'success') {
-      setIsWorkspaceReady(true)
-      setWorkspaceData(data?.data)
-      logEvent({
-        eventName: 'Workspace Provisioned',
-        eventType: 'track',
-        attributes: {
-          workspaceData: data?.data,
-          email: decodeURIComponent(email || ''),
-        },
-      })
-    } else if (data.status === 'error') {
+      if (data.status === 'success') {
+        setIsWorkspaceReady(true)
+        setWorkspaceData(data?.data)
+        logEvent({
+          eventName: 'Workspace Provisioned',
+          eventType: 'track',
+          attributes: {
+            workspaceData: data?.data,
+            email: decodedEmail,
+          },
+        })
+      } else if (data.type === 'invalid-input') {
+        // Verification code expired mid-flow — stop polling and offer resend
+        setVerificationState('expired')
+        logEvent({
+          eventName: 'Email Verification Link Expired',
+          eventType: 'track',
+          attributes: {
+            status: res.status,
+            type: data.type,
+            source: 'cesearch',
+            email: decodedEmail,
+          },
+        })
+      } else {
+        setRetryCount((currentRetryCount) => currentRetryCount + 1)
+      }
+    } catch (error) {
       setRetryCount((currentRetryCount) => currentRetryCount + 1)
     }
   }
 
+  const handleResendVerificationEmail = async () => {
+    if (!email || !resendRegion) {
+      return
+    }
+
+    setResendStatus('sending')
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/users/notify`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: decodedEmail,
+          region: {
+            name: resendRegion,
+          },
+        }),
+      })
+
+      if (res.ok) {
+        setResendStatus('sent')
+        logEvent({
+          eventName: 'Verification Email Resent',
+          eventType: 'track',
+          attributes: {
+            email: decodedEmail,
+            region: resendRegion,
+          },
+        })
+      } else {
+        setResendStatus('failed')
+        logEvent({
+          eventName: 'Verification Email Resend Failed',
+          eventType: 'track',
+          attributes: {
+            status: res.status,
+            email: decodedEmail,
+            region: resendRegion,
+          },
+        })
+      }
+    } catch (error) {
+      setResendStatus('failed')
+      logEvent({
+        eventName: 'Verification Email Resend Failed',
+        eventType: 'track',
+        attributes: {
+          error: 'network-error',
+          email: decodedEmail,
+          region: resendRegion,
+        },
+      })
+    }
+  }
+
   useEffect(() => {
+    try {
+      setStoredRegion(localStorage.getItem('region'))
+    } catch (error) {
+      setStoredRegion(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!code || !email) {
+      setVerificationState('error')
+      logEvent({
+        eventName: 'Email Verification Failed',
+        eventType: 'track',
+        attributes: {
+          error: 'missing-params',
+          email: decodedEmail,
+        },
+      })
+      return
+    }
+
+    verifyEmail()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    // Poll only after the email is verified.
     // poll every 3s for the first minute, then every 15s for the next 4 minutes
     // total polling time is 5 minutes
     // 3s * 20 * 1 = 1 minute (20 polls)
     // 15s * 4 * 4 = 4 minutes (16 polls)
-    if (retryCount <= 36) {
-      if (retryCount <= 20) {
-        setPollingInterval(3000)
-      } else {
-        setPollingInterval(15000)
-      }
+    if (verificationState !== 'verified') {
+      return
+    }
 
-      setTimeout(verifyWorkspaceSetup, pollingInterval)
+    if (retryCount <= 36) {
+      const interval = retryCount <= 20 ? 3000 : 15000
+      const timer = setTimeout(verifyWorkspaceSetup, interval)
+      return () => clearTimeout(timer)
     } else {
       setIsWorkspaceSetupDelayed(true)
       logEvent({
@@ -130,34 +282,32 @@ function WorkspaceSetupHome() {
         eventType: 'track',
         attributes: {
           retryCount: retryCount,
-          email: decodeURIComponent(email || ''),
+          email: decodedEmail,
         },
       })
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [retryCount])
-
-  useEffect(() => {
-    verifyEmail()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(() => {
-    if (isEmailVerified && isPollingEnabled) {
-      verifyWorkspaceSetup()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEmailVerified])
+  }, [retryCount, verificationState])
 
   return (
     <Suspense>
       {isWorkspaceReady ? (
         <WorkspaceReady workspaceData={workspaceData} userEmail={email} />
+      ) : verificationState === 'expired' || verificationState === 'error' ? (
+        <VerificationFailed
+          variant={verificationState}
+          email={decodedEmail}
+          errorMessage={verificationError}
+          resendStatus={resendStatus}
+          canResend={canResend}
+          onResend={handleResendVerificationEmail}
+        />
       ) : (
         <WorkspaceSetup
+          isEmailVerified={verificationState === 'verified'}
           isWorkspaceSetupDelayed={isWorkspaceSetupDelayed}
-          email={decodeURIComponent(email || '')}
+          email={decodedEmail}
           workspaceData={workspaceData}
         />
       )}

--- a/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
+++ b/app/(site)/workspace-setup/WorkspaceSetupHome.tsx
@@ -140,7 +140,11 @@ function WorkspaceSetupHome() {
       return
     }
 
-    const verifyWorkSpaceSetupURL = `${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/deployments/cesearch?code=${code}&email=${email}`
+    // encode params: searchParams.get() returns decoded values, so characters
+    // like `+` in the email would otherwise be read as a space by the backend
+    const verifyWorkSpaceSetupURL = `${process.env.NEXT_PUBLIC_CONTROL_PLANE_URL}/deployments/cesearch?code=${encodeURIComponent(
+      code
+    )}&email=${encodeURIComponent(email)}`
 
     try {
       const res = await fetch(verifyWorkSpaceSetupURL)
@@ -297,7 +301,6 @@ function WorkspaceSetupHome() {
       ) : verificationState === 'expired' || verificationState === 'error' ? (
         <VerificationFailed
           variant={verificationState}
-          email={decodedEmail}
           errorMessage={verificationError}
           resendStatus={resendStatus}
           canResend={canResend}

--- a/constants/regions.ts
+++ b/constants/regions.ts
@@ -5,7 +5,7 @@ export interface Region {
 }
 
 export const REGIONS: Region[] = [
-  { name: 'United States', id: 'us', iconURL: '/svgs/icons/us.svg' },
-  { name: 'Europe', id: 'eu', iconURL: '/svgs/icons/eu.svg' },
-  { name: 'India', id: 'in', iconURL: '/svgs/icons/india.svg' },
+  { name: 'United States', id: 'us2', iconURL: '/svgs/icons/us.svg' },
+  { name: 'Europe', id: 'eu2', iconURL: '/svgs/icons/eu.svg' },
+  { name: 'India', id: 'in2', iconURL: '/svgs/icons/india.svg' },
 ]


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Backend recently added a TTL to email verification codes and new multi-evaluation error messages. Before this PR, a user clicking an expired or stale verification link hit a dead end: the `/workspace-setup` page silently swallowed the verify failure, showed "Email verified! Looking good." with a spinner for 5 minutes, and then a vague "taking longer" message.

This PR:

- **Adds an expired-link recovery flow** - verify failures are now branched on HTTP status + error `type` (never message strings). Expired (400 `invalid-input`) or stale/regenerated (404 `not-found`) codes show a new "Your verification link has expired" screen with a **Resend verification email** button (`PUT /users/notify`). Region for resend comes from the URL param first (email links carry it), with localStorage as fallback.
- **Adds a proper error screen** - other failures show the backend error message verbatim with a contact-support CTA.
- **Gates workspace polling on verification** - `cesearch` polling now starts only after the email is actually verified, and stops (switching to the expired screen) if the code expires mid-flow. The loading view shows real state: "Verifying your email ..." → "Email verified! Looking good." → "Preparing your cloud workspace ...".
- **Migrates signup region ids to `us2`/`eu2`/`in2`**

Keeping backend as the single source of truth for error semantics (branch on `type`, display backend `error` text).

#### Screenshots / Screen Recordings (if applicable)


#### Issues closed by this PR

Closes https://github.com/SigNoz/growth-pod/issues/1207 

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: none (no existing test coverage for this page; verified via `yarn lint`, `tsc`, `yarn check:stale-urls` + `yarn test:stale-urls`)
- Manual verification (against staging):
  - Happy path: signup on `/teams` → email link → verify 204 → polling → WorkspaceReady
  - Expired code (400 `invalid-input`) → expired screen → Resend → notify 204 → confirmation → new email link verifies
  - Stale/regenerated code (404 `not-found`) → same expired flow
  - Code expiring mid-poll (cesearch 400 `invalid-input`) → polling stops, expired screen shown
  - Page refresh after verify (409 `already-exists`) → treated as verified, provisioning continues
  - Social signup path (lands on `/users?...` → `/workspace-setup`) → 409 path → provisioned
  - Email with `+` (e.g. `name+tag@testemail.something`) → cesearch now succeeds
  - `/teams` backend errors (e.g. max deployments) → backend message shown verbatim
  - Missing `code`/`email` params → error state immediately, no polling, no crash
  - Delayed provisioning (consumer disabled on staging) → delayed message after 5 min of polling
  - Analytics events verified for verify success/expired/error, resend click/success/failure
- Edge cases covered: legacy region values (`us`/`eu`/`in`) in old email links and localStorage - auto-mapped by backend; non-JSON error bodies; resend without a region source (button hidden, support link shown)


---

### ⚠️ Risk & Impact Assessment

- Blast radius: the cloud signup funnel — `/teams` signup default region, `/workspace-setup` verification + provisioning polling. `/verify-email`, login, and the docs region selector are untouched.
- Potential regressions: signup flow breaking
- Rollback plan: try to fix what is breaking, if not possible within some timeframe, revert this PR.

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The frontend never branches on backend message strings - only on status + `type`. Backend `error` text is displayed verbatim, so backend copy changes need no frontend release.
- After a successful resend, polling stays stopped on the old page - the old link's code may have been regenerated, so the user must click the fresh link from the new email.
- Polling schedule preserved from before: 3s × 20 then 15s × 16 (~5 min total) before showing the delayed message.
- Incorporates feedback from the staging walkthrough: ~cesearch URL encoding fix~ (removing, not in scope), single-line resend confirmation copy, minor copy typo fix.
