### PR TITLE
docs(llm): add query-matched meta_title to 11 LLM observability guides

### DIFF
--- a/data/docs/agno-monitoring.mdx
+++ b/data/docs/agno-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Agno Monitoring and Observability with OpenTelemetry
+meta_title: "Agno Observability: Trace Agents and Tokens"
 description: Learn how to monitor Agno agents with OpenTelemetry and SigNoz. Track traces, logs, and metrics for real-time visibility into latency, errors, and usage.
 doc_type: howto
 ---

--- a/data/docs/anthropic-monitoring.mdx
+++ b/data/docs/anthropic-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Anthropic Monitoring & Observability with OpenTelemetry
+meta_title: "Anthropic API Observability: Trace Claude"
 description: Learn how to monitor Anthropic API calls using OpenTelemetry and SigNoz. Track latency, errors, and usage trends for better AI observability.
 doc_type: howto
 ---

--- a/data/docs/crewai-observability.mdx
+++ b/data/docs/crewai-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: CrewAI Observability & Monitoring with OpenTelemetry
+meta_title: "CrewAI Observability: Trace Agents and Crews"
 description: Set up CrewAI observability with OpenTelemetry and SigNoz for full CrewAI monitoring. Track agent, tool, and model performance with traces, logs, and metrics.
 doc_type: howto
 ---

--- a/data/docs/grok-monitoring.mdx
+++ b/data/docs/grok-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: xAI Grok Monitoring & Observability with OpenTelemetry
+meta_title: "Grok Monitoring: Trace xAI Calls and Tokens"
 description: Learn how to monitor xAI Grok using OpenTelemetry and SigNoz. Track traces, logs, and metrics for your Grok LLM applications with real-time dashboards.
 doc_type: howto
 ---

--- a/data/docs/langchain-observability.mdx
+++ b/data/docs/langchain-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: LangChain & LangGraph Observability with OpenTelemetry
+meta_title: "LangGraph and LangChain Observability"
 description: Set up LangChain and LangGraph observability with OpenTelemetry and SigNoz. Monitor agent reasoning, tool calls, and chain execution with real-time traces.
 doc_type: howto
 ---

--- a/data/docs/livekit-observability.mdx
+++ b/data/docs/livekit-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: LiveKit Observability & Monitoring with OpenTelemetry
+meta_title: "LiveKit Observability: Trace Voice Agents"
 description: Learn how to instrument LiveKit voice agents with OpenTelemetry and export traces, logs, and metrics to SigNoz to monitor latency and errors.
 doc_type: howto
 ---

--- a/data/docs/llamaindex-observability.mdx
+++ b/data/docs/llamaindex-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: LlamaIndex Observability & Monitoring with OpenTelemetry
+meta_title: "LlamaIndex Observability: Trace RAG Workflows"
 description: Learn how to instrument LlamaIndex RAG workflows with OpenTelemetry and OpenInference, and stream traces to SigNoz for end-to-end visibility.
 ---
 

--- a/data/docs/mastra-observability.mdx
+++ b/data/docs/mastra-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Mastra Observability & Monitoring with OpenTelemetry
+meta_title: "Mastra Observability: Trace Agents and Tools"
 description: Set up Mastra observability with OpenTelemetry and SigNoz. Track traces for Mastra monitoring - model performance, latency, and error rates.
 doc_type: howto
 ---

--- a/data/docs/openrouter-observability.mdx
+++ b/data/docs/openrouter-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: OpenRouter Observability & Monitoring with OpenTelemetry
+meta_title: "OpenRouter Observability: Trace LLM Requests"
 description: Set up OpenRouter observability and monitoring with OpenTelemetry and SigNoz. Track traces, monitor LLM API routing, and analyze usage across models.
 doc_type: howto
 ---

--- a/data/docs/pipecat-monitoring.mdx
+++ b/data/docs/pipecat-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Pipecat Monitoring & Observability with OpenTelemetry
+meta_title: "Pipecat Agent Monitoring: Trace Voice Latency"
 description: Learn how to monitor Pipecat voice agents with OpenTelemetry and SigNoz. Track latency, errors, and model performance in real-time dashboards.
 doc_type: tutorial
 ---

--- a/data/docs/vercel-ai-sdk-observability.mdx
+++ b/data/docs/vercel-ai-sdk-observability.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Vercel AI SDK Observability & Monitoring with OpenTelemetry
+meta_title: "Vercel AI SDK Observability: Trace AI Calls"
 description: Set up Vercel AI SDK observability with OpenTelemetry and SigNoz. Monitor AI function calls, trace requests end-to-end in your Next.js app.
 doc_type: howto
 ---


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

**The change.** Adds `meta_title` to eleven pages. `generateMetadata` resolves `const seoTitle = post?.meta_title || post?.title` (`app/(site)/docs/(main-docs)/[...slug]/page.tsx:25`) and returns it as a plain string, so the layout template wraps it. The field therefore sets the search-result title independently of the on-page `<h1>`, and is already used by 130 other SigNoz docs, so this is an established pattern rather than a new mechanism. `title`, `description`, headings and body are untouched, so the reader-facing page is byte-identical.

