### PR TITLE
docs(dashboards): retitle the Anthropic dashboard for its dominant query

### DIFF
--- a/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
@@ -1,7 +1,8 @@
 ---
-date: 2026-07-31
+date: 2026-08-07
 
 title: Anthropic API Dashboard
+meta_title: "Anthropic API Usage Dashboard: Tokens, Errors"
 description: Monitor Anthropic/Claude API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
 ---

--- a/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
@@ -2,7 +2,7 @@
 date: 2026-08-07
 
 title: Anthropic API Dashboard
-meta_title: Anthropic API Usage Dashboard
+meta_title: Anthropic Claude API Usage Dashboard
 description: Monitor Anthropic/Claude API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
 ---

--- a/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/anthropic-dashboard.mdx
@@ -2,7 +2,7 @@
 date: 2026-08-07
 
 title: Anthropic API Dashboard
-meta_title: "Anthropic API Usage Dashboard: Tokens, Errors"
+meta_title: Anthropic API Usage Dashboard
 description: Monitor Anthropic/Claude API usage and performance including token consumption, model distribution, error rates, request volumes, and latency trends for optimal AI workload observability.
 doc_type: explanation
 ---


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary



**The change is one line:**

```
title:      Anthropic API Dashboard         (unchanged, remains the H1)
meta_title: Anthropic API Usage Dashboard   (43 chars rendered)
```

`meta_title` sets the search-result title independently of the on-page `<h1>` (`app/(site)/docs/(main-docs)/[...slug]/page.tsx:25`, wrapped by the `'%s | SigNoz Docs'` template at `app/(site)/docs/layout.tsx:9`).


#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

These dashboard docs were generated from a shared template that names each page after the product, "Anthropic API Dashboard". That is a reasonable heading but an incomplete search title: it omits "usage", which appears in 34 of the queries the page receives and is present in its single best-converting query. The mismatch is only visible in query-level data.

#### Fix Strategy

Set the search-result title to the smallest phrase that fully contains the page's dominant queries, and leave the on-page heading untouched so nothing changes for readers.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. Frontmatter only, no code paths touched.
- **Manual verification:**
  - Parsed via `gray-matter`; `meta_title` resolves to `"Anthropic API Usage Dashboard"`
  - Renders at **43 characters** including the ` | SigNoz Docs` suffix, so no truncation risk
  - Confirmed the resolution path: `page.tsx:25` returns the value as a plain string, `layout.tsx:9` applies the template
  - Query coverage computed directly from the page's Search Console query export
  - `yarn check:docs-metadata` and `yarn check:doc-redirects` both pass
  - Husky pre-commit passed, including the CMS asset check
- **Edge cases covered:** `date` bumped to today per the repo's 7-day freshness rule, which the pre-commit hook enforces.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one frontmatter line. The rendered page is unchanged; only the search-result title differs.
- **Potential regressions:** minimal. The new title is a strict superset of the old one's words, so no query loses a term it previously matched. Google may rewrite the title, in which case this is a no-op.
- **Rollback plan:** revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | The Anthropic dashboard doc now surfaces under the phrase people actually search for. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

