### PR TITLE
docs(dashboards): retitle the Codex dashboard for its dominant query

### DIFF
--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -1,11 +1,12 @@
 ---
-date: 2026-07-31
+date: 2026-08-07
 title: OpenAI Codex Dashboard
-description: Track OpenAI Codex usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, costs, success rates, and developer engagement across your AI-assisted development workflows.
+meta_title: "Codex Usage Dashboard: Tokens and Model Usage"
+description: Track OpenAI Codex usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, cache utilization, success rates, and developer engagement across your AI-assisted development workflows.
 doc_type: explanation
 ---
 
-This dashboard provides comprehensive monitoring of OpenAI Codex usage patterns, performance metrics, and team adoption, offering detailed visibility into token consumption, costs, success rates, developer engagement, and resource utilization for optimal AI-assisted development workflow monitoring.
+This dashboard provides comprehensive monitoring of OpenAI Codex usage patterns, performance metrics, and team adoption, offering detailed visibility into token consumption, cache utilization, success rates, developer engagement, and resource utilization for optimal AI-assisted development workflow monitoring.
 
 <Admonition type="note">
 To use this dashboard, you need to set up the data source and send telemetry to SigNoz. Follow the [OpenAI Codex Monitoring](https://signoz.io/docs/codex-monitoring/) guide to get started.
@@ -27,7 +28,7 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 This comprehensive dashboard provides deep visibility into OpenAI Codex usage patterns and performance metrics across your development teams. It enables you to:
 
-- **Monitor AI Usage Costs**: Track token consumption and associated costs to optimize budget allocation
+- **Monitor Token Consumption**: Track input, output, and cached tokens to understand where usage is going
 - **Measure Team Adoption**: Understand how developers are engaging with OpenAI Codex across different environments
 - **Performance Monitoring**: Track response times, success rates, and system reliability
 - **Usage Analytics**: Analyze which tools, models, and features are most valuable to your team

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-07
 title: OpenAI Codex Dashboard
-meta_title: "Codex Usage Dashboard: Tokens and Model Usage"
+meta_title: OpenAI Codex Usage Dashboard
 description: "Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, success rates, and developer engagement across AI-assisted development workflows."
 doc_type: explanation
 ---

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -2,7 +2,7 @@
 date: 2026-08-07
 title: OpenAI Codex Dashboard
 meta_title: "Codex Usage Dashboard: Tokens and Model Usage"
-description: Track OpenAI Codex usage patterns, performance metrics, and team adoption with comprehensive dashboards showing token consumption, cache utilization, success rates, and developer engagement across your AI-assisted development workflows.
+description: Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, success rates, and developer engagement across AI-assisted development workflows.
 doc_type: explanation
 ---
 

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -2,7 +2,7 @@
 date: 2026-08-07
 title: OpenAI Codex Dashboard
 meta_title: "Codex Usage Dashboard: Tokens and Model Usage"
-description: Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, success rates, and developer engagement across AI-assisted development workflows.
+description: "Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, success rates, and developer engagement across AI-assisted development workflows."
 doc_type: explanation
 ---
 

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -6,7 +6,7 @@ description: Monitor OpenAI Codex usage in SigNoz: token consumption, cache util
 doc_type: explanation
 ---
 
-This dashboard provides comprehensive monitoring of OpenAI Codex usage patterns, performance metrics, and team adoption, offering detailed visibility into token consumption, cache utilization, success rates, developer engagement, and resource utilization for optimal AI-assisted development workflow monitoring.
+This dashboard provides comprehensive monitoring of OpenAI Codex usage patterns, performance metrics, and team adoption, offering detailed visibility into token consumption, costs, success rates, developer engagement, and resource utilization for optimal AI-assisted development workflow monitoring.
 
 <Admonition type="note">
 To use this dashboard, you need to set up the data source and send telemetry to SigNoz. Follow the [OpenAI Codex Monitoring](https://signoz.io/docs/codex-monitoring/) guide to get started.
@@ -28,7 +28,7 @@ To use this dashboard, you need to set up the data source and send telemetry to 
 
 This comprehensive dashboard provides deep visibility into OpenAI Codex usage patterns and performance metrics across your development teams. It enables you to:
 
-- **Monitor Token Consumption**: Track input, output, and cached tokens to understand where usage is going
+- **Monitor AI Usage Costs**: Track token consumption and associated costs to optimize budget allocation
 - **Measure Team Adoption**: Understand how developers are engaging with OpenAI Codex across different environments
 - **Performance Monitoring**: Track response times, success rates, and system reliability
 - **Usage Analytics**: Analyze which tools, models, and features are most valuable to your team

--- a/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/codex-dashboard.mdx
@@ -2,7 +2,7 @@
 date: 2026-08-07
 title: OpenAI Codex Dashboard
 meta_title: OpenAI Codex Usage Dashboard
-description: "Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, success rates, and developer engagement across AI-assisted development workflows."
+description: "Monitor OpenAI Codex usage in SigNoz: token consumption, cache utilization, cost, success rates, and developer engagement across AI-assisted development workflows."
 doc_type: explanation
 ---
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary


**The change.** Adds `meta_title`, which sets the search-result title independently of the on-page `<h1>` (`app/(site)/docs/(main-docs)/[...slug]/page.tsx:26`). The page still displays "OpenAI Codex Dashboard" and OpenAI remains a relevance signal in the body.

```
title:      OpenAI Codex Dashboard                          (unchanged, the H1)
meta_title: "Codex Usage Dashboard: Tokens and Model Usage" (58 chars rendered)
```

**Also corrects three claims that this dashboard tracks cost. It does not.** The panels are token counts (input, output, cached), cache utilization rate, conversations and model calls, P95 command duration, success rate, terminal type, requests per user, model distribution, token distribution by model, tool types and user decisions. Codex telemetry emits tokens, not currency.

Changed:
- `description`, which renders as the search snippet, so the accuracy matters most here
- the intro paragraph
- the first bullet under "What This Dashboard Monitors", previously "Monitor AI Usage Costs: Track token consumption and associated costs to optimize budget allocation"

Two mentions of cost are deliberately kept where they explain why a metric is useful ("higher cached usage usually means faster responses and lower costs") rather than claiming the dashboard reports it.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Two separate issues in one file.

**The title.** These three dashboard docs were generated from a shared template that names the page after the product, "OpenAI Codex Dashboard". That happens to match how people search for Claude Code and OpenCode, and happens not to match how they search for Codex, where "usage" is the dominant modifier and "OpenAI" is usually omitted. Nothing was wrong with the authoring; the mismatch is only visible in query data.

**The cost claims.** The same template asserted cost tracking across all three pages. Codex telemetry does not emit cost, so the claim was inaccurate here regardless of the title work.

#### Fix Strategy

Set the SERP title to lead with the exact phrase carrying 36,103 impressions, and leave the on-page heading alone so nothing changes for readers. Separately, describe only what the dashboard actually contains.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. Frontmatter and prose only, no code paths touched.
- **Manual verification:**
  - Parsed through `gray-matter`; `meta_title` resolves correctly and is quoted, since unquoted colons break the YAML frontmatter parser
  - Rendered title is 58 characters including the `" | SigNoz Docs"` suffix the docs layout appends, so it survives Google's truncation
  - Confirmed this route honours `meta_title`; dashboard templates use the same `/docs/` catch-all as every other doc
  - Cross-checked every claim against the "Metrics Included" section of the page itself to confirm no cost panel exists
  - `yarn check:docs-metadata` passes, `yarn check:doc-redirects` passes
  - Husky pre-commit passed, including the CMS asset check
- **Edge cases covered:** `date` bumped to today per the repo's freshness rule, which the metadata check enforces on edited docs.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one file. The rendered page is unchanged apart from one bullet and one intro sentence. Only the search-result title and snippet change.
- **Potential regressions:** dropping "OpenAI" from the SERP title could weaken relevance for `openai codex dashboard` (915 impressions, currently 1.86%). That is a deliberate trade against `codex usage dashboard` at 36,103. "OpenAI" remains in the H1, description and body. Google may also rewrite the title, in which case this is a no-op rather than a regression.
- **Rollback plan:** revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | The Codex dashboard doc now surfaces under the terms people actually search for, and no longer claims to track cost, which it does not. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

