### PR TITLE
docs: correct GCP integrations to metrics-only (logs removed)

### DIFF
--- a/data/docs/integrations/gcp/cloud-sql-postgresql.mdx
+++ b/data/docs/integrations/gcp/cloud-sql-postgresql.mdx
@@ -1,15 +1,19 @@
 ---
-date: 2026-07-13
+date: 2026-08-08
 title: GCP Cloud SQL for PostgreSQL Monitoring with SigNoz
 description: Monitor GCP Cloud SQL for PostgreSQL with SigNoz. Collect 13 metrics covering health, connections, transactions, query execution, and replication.
 doc_type: howto
 tags: [SigNoz Cloud]
 ---
 
-The GCP Cloud SQL for PostgreSQL integration collects metrics and logs from your Cloud SQL for PostgreSQL instances and ships an out-of-the-box overview dashboard covering health, connections, transactions, query execution, and replication. It is the first available GCP service in the [GCP Cloud Integration](https://signoz.io/docs/integrations/gcp/gcp-cloud-integration/).
+The GCP Cloud SQL for PostgreSQL integration collects metrics from your Cloud SQL for PostgreSQL instances and ships an out-of-the-box overview dashboard covering health, connections, transactions, query execution, and replication. It is the first available GCP service in the [GCP Cloud Integration](https://signoz.io/docs/integrations/gcp/gcp-cloud-integration/).
 
 <Admonition type="info">
 This integration is available on SigNoz Cloud and Self-Hosted Enterprise.
+</Admonition>
+
+<Admonition type="info">
+GCP Cloud SQL for PostgreSQL collects metrics only. Enable **Metrics** to start ingesting data.
 </Admonition>
 
 ## Getting started
@@ -20,7 +24,7 @@ Once connected:
 
 1. In SigNoz, navigate to **Integrations** > **GCP**.
 2. Select **GCP Cloud SQL for PostgreSQL**.
-3. Toggle **Metrics** and **Logs** on. Each signal is controlled independently.
+3. Toggle **Metrics** on.
 
 Enabling the integration creates the **GCP Cloud SQL for PostgreSQL Overview** dashboard automatically. Data starts flowing within a few minutes.
 
@@ -65,7 +69,7 @@ The dashboard includes two filter variables that scope every panel:
 
 ## Migrating from the earlier `cloudsql` integration
 
-The service ID was renamed from `cloudsql` to `cloudsql_postgres`. If you configured the earlier stub integration under the old ID, re-enable the service under **GCP Cloud SQL for PostgreSQL** so metrics and logs continue to flow to the current dashboard.
+The service ID was renamed from `cloudsql` to `cloudsql_postgres`. If you configured the earlier stub integration under the old ID, re-enable the service under **GCP Cloud SQL for PostgreSQL** so metrics continue to flow to the current dashboard.
 
 ## Next steps
 
@@ -75,4 +79,3 @@ The service ID was renamed from `cloudsql` to `cloudsql_postgres`. If you config
 ## Get Help
 
 <GetHelp />
-</content>

--- a/data/docs/integrations/gcp/cloud-storage.mdx
+++ b/data/docs/integrations/gcp/cloud-storage.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-08-08
 title: GCP Cloud Storage Monitoring and Dashboards with SigNoz
 description: Monitor GCP Cloud Storage with SigNoz. Collect 7 metrics covering storage, API usage, authentication, and network traffic on an out-of-the-box dashboard.
 doc_type: howto
@@ -12,8 +12,8 @@ The GCP Cloud Storage integration collects Cloud Monitoring metrics from your Cl
 This integration is available on SigNoz Cloud and Self-Hosted Enterprise.
 </Admonition>
 
-<Admonition type="warning">
-Cloud Storage is metrics-only today. Log collection is not yet available for this service, so enable **Metrics** to start ingesting data.
+<Admonition type="info">
+GCP Cloud Storage collects metrics only. Enable **Metrics** to start ingesting data.
 </Admonition>
 
 ## Getting started

--- a/data/docs/integrations/gcp/gcp-cloud-integration.mdx
+++ b/data/docs/integrations/gcp/gcp-cloud-integration.mdx
@@ -1,12 +1,12 @@
 ---
-date: 2026-07-30
+date: 2026-08-08
 title: GCP Cloud Integration Setup and Configuration Guide
-description: Connect Google Cloud to SigNoz with the GCP Cloud Integration. Configure the deployment project, region, and monitored projects to collect metrics and logs.
+description: Connect Google Cloud to SigNoz with the GCP Cloud Integration. Configure the deployment project, region, and monitored projects to collect metrics.
 doc_type: howto
 tags: [SigNoz Cloud]
 ---
 
-The GCP Cloud Integration connects your Google Cloud projects to SigNoz so you can collect metrics and logs from supported GCP services and view them on out-of-the-box dashboards. GCP joins AWS and Microsoft Azure as a supported cloud provider in the Integrations module.
+The GCP Cloud Integration connects your Google Cloud projects to SigNoz so you can collect metrics from supported GCP services and view them on out-of-the-box dashboards. GCP joins AWS and Microsoft Azure as a supported cloud provider in the Integrations module.
 
 <Admonition type="info">
 GCP Cloud Integration is available on SigNoz Cloud and Self-Hosted Enterprise. It is distinct from the [manual GCP monitoring guides](https://signoz.io/docs/gcp-monitoring/), which configure the OpenTelemetry Collector yourself. Use this integration for a managed setup driven from the SigNoz UI.
@@ -58,16 +58,20 @@ The deployment region must be a supported GCP region. Supported regions span Afr
 After connecting an account, enable the services you want to monitor:
 
 1. In **Integrations** > **GCP**, select a service (for example, [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/)).
-2. Toggle **Metrics** and **Logs** on or off. Each signal is controlled independently, so you can collect metrics only, logs only, or both.
+2. Toggle **Metrics** on.
 3. Enabling a service creates its out-of-the-box dashboard automatically.
 
 ## Supported services
 
 | Service | Signals |
 |---------|---------|
-| [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/) | Metrics, Logs |
+| [GCP Cloud SQL for PostgreSQL](https://signoz.io/docs/integrations/gcp/cloud-sql-postgresql/) | Metrics |
 | [GCP Cloud Storage](https://signoz.io/docs/integrations/gcp/cloud-storage/) | Metrics |
-| [GCP Kubernetes Engine](https://signoz.io/docs/integrations/gcp/gke/) | Metrics, Logs |
+| [GCP Kubernetes Engine](https://signoz.io/docs/integrations/gcp/gke/) | Metrics |
+
+<Admonition type="info">
+GCP services currently collect metrics only. Each service exposes a **Metrics** toggle.
+</Admonition>
 
 More GCP services will be added in future releases.
 

--- a/data/docs/integrations/gcp/gke.mdx
+++ b/data/docs/integrations/gcp/gke.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-08-08
 title: GCP Kubernetes Engine (GKE) Monitoring and Dashboards
 description: Monitor GCP Kubernetes Engine (GKE) with SigNoz. Collect 16 container, pod, and node metrics on an out-of-the-box dashboard across five sections.
 doc_type: howto
@@ -24,8 +24,8 @@ Once connected:
 
 Enabling the integration creates the **GCP Kubernetes Engine Overview** dashboard automatically. Data starts flowing within a few minutes.
 
-<Admonition type="warning">
-GKE exposes both a **Metrics** and a **Logs** toggle. The 16 metrics below and the overview dashboard are the metrics dataset. A predefined GKE log dataset is not shipped yet, so enable **Metrics** to get the out-of-the-box dashboard. When logs become available they are delivered through the shared GCP Cloud Logging routing described in the [GCP Cloud Integration](https://signoz.io/docs/integrations/gcp/gcp-cloud-integration/) setup.
+<Admonition type="info">
+GCP Kubernetes Engine collects metrics only. Enable **Metrics** to get the out-of-the-box dashboard.
 </Admonition>
 
 ## Data collected


### PR DESCRIPTION
## Description

Product PR #12471 sets `supportedSignals.logs = false` for every GCP Cloud Integration service (Cloud SQL Postgres, Cloud Storage, Compute Engine, GKE, Memorystore Redis). These integrations are metrics-only, and the UI hides the Logs toggle when logs are unsupported. This corrects the docs that still described a logs capability.

- **cloud-sql-postgresql.mdx**: dropped "metrics and logs" prose, changed the enable step to **Metrics** only, added a metrics-only note. Also removed a stray `</content>` closing tag left from the original page.
- **cloud-storage.mdx**: replaced the "log collection not yet available" warning with a metrics-only info note.
- **gke.mdx**: replaced the "Metrics and Logs toggle / log dataset not shipped yet" warning with a metrics-only info note.
- **gcp-cloud-integration.mdx**: corrected the overview sentence, the enable-a-service step, and the supported-services signals table to metrics-only.
- Updated the `date` frontmatter to today on all four files.

The account-level Pub/Sub / log-delivery connection config is intentionally left unchanged: `deploymentProjectId` remains a required field in the connection schema (unaffected by #12471).

No screenshots: GCP is not yet present on the demo environment (AWS and Azure only), so this batch is prose-only.

## Issues closed by this PR

Source PRs: #12471

Auto-generated by docs-sync pipeline