### PR TITLE
feat(layout): add ask in ai row in footer

### DIFF
--- a/components/AskAIRow/AskAIRow.test.tsx
+++ b/components/AskAIRow/AskAIRow.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AskAIRow from './AskAIRow'
+import { buildAgentPrompt } from '../OpenInAI/OpenInAI.utils'
+
+const mockLogEvent = vi.fn()
+vi.mock('@/hooks/useLogEvent', () => ({
+  useLogEvent: () => mockLogEvent,
+}))
+
+const mockPathname = vi.fn(() => '/docs/install/')
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}))
+
+const openSpy = vi.fn()
+
+beforeEach(() => {
+  mockLogEvent.mockClear()
+  openSpy.mockClear()
+  mockPathname.mockReturnValue('/docs/install/')
+  vi.stubGlobal('open', openSpy)
+})
+
+describe('AskAIRow', () => {
+  it('renders the label and one button per AI provider', () => {
+    render(<AskAIRow />)
+
+    expect(screen.getByText('Ask AI about this page')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open in ChatGPT' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open in Claude' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open in Perplexity' })).toBeTruthy()
+  })
+
+  it('is marked as human-only chrome for markdown parity', () => {
+    const { container } = render(<AskAIRow />)
+
+    expect(container.firstElementChild?.hasAttribute('data-markdown-ignore')).toBe(true)
+  })
+
+  it('opens the provider with a prompt for the current page .md URL', () => {
+    mockPathname.mockReturnValue('/pricing/')
+    render(<AskAIRow />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in Claude' }))
+
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const [url, target, features] = openSpy.mock.calls[0]
+    expect(target).toBe('_blank')
+    expect(features).toBe('noopener,noreferrer')
+    expect(url).toContain('https://claude.ai/new?q=')
+    const prompt = decodeURIComponent(url.split('q=')[1])
+    expect(prompt).toContain('/pricing.md')
+    expect(prompt).toContain('https://signoz.io/llms.txt')
+  })
+
+  it('tracks clicks with the footer location and page path', () => {
+    render(<AskAIRow />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in ChatGPT' }))
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: 'Website Click',
+        attributes: expect.objectContaining({
+          clickName: 'ask_ai_chatgpt',
+          clickLocation: 'footer',
+          pagePath: '/docs/install/',
+        }),
+      })
+    )
+  })
+})
+
+describe('buildAgentPrompt', () => {
+  it('references the .md URL and llms.txt', () => {
+    const prompt = buildAgentPrompt('https://signoz.io/docs/install/')
+
+    expect(prompt).toContain('https://signoz.io/docs/install.md')
+    expect(prompt).not.toContain('install/.md')
+    expect(prompt).toContain('https://signoz.io/llms.txt')
+  })
+
+  it('keeps the homepage URL as-is instead of a broken .md suffix', () => {
+    const prompt = buildAgentPrompt('https://signoz.io/')
+
+    expect(prompt).toContain('Read https://signoz.io/ ')
+    expect(prompt).not.toContain('signoz.io.md')
+  })
+})

