### PR TITLE
docs(llm): redirect the LLM observability blog post to the docs hub

### DIFF
--- a/data/blog/langchain-observability-with-opentelemetry.mdx
+++ b/data/blog/langchain-observability-with-opentelemetry.mdx
@@ -8,7 +8,7 @@ keywords: [monitor, observe, opentelemetry, LangChain, agent, SigNoz]
 related_articles:
   - '/blog/llm-observability-opentelemetry'
   - '/blog/monitoring-langchain-agent-querying-signoz-mcp-server'
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/comparisons/llm-observability-tools'
 ---
 

--- a/data/blog/opentelemetry-llamaindex.mdx
+++ b/data/blog/opentelemetry-llamaindex.mdx
@@ -8,7 +8,7 @@ keywords: [monitor, observe, opentelemetry, LlamaIndex, integrations, SigNoz]
 related_articles:
   - '/blog/langchain-observability-with-opentelemetry'
   - '/blog/llm-observability-opentelemetry'
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/blog/opentelemetry-vercel-ai-sdk'
 ---
 

--- a/data/comparisons/langsmith-alternatives.mdx
+++ b/data/comparisons/langsmith-alternatives.mdx
@@ -11,7 +11,7 @@ keywords: ["langsmith alternatives", "langsmith alternative", "llm observability
 related_articles:
   - '/comparisons/llm-observability-tools'
   - '/blog/distributed-tracing-in-microservices'
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/blog/llm-observability-opentelemetry'
   - '/comparisons/better-stack-alternatives'
 

--- a/data/comparisons/llm-observability-tools.mdx
+++ b/data/comparisons/llm-observability-tools.mdx
@@ -30,7 +30,7 @@ Observability in LLMs means tracking prompt performance over time, tracing how m
 
 <KeyPointCallout title="Evolving LLM Observability Standards">
 
-The [LLM-observability](https://signoz.io/blog/llm-observability/) landscape has converged on OpenTelemetry's GenAI semantic conventions as the vendor-neutral baseline: the `gen_ai.*` attributes standardize how prompts, model names, token usage, and tool or agent calls are recorded, and most tools now ingest them (it is a CNCF-backed standard). The practical 2026 differentiator is whether a tool is OpenTelemetry-native, accepting `gen_ai.*` spans through your existing [Collector](https://signoz.io/blog/opentelemetry-collector-complete-guide/) pipeline, or requires a proprietary SDK and a parallel instrumentation path. 
+The [LLM-observability](https://signoz.io/docs/llm-observability/) landscape has converged on OpenTelemetry's GenAI semantic conventions as the vendor-neutral baseline: the `gen_ai.*` attributes standardize how prompts, model names, token usage, and tool or agent calls are recorded, and most tools now ingest them (it is a CNCF-backed standard). The practical 2026 differentiator is whether a tool is OpenTelemetry-native, accepting `gen_ai.*` spans through your existing [Collector](https://signoz.io/blog/opentelemetry-collector-complete-guide/) pipeline, or requires a proprietary SDK and a parallel instrumentation path. 
 
 To see these `gen_ai.*` conventions in action, check out our hands-on guide to [observing LLM applications with OpenTelemetry](https://signoz.io/blog/opentelemetry-llm/).
 

--- a/data/guides/ai-observability.mdx
+++ b/data/guides/ai-observability.mdx
@@ -7,7 +7,7 @@ authors: [sushant_gaurav]
 description: Explore AI observability's role in enhancing ML model performance. Learn key components, best practices, and implementation strategies for robust AI systems.
 keywords: [AI observability, machine learning, model performance, data quality, system health, responsible AI]
 related_articles:
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/guides/model-monitoring'
   - '/guides/observability-architecture'
   - '/guides/network-observability'

--- a/data/guides/llmops.mdx
+++ b/data/guides/llmops.mdx
@@ -7,7 +7,7 @@ authors: [sushant_gaurav]
 description: Discover LLMOps - the key to managing large language models effectively. Learn best practices, and implementation strategies, and overcome challenges in AI operations.
 keywords: [LLMOps, AI operations, language models, MLOps, AI development, model monitoring, SigNoz]
 related_articles:
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/guides/model-monitoring'
   - '/guides/ai-observability'
   - '/guides/claude-api-latency'

--- a/data/guides/model-monitoring.mdx
+++ b/data/guides/model-monitoring.mdx
@@ -10,7 +10,7 @@ description: "Model monitoring for machine learning in 2026: detect data drift, 
 keywords: [model monitoring, machine learning, ML production, data drift, model performance, AI observability]
 related_articles:
   - '/guides/ai-observability'
-  - '/blog/llm-observability'
+  - '/docs/llm-observability'
   - '/guides/aws-monitoring'
   - '/guides/database-monitoring'
   - '/guides/llmops'

--- a/next.config.js
+++ b/next.config.js
@@ -3063,11 +3063,6 @@ module.exports = () => {
           destination: '/docs/llm-observability/',
           permanent: true,
         },
-        {
-          source: '/blog/llm-observability',
-          destination: '/docs/llm-observability/',
-          permanent: true,
-        },
       ])
     },
     webpack: (config, options) => {

--- a/next.config.js
+++ b/next.config.js
@@ -3058,6 +3058,16 @@ module.exports = () => {
           destination: '/docs/integrations/gcp/collect-metrics/',
           permanent: true,
         },
+        {
+          source: '/blog/llm-observability/',
+          destination: '/docs/llm-observability/',
+          permanent: true,
+        },
+        {
+          source: '/blog/llm-observability',
+          destination: '/docs/llm-observability/',
+          permanent: true,
+        },
       ])
     },
     webpack: (config, options) => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Seven SigNoz URLs compete for the query `llm observability`. Google cycles between them and ranks all of them badly. Search Console, trailing twelve months, filtered to that query:

