### PR TITLE
docs: document pin chart tooltip in Kubernetes infra monitoring

### DIFF
--- a/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-06
 title: Kubernetes Monitoring - Pods, Nodes & Workloads
 description: Monitor Kubernetes pods, nodes, and workloads in SigNoz with resource utilization and correlated traces, logs, and events for every cluster resource type.
 doc_type: explanation
@@ -79,6 +79,19 @@ Click any entity name to open its detail page. Most entities have four tabs: **M
   caption="Nodes View with sidebar navigation"
   className="box-shadowed-image"
 />
+
+### Chart Tooltip Interactions
+
+Every metric chart in the **Metrics** tab of an entity detail page supports the same tooltip interactions. Hover over a chart to read the value at a point in time. The tooltip footer surfaces two hints while your cursor is over the chart:
+
+- **Click and drag to zoom into a time range** to focus the chart on a narrower window.
+- **Press P to pin the tooltip** so it stays visible without continued hovering.
+
+Pinning is useful when you want to compare values across charts or reference a specific point while you scroll. Once a tooltip is pinned, the footer updates to **Press P or Esc to unpin** and shows an **Unpin** button. To dismiss a pinned tooltip, press **P**, press **Esc**, or click **Unpin**.
+
+<Admonition type="info">
+These tooltip interactions apply to the Metrics tab of every Kubernetes entity detail page (Pods, Nodes, Clusters, Namespaces, Deployments, StatefulSets, DaemonSets, Jobs, and Volumes). They are available in all editions (Cloud, OSS, and Enterprise) with no configuration required.
+</Admonition>
 
 ## Next steps
 

--- a/data/docs/infrastructure-monitoring/kubernetes/nodes.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/nodes.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-06
 title: "Kubernetes Nodes Monitoring: CPU, Memory, and Capacity"
 description: Monitor Kubernetes node CPU, memory, and network performance in SigNoz, covering usage vs allocatable capacity and filesystem utilization.
 doc_type: explanation
@@ -73,6 +73,8 @@ The **Nodes** view shows CPU and memory usage alongside allocatable capacity for
 ## Node Detail Page
 
 Click a node name to open the detail page. The header shows **Node Name** and **Cluster Name**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+
+The Metrics tab charts support hover tooltips, drag-to-zoom, and pinning (press **P** to pin, **P** / **Esc** / **Unpin** to dismiss). See [Chart Tooltip Interactions](https://signoz.io/docs/infrastructure-monitoring/kubernetes-monitoring/#chart-tooltip-interactions).
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-nodes-detail.webp"

--- a/data/docs/infrastructure-monitoring/kubernetes/pods.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes/pods.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-06
 title: "Kubernetes Pods Monitoring: CPU, Memory, and Health"
 description: Monitor Kubernetes pod CPU, memory, and network performance in SigNoz, covering request/limit utilization and correlated traces and logs.
 doc_type: explanation
@@ -89,6 +89,8 @@ The **Pods** view is the default Kubernetes monitoring view. It shows all active
 ## Pod Detail Page
 
 Click a pod name to open the detail page. The header shows **Namespace**, **Cluster Name**, and **Node**. The detail page includes four tabs: **Metrics**, **Logs**, **Traces**, and **Events**.
+
+The Metrics tab charts support hover tooltips, drag-to-zoom, and pinning (press **P** to pin, **P** / **Esc** / **Unpin** to dismiss). See [Chart Tooltip Interactions](https://signoz.io/docs/infrastructure-monitoring/kubernetes-monitoring/#chart-tooltip-interactions).
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-pods-detail.webp"


### PR DESCRIPTION
## Summary
- Added a **Chart Tooltip Interactions** subsection to `kubernetes-monitoring.mdx` documenting: hover tooltips, the footer hint bar, press **P** to pin a tooltip, and press **P** / **Esc** / click **Unpin** to dismiss. Also surfaces the pre-existing click-and-drag-to-zoom affordance now shown as a footer hint.
- Added an Admonition noting the interactions apply to the Metrics tab of every Kubernetes entity type (all editions, no config).
- Added brief cross-reference notes in `kubernetes/pods.mdx` and `kubernetes/nodes.mdx` pointing to the shared description (avoids duplication).
- Updated frontmatter `date` to 2026-08-06 on all edited files.

## Verification notes
- Confirmed the pin key is **P** (source constant `DEFAULT_PIN_TOOLTIP_KEY = 'p'`, authoritative over the stale `'l'` JSDoc).
- Verified on demo.in.signoz.cloud: the Metrics-tab tooltip and crosshair work, but the footer hint bar and P-to-pin behavior are **not yet live** (PR merged 2026-08-06, demo lags). Screenshots of the pinned/hint states are pending a demo build catch-up, so this update is prose-only.
- Drag-to-zoom is a pre-existing behavior (already documented on host-monitoring); documented here only as the newly-surfaced footer hint.
- Excluded the Hosts detail drawer: `canPinTooltip` is wired through the K8s `EntityMetrics` component only.

Source PRs: #12414

Auto-generated by docs-sync pipeline