--- a/components/AskAIRow/AskAIRow.test.tsx
+++ b/components/AskAIRow/AskAIRow.test.tsx
@@ -26,10 +26,18 @@ describe('AskAIRow', () => {
   it('renders the label and one button per AI provider', () => {
     render(<AskAIRow />)
 
-    expect(screen.getByText('Ask AI about this page')).toBeTruthy()
+    expect(screen.getByText('Ask AI about SigNoz')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Open in ChatGPT' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Open in Claude' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open in AI Mode' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Open in Perplexity' })).toBeTruthy()
+  })
+
+  it('lists AI Mode before Perplexity', () => {
+    render(<AskAIRow />)
+
+    const labels = screen.getAllByRole('button').map((button) => button.getAttribute('aria-label'))
+    expect(labels.indexOf('Open in AI Mode')).toBeLessThan(labels.indexOf('Open in Perplexity'))
   })
 
   it('is marked as human-only chrome for markdown parity', () => {
@@ -38,8 +46,7 @@ describe('AskAIRow', () => {
     expect(container.firstElementChild?.hasAttribute('data-markdown-ignore')).toBe(true)
   })
 
-  it('opens the provider with a prompt for the current page .md URL', () => {
-    mockPathname.mockReturnValue('/pricing/')
+  it('opens every provider with the shared SigNoz prompt', () => {
     render(<AskAIRow />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Open in Claude' }))
@@ -50,11 +57,22 @@ describe('AskAIRow', () => {
     expect(features).toBe('noopener,noreferrer')
     expect(url).toContain('https://claude.ai/new?q=')
     const prompt = decodeURIComponent(url.split('q=')[1])
-    expect(prompt).toContain('/pricing.md')
-    expect(prompt).toContain('https://signoz.io/llms.txt')
+    expect(prompt).toContain('I want to learn more about SigNoz Cloud')
+    expect(prompt).toContain('https://signoz.io/agent-native-observability')
   })
 
-  it('tracks clicks with the footer location and page path', () => {
+  it('opens AI Mode as a Google search with udm=50', () => {
+    render(<AskAIRow />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in AI Mode' }))
+
+    const [url] = openSpy.mock.calls[0]
+    expect(url).toContain('https://www.google.com/search?udm=50&q=')
+    const prompt = decodeURIComponent(url.split('q=')[1])
+    expect(prompt).toContain('I want to learn more about SigNoz Cloud')
+  })
+
+  it('tracks clicks with the shared clickName and provider in clickText', () => {
     render(<AskAIRow />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Open in ChatGPT' }))
@@ -63,9 +81,11 @@ describe('AskAIRow', () => {
       expect.objectContaining({
         eventName: 'Website Click',
         attributes: expect.objectContaining({
-          clickName: 'ask_ai_chatgpt',
-          clickLocation: 'footer',
-          pagePath: '/docs/install/',
+          clickType: 'External Click',
+          clickName: 'Open in AI Button',
+          clickText: 'ChatGPT',
+          clickLocation: 'Footer',
+          pageLocation: '/docs/install/',
         }),
       })
     )

--- a/components/AskAIRow/AskAIRow.tsx
+++ b/components/AskAIRow/AskAIRow.tsx
@@ -1,42 +1,76 @@
 'use client'
 
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback } from 'react'
 import { usePathname } from 'next/navigation'
 import { ArrowUpRight } from 'lucide-react'
+import type { IconType } from 'react-icons'
+import { SiClaude, SiGooglegemini, SiOpenai, SiPerplexity } from 'react-icons/si'
 
 import { cn } from '../../app/lib/utils'
 import { useLogEvent } from '@/hooks/useLogEvent'
 
-import { AI_OPTIONS } from '../OpenInAI/OpenInAI.constants'
-import type { AIOption } from '../OpenInAI/OpenInAI.types'
-import { getAbsoluteUrl } from '../OpenInAI/OpenInAI.utils'
+const ASK_AI_PROMPT = `I want to learn more about SigNoz Cloud which brings traces, metrics, and logs into one OpenTelemetry-native platform, with simple usage-based pricing and the freedom to run it on our own infrastructure.
+Read https://signoz.io/, https://signoz.io/docs, and https://signoz.io/agent-native-observability. Explain what SigNoz does, how engineers and AI agents use it to find and troubleshoot production issues, what it integrates with, and how it differs from other monitoring tools. Use clear examples and include links to your sources.`
+
+const ENCODED_PROMPT = encodeURIComponent(ASK_AI_PROMPT)
+
+type AskAIProvider = {
+  id: string
+  label: string
+  Icon: IconType
+  url: string
+}
+
+const ASK_AI_PROVIDERS: AskAIProvider[] = [
+  {
+    id: 'chatgpt',
+    label: 'ChatGPT',
+    Icon: SiOpenai,
+    url: `https://chatgpt.com/?hints=search&q=${ENCODED_PROMPT}`,
+  },
+  {
+    id: 'claude',
+    label: 'Claude',
+    Icon: SiClaude,
+    url: `https://claude.ai/new?q=${ENCODED_PROMPT}`,
+  },
+  {
+    id: 'ai-mode',
+    label: 'AI Mode',
+    Icon: SiGooglegemini,
+    url: `https://www.google.com/search?udm=50&q=${ENCODED_PROMPT}`,
+  },
+  {
+    id: 'perplexity',
+    label: 'Perplexity',
+    Icon: SiPerplexity,
+    url: `https://www.perplexity.ai/search/new?q=${ENCODED_PROMPT}`,
+  },
+]
 
 const buttonClass =
   'inline-flex h-8 items-center gap-1.5 rounded-[4px] border border-[var(--l1-border)] bg-[var(--l2-background-60)] px-2.5 text-[13px] leading-none text-[var(--l2-foreground)] transition-colors hover:bg-[var(--l1-background-hover)] hover:text-[var(--l1-foreground-hover)]'
 
-const providerLabel = (option: AIOption): string => option.name.replace(/^Open in /, '')
-
 function AskAIRow({ className }: { className?: string }) {
   const pathname = usePathname()
   const logEvent = useLogEvent()
-  const absolutePageUrl = useMemo(() => getAbsoluteUrl(pathname || '/'), [pathname])
 
   const handleClick = useCallback(
-    (option: AIOption) => {
+    (provider: AskAIProvider) => {
       logEvent({
         eventName: 'Website Click',
         eventType: 'track',
         attributes: {
-          clickType: 'button',
-          clickName: `ask_ai_${option.id}`,
-          clickLocation: 'footer',
-          clickText: option.name,
-          pagePath: pathname,
+          clickType: 'External Click',
+          clickName: 'Open in AI Button',
+          clickText: provider.label,
+          clickLocation: 'Footer',
+          pageLocation: pathname,
         },
       })
-      window.open(option.getUrl(absolutePageUrl), '_blank', 'noopener,noreferrer')
+      window.open(provider.url, '_blank', 'noopener,noreferrer')
     },
-    [logEvent, absolutePageUrl, pathname]
+    [logEvent, pathname]
   )
 
   return (
@@ -44,21 +78,19 @@ function AskAIRow({ className }: { className?: string }) {
       data-markdown-ignore=""
       className={cn('flex flex-wrap items-center gap-x-4 gap-y-3', className)}
     >
-      <span className="text-sm font-medium text-[var(--l2-foreground)]">
-        Ask AI about this page
-      </span>
+      <span className="text-sm font-medium text-[var(--l2-foreground)]">Ask AI about SigNoz</span>
       <div className="flex flex-wrap items-center gap-2">
-        {AI_OPTIONS.map((option) => (
+        {ASK_AI_PROVIDERS.map((provider) => (
           <button
-            key={option.id}
+            key={provider.id}
             type="button"
-            onClick={() => handleClick(option)}
+            onClick={() => handleClick(provider)}
             className={buttonClass}
-            aria-label={option.name}
-            title={option.name}
+            aria-label={`Open in ${provider.label}`}
+            title={`Open in ${provider.label}`}
           >
-            <option.Icon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span className="whitespace-nowrap">{providerLabel(option)}</span>
+            <provider.Icon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span className="whitespace-nowrap">{provider.label}</span>
             <ArrowUpRight className="size-3 shrink-0" aria-hidden="true" />
           </button>
         ))}

--- a/components/AskAIRow/AskAIRow.tsx
+++ b/components/AskAIRow/AskAIRow.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { memo, useCallback, useMemo } from 'react'
+import { usePathname } from 'next/navigation'
+import { ArrowUpRight } from 'lucide-react'
+
+import { cn } from '../../app/lib/utils'
+import { useLogEvent } from '@/hooks/useLogEvent'
+
+import { AI_OPTIONS } from '../OpenInAI/OpenInAI.constants'
+import type { AIOption } from '../OpenInAI/OpenInAI.types'
+import { getAbsoluteUrl } from '../OpenInAI/OpenInAI.utils'
+
+const buttonClass =
+  'inline-flex h-8 items-center gap-1.5 rounded-[4px] border border-[var(--l1-border)] bg-[var(--l2-background-60)] px-2.5 text-[13px] leading-none text-[var(--l2-foreground)] transition-colors hover:bg-[var(--l1-background-hover)] hover:text-[var(--l1-foreground-hover)]'
+
+const providerLabel = (option: AIOption): string => option.name.replace(/^Open in /, '')
+
+function AskAIRow({ className }: { className?: string }) {
+  const pathname = usePathname()
+  const logEvent = useLogEvent()
+  const absolutePageUrl = useMemo(() => getAbsoluteUrl(pathname || '/'), [pathname])
+
+  const handleClick = useCallback(
+    (option: AIOption) => {
+      logEvent({
+        eventName: 'Website Click',
+        eventType: 'track',
+        attributes: {
+          clickType: 'button',
+          clickName: `ask_ai_${option.id}`,
+          clickLocation: 'footer',
+          clickText: option.name,
+          pagePath: pathname,
+        },
+      })
+      window.open(option.getUrl(absolutePageUrl), '_blank', 'noopener,noreferrer')
+    },
+    [logEvent, absolutePageUrl, pathname]
+  )
+
+  return (
+    <div
+      data-markdown-ignore=""
+      className={cn('flex flex-wrap items-center gap-x-4 gap-y-3', className)}
+    >
+      <span className="text-sm font-medium text-[var(--l2-foreground)]">
+        Ask AI about this page
+      </span>
+      <div className="flex flex-wrap items-center gap-2">
+        {AI_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => handleClick(option)}
+            className={buttonClass}
+            aria-label={option.name}
+            title={option.name}
+          >
+            <option.Icon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span className="whitespace-nowrap">{providerLabel(option)}</span>
+            <ArrowUpRight className="size-3 shrink-0" aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default memo(AskAIRow)

--- a/components/OpenInAI/OpenInAI.utils.ts
+++ b/components/OpenInAI/OpenInAI.utils.ts
@@ -11,14 +11,22 @@ export function getAbsoluteUrl(url: string): string {
   return `${SIGNOZ_BASE_URL}${url.startsWith('/') ? '' : '/'}${url}`
 }
 
+export function buildAgentPrompt(pageUrl: string): string {
+  const trimmed = pageUrl.replace(/\/+$/, '')
+  // The homepage has no .md alternate; every other page does.
+  const isOriginOnly = /^https?:\/\/[^/]+$/.test(trimmed)
+  const readUrl = isOriginOnly ? pageUrl : `${trimmed}.md`
+  return `Read ${readUrl} so I can ask questions about it. For the full SigNoz docs index, see ${SIGNOZ_BASE_URL}/llms.txt.`
+}
+
 export function buildChatGPTUrl(pageUrl: string): string {
-  return `https://chatgpt.com/?hints=search&q=${encodeURIComponent(`Read from ${pageUrl} so I can ask questions about it.`)}`
+  return `https://chatgpt.com/?hints=search&q=${encodeURIComponent(buildAgentPrompt(pageUrl))}`
 }
 
 export function buildClaudeUrl(pageUrl: string): string {
-  return `https://claude.ai/new?q=${encodeURIComponent(`Read from ${pageUrl} so I can ask questions about it.`)}`
+  return `https://claude.ai/new?q=${encodeURIComponent(buildAgentPrompt(pageUrl))}`
 }
 
 export function buildPerplexityUrl(pageUrl: string): string {
-  return `https://www.perplexity.ai/search/new?q=${encodeURIComponent(`Read from ${pageUrl} so I can ask questions about it.`)}`
+  return `https://www.perplexity.ai/search/new?q=${encodeURIComponent(buildAgentPrompt(pageUrl))}`
 }

--- a/components/mainFooter.tsx
+++ b/components/mainFooter.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image'
 import { Github, Linkedin, Slack, Twitter, Youtube } from '@/components/social-icons/SolidIcons'
 import { usePathname } from 'next/navigation'
 import { cn } from 'app/lib/utils'
+import AskAIRow from '@/components/AskAIRow/AskAIRow'
 import './footer/footer-pill-links.css'
 
 type FooterPillLinkProps = {
@@ -333,6 +334,16 @@ function Footer({ inDocsShell = false }: FooterProps) {
               </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        className={cn(
+          'flex w-full min-w-0 items-center border-t border-solid border-[var(--l1-border)] px-4 py-6',
+          inDocsShell ? 'justify-start' : 'justify-center'
+        )}
+      >
+        <div className="w-full min-w-0 max-w-8xl">
+          <AskAIRow />
         </div>
       </div>
     </div>

--- a/components/mainFooter.tsx
+++ b/components/mainFooter.tsx
@@ -338,8 +338,9 @@ function Footer({ inDocsShell = false }: FooterProps) {
       </div>
       <div
         className={cn(
-          'flex w-full min-w-0 items-center border-t border-solid border-[var(--l1-border)] px-4 py-6',
-          inDocsShell ? 'justify-start' : 'justify-center'
+          'flex w-full min-w-0 items-center border-t border-solid border-[var(--l1-border)] px-4 pt-6',
+          // Docs pages float the fixed NozPeek dock over the page bottom; leave room so the row stays clickable.
+          inDocsShell ? 'justify-start pb-24' : 'justify-center pb-6'
         )}
       >
         <div className="w-full min-w-0 max-w-8xl">


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

This PR adds an "Ask AI about SigNoz" row to the site footer so visitors can hand SigNoz to their AI assistant with one click.

#### Screenshots / Screen Recordings (if applicable)

<img width="1531" height="648" alt="Screenshot 2026-08-13 at 16 18 19" src="https://github.com/user-attachments/assets/566d2797-265b-4101-8c3d-ba264828c5d5" />


#### Issues closed by this PR

Closes SigNoz/growth-pod#1186

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: Added
- Manual verification: Done on preview, visual and click check prompt validation only + stack smoke test
  - Visual check on docs (left-aligned, clear of the NozPeek dock) and homepage (centered) - screenshots above.
- Edge cases covered:
  - Trailing-slash and origin-only URLs in `buildAgentPrompt` (unit-tested).

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `mainFooter.tsx` renders on every page, so the row is visible site-wide. The component is memoized, client-side only, and reads nothing but `usePathname`; the three existing docs-header OpenInAI buttons share the new prompt builder, so their prompt text changes too (now referencing `.md` + llms.txt).
- Potential regressions: layout shift in the footer (bounded: a single bordered row appended after the existing footer content, verified visually on docs and home); provider prefill URL formats could change upstream, degrading to the provider's blank input rather than an error.
- Rollback plan: revert the pr.


---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (additive UI; markdown outputs unchanged via `data-markdown-ignore`; existing OpenInAI buttons keep working with the improved prompt)

---

## 👀 Notes for Reviewers


---
