### PR TITLE
feat(agent): publish .well-known MCP discovery metadata

### DIFF
--- a/app/(site)/.well-known/mcp.json/route.ts
+++ b/app/(site)/.well-known/mcp.json/route.ts
@@ -1,7 +1,7 @@
 import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
 import { agentResponse } from '@/utils/agentResponseHeaders'
 
-export async function GET(request: Request) {
+export async function GET() {
   const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
-  return agentResponse(request, body, { contentType: 'application/json; charset=utf-8' })
+  return agentResponse(body, { contentType: 'application/json; charset=utf-8' })
 }

--- a/app/(site)/.well-known/mcp.json/route.ts
+++ b/app/(site)/.well-known/mcp.json/route.ts
@@ -1,7 +1,1 @@
-import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
-import { agentResponse } from '@/utils/agentResponseHeaders'
-
-export async function GET() {
-  const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
-  return agentResponse(body, { contentType: 'application/json; charset=utf-8' })
-}
+export { mcpDiscoveryResponse as GET } from '@/utils/docs/buildMcpDiscoveryDocument'

--- a/app/(site)/.well-known/mcp.json/route.ts
+++ b/app/(site)/.well-known/mcp.json/route.ts
@@ -1,0 +1,7 @@
+import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
+import { agentResponse } from '@/utils/agentResponseHeaders'
+
+export async function GET(request: Request) {
+  const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
+  return agentResponse(request, body, { contentType: 'application/json; charset=utf-8' })
+}

--- a/app/(site)/.well-known/mcp/route.ts
+++ b/app/(site)/.well-known/mcp/route.ts
@@ -1,7 +1,7 @@
 import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
 import { agentResponse } from '@/utils/agentResponseHeaders'
 
-export async function GET(request: Request) {
+export async function GET() {
   const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
-  return agentResponse(request, body, { contentType: 'application/json; charset=utf-8' })
+  return agentResponse(body, { contentType: 'application/json; charset=utf-8' })
 }

--- a/app/(site)/.well-known/mcp/route.ts
+++ b/app/(site)/.well-known/mcp/route.ts
@@ -1,7 +1,1 @@
-import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
-import { agentResponse } from '@/utils/agentResponseHeaders'
-
-export async function GET() {
-  const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
-  return agentResponse(body, { contentType: 'application/json; charset=utf-8' })
-}
+export { mcpDiscoveryResponse as GET } from '@/utils/docs/buildMcpDiscoveryDocument'

--- a/app/(site)/.well-known/mcp/route.ts
+++ b/app/(site)/.well-known/mcp/route.ts
@@ -1,0 +1,7 @@
+import { getMcpDiscoveryDocument } from '@/utils/docs/buildMcpDiscoveryDocument'
+import { agentResponse } from '@/utils/agentResponseHeaders'
+
+export async function GET(request: Request) {
+  const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
+  return agentResponse(request, body, { contentType: 'application/json; charset=utf-8' })
+}

--- a/tests/agent-markdown-routing.test.js
+++ b/tests/agent-markdown-routing.test.js
@@ -93,6 +93,7 @@ test('shouldRewritePageToMarkdown excludes docs, api, api-reference, and content
   assert.equal(shouldRewritePageToMarkdown('/docs-onboarding/foo', true), false)
   assert.equal(shouldRewritePageToMarkdown('/api/page-markdown/pricing', true), false)
   assert.equal(shouldRewritePageToMarkdown('/api-reference/latest', true), false)
+  assert.equal(shouldRewritePageToMarkdown('/.well-known/mcp', true), false)
   assert.equal(shouldRewritePageToMarkdown('/blog/some-post.md', false), false)
   assert.equal(shouldRewritePageToMarkdown('/blog/some-post', true), false)
 })

--- a/tests/mcp-discovery.test.js
+++ b/tests/mcp-discovery.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { buildMcpDiscoveryDocument, MCP_URL_TEMPLATE } = loadTsModule(
+  'utils/docs/buildMcpDiscoveryDocument.ts'
+)
+const { GET: getMcpJson } = loadTsModule('app/(site)/.well-known/mcp.json/route.ts')
+const { GET: getMcp } = loadTsModule('app/(site)/.well-known/mcp/route.ts')
+
+const SERVER_URL_PATTERN = /^https:\/\/mcp\.[^.]+\.signoz\.cloud\/mcp$/
+
+const assertDiscoverySchema = (document) => {
+  assert.equal(document.version, '1.0.0')
+  assert.equal(document.transport, 'http')
+  assert.equal(typeof document.url, 'string')
+  assert.equal(Array.isArray(document.servers), true)
+  assert.equal(document.servers.length > 0, true)
+
+  document.servers.forEach((server) => {
+    assert.equal(typeof server.name, 'string')
+    assert.match(server.url, SERVER_URL_PATTERN)
+    assert.equal(server.transport, 'http')
+    assert.equal(server.authentication, 'oauth2')
+  })
+}
+
+test('discovery document lists one server per control-plane region', () => {
+  const document = buildMcpDiscoveryDocument(['us', 'eu', 'in'])
+
+  assertDiscoverySchema(document)
+  assert.deepEqual(
+    document.servers.map((server) => server.url),
+    ['us', 'eu', 'in'].map((region) => `https://mcp.${region}.signoz.cloud/mcp`)
+  )
+})
+
+test('discovery document falls back to the <region> placeholder with instructions', () => {
+  const document = buildMcpDiscoveryDocument([])
+
+  assert.equal(document.servers.length, 1)
+  assert.equal(document.servers[0].url, MCP_URL_TEMPLATE)
+  assert.equal(document.servers[0].url.includes('<region>'), true)
+  assert.match(document.servers[0].description, /Replace <region> with your SigNoz Cloud region/)
+})
+
+test('discovery document keeps the region placeholder as the canonical url', () => {
+  const document = buildMcpDiscoveryDocument(['us', 'eu'])
+
+  assert.equal(document.url, MCP_URL_TEMPLATE)
+  assert.match(document.instructions, /Replace <region> with your SigNoz Cloud region/)
+})
+
+test('discovery document records the authentication model and self-hosted path', () => {
+  const document = buildMcpDiscoveryDocument(['us'])
+
+  assert.equal(document.authentication.type, 'oauth2')
+  assert.match(document.authentication.description, /OAuth 2\.1/)
+  assert.match(document.authentication.description, /SIGNOZ-API-KEY/)
+  assert.equal(document.documentation, 'https://signoz.io/docs/ai/signoz-mcp-server/')
+  assert.equal(document.selfHosted.repository, 'https://github.com/SigNoz/signoz-mcp-server')
+})
+
+const fetchRouteBody = async (handler, url) => {
+  const response = await handler(new Request(url))
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('content-type'), /^application\/json/)
+  return response.text()
+}
+
+test('both .well-known routes serve the same valid discovery JSON', async () => {
+  const [json, bare] = await Promise.all([
+    fetchRouteBody(getMcpJson, 'https://signoz.io/.well-known/mcp.json'),
+    fetchRouteBody(getMcp, 'https://signoz.io/.well-known/mcp'),
+  ])
+
+  assert.equal(bare, json)
+
+  const document = JSON.parse(json)
+  const serverUrls = document.servers.map((server) => server.url)
+  assert.equal(document.version, '1.0.0')
+  assert.equal(document.transport, 'http')
+  serverUrls.forEach((url) => {
+    assert.equal(SERVER_URL_PATTERN.test(url) || url === MCP_URL_TEMPLATE, true, url)
+  })
+})

