### PR TITLE
docs: document search() function in logs query builder

### DIFF
--- a/data/docs/userguide/full-text-search.mdx
+++ b/data/docs/userguide/full-text-search.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-07-27
+date: 2026-08-13
 title: Full-Text Search Guide
-description: Learn how to use full-text search in SigNoz to search log body content. Covers quoted phrases, regex, tabs and newlines, escaping, and field filters.
+description: Learn how to use full-text search in SigNoz to search log body content. Covers quoted phrases, the search() function, regex, escaping, and field filters.
 doc_type: reference
 ---
 
@@ -139,6 +139,37 @@ Match logs where the body contains email addresses:
 ```
 '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
 ```
+
+## The search() Function
+
+You can also run a full-text search with the explicit `search()` function. Type `search` in the Logs Explorer filter bar and pick `search()` from the autocomplete, then enter your term inside the parentheses:
+
+```
+search('error')
+search(error)
+```
+
+Both forms search the log body for the term, exactly like a bare quoted phrase. The argument is treated as literal search text, not an attribute key, so `search('error')` does not create an `error` filter chip.
+
+`search()` is available in the Logs Explorer only. The Traces and Metrics query builders do not offer it, and the autocomplete omits it when either signal is active.
+
+<Admonition type="info">
+Only the single-term forms `search('term')` and `search(term)` are supported. A scope argument such as `search('err', body)` parses but has no effect yet.
+</Admonition>
+
+### Combining search() with attribute filters
+
+Combine `search()` with attribute filters using `AND`:
+
+```
+search('error') AND service.name = 'api'
+```
+
+Only the attribute condition appears as a discrete filter chip. The search term stays inside the `search()` call.
+
+<Admonition type="warning">
+`search` is now a reserved word. Filter expressions that use `search` as an attribute key, such as `search = 'x'` or `search exists`, no longer parse. Rename any saved query, alert, or dashboard panel that referenced an attribute named `search` so it keeps working.
+</Admonition>
 
 ## Combining Full-Text with Field Searches
 

--- a/data/docs/userguide/functions-reference.mdx
+++ b/data/docs/userguide/functions-reference.mdx
@@ -1,8 +1,8 @@
 ---
-date: 2026-07-27
+date: 2026-08-13
 
 title: Functions Reference Guide
-description: Reference guide for SigNoz query functions for arrays and token matching. Learn syntax and usage examples.
+description: Reference guide for SigNoz query functions for arrays, token matching, and full-text search. Learn syntax and usage examples.
 doc_type: reference
 ---
 
@@ -60,9 +60,31 @@ has(body.tags, 'production')
 has(body.regions, 'us-east')
 ```
 
+### search() Function
+
+Runs a full-text search across the log body. Type `search` in the Logs Explorer filter bar and pick `search()` from the autocomplete, then enter your term inside the parentheses.
+
+**Syntax:**
+```
+search('term')
+search(term)
+```
+
+**Examples:**
+```
+search('error connecting to database')
+search(timeout)
+```
+
+The argument is literal search text, not an attribute key, so it does not become a filter chip. `search()` is available in the **Logs Explorer** only. For quoted vs unquoted behavior, regex, and escaping, see the [Full-Text Search Guide](https://signoz.io/docs/userguide/full-text-search/#the-search-function).
+
+## Reserved Words
+
+Function names are reserved words in the filter grammar and cannot be used as attribute keys: `has`, `hasAny`, `hasAll`, `hasToken`, and `search`. An expression such as `search = 'x'` or `search exists` no longer parses. If a saved query, alert, or dashboard panel used one of these as an attribute name, rename that expression.
+
 ## Important Notes
 
-1. **Body fields only** - Functions currently work only with JSON body fields (fields prefixed with `body.`) except for the hasToken function.
+1. **Body fields only** - Functions currently work only with JSON body fields (fields prefixed with `body.`), except for the `hasToken()` and `search()` functions.
 2. **Array data** - The field must contain an array for these functions to work properly
 
 ## Combining with Other Conditions

--- a/data/docs/userguide/search-troubleshooting.mdx
+++ b/data/docs/userguide/search-troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-07-27
+date: 2026-08-13
 title: Search Query Troubleshooting Guide
-description: Diagnose and fix common SigNoz search query errors including syntax errors, ambiguous fields, missing keys, and function-related issues with clear examples.
+description: Diagnose and fix common SigNoz search query errors including syntax errors, ambiguous fields, missing keys, reserved words, and function issues.
 doc_type: howto
 ---
 
@@ -74,6 +74,28 @@ searching for AND operator
 # Correct — quote the phrase
 'searching for AND operator'
 ```
+
+</details>
+
+### Q. My query that filtered on a `search` attribute stopped parsing — what changed?
+
+A. `search` is now a reserved word (it registers the `search()` full-text function in the Logs Explorer), joining the other function names `has`, `hasAny`, `hasAll`, and `hasToken`. Expressions that used `search` as an attribute key no longer parse.
+
+<details>
+
+<summary>Show causes and fixes</summary>
+
+```
+# Wrong — search is reserved and cannot be an attribute key
+search = 'x'
+search exists
+
+# Correct — reference the attribute under an explicit context prefix
+attribute.search = 'x'
+attribute.search EXISTS
+```
+
+Update any saved query, alert, or dashboard panel that referenced an attribute named `search`. To run a full-text search instead, use the [`search()` function](https://signoz.io/docs/userguide/full-text-search/#the-search-function).
 
 </details>
 
@@ -197,7 +219,7 @@ If you are querying traces or metrics, rewrite the query to target a specific fi
 
 ### Q. I'm getting `unknown function '<name>'` — which functions are supported?
 
-A. Only specific functions are supported in the filter bar. Currently the only supported function is `has()`, which checks if a JSON array field contains a value.
+A. Only specific functions are supported in the filter bar: `has()` (checks whether a JSON array field contains a value), `hasToken()` (whole-token match in a string), and `search()` (full-text search across the log body, Logs Explorer only).
 
 <details>
 


### PR DESCRIPTION
## Description

Documents the `search()` query builder function added in SigNoz/signoz#12513, and the related `search` reserved-word breaking change.

- **Full-Text Search Guide**: new `search()` Function section covering `search('term')`/`search(term)` syntax, literal-text-not-a-key behavior, Logs-only scope, combining with attribute filters, the unsupported scope-argument limitation, and a reserved-word warning.
- **Functions Reference**: added a `search()` entry and a Reserved Words note listing `has`, `hasAny`, `hasAll`, `hasToken`, `search`.
- **Search Query Troubleshooting**: new Q&A for the `search`-attribute parse break (workaround verified against the FilterQuery grammar: `attribute.search` lexes as a single KEY), and corrected the outdated "only supported function is has()" answer to include `hasToken()` and `search()`.
- Updated the `date` frontmatter to today on all three edited files.

Prose-only: the source PR merged 2026-08-12 and the feature is not yet live on the demo instance, so no new screenshots were captured.

Source PRs: #12513

Auto-generated by docs-sync pipeline