| URL | Impressions | Clicks | Position |
|---|---|---|---|
| `/blog/llm-observability/` | 6,888 (65%) | 1 | 52.8 |
| `/docs/llm-observability/` | 3,442 | 11 | 33.1 |
| `/blog/llm-observability-opentelemetry/` | 88 | 2 | 10.8 |
| `/llm-observability/` | 80 | 0 | 44.4 |
| **total across 7 URLs** | **10,645** | **14** | |

The blog post absorbs 65% of the impressions and converts one of them, from position 52.8. The docs hub earns 11 of the 14 clicks on a third of the impressions, so it is the designated canonical page.

**The blog post is not worth defending on its own.** Across all its queries it earns 35 clicks a year from 32,226 impressions, and 32 of those 35 are branded (`signoz llm observability`, `signoz llm`). That is three non-branded clicks in twelve months, and 534 of its 540 queries produce zero clicks. The redirect costs almost nothing and passes two years of accumulated links to the destination.

**The change is a redirect pair plus seven link updates:**

```js
{ source: '/blog/llm-observability/', destination: '/docs/llm-observability/', permanent: true },
{ source: '/blog/llm-observability',  destination: '/docs/llm-observability/', permanent: true },
```

`permanent: true` emits a 301. Both slash variants are paired, matching the convention used by the surrounding entries.

**`data/blog/llm-observability.mdx` is deliberately retained.** Only the route is redirected. Next.js evaluates redirects before page resolution, so the file being present does not affect the forward. The consequences are cosmetic but real: the post still emits a sitemap entry (`app/(site)/blogs/sitemap.ts:65` filters only on `excludeFromSitemap`) and still appears in the RSS feed (`app/(site)/rss/rssUtils.ts:134` filters only on `draft`), so both surfaces now advertise a URL that 301s. The repo has a precedent for suppressing exactly this: `data/blog/what-is-opentelemetry.mdx` is retained behind a redirect with `excludeFromSitemap: true` and a comment explaining why. Adding that flag here is a one-line follow-up, deliberately left out of this PR.

**Author approval.** Jaikanth J wrote the post (`authors: [jaikanth]`); Yuvraj Singh Jadon did the 2024-09-12 SEO rewrite that produced the current version. Both have approved the redirect.

**Depends on #3966.** That PR rewrites `/docs/llm-observability/` from 82 words to roughly 2,400. It should merge first or alongside this one. Redirecting onto the current 82-word version would move traffic onto a thinner page than the one it left.

#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

Not a bug fix, but the root cause is worth stating.

#### Root Cause

The blog post (January 2024) and the docs hub were written for different jobs and never reconciled. Both target the same head term, and over two years five more URLs accumulated claims on it. Nothing was wrong with either page in isolation. The damage is only visible when the query is viewed across the whole set, where seven competing URLs split the signal and Google settles on none of them.

#### Fix Strategy