--- a/utils/agentMarkdownRouting.ts
+++ b/utils/agentMarkdownRouting.ts
@@ -91,7 +91,13 @@ export const buildContentMarkdownRewritePath = (pathname: string): string => {
 
 // Paths with their own markdown/negotiation handling, or that must never be
 // rewritten to the generic page pipeline.
-const PAGE_MARKDOWN_EXCLUDED_PREFIXES = ['/api', '/docs', '/docs-onboarding', '/api-reference']
+const PAGE_MARKDOWN_EXCLUDED_PREFIXES = [
+  '/api',
+  '/docs',
+  '/docs-onboarding',
+  '/api-reference',
+  '/.well-known',
+]
 
 // Real .md resources served by their own routes; the suffix is part of the
 // path, not a markdown-alternate marker.

--- a/utils/docs/buildMcpDiscoveryDocument.ts
+++ b/utils/docs/buildMcpDiscoveryDocument.ts
@@ -1,4 +1,5 @@
 import siteMetadata from '@/data/siteMetadata'
+import { agentResponse } from '@/utils/agentResponseHeaders'
 
 export const MCP_URL_TEMPLATE = 'https://mcp.<region>.signoz.cloud/mcp'
 
@@ -67,4 +68,9 @@ export function buildMcpDiscoveryDocument(regionNames: string[]) {
 
 export async function getMcpDiscoveryDocument() {
   return buildMcpDiscoveryDocument(await fetchRegionNames())
+}
+
+export async function mcpDiscoveryResponse() {
+  const body = JSON.stringify(await getMcpDiscoveryDocument(), null, 2)
+  return agentResponse(body, { contentType: 'application/json; charset=utf-8' })
 }

--- a/utils/docs/buildMcpDiscoveryDocument.ts
+++ b/utils/docs/buildMcpDiscoveryDocument.ts
@@ -1,0 +1,70 @@
+import siteMetadata from '@/data/siteMetadata'
+
+export const MCP_URL_TEMPLATE = 'https://mcp.<region>.signoz.cloud/mcp'
+
+export const REGION_INSTRUCTIONS =
+  'Replace <region> with your SigNoz Cloud region. Find it under Settings → Ingestion in SigNoz, or see https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint. Using the wrong region fails authentication.'
+
+type ControlPlaneRegion = { name?: string }
+type ControlPlaneRegionsResponse = { status?: string; data?: ControlPlaneRegion[] }
+
+const fetchRegionNames = async (): Promise<string[]> => {
+  const controlPlaneUrl = process.env.NEXT_PUBLIC_CONTROL_PLANE_URL
+  if (!controlPlaneUrl) return []
+
+  try {
+    const response = await fetch(`${controlPlaneUrl}/regions`, { next: { revalidate: 3600 } })
+    const data: ControlPlaneRegionsResponse = await response.json()
+    if (data.status === 'success' && data.data && data.data.length > 0) {
+      return data.data.map((region) => region.name).filter((name): name is string => Boolean(name))
+    }
+  } catch {
+    // Fall through to the placeholder server below.
+  }
+
+  return []
+}
+
+const regionServer = (region: string) => ({
+  name: `signoz-cloud-${region}`,
+  description: `SigNoz Cloud MCP server for the ${region} region.`,
+  url: `https://mcp.${region}.signoz.cloud/mcp`,
+  transport: 'http',
+  authentication: 'oauth2',
+})
+
+const placeholderServer = () => ({
+  name: 'signoz-cloud',
+  description: `SigNoz Cloud MCP server. ${REGION_INSTRUCTIONS}`,
+  url: MCP_URL_TEMPLATE,
+  transport: 'http',
+  authentication: 'oauth2',
+})
+
+export function buildMcpDiscoveryDocument(regionNames: string[]) {
+  return {
+    version: '1.0.0',
+    name: 'SigNoz',
+    description:
+      'SigNoz Cloud hosted MCP servers for querying your observability data (metrics, traces, logs, alerts, dashboards) through natural language. Connect to the regional endpoint that matches your SigNoz Cloud account.',
+    transport: 'http',
+    url: MCP_URL_TEMPLATE,
+    instructions: REGION_INSTRUCTIONS,
+    documentation: `${siteMetadata.siteUrl}/docs/ai/signoz-mcp-server/`,
+    authentication: {
+      type: 'oauth2',
+      description:
+        'OAuth 2.1 with Dynamic Client Registration (RFC 7591) and Authorization Code + PKCE; auth endpoints are discovered from the server metadata. Clients that cannot run interactive OAuth flows can instead send SIGNOZ-API-KEY and X-SigNoz-URL request headers.',
+    },
+    servers: regionNames.length > 0 ? regionNames.map(regionServer) : [placeholderServer()],
+    selfHosted: {
+      description:
+        'Self-hosted SigNoz users run the open-source MCP server locally over stdio or HTTP.',
+      repository: 'https://github.com/SigNoz/signoz-mcp-server',
+    },
+  }
+}
+
+export async function getMcpDiscoveryDocument() {
+  return buildMcpDiscoveryDocument(await fetchRegionNames())
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

This PR publishes `.well-known` MCP discovery metadata so agents can find the SigNoz MCP servers from the site root.


#### Screenshots / Screen Recordings (if applicable)

Served mcp.json on preview

<img width="2880" height="1724" alt="pr09-mcp-json" src="https://github.com/user-attachments/assets/011bc42b-2a97-4192-8beb-8bb444c0d069" />

#### Issues closed by this PR

Closes SigNoz/growth-pod#1181

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---


### 🧪 Testing Strategy

- Tests added/updated: Done
- Manual verification: Done on preview
  - `GET /.well-known/mcp.json`: 200, `content-type: application/json; charset=utf-8`, 1,857 bytes, 0.5s warm.
  - `GET /.well-known/mcp`: 200 directly (no 308 redirect, contrary to the plan's dot-directory concern), byte-identical body to `mcp.json`.
  - Live region fetch working: preview lists 3 servers (us, us2, in2) because the staging control plane returns 3; production control plane returns 6 regions (us, us2, eu, eu2, in, in2), so production will list all 6 regional MCP servers.
- Edge cases covered:
  - `Accept: text/markdown` on `/.well-known/mcp`: still serves JSON (exclusion prefix works, no pipeline rewrite).
  - `/.well-known/mcp.json.md`: 404.
  - Control-plane failure path: unit-tested fallback to the placeholder server (never an empty `servers[]`, never a 500).

---

### ⚠️ Risk & Impact Assessment

- Blast radius: two new routes plus one prefix added to the proxy's page-markdown exclusion list, evaluated per non-docs page request. No existing route or page changes; the control-plane fetch happens only inside the new routes with a 1-hour revalidate.
- Potential regressions: if the control plane changes its `/regions` response shape, the document degrades to the placeholder server, not an error. If the exclusion prefix were wrong, `/.well-known/*` would be rewritten and 404; the routing test plus preview verification rule this out.
- Rollback plan: revert the pr.

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (additive routes; exclusion verified against the page-markdown pipeline; `noindex` header, no sitemap/robots changes)

---

## 👀 Notes for Reviewers


---