| Page | New `meta_title` | Rendered | Evidence |
|---|---|---|---|
| grok-monitoring | Grok Monitoring: Trace xAI Calls and Tokens | 57 | `grok monitoring` converts at 8.7% |
| llamaindex-observability | LlamaIndex Observability: Trace RAG Workflows | 59 | "observability" 955 impr, "tracing" strong second |
| crewai-observability | CrewAI Observability: Trace Agents and Crews | 58 | "observability" 745 impr |
| openrouter-observability | OpenRouter Observability: Trace LLM Requests | 58 | `openrouter observability` 304 impr at position 5.0 |
| vercel-ai-sdk-observability | Vercel AI SDK Observability: Trace AI Calls | 57 | `ai sdk observability` 335 beats the branded form at 306 |
| livekit-observability | LiveKit Observability: Trace Voice Agents | 55 | observability plus otel, voice-agent niche |
| pipecat-monitoring | Pipecat Agent Monitoring: Trace Voice Latency | 59 | **"agent monitoring" 367 impr beats "observability" 97** |
| mastra-observability | Mastra Observability: Trace Agents and Tools | 58 | "observability" 1,284 impr, dominant |
| langchain-observability | LangGraph and LangChain Observability | 51 | **LangGraph queries 861 impr vs LangChain 399** |
| anthropic-monitoring | Anthropic API Observability: Trace Claude | 55 | "observability" 810 beats "monitoring" 155 |
| agno-monitoring | Agno Observability: Trace Agents and Tokens | 57 | three forms near-tied, observability leads |

Underlying the wording choice, across all human-shaped non-branded queries in the cluster:

| Query contains | Impressions | Clicks | CTR |
|---|---|---|---|
| `otel` / `otlp` / `opentelemetry` | 15,643 | 621 | 3.97% |
| `telemetry` | 9,994 | 193 | 1.93% |
| `observability` | 15,435 | 149 | 0.97% |
| `monitoring` / `monitor` | 11,894 | 82 | 0.69% |

Part of that spread is position rather than wording, since `otel` queries are narrow and we rank 2 to 4 on them while `observability` is broad and we rank 7 to 9. It is the reason no single formula was applied.

The **eleven control pages must stay unedited until 2026-10-01** or the measurement is lost: `semantic-kernel-observability`, `inkeep-monitoring`, `openclaw-observability`, `azure-openai-monitoring`, `openai-monitoring`, `claude-agent-monitoring`, `temporal-observability`, `litellm-observability`, `pydantic-ai-observability`, `google-gemini-monitoring`, `n8n-monitoring`.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

Not a bug fix, but the root cause is worth stating.

These guides were authored from a shared template that put the same descriptive phrase in every `title`. Because no page set `meta_title`, that one field had to serve as both the on-page heading and the search-result title, and it is poorly suited to the second job: too long once the site suffix is appended, and identical across the set. Decoupling the two fields resolves it without touching what readers see.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. Frontmatter-only, no code paths change.
- **Manual verification:**
  - `yarn check:docs-metadata` passes on all 11
  - `yarn check:doc-redirects` passes
  - `yarn test:doc-redirects` passes 13/13
  - All 11 parse correctly through `gray-matter`, verified explicitly
  - All 11 render under 60 characters with the `" | SigNoz Docs"` suffix included
  - Husky pre-commit hooks all passed (lint-staged, redirects, metadata, stale URLs, CMS assets)
- **Edge cases covered:** unquoted colons break the YAML frontmatter parser. `meta_title: Pipecat Agent Monitoring: Trace Voice Latency` throws `incomplete explicit mapping pair`. Caught before commit by running `gray-matter` against each file; all values are quoted.

**Known pre-existing failure, unrelated to this PR.** `yarn test:docs-metadata` fails one assertion, `should allow date exactly 7 days in the past` (`tests/docs-metadata.test.js:262`). This is a boundary test of the checker's own logic against fixtures, not against docs content. Reproduced identically on a clean `main` worktree (29 pass / 1 fail), and this branch touches nothing under `tests/` or `scripts/`.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** 11 MDX frontmatter lines. No code, no routing, no redirects, no rendered page content. `meta_title` already flows through `generateMetadata` for every other docs page that sets it.
- **Potential regressions:** Google rewrites titles it considers a poor match, so some may not render exactly as written. That is a no-op rather than a regression, since the current titles are already being truncated. The real risk is editing a control page and losing the measurement, which is why they are listed above.
- **Rollback plan:** revert the commit. Frontmatter-only, no migration or cache concerns.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Maintenance |
| Description | Search-result titles for 11 LLM observability guides now lead with the terms people actually search for and fit within Google's display limit. On-page content is unchanged. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The eleven titles are the part worth challenging. They were derived from Search Console query data rather than from using these products, so anyone who knows a given tool well may spot a better phrase. `OpenRouter Observability: Trace LLM Requests` is the one I am least sure of, since "requests" may not be how OpenRouter users think about what they are tracing.

Worth knowing that the query-to-page attribution behind the evidence column is inferred. GSC exports pages and queries as separate tables with no join, so queries were matched to pages by tool name. It also only covers the top 1,000 queries GSC returns, which is 17% of the cluster's impressions; the rest is anonymised long tail.

Please **do not edit the eleven control pages** before 2026-10-01. Full experiment design, baselines, power calculation and the read-out procedure are recorded outside the repo and can be shared on request.
