### PR TITLE
fix: region selector change resets docs scroll position

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -9,7 +9,7 @@ export default function SiteLayout({ children }: { children: React.ReactNode }) 
     <TooltipProviderWrapper>
       <MobileDocsSidebarProvider>
         <SectionContainer>
-          <div className="relative flex h-screen flex-col justify-between">
+          <div className="relative flex min-h-screen flex-col justify-between">
             <TopNav />
             <main className="mb-auto mt-[48px] bg-[var(--l1-background)]">{children}</main>
             <MainFooter />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -6,7 +6,7 @@ import MainFooter from '@/components/mainFooter'
 export default function NotFound() {
   return (
     <SectionContainer>
-      <div className="relative flex h-screen flex-col justify-between ">
+      <div className="relative flex min-h-screen flex-col justify-between ">
         <TopNav />
         <main className="mb-auto mt-[48px] bg-[var(--l1-background)]">
           <NotFoundRecoveryClient />


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Two scroll regressions appear on docs pages:

1. Changing the region from the sidebar region selector reset the page scroll to top.
2. Clicking a Figure (image zoom) scrolled the page to top.

Both are the same underlying bug: the site layout wrapper used `h-screen` (sticky-footer antipattern), capping `<body>` at viewport height while content visibly overflowed it. Any library that momentarily sets `body { overflow: hidden }` (Radix Select's RemoveScroll, `react-medium-image-zoom`'s `bodyScrollDisable`) caused the body to clip its overflowing content - `document.documentElement.scrollHeight` collapsed to ~900px, so the browser clamped `scrollY` to 0 and the position was permanently lost.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/3c2b5515-ed8e-4dd6-886b-ca3b8e680f23


https://github.com/user-attachments/assets/db32ee5b-ca74-40b5-8a3d-143509e425fa


After:


https://github.com/user-attachments/assets/e43ba0a0-e0cb-4077-8315-77ea63e94401


https://github.com/user-attachments/assets/2a7c3954-6b17-4d05-bd4f-bf2e3a2d61ce



#### Issues closed by this PR

Closes https://github.com/SigNoz/growth-pod/issues/1241 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

- `app/(site)/layout.tsx` wraps the whole site in `<div className="relative flex h-screen flex-col justify-between">`. With `h-screen`, the wrapper (and therefore `<body>`) is only viewport-height (~900px) while page content spills out of that box. This is the classic sticky-footer antipattern - it should be `min-h-screen`.
- Pre-revamp this was masked: when a scroll-lock library set `body { overflow: hidden }`, the overflow value propagated from `<body>` to the viewport (since `<html>` overflow was the default `visible`). Viewport-level `overflow: hidden` locks scrolling but **preserves** scroll position.
- The revamp added `html { overflow-y: auto }` in `css/global.css`. Per CSS spec, once `<html>` has non-`visible` overflow, the body's overflow no longer propagates to the viewport - it now applies to the `<body>` box itself. So `body { overflow: hidden }` makes the 900px-tall body **clip** its spilled content: measured `document.documentElement.scrollHeight` collapsed from 11030 → 900, the browser clamps `scrollY` into the new valid range (0), and the position is lost even after overflow is restored.
- Both symptoms are this one mechanism:
  - **Region selector** (`components/DocsSidebar/SidebarRegionSelector.tsx`): Radix Select's RemoveScroll sets `body { overflow: hidden }`. While the menu is open, the `[data-region-select-open]` CSS hack neutralizes it — but on selection the attribute is removed a few frames before RemoveScroll unmounts, leaving a brief window of `overflow: hidden` → collapse → jump to 0.
  - **Figure zoom** (`react-medium-image-zoom` v5 `bodyScrollDisable()`): sets `body { overflow: hidden }` on zoom open → same collapse → immediate jump to 0.

#### Fix Strategy
> How does this PR address the root cause?

Restore the layout box to content height: `h-screen` → `min-h-screen` in `app/(site)/layout.tsx` (and `app/not-found.tsx`, same antipattern). With the body at full content height, `body { overflow: hidden }` has nothing to clip, `scrollHeight` stays intact, and scroll position is preserved through scroll-lock open/close cycles. No changes needed to `RegionContext`, `ClientZoom`, `SidebarRegionSelector`, or `global.css`.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview, video attached
- Edge cases covered: short pages (footer pinning via `justify-between`/`mb-auto`), zoom open **and** close, scroll position during the open menu as well as after selection

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Site-wide layout wrapper (all pages under `app/(site)`) + 404 page. Only the wrapper's height constraint changes; flex layout, footer pinning, and sticky elements are unaffected.
- Potential regressions: Anything that relied on the wrapper being exactly viewport height. None found - content already overflowed the box, so nothing was actually sized by it.
- Rollback plan: Revert the two-line diff.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The whole fix is two one-word class changes; everything else in this description is diagnosis.
- `app/not-found.tsx` was fixed as well because it copies the same wrapper markup and might hit the same class of bugs.

---
