### PR TITLE
fix(listicles): add trailing slashes to LLM monitoring hrefs

### DIFF
--- a/constants/listicles/llm-monitoring.json
+++ b/constants/listicles/llm-monitoring.json
@@ -8,274 +8,274 @@
   "items": [
     {
       "name": "Agno",
-      "href": "/docs/agno-monitoring",
+      "href": "/docs/agno-monitoring/",
       "clickName": "Agno Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/agno-logo.webp"
     },
     {
       "name": "Amazon Bedrock",
-      "href": "/docs/amazon-bedrock-monitoring",
+      "href": "/docs/amazon-bedrock-monitoring/",
       "clickName": "Amazon Bedrock Monitoring",
       "icon": "/img/icons/listicle/si-aws.svg"
     },
     {
       "name": "Anthropic API",
-      "href": "/docs/anthropic-monitoring",
+      "href": "/docs/anthropic-monitoring/",
       "clickName": "Anthropic API Monitoring",
       "icon": "/img/icons/listicle/si-anthropic.svg"
     },
     {
       "name": "AutoGen",
-      "href": "/docs/autogen-observability",
+      "href": "/docs/autogen-observability/",
       "clickName": "AutoGen Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/autogen-logo.webp"
     },
     {
       "name": "Azure OpenAI API",
-      "href": "/docs/azure-openai-monitoring",
+      "href": "/docs/azure-openai-monitoring/",
       "clickName": "Azure OpenAI API Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/azure-logo.webp"
     },
     {
       "name": "Baseten",
-      "href": "/docs/baseten-monitoring",
+      "href": "/docs/baseten-monitoring/",
       "clickName": "Baseten Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/baseten-logo.webp"
     },
     {
       "name": "Claude Code",
-      "href": "/docs/claude-code-monitoring",
+      "href": "/docs/claude-code-monitoring/",
       "clickName": "Claude Code Monitoring",
       "icon": "/img/icons/listicle/si-claude.svg"
     },
     {
       "name": "Claude Agent SDK",
-      "href": "/docs/claude-agent-monitoring",
+      "href": "/docs/claude-agent-monitoring/",
       "clickName": "Claude Agent SDK Monitoring",
       "icon": "/img/icons/listicle/si-claude-b55c04.svg"
     },
     {
       "name": "Codex (OpenAI)",
-      "href": "/docs/codex-monitoring",
+      "href": "/docs/codex-monitoring/",
       "clickName": "Codex (OpenAI) Monitoring",
       "icon": "/img/icons/listicle/si-openai.svg"
     },
     {
       "name": "Cohere",
-      "href": "/docs/cohere-monitoring",
+      "href": "/docs/cohere-monitoring/",
       "clickName": "Cohere Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/cohere-logo.svg"
     },
     {
       "name": "Crew AI",
-      "href": "/docs/crewai-observability",
+      "href": "/docs/crewai-observability/",
       "clickName": "Crew AI Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/crewai-logo.svg"
     },
     {
       "name": "DeepSeek API",
-      "href": "/docs/deepseek-monitoring",
+      "href": "/docs/deepseek-monitoring/",
       "clickName": "DeepSeek Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/deepseek-icon.svg"
     },
     {
       "name": "Dify",
-      "href": "/docs/dify-observability",
+      "href": "/docs/dify-observability/",
       "clickName": "Dify Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/dify-logo.svg"
     },
     {
       "name": "DSPy",
-      "href": "/docs/dspy-observability",
+      "href": "/docs/dspy-observability/",
       "clickName": "DSPy Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/dspy-logo.webp"
     },
     {
       "name": "Firecrawl",
-      "href": "/docs/firecrawl-monitoring",
+      "href": "/docs/firecrawl-monitoring/",
       "clickName": "Firecrawl Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/firecrawl-logo.webp"
     },
     {
       "name": "Google ADK",
-      "href": "/docs/google-adk-observability",
+      "href": "/docs/google-adk-observability/",
       "clickName": "Google ADK Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/google-adk-logo.webp"
     },
     {
       "name": "Google Gemini",
-      "href": "/docs/google-gemini-monitoring",
+      "href": "/docs/google-gemini-monitoring/",
       "clickName": "Google Gemini Monitoring",
       "icon": "/img/icons/listicle/si-gemini.svg"
     },
     {
       "name": "Grok",
-      "href": "/docs/grok-monitoring",
+      "href": "/docs/grok-monitoring/",
       "clickName": "Grok Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/grok-logo.webp"
     },
     {
       "name": "Groq",
-      "href": "/docs/groq-observability",
+      "href": "/docs/groq-observability/",
       "clickName": "Groq Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/groq-logo.webp"
     },
     {
       "name": "Haystack",
-      "href": "/docs/haystack-monitoring",
+      "href": "/docs/haystack-monitoring/",
       "clickName": "Haystack Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/haystack-logo.webp"
     },
     {
       "name": "Hermes Agent",
-      "href": "/docs/hermes-monitoring",
+      "href": "/docs/hermes-monitoring/",
       "clickName": "Hermes Agent Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/hermes-logo.webp"
     },
     {
       "name": "Hugging Face",
-      "href": "/docs/huggingface-observability",
+      "href": "/docs/huggingface-observability/",
       "clickName": "Hugging Face Monitoring",
       "icon": "/img/icons/listicle/si-huggingface.svg"
     },
     {
       "name": "Inkeep",
-      "href": "/docs/inkeep-monitoring",
+      "href": "/docs/inkeep-monitoring/",
       "clickName": "Inkeep Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/inkeep-logo.webp"
     },
     {
       "name": "LangChain/LangGraph",
-      "href": "/docs/langchain-observability",
+      "href": "/docs/langchain-observability/",
       "clickName": "LangChain Monitoring",
       "icon": "/img/icons/listicle/si-langchain.svg"
     },
     {
       "name": "Langflow",
-      "href": "/docs/langflow-observability",
+      "href": "/docs/langflow-observability/",
       "clickName": "Langflow Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/langflow-logo.svg"
     },
     {
       "name": "Langtrace",
-      "href": "/docs/langtrace",
+      "href": "/docs/langtrace/",
       "icon": "/svgs/icons/LLMMonitoring/langtrace-logo.webp"
     },
     {
       "name": "LiteLLM",
-      "href": "/docs/litellm-observability",
+      "href": "/docs/litellm-observability/",
       "clickName": "LiteLLM Monitoring",
       "icon": "/img/docs/llm/litellm/litellm-logo.webp"
     },
     {
       "name": "LiveKit",
-      "href": "/docs/livekit-observability",
+      "href": "/docs/livekit-observability/",
       "clickName": "LiveKit Monitoring",
       "icon": "/img/docs/llm/livekit/livekit-icon.svg"
     },
     {
       "name": "LlamaIndex",
-      "href": "/docs/llamaindex-observability",
+      "href": "/docs/llamaindex-observability/",
       "clickName": "LlamaIndex Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/llamaindex-icon.svg"
     },
     {
       "name": "Mastra",
-      "href": "/docs/mastra-observability",
+      "href": "/docs/mastra-observability/",
       "clickName": "Mastra Monitoring",
       "icon": "/img/docs/llm/mastra/mastra-icon.webp"
     },
     {
       "name": "Mistral AI",
-      "href": "/docs/mistral-observability",
+      "href": "/docs/mistral-observability/",
       "clickName": "Mistral AI Monitoring",
       "icon": "/img/docs/llm/mistral/mistral-logo.webp"
     },
     {
       "name": "n8n Cloud",
-      "href": "/docs/n8n-monitoring",
+      "href": "/docs/n8n-monitoring/",
       "clickName": "n8n Cloud Monitoring",
       "icon": "/img/icons/listicle/si-n8n.svg"
     },
     {
       "name": "Ollama",
-      "href": "/docs/ollama-monitoring",
+      "href": "/docs/ollama-monitoring/",
       "clickName": "Ollama Monitoring",
       "icon": "/img/icons/listicle/si-ollama.svg"
     },
     {
       "name": "OpenAI",
-      "href": "/docs/openai-monitoring",
+      "href": "/docs/openai-monitoring/",
       "clickName": "OpenAI Monitoring",
       "icon": "/img/icons/listicle/si-openai-green400.svg"
     },
     {
       "name": "OpenClaw",
-      "href": "/docs/openclaw-observability",
+      "href": "/docs/openclaw-observability/",
       "clickName": "OpenClaw Observability",
       "icon": "/img/docs/llm/openclaw/openclaw-logo.svg"
     },
     {
       "name": "OpenCode",
-      "href": "/docs/opencode-observability",
+      "href": "/docs/opencode-observability/",
       "clickName": "OpenCode Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/opencode-logo.webp"
     },
     {
       "name": "OpenLIT",
-      "href": "/docs/openlit",
+      "href": "/docs/openlit/",
       "icon": "/svgs/icons/LLMMonitoring/openlit-logo.webp"
     },
     {
       "name": "OpenRouter",
-      "href": "/docs/openrouter-observability",
+      "href": "/docs/openrouter-observability/",
       "clickName": "OpenRouter Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/openrouter-logo.webp"
     },
     {
       "name": "Open WebUI",
-      "href": "/docs/open-webui-monitoring",
+      "href": "/docs/open-webui-monitoring/",
       "clickName": "Open WebUI Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/openwebui-logo.webp"
     },
     {
       "name": "Pipecat",
-      "href": "/docs/pipecat-monitoring",
+      "href": "/docs/pipecat-monitoring/",
       "clickName": "Pipecat Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/pipecat-logo.webp"
     },
     {
       "name": "Pydantic AI",
-      "href": "/docs/pydantic-ai-observability",
+      "href": "/docs/pydantic-ai-observability/",
       "clickName": "Pydantic AI Monitoring",
       "icon": "/img/icons/listicle/si-pydantic.svg"
     },
     {
       "name": "Qwen",
-      "href": "/docs/qwen-observability",
+      "href": "/docs/qwen-observability/",
       "clickName": "Qwen Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/qwen-logo.webp"
     },
     {
       "name": "Semantic Kernel",
-      "href": "/docs/semantic-kernel-observability",
+      "href": "/docs/semantic-kernel-observability/",
       "clickName": "Semantic Kernel Monitoring",
       "icon": "/img/docs/llm/semantic-kernel/sk-logo.webp"
     },
     {
       "name": "Temporal",
-      "href": "/docs/temporal-observability",
+      "href": "/docs/temporal-observability/",
       "clickName": "Temporal Monitoring",
       "icon": "/img/icons/listicle/si-temporal.svg"
     },
     {
       "name": "Traceloop (OpenLLMetry)",
-      "href": "/docs/traceloop",
+      "href": "/docs/traceloop/",
       "icon": "/svgs/icons/LLMMonitoring/traceloop-logo.webp"
     },
     {
       "name": "Vercel AI SDK",
-      "href": "/docs/vercel-ai-sdk-observability",
+      "href": "/docs/vercel-ai-sdk-observability/",
       "clickName": "Vercel AI SDK Monitoring",
       "icon": "/img/icons/listicle/si-vercel-white.svg"
     }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`next.config.js:88` sets `trailingSlash: true`, so `/docs/agno-monitoring` answers **308** with `location: /docs/agno-monitoring/`. All 46 hrefs in `constants/listicles/llm-monitoring.json` omit the slash, so **every click from the LLM observability hub grid costs two requests instead of one**.

Verified against production:

```
$ curl -sI https://signoz.io/docs/agno-monitoring
HTTP/2 308
location: /docs/agno-monitoring/
```

**Why these particular links escaped normalisation.** The grid renders each item through `ListicleCardGrid` → `TrackingLink` → `next/link`, and the resulting markup is an **absolute** URL:

```html
<a href="https://signoz.io/docs/agno-monitoring">
```

`next/link` normalises relative hrefs against `trailingSlash`, but treats absolute URLs as external and passes them through untouched. The sidebar on the same page renders `/docs/introduction/` correctly for exactly that reason, which is why this went unnoticed.

**The change.** Adds a trailing slash to all 46 `href` values. `clickName` and `icon` are untouched, so Mixpanel event names are unaffected.

**Impact, stated honestly.** This is hygiene rather than a growth lever: one fewer round trip per click, and redirected links pass marginally less ranking signal than direct ones. It is worth doing because it is a one-character change per line, not because it will move traffic.

**One thing it does not fix.** Google Search Console shows ten of these pages indexed at both `/docs/x` and `/docs/x/`. That is a separate issue needing a self-referential canonical tag on docs pages; the 308 already consolidates correctly, so these internal hrefs are unlikely to be the cause.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

The listicle JSON stores hrefs in the site-relative form without a trailing slash, which is correct-looking and works. It only becomes a redirect because the rendering path converts it to an absolute URL before `next/link` sees it, bypassing the normalisation that `trailingSlash: true` would otherwise apply. Nothing in CI checks for it, since the links resolve fine, just indirectly.

#### Fix Strategy

Store the canonical form in the JSON so it renders correctly regardless of whether the consumer emits a relative or absolute URL.

Note this is a targeted fix for the LLM listicle only. Other listicle JSONs likely share the pattern, and a component-level fix in `TrackingLink` or `ListicleCardGrid` would prevent recurrence across all of them. Deliberately out of scope here.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. Data-only change, no code paths touched.
- **Manual verification:**
  - Re-parsed the JSON after editing: 46 items, all seven top-level keys intact, zero hrefs still missing a slash
  - **Requested all 46 URLs against production: every one returns 200 with zero redirects**
  - `yarn check:doc-redirects` passes
  - `yarn check:stale-urls` passes, no stale or redirect-source URLs found
  - `yarn check:docs-metadata` no-ops correctly, no docs files changed
  - Husky pre-commit passed, including `prettier --write` on the JSON
- **Edge cases covered:** confirmed nothing matches on the old href format. `constants/listicles/registry.ts` imports the file wholesale rather than keying on href values.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one JSON file, 46 href values. Rendered by the `<Listicle name="llm-monitoring" />` component on `/docs/llm-observability` and anywhere else that listicle is embedded.
- **Potential regressions:** essentially none. Both URL forms resolve to the same page; this removes a hop rather than changing a destination. The only way to break something would be if code compared hrefs as strings, and nothing does.
- **Rollback plan:** revert the commit. Data-only.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | Links in the LLM observability integration grid now point directly at their destination instead of going through a redirect. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The diff reads as 46 insertions and 46 deletions, but it is one character per line.

Worth deciding as a follow-up whether this belongs at the component level. If `ListicleCardGrid` normalised hrefs on render, every listicle would be correct and future entries could not reintroduce the problem. I scoped this PR to the LLM listicle because that is the section I own, but the same pattern almost certainly exists elsewhere in `constants/listicles/`.
