### PR TITLE
fix(docs-nav): skip duplicate route in flattenRoutes

### DIFF
--- a/utils/common.ts
+++ b/utils/common.ts
@@ -6,7 +6,10 @@ function flattenRoutes(navItems) {
   let routes: RoutesProps[] = []
 
   navItems.forEach((item) => {
-    if (item.route) {
+    // Skip category route if it duplicates its first child's route
+    const isDuplicateOfFirstChild = item.items?.[0]?.route === item.route
+
+    if (item.route && !isDuplicateOfFirstChild) {
       routes.push({ route: item.route, label: item.label })
     }
     if (item.items) {

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -7,7 +7,9 @@ function flattenRoutes(navItems) {
 
   navItems.forEach((item) => {
     // Skip category route if it duplicates its first child's route
-    const isDuplicateOfFirstChild = item.items?.[0]?.route === item.route
+    const normalize = (r?: string) => (r?.endsWith('/') ? r.slice(0, -1) : r)
+    const isDuplicateOfFirstChild =
+      !!item.route && normalize(item.items?.[0]?.route) === normalize(item.route)
 
     if (item.route && !isDuplicateOfFirstChild) {
       routes.push({ route: item.route, label: item.label })


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Fixes broken Next button on doc Overview pages. Category root nodes like "Overview" often share a route with their first child page. flattenRoutes listed that route twice, so Next on those pages linked back to the same page. The duplicate is now skipped.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
