### PR TITLE
fix: broken and redirected links in docs homepage

### DIFF
--- a/app/(site)/docs/introduction/constants.tsx
+++ b/app/(site)/docs/introduction/constants.tsx
@@ -56,7 +56,7 @@ export const SEND_DATA_CARDS: CardData[] = [
   {
     title: 'Send Metrics',
     description: 'Configure metrics collection & visualization.',
-    href: '/docs/userguide/send-metrics-cloud/',
+    href: '/docs/metrics-management/send-metrics/',
     icon: <LucideChartNoAxesColumn size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
@@ -68,7 +68,7 @@ export const SEND_DATA_CARDS: CardData[] = [
   {
     title: 'Agent-Native',
     description: 'Use AI agents for instrumentation',
-    href: '/docs/agent-native/',
+    href: '/docs/ai/overview/',
     icon: <Bot size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
@@ -90,7 +90,7 @@ export const EXPLORE_SIGNOZ_CARDS: CardData[] = [
   {
     title: 'Dashboards',
     description: 'Build, share, use templates',
-    href: '/docs/userguide/dashboards/',
+    href: '/docs/dashboards/overview/',
     icon: <LayoutDashboard size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
@@ -102,7 +102,7 @@ export const EXPLORE_SIGNOZ_CARDS: CardData[] = [
   {
     title: 'Explore Traces',
     description: 'Analyze your traces with trace explorer',
-    href: '/docs/product-features/trace-explorer/',
+    href: '/docs/userguide/traces/',
     icon: <Waypoints size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
@@ -114,7 +114,7 @@ export const EXPLORE_SIGNOZ_CARDS: CardData[] = [
   {
     title: 'Query Builder',
     description: 'The visual query interface for signals',
-    href: '/docs/userguide/query-builder/',
+    href: '/docs/userguide/query-builder-v5/',
     icon: <ListFilter size={24} className="text-[var(--l1-foreground)]" />,
   },
 ]
@@ -130,13 +130,13 @@ export const MIGRATE_CARDS: CardData[] = [
   {
     title: 'Migrate from Grafana',
     description: 'Step-by-step guide to migrate from Grafana',
-    href: '/docs/migration/migrate-from-grafana/',
+    href: '/docs/migration/migrate-from-grafana-to-signoz/',
     icon: <BookText size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
     title: 'Migrate from New Relic',
     description: 'Step-by-step guide to migrate from New Relic',
-    href: '/docs/migration/migrate-from-newrelic/',
+    href: '/docs/migration/migrate-from-newrelic-to-signoz/',
     icon: <BookText size={24} className="text-[var(--l1-foreground)]" />,
   },
 ]
@@ -152,7 +152,7 @@ export const SECURITY_CARDS: CardData[] = [
   {
     title: 'SSO SAML',
     description: 'Set up Single Sign-On with SAML',
-    href: '/docs/userguide/sso-authentication/',
+    href: '/docs/manage/administrator-guide/sso/overview/',
     icon: <Settings size={24} className="text-[var(--l1-foreground)]" />,
   },
   {
@@ -168,7 +168,7 @@ export const TROUBLESHOOTING_CARDS: CardData[] = [
   {
     title: 'FAQ',
     description: 'Find solutions to common issues',
-    href: 'https://signoz.io/docs/troubleshooting/signoz-cloud/general-troubleshooting/',
+    href: '/docs/faqs/general/',
     icon: <HelpCircle size={24} className="text-[var(--l1-foreground)]" />,
   },
   {

--- a/app/(site)/docs/introduction/page.tsx
+++ b/app/(site)/docs/introduction/page.tsx
@@ -33,7 +33,7 @@ export default async function DocsIntroductionPage() {
         title="Explore the rest of SigNoz"
         description="Once your data is flowing in — go deeper into what we offer."
         guidesCount={12}
-        viewAllHref="/docs/userguide/"
+        viewAllHref="/docs/what-is-signoz/"
         illustration="/img/docs-introduction/explore-illustration.webp"
         illustrationAlt="Explore SigNoz"
         cards={EXPLORE_SIGNOZ_CARDS}
@@ -43,7 +43,7 @@ export default async function DocsIntroductionPage() {
         title="Migrate"
         description="Seamlessly transition from your existing observability stack."
         guidesCount={8}
-        viewAllHref="/docs/migration/"
+        viewAllHref="/docs/migration/migrate-to-signoz/"
         cards={MIGRATE_CARDS}
       />
       <DocsIntroSection

--- a/app/(site)/docs/introduction/page.tsx
+++ b/app/(site)/docs/introduction/page.tsx
@@ -33,7 +33,7 @@ export default async function DocsIntroductionPage() {
         title="Explore the rest of SigNoz"
         description="Once your data is flowing in — go deeper into what we offer."
         guidesCount={12}
-        viewAllHref="/docs/what-is-signoz/"
+        viewAllHref="/docs/querying/overview/"
         illustration="/img/docs-introduction/explore-illustration.webp"
         illustrationAlt="Explore SigNoz"
         cards={EXPLORE_SIGNOZ_CARDS}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Fixes broken links in the homepage for docs


#### Screenshots / Screen Recordings (if applicable)
> NA

#### Issues closed by this PR
> NA, bugfix

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> 404 and redirected pages in docs homepage introduced in revamp https://github.com/SigNoz/signoz.io/pull/3880 - the stale url check should have caught redirects but regex didn't match patterns used, so they were missed and the pre-commit and check never detected broken urls, in a follow up, we should extend the workflow to catch these issues early on.

#### Root Cause
> Regression, miss on dev and testing.

#### Fix Strategy
> Fixing the broken urls and redirected in current pr, in a follow up, extending the workflow to handle broken and redirected urls with a wider regex so such misses do not reach production.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview.
- Edge cases covered: None in current PR.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Docs homepage links
- Potential regressions: None
- Rollback plan: Not needed, if any issues, we should fix those but PR has low blast radius due to url only changes.

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

In a follow up, fixing the workflows and url checks.

---
