### PR TITLE
docs: add v0.137.0 upgrade note for saved-view migrations

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -253,6 +253,11 @@
           },
           {
             "type": "doc",
+            "route": "/docs/operate/migration/upgrade-0-137",
+            "label": "Upgrade to v0.137"
+          },
+          {
+            "type": "doc",
             "route": "/docs/operate/migration/upgrade-0-135",
             "label": "Upgrade to v0.135"
           },

--- a/data/docs/operate/migration/upgrade-0-137.mdx
+++ b/data/docs/operate/migration/upgrade-0-137.mdx
@@ -1,0 +1,62 @@
+---
+date: 2026-08-11
+title: Upgrade SigNoz to v0.137.0 and Repair Saved Views Data
+tags: [Self-Hosted Community, Self-Hosted Enterprise]
+description: Upgrade self-hosted SigNoz to v0.137.0. Automatic migrations repair saved views and remove unrepairable ones, so back up the Metastore before you upgrade.
+doc_type: howto
+---
+
+SigNoz v0.137.0 runs two automatic migrations that repair the stored data behind your saved views (the named filter-and-column presets in the Logs and Traces explorers). Most views are repaired in place with no action needed. A view whose stored data cannot be repaired is deleted, so back up the SigNoz Metastore before you upgrade.
+
+<Admonition type="warning" title="Unrepairable saved views are deleted during the upgrade">
+The repair migration rewrites saved views whose stored spec has unreadable fields. A view that still cannot be parsed field-by-field is removed from the database, and this deletion is not reversible. Back up the Metastore (SQLite or Postgres) before upgrading so you can restore any view that gets dropped.
+</Admonition>
+
+## Who needs to act
+
+| If you | Then |
+| --- | --- |
+| Use saved views only through the UI | Back up the Metastore first. Views are repaired automatically; check your saved views afterward for any that went missing |
+| Call the Saved Views API directly (create, update, get) | [Update your payloads](#saved-views-api-payloads-change-shape): the request and response wire format changes in this release |
+
+## Back up before you upgrade
+
+Saved views live in the SigNoz Metastore alongside dashboards and alerts. Back up the Metastore before starting the upgrade. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops before jumping to v0.137.0.
+
+For the general upgrade steps for your deployment (Foundry, Helm, Docker, or binary), follow the [standard upgrade guide](https://signoz.io/docs/operate/migration/upgrade-standard/).
+
+## What the saved-view migrations do
+
+Two migrations run once, automatically, when the server starts on v0.137.0:
+
+- **Repair unreadable fields.** For each saved view whose stored spec has a field that no longer parses (for example a malformed `selectedFields` entry), the migration resets that field to its empty default and keeps the rest of the view. A view that cannot be parsed field-by-field is deleted and logged with its saved-view ID.
+- **Backfill `requestType`.** Existing views that predate the new required `requestType` field are backfilled so they load correctly under the new schema.
+
+The server logs a summary of how many views were repaired and how many were deleted. If a view you expected is gone after the upgrade, search the server logs for `saved view data could not be repaired` to find the affected saved-view IDs, then restore them from your backup.
+
+## Verify the upgrade
+
+1. Pods and containers are healthy (`kubectl get pods -n signoz`, `docker compose ps`, or `systemctl status 'signoz-*'`).
+2. SigNoz reports v0.137.0 under **Settings**.
+3. Open the **Logs** and **Traces** explorers and confirm your saved views load and apply their filters and columns.
+
+## Saved Views API payloads change shape
+
+If you call the Saved Views API directly (`/api/v2/saved_views` and `/api/v2/saved_views/{id}`), the create, update, and get payloads change in v0.137.0. Update your scripts before you upgrade:
+
+- **The `data` wrapper is removed.** `schemaVersion` and `spec` are now top-level fields on the request and response body instead of nested under `data`. Callers that read `response.data.data.spec.*` must change to `response.data.spec.*`.
+- **`spec` now requires `requestType`.** Set it to one of `raw`, `trace`, `time_series`, or `scalar`.
+- **`spec.queries` must contain at least one item.** An empty `queries` array is rejected with `400 Bad Request`.
+- **`selectedFields` and `display` are optional.** Omitting them reads back as empty defaults.
+- **`schemaVersion` is enforced as `v2`.** It is the only accepted value.
+- **Duplicate names return `409 Conflict`.** Creating a saved view whose name already exists in the org now fails with `409` instead of undefined behavior.
+
+For the full request and response schema, see the Saved Views endpoints in the [SigNoz API reference](https://signoz.io/api-reference/).
+
+## Getting help
+
+- [SigNoz Documentation](https://signoz.io/docs/introduction/)
+- [GitHub Issues](https://github.com/SigNoz/signoz/issues)
+- [Community Slack](https://signoz.io/slack/)
+</content>
+</invoke>

--- a/data/docs/operate/migration/upgrade-0-137.mdx
+++ b/data/docs/operate/migration/upgrade-0-137.mdx
@@ -6,13 +6,17 @@ description: Upgrade self-hosted SigNoz to v0.137.0. A migration repairs saved v
 doc_type: howto
 ---
 
-SigNoz v0.137.0 moves saved views (the named filter-and-column presets in the Logs and Traces explorers) to a typed schema. Existing views are converted automatically, so no action is needed if you use saved views only through the UI. This release also adds a new Saved Views v2 API alongside the existing v1 endpoints.
+SigNoz v0.137.0 moves saved views (the named filter-and-column presets in the Logs and Traces explorers) to a typed schema. Existing views are converted automatically, so no action is needed if you use saved views only through the UI. This release also adds a Saved Views v2 API and deprecates the v1 endpoints.
 
 <Admonition type="warning" title="Unrepairable saved views are deleted during the upgrade">
 The repair migration rewrites a saved view whose stored spec has unreadable fields, resetting each bad field to its empty default. A view that still cannot be parsed field-by-field is deleted from the database, and this deletion is not reversible. Back up the Metastore (SQLite or Postgres) before you upgrade. If a view is missing afterward, search the server logs for `saved view data could not be repaired` to find the affected saved-view IDs, then restore them from your backup.
 </Admonition>
 
-If you use saved views only through the UI, back up the Metastore, upgrade, then check your views for any that went missing. If you call `/api/v1/explorer/views` from scripts, those routes keep working, but [queries are now validated](#what-changes-for-v1-api-callers).
+<Admonition type="info" title="The v1 saved-view endpoints are deprecated">
+`/api/v1/explorer/views` keeps working in v0.137.0, but it is deprecated and will be removed in a future release once the SigNoz UI moves to the v2 endpoints. If you call it from scripts, plan your move to [the v2 API](#the-new-saved-views-v2-api).
+</Admonition>
+
+If you use saved views only through the UI, back up the Metastore, upgrade, then check your views for any that went missing. If you call the v1 endpoints from scripts, note that [queries are now validated](#what-changes-for-v1-api-callers).
 
 ## Upgrade self-hosted SigNoz
 
@@ -62,7 +66,7 @@ For Docker or binary deployments, follow the [standard upgrade guide](https://si
 
 ## What changes for v1 API callers
 
-The v1 endpoints (`/api/v1/explorer/views`) are unchanged and keep working. Two behaviors change behind them:
+The v1 endpoints (`/api/v1/explorer/views`) are deprecated in v0.137.0. They keep working for now and will be removed in a future release once the SigNoz UI moves to the v2 endpoints, so plan your migration to [the v2 API](#the-new-saved-views-v2-api). Two behaviors also change behind them:
 
 - **Queries are validated on create and update.** A request whose query is not in the v5 query-builder format, or is otherwise invalid, is rejected with `400 Bad Request`. Requests that SigNoz accepted silently before can now fail.
 - **Unknown `extraData` keys are dropped.** The migration and the v1 endpoints keep only the column selection (`selectColumns`) and the display settings (`maxLines`, `fontSize`, `format`, `color`). Anything else stored in `extraData` is discarded, and a malformed `extraData` leaves those fields empty instead of failing the request.
@@ -71,7 +75,7 @@ The v1 endpoints (`/api/v1/explorer/views`) are unchanged and keep working. Two 
 
 v0.137.0 adds `/api/v2/saved_views` and `/api/v2/saved_views/{id}`. These endpoints are new in this release, so no existing script depends on them. Migrate when you are ready.
 
-Responses keep the standard SigNoz envelope. `schemaVersion` and `spec` sit beside `id` and `name` inside the envelope's `data` field, not under a second nested `data` object, so an Axios caller reads the spec at `response.data.data.spec`. On requests, `spec.requestType` is required, and it accepts `raw`, `raw_stream`, `trace`, `time_series`, or `scalar`.
+Responses keep the standard SigNoz envelope, with the view under the top-level `data` field. `schemaVersion` and `spec` sit beside `id` and `name` on it, so the view spec is at `response.data.spec`. On requests, `spec.requestType` is required, and it accepts `raw`, `raw_stream`, `trace`, `time_series`, or `scalar`.
 
 For the full request and response schema, see the Saved Views endpoints in the [SigNoz API reference](https://signoz.io/api-reference/).
 

--- a/data/docs/operate/migration/upgrade-0-137.mdx
+++ b/data/docs/operate/migration/upgrade-0-137.mdx
@@ -2,61 +2,81 @@
 date: 2026-08-11
 title: Upgrade SigNoz to v0.137.0 and Repair Saved Views Data
 tags: [Self-Hosted Community, Self-Hosted Enterprise]
-description: Upgrade self-hosted SigNoz to v0.137.0. Automatic migrations repair saved views and remove unrepairable ones, so back up the Metastore before you upgrade.
+description: Upgrade self-hosted SigNoz to v0.137.0. A migration repairs saved views and deletes the ones it cannot fix, so back up the Metastore first.
 doc_type: howto
 ---
 
-SigNoz v0.137.0 runs two automatic migrations that repair the stored data behind your saved views (the named filter-and-column presets in the Logs and Traces explorers). Most views are repaired in place with no action needed. A view whose stored data cannot be repaired is deleted, so back up the SigNoz Metastore before you upgrade.
+SigNoz v0.137.0 moves saved views (the named filter-and-column presets in the Logs and Traces explorers) to a typed schema. Existing views are converted automatically, so no action is needed if you use saved views only through the UI. This release also adds a new Saved Views v2 API alongside the existing v1 endpoints.
 
 <Admonition type="warning" title="Unrepairable saved views are deleted during the upgrade">
-The repair migration rewrites saved views whose stored spec has unreadable fields. A view that still cannot be parsed field-by-field is removed from the database, and this deletion is not reversible. Back up the Metastore (SQLite or Postgres) before upgrading so you can restore any view that gets dropped.
+The repair migration rewrites a saved view whose stored spec has unreadable fields, resetting each bad field to its empty default. A view that still cannot be parsed field-by-field is deleted from the database, and this deletion is not reversible. Back up the Metastore (SQLite or Postgres) before you upgrade. If a view is missing afterward, search the server logs for `saved view data could not be repaired` to find the affected saved-view IDs, then restore them from your backup.
 </Admonition>
 
-## Who needs to act
+If you use saved views only through the UI, back up the Metastore, upgrade, then check your views for any that went missing. If you call `/api/v1/explorer/views` from scripts, those routes keep working, but [queries are now validated](#what-changes-for-v1-api-callers).
 
-| If you | Then |
-| --- | --- |
-| Use saved views only through the UI | Back up the Metastore first. Views are repaired automatically; check your saved views afterward for any that went missing |
-| Call the Saved Views API directly (create, update, get) | [Update your payloads](#saved-views-api-payloads-change-shape): the request and response wire format changes in this release |
+## Upgrade self-hosted SigNoz
 
-## Back up before you upgrade
+### Step 1: Back up your data
 
-Saved views live in the SigNoz Metastore alongside dashboards and alerts. Back up the Metastore before starting the upgrade. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops before jumping to v0.137.0.
+Saved views live in the SigNoz Metastore alongside dashboards and alerts. Back up the Metastore before you start. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops before you move to v0.137.0.
 
-For the general upgrade steps for your deployment (Foundry, Helm, Docker, or binary), follow the [standard upgrade guide](https://signoz.io/docs/operate/migration/upgrade-standard/).
+### Step 2: Upgrade SigNoz
 
-## What the saved-view migrations do
+The saved-view migrations run once, automatically, when the server starts on the new version.
 
-Two migrations run once, automatically, when the server starts on v0.137.0:
+<Tabs entityName="installer">
+<TabItem value="foundry" label="Foundry" default>
 
-- **Repair unreadable fields.** For each saved view whose stored spec has a field that no longer parses (for example a malformed `selectedFields` entry), the migration resets that field to its empty default and keeps the rest of the view. A view that cannot be parsed field-by-field is deleted and logged with its saved-view ID.
-- **Backfill `requestType`.** Existing views that predate the new required `requestType` field are backfilled so they load correctly under the new schema.
+Upgrade <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">foundryctl</a> to pick up the v0.137.0 defaults, then re-apply your existing `casting.yaml`:
 
-The server logs a summary of how many views were repaired and how many were deleted. If a view you expected is gone after the upgrade, search the server logs for `saved view data could not be repaired` to find the affected saved-view IDs, then restore them from your backup.
+```bash
+curl -fsSL https://signoz.io/foundry.sh | bash
+foundryctl cast -f casting.yaml
+```
 
-## Verify the upgrade
+If your <a href="https://github.com/SigNoz/foundry/blob/main/docs/reference/casting-file.md" target="_blank" rel="noopener noreferrer nofollow">casting.yaml</a> pins image versions, the new defaults will not override them (your config wins), so bump the SigNoz image pin to v0.137.0 yourself.
 
-1. Pods and containers are healthy (`kubectl get pods -n signoz`, `docker compose ps`, or `systemctl status 'signoz-*'`).
+</TabItem>
+<TabItem value="helm" label="Kubernetes (Helm chart)">
+
+Update the <a href="https://github.com/SigNoz/charts" target="_blank" rel="noopener noreferrer nofollow">chart</a> and upgrade. Replace `<namespace>` and `<release-name>` with your own values:
+
+```bash
+helm repo update
+helm -n <namespace> upgrade <release-name> signoz/signoz
+```
+
+`helm upgrade` takes the newest chart; add `--version 0.137.0` to pin the v0.137.0 chart.
+
+</TabItem>
+</Tabs>
+
+For Docker or binary deployments, follow the [standard upgrade guide](https://signoz.io/docs/operate/migration/upgrade-standard/) and set the target version to v0.137.0.
+
+### Step 3: Verify the upgrade
+
+1. Pods and containers are healthy (`kubectl get pods -n <namespace>`, `docker compose ps`, or `systemctl status 'signoz-*'`).
 2. SigNoz reports v0.137.0 under **Settings**.
-3. Open the **Logs** and **Traces** explorers and confirm your saved views load and apply their filters and columns.
+3. Open the **Logs** and **Traces** explorers, and confirm your saved views load and apply their filters and columns.
+4. Search the server logs for `saved view data could not be repaired`. Restore any listed view from your backup.
 
-## Saved Views API payloads change shape
+## What changes for v1 API callers
 
-If you call the Saved Views API directly (`/api/v2/saved_views` and `/api/v2/saved_views/{id}`), the create, update, and get payloads change in v0.137.0. Update your scripts before you upgrade:
+The v1 endpoints (`/api/v1/explorer/views`) are unchanged and keep working. Two behaviors change behind them:
 
-- **The `data` wrapper is removed.** `schemaVersion` and `spec` are now top-level fields on the request and response body instead of nested under `data`. Callers that read `response.data.data.spec.*` must change to `response.data.spec.*`.
-- **`spec` now requires `requestType`.** Set it to one of `raw`, `trace`, `time_series`, or `scalar`.
-- **`spec.queries` must contain at least one item.** An empty `queries` array is rejected with `400 Bad Request`.
-- **`selectedFields` and `display` are optional.** Omitting them reads back as empty defaults.
-- **`schemaVersion` is enforced as `v2`.** It is the only accepted value.
-- **Duplicate names return `409 Conflict`.** Creating a saved view whose name already exists in the org now fails with `409` instead of undefined behavior.
+- **Queries are validated on create and update.** A request whose query is not in the v5 query-builder format, or is otherwise invalid, is rejected with `400 Bad Request`. Requests that SigNoz accepted silently before can now fail.
+- **Unknown `extraData` keys are dropped.** The migration and the v1 endpoints keep only the column selection (`selectColumns`) and the display settings (`maxLines`, `fontSize`, `format`, `color`). Anything else stored in `extraData` is discarded, and a malformed `extraData` leaves those fields empty instead of failing the request.
+
+## The new Saved Views v2 API
+
+v0.137.0 adds `/api/v2/saved_views` and `/api/v2/saved_views/{id}`. These endpoints are new in this release, so no existing script depends on them. Migrate when you are ready.
+
+Responses keep the standard SigNoz envelope. `schemaVersion` and `spec` sit beside `id` and `name` inside the envelope's `data` field, not under a second nested `data` object, so an Axios caller reads the spec at `response.data.data.spec`. On requests, `spec.requestType` is required, and it accepts `raw`, `raw_stream`, `trace`, `time_series`, or `scalar`.
 
 For the full request and response schema, see the Saved Views endpoints in the [SigNoz API reference](https://signoz.io/api-reference/).
 
 ## Getting help
 
 - [SigNoz Documentation](https://signoz.io/docs/introduction/)
-- [GitHub Issues](https://github.com/SigNoz/signoz/issues)
+- <a href="https://github.com/SigNoz/signoz/issues" target="_blank" rel="noopener noreferrer nofollow">GitHub Issues</a>
 - [Community Slack](https://signoz.io/slack/)
-</content>
-</invoke>


### PR DESCRIPTION
## Description

Adds a v0.137.0 upgrade note for the Saved Views changes in [signoz#12477](https://github.com/SigNoz/signoz/pull/12477).

- New `upgrade-0-137.mdx` warns operators that the automatic saved-view repair migration **deletes** views whose stored data cannot be repaired, and advises backing up the Metastore before upgrading.
- Documents what the two migrations do (field repair + `requestType` backfill) and how to find deleted views in the logs.
- Summarizes the breaking Saved Views API wire-format change for direct API callers (`data` wrapper removed, top-level `schemaVersion`/`spec`, required `requestType`, `queries` min 1, `409` on duplicate name), linking to the auto-generated API reference for the full schema.
- Adds the sidebar entry and updates the frontmatter `date`.

The API payload/response schema itself (features 1-7 of the deliverable) is served by the auto-generated OpenAPI reference; no hand-authored Saved Views API page exists, so only this operator-facing migration note needed adding.

## Issues closed by this PR

Closes https://github.com/SigNoz/growth-pod/issues/1274

Source PRs: #12477

Doc: [Link](https://staging.signoz.io/docs/operate/migration/upgrade-0-137/)

Auto-generated by docs-sync pipeline