Consolidate onto one canonical URL and give it the accumulated link equity, rather than continuing to run two pages against the same query.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none required. One config file and seven content links, no code paths touched.
- **Manual verification:**
  - `yarn check:doc-redirects` passes: `Doc redirect check passed`
  - `yarn check:stale-urls` passes: `Stale URL check passed. No stale or redirect-source URLs found.`
  - `yarn check:docs-metadata` reports `No documentation files to check`, which is correct here since no file under `data/docs/` changed
  - `yarn test:doc-redirects` passes 13/13
  - `yarn test:stale-urls` passes 19/19
  - `yarn test:docs-metadata` passes 30/30
  - Husky pre-commit passed in full: lint-staged, doc redirect verification, the all-files stale URL scan that `next.config.js` changes trigger, and the CMS asset check for the 7 synced files
  - Confirmed `/blog/llm-observability-opentelemetry/` is untouched. It is a different post, ranks 10.8 for the head term, and every grep was filtered to exclude it.
  - Confirmed none of the eleven frozen control pages from #3904 is touched.
  - Verified `docs` is a supported `related_articles` prefix (`utils/contentRepository.ts:89`) and that `data/docs` is loaded into the local content maps (`utils/contentRepository.ts:327`), so the repointed entries resolve locally without the CMS.
  - Post-edit grep for `blog/llm-observability` across `data/`, `app/`, `components/`, `constants/`, `utils/` and `hooks/`, excluding `llm-observability-opentelemetry`, returns zero hits.
- **Edge cases covered:** `check:stale-urls` does not scan `related_articles` frontmatter. It extracts markdown links, `href=` and `url:` only (`scripts/check-stale-urls.js`, `extractUrls`). Six of the seven references are `related_articles` entries and would not have been caught by it. They were found by grep and fixed by hand.

Inbound references repointed at `/docs/llm-observability/`:

| File | Line | Form |
|---|---|---|
| `data/comparisons/langsmith-alternatives.mdx` | 14 | `related_articles` |
| `data/comparisons/llm-observability-tools.mdx` | 33 | markdown link |
| `data/blog/langchain-observability-with-opentelemetry.mdx` | 11 | `related_articles` |
| `data/blog/opentelemetry-llamaindex.mdx` | 11 | `related_articles` |
| `data/guides/model-monitoring.mdx` | 13 | `related_articles` |
| `data/guides/ai-observability.mdx` | 10 | `related_articles` |
| `data/guides/llmops.mdx` | 10 | `related_articles` |

Three of those files also list `/blog/llm-observability-opentelemetry` in the same `related_articles` array. Those entries are intentionally left alone.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one URL and seven internal links. `/blog/llm-observability/` stops serving and forwards.
- **Potential regressions:**
  - **The 32 branded clicks a year are the real exposure.** People searching `signoz llm observability` currently land on a blog post and will land on a docs hub instead. That is a different page shape for the same intent, and if the docs hub answers them worse, this trades 32 known clicks for an uncertain gain. The bet is that it does not, but the destination has to be the rewritten version for that to hold, which is why #3966 gates this.
  - **Consolidation is not guaranteed to work.** Google may take weeks to months to transfer signals, and cannibalization fixes sometimes fail to lift the survivor. The honest floor is that the blog post's three non-branded clicks a year disappear and nothing replaces them.
  - **Five other URLs still compete on this query.** This PR removes the largest impression sink but does not finish the consolidation. `/llm-observability/` (80 impressions, 0 clicks, position 44.4) is the next candidate. `/blog/llm-observability-opentelemetry/` should be left alone, since it ranks 10.8 and is genuinely a different topic.
  - Sitemap and RSS still list the redirected URL, as described above. Harmless for ranking, untidy for crawlers.
- **Rollback plan:** revert the commit. The MDX file was never deleted, so the post returns to serving immediately with no content restoration needed. That is the main reason retaining the file is defensible.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | `/blog/llm-observability/` now redirects permanently to `/docs/llm-observability/`. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Three things worth a second opinion:

1. **Merge order.** #3966 should land first or alongside. If this merges alone, traffic redirects onto the 82-word hub.
2. **Retaining the MDX is deliberate,** and it runs against the dominant repo precedent: of the 22 blog posts that sat behind redirects in `next.config.js` before this change, 21 have had their source file deleted. The single exception, `what-is-opentelemetry.mdx`, keeps the file and sets `excludeFromSitemap: true`. If you want the sitemap and feed entries gone, that flag is the established way and is a one-line change.
3. **These are the first `/docs/` entries in `related_articles` anywhere in `data/`.** The resolver supports the prefix but it has never been exercised. Worth a glance on a preview deploy to confirm the related-articles widget renders them.

---
