### PR TITLE
feat(docs): Add observability and OpenTelemetry glossary

### DIFF
--- a/app/(site)/upgrade-path/components/UpgradePathTool.tsx
+++ b/app/(site)/upgrade-path/components/UpgradePathTool.tsx
@@ -157,9 +157,7 @@ const UpgradePathTool: React.FC<UpgradePathToolProps> = ({ docMetaBySlug, compil
           <div className="absolute left-0 right-0 top-0 mx-auto h-[300px] w-full flex-shrink-0 rounded-[956px] bg-gradient-to-b from-[rgba(190,107,241,1)] to-[rgba(69,104,220,0)] bg-[length:110%] bg-no-repeat opacity-30 blur-[300px] sm:h-[450px] sm:bg-[center_-500px] md:h-[956px]" />
           <div className="relative mx-auto flex w-full max-w-7xl flex-col items-center gap-8 px-4 sm:px-6 lg:px-8">
             <div className="text-center">
-              <h1 className="text-gradient mb-2 font-bold">
-                Self-Hosted SigNoz Upgrade Path Tool
-              </h1>
+              <h1 className="text-gradient mb-2 font-bold">Self-Hosted SigNoz Upgrade Path Tool</h1>
               <span className="text-signoz_vanilla-400">
                 Plan version upgrades for Self-Hosted SigNoz. SigNoz Cloud upgrades are managed by
                 SigNoz and require no action in this tool.

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import CustomLink from '@/components/Link'
 
 interface TooltipProps {
   /** The text to underline and trigger the tooltip */
@@ -13,6 +15,44 @@ interface TooltipProps {
   linkText?: string
 }
 
+// The dashed underline and colors follow the current text and the design-system
+// tokens, so the tooltip works in both light and dark mode.
+const TRIGGER_CLASSES =
+  'border-b border-dashed border-current/40 transition-colors hover:border-current'
+
+// Width of the tooltip card, in pixels. Matches the `w-64` class below.
+const TOOLTIP_WIDTH = 256
+// Keep the tooltip this far from the edge of the viewport.
+const EDGE_PADDING = 8
+// Gap between the trigger and the tooltip.
+const GAP = 8
+// Keep the tooltip below the sticky top navigation, which is about 64px tall.
+const NAV_SAFE_TOP = 72
+
+// Find the nearest ancestor that clips its content (the docs content column uses
+// `overflow-clip`). The tooltip itself is portalled out, so this is used only to
+// keep the card horizontally inside the reading column instead of sprawling over
+// the sidebar or table of contents.
+function getClipAncestor(element: HTMLElement | null): HTMLElement | null {
+  let node = element?.parentElement ?? null
+  while (node && node !== document.body) {
+    const style = getComputedStyle(node)
+    if ([style.overflow, style.overflowX, style.overflowY].some((value) => value !== 'visible')) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+interface Position {
+  top: number
+  left: number
+  placement: 'top' | 'bottom'
+  // Arrow offset from the tooltip's left edge, so it stays over the trigger.
+  arrowLeft: number
+}
+
 export default function Tooltip({
   text,
   content,
@@ -20,7 +60,11 @@ export default function Tooltip({
   linkText = 'Explore more →',
 }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false)
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
+  const [position, setPosition] = useState<Position | null>(null)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const triggerRef = useRef<HTMLSpanElement>(null)
+  const tooltipRef = useRef<HTMLSpanElement>(null)
+  const tooltipId = useId()
 
   const showTooltip = () => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
@@ -33,60 +77,147 @@ export default function Tooltip({
     }, 300)
   }
 
+  // Clear the pending hide on unmount so it cannot fire against a gone component.
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  // The tooltip renders in a portal on `document.body`, so it escapes every
+  // `overflow` ancestor (the docs content column, Admonitions, tables, code
+  // blocks) that would otherwise clip it. Because it is detached from the
+  // trigger's box, position it against the viewport with `position: fixed` and
+  // recompute on scroll and resize while it is open.
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      setPosition(null)
+      return undefined
+    }
+
+    const place = () => {
+      const trigger = triggerRef.current
+      const tooltip = tooltipRef.current
+      if (!trigger || !tooltip) return
+      const triggerRect = trigger.getBoundingClientRect()
+      const height = tooltip.offsetHeight
+      const width = tooltip.offsetWidth || TOOLTIP_WIDTH
+
+      // Clamp horizontally to the reading column so the portalled card never
+      // sprawls over the sidebar or table of contents. The docs body is an
+      // `<article>`; fall back to the nearest clipping ancestor, then the viewport.
+      const column = trigger.closest('article') ?? getClipAncestor(trigger)
+      const clipRect = column
+        ? column.getBoundingClientRect()
+        : { left: 0, right: window.innerWidth }
+      const centerX = triggerRect.left + triggerRect.width / 2
+      const minLeft = clipRect.left + EDGE_PADDING
+      const maxLeft = clipRect.right - width - EDGE_PADDING
+      const left = Math.min(Math.max(centerX - width / 2, minLeft), Math.max(maxLeft, minLeft))
+
+      const spaceAbove = triggerRect.top - NAV_SAFE_TOP
+      const placement: 'top' | 'bottom' = height + GAP > spaceAbove ? 'bottom' : 'top'
+      const top = placement === 'top' ? triggerRect.top - height - GAP : triggerRect.bottom + GAP
+
+      setPosition({ top, left, placement, arrowLeft: centerX - left })
+    }
+
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+    // Re-measuring depends only on visibility; content is stable per instance.
+  }, [isVisible])
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape' && isVisible) {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      setIsVisible(false)
+    }
+  }
+
+  const isTop = position?.placement === 'top'
+
   return (
     <span
+      ref={triggerRef}
       className="relative inline-block"
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
       onFocus={showTooltip}
       onBlur={hideTooltip}
+      onKeyDown={handleKeyDown}
     >
-      {/* Trigger Text */}
-      {/* Trigger Text */}
       {link ? (
-        <>
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener"
-            className="cursor-pointer border-b border-dashed border-zinc-500 no-underline decoration-zinc-500 transition-colors hover:border-zinc-200 hover:text-zinc-100"
-          >
-            {text}
-          </a>
-          <span>&nbsp;</span>
-        </>
-      ) : (
-        <>
-          <span className="cursor-help border-b border-dashed border-zinc-500 decoration-zinc-500 transition-colors hover:border-zinc-200 hover:text-zinc-100">
-            {text}
-          </span>
-          <span>&nbsp;</span>
-        </>
-      )}
-
-      {/* Tooltip Popup */}
-      {isVisible && (
-        <div
-          className="animate-in fade-in slide-in-from-bottom-1 absolute bottom-full left-1/2 z-50 mb-2 w-64 -translate-x-1/2 rounded-lg border border-zinc-700 bg-zinc-800 p-4 text-sm text-zinc-100 shadow-xl duration-200"
-          role="tooltip"
+        <CustomLink
+          href={link}
+          aria-describedby={isVisible ? tooltipId : undefined}
+          className={`cursor-pointer no-underline ${TRIGGER_CLASSES}`}
         >
-          {/* Arrow */}
-          <div className="absolute left-1/2 top-full -mt-2 -translate-x-1/2 border-4 border-transparent border-t-zinc-800" />
-
-          <p className="mb-2 mt-0 font-medium leading-relaxed">{content}</p>
-
-          {link && (
-            <a
-              href={link}
-              target="_blank"
-              rel="noopener"
-              className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-blue-300 transition-colors hover:text-blue-200"
-            >
-              {linkText}
-            </a>
-          )}
-        </div>
+          {text}
+        </CustomLink>
+      ) : (
+        // Focusable so the definition is reachable without a mouse.
+        <span
+          tabIndex={0}
+          role="button"
+          aria-describedby={isVisible ? tooltipId : undefined}
+          className={`cursor-help ${TRIGGER_CLASSES}`}
+        >
+          {text}
+        </span>
       )}
+
+      {isVisible &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <span
+            ref={tooltipRef}
+            id={tooltipId}
+            role="tooltip"
+            // Keep the tooltip open while the pointer or focus is on it, so its
+            // link stays reachable. The trigger's 300ms hide delay bridges the gap.
+            onMouseEnter={showTooltip}
+            onMouseLeave={hideTooltip}
+            onFocus={showTooltip}
+            onBlur={hideTooltip}
+            onKeyDown={handleKeyDown}
+            style={{
+              top: position?.top ?? 0,
+              left: position?.left ?? 0,
+              // Hide until measured, so it does not flash at the corner.
+              visibility: position ? 'visible' : 'hidden',
+            }}
+            className={`animate-in fade-in fixed z-50 block w-64 rounded-lg border border-[var(--l2-border)] bg-[var(--l2-background)] p-4 text-sm text-[var(--l1-foreground)] shadow-xl duration-200 ${
+              isTop ? 'slide-in-from-bottom-1' : 'slide-in-from-top-1'
+            }`}
+          >
+            {/* Arrow points at the trigger and is positioned over it. */}
+            <span
+              style={{ left: position?.arrowLeft ?? 0 }}
+              className={`absolute block -translate-x-1/2 border-4 border-transparent ${
+                isTop
+                  ? 'top-full -mt-2 border-t-[var(--l2-background)]'
+                  : 'bottom-full -mb-2 border-b-[var(--l2-background)]'
+              }`}
+            />
+
+            <span className="mb-2 block font-medium leading-relaxed">{content}</span>
+
+            {link && (
+              <CustomLink
+                href={link}
+                className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-signoz_robin-400 transition-colors hover:text-signoz_robin-300"
+              >
+                {linkText}
+              </CustomLink>
+            )}
+          </span>,
+          document.body
+        )}
     </span>
   )
 }

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
-import CustomLink from '@/components/Link'
+import React, { useState } from 'react'
 
 interface TooltipProps {
   /** The text to underline and trigger the tooltip */
@@ -15,44 +13,6 @@ interface TooltipProps {
   linkText?: string
 }
 
-// The dashed underline and colors follow the current text and the design-system
-// tokens, so the tooltip works in both light and dark mode.
-const TRIGGER_CLASSES =
-  'border-b border-dashed border-current/40 transition-colors hover:border-current'
-
-// Width of the tooltip card, in pixels. Matches the `w-64` class below.
-const TOOLTIP_WIDTH = 256
-// Keep the tooltip this far from the edge of the viewport.
-const EDGE_PADDING = 8
-// Gap between the trigger and the tooltip.
-const GAP = 8
-// Keep the tooltip below the sticky top navigation, which is about 64px tall.
-const NAV_SAFE_TOP = 72
-
-// Find the nearest ancestor that clips its content (the docs content column uses
-// `overflow-clip`). The tooltip itself is portalled out, so this is used only to
-// keep the card horizontally inside the reading column instead of sprawling over
-// the sidebar or table of contents.
-function getClipAncestor(element: HTMLElement | null): HTMLElement | null {
-  let node = element?.parentElement ?? null
-  while (node && node !== document.body) {
-    const style = getComputedStyle(node)
-    if ([style.overflow, style.overflowX, style.overflowY].some((value) => value !== 'visible')) {
-      return node
-    }
-    node = node.parentElement
-  }
-  return null
-}
-
-interface Position {
-  top: number
-  left: number
-  placement: 'top' | 'bottom'
-  // Arrow offset from the tooltip's left edge, so it stays over the trigger.
-  arrowLeft: number
-}
-
 export default function Tooltip({
   text,
   content,
@@ -60,11 +20,7 @@ export default function Tooltip({
   linkText = 'Explore more →',
 }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false)
-  const [position, setPosition] = useState<Position | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const triggerRef = useRef<HTMLSpanElement>(null)
-  const tooltipRef = useRef<HTMLSpanElement>(null)
-  const tooltipId = useId()
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 
   const showTooltip = () => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
@@ -77,147 +33,60 @@ export default function Tooltip({
     }, 300)
   }
 
-  // Clear the pending hide on unmount so it cannot fire against a gone component.
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [])
-
-  // The tooltip renders in a portal on `document.body`, so it escapes every
-  // `overflow` ancestor (the docs content column, Admonitions, tables, code
-  // blocks) that would otherwise clip it. Because it is detached from the
-  // trigger's box, position it against the viewport with `position: fixed` and
-  // recompute on scroll and resize while it is open.
-  useLayoutEffect(() => {
-    if (!isVisible) {
-      setPosition(null)
-      return undefined
-    }
-
-    const place = () => {
-      const trigger = triggerRef.current
-      const tooltip = tooltipRef.current
-      if (!trigger || !tooltip) return
-      const triggerRect = trigger.getBoundingClientRect()
-      const height = tooltip.offsetHeight
-      const width = tooltip.offsetWidth || TOOLTIP_WIDTH
-
-      // Clamp horizontally to the reading column so the portalled card never
-      // sprawls over the sidebar or table of contents. The docs body is an
-      // `<article>`; fall back to the nearest clipping ancestor, then the viewport.
-      const column = trigger.closest('article') ?? getClipAncestor(trigger)
-      const clipRect = column
-        ? column.getBoundingClientRect()
-        : { left: 0, right: window.innerWidth }
-      const centerX = triggerRect.left + triggerRect.width / 2
-      const minLeft = clipRect.left + EDGE_PADDING
-      const maxLeft = clipRect.right - width - EDGE_PADDING
-      const left = Math.min(Math.max(centerX - width / 2, minLeft), Math.max(maxLeft, minLeft))
-
-      const spaceAbove = triggerRect.top - NAV_SAFE_TOP
-      const placement: 'top' | 'bottom' = height + GAP > spaceAbove ? 'bottom' : 'top'
-      const top = placement === 'top' ? triggerRect.top - height - GAP : triggerRect.bottom + GAP
-
-      setPosition({ top, left, placement, arrowLeft: centerX - left })
-    }
-
-    place()
-    window.addEventListener('scroll', place, true)
-    window.addEventListener('resize', place)
-    return () => {
-      window.removeEventListener('scroll', place, true)
-      window.removeEventListener('resize', place)
-    }
-    // Re-measuring depends only on visibility; content is stable per instance.
-  }, [isVisible])
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape' && isVisible) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      setIsVisible(false)
-    }
-  }
-
-  const isTop = position?.placement === 'top'
-
   return (
     <span
-      ref={triggerRef}
       className="relative inline-block"
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
       onFocus={showTooltip}
       onBlur={hideTooltip}
-      onKeyDown={handleKeyDown}
     >
+      {/* Trigger Text */}
+      {/* Trigger Text */}
       {link ? (
-        <CustomLink
-          href={link}
-          aria-describedby={isVisible ? tooltipId : undefined}
-          className={`cursor-pointer no-underline ${TRIGGER_CLASSES}`}
-        >
-          {text}
-        </CustomLink>
+        <>
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener"
+            className="cursor-pointer border-b border-dashed border-zinc-500 no-underline decoration-zinc-500 transition-colors hover:border-zinc-200 hover:text-zinc-100"
+          >
+            {text}
+          </a>
+          <span>&nbsp;</span>
+        </>
       ) : (
-        // Focusable so the definition is reachable without a mouse.
-        <span
-          tabIndex={0}
-          role="button"
-          aria-describedby={isVisible ? tooltipId : undefined}
-          className={`cursor-help ${TRIGGER_CLASSES}`}
-        >
-          {text}
-        </span>
+        <>
+          <span className="cursor-help border-b border-dashed border-zinc-500 decoration-zinc-500 transition-colors hover:border-zinc-200 hover:text-zinc-100">
+            {text}
+          </span>
+          <span>&nbsp;</span>
+        </>
       )}
 
-      {isVisible &&
-        typeof document !== 'undefined' &&
-        createPortal(
-          <span
-            ref={tooltipRef}
-            id={tooltipId}
-            role="tooltip"
-            // Keep the tooltip open while the pointer or focus is on it, so its
-            // link stays reachable. The trigger's 300ms hide delay bridges the gap.
-            onMouseEnter={showTooltip}
-            onMouseLeave={hideTooltip}
-            onFocus={showTooltip}
-            onBlur={hideTooltip}
-            onKeyDown={handleKeyDown}
-            style={{
-              top: position?.top ?? 0,
-              left: position?.left ?? 0,
-              // Hide until measured, so it does not flash at the corner.
-              visibility: position ? 'visible' : 'hidden',
-            }}
-            className={`animate-in fade-in fixed z-50 block w-64 rounded-lg border border-[var(--l2-border)] bg-[var(--l2-background)] p-4 text-sm text-[var(--l1-foreground)] shadow-xl duration-200 ${
-              isTop ? 'slide-in-from-bottom-1' : 'slide-in-from-top-1'
-            }`}
-          >
-            {/* Arrow points at the trigger and is positioned over it. */}
-            <span
-              style={{ left: position?.arrowLeft ?? 0 }}
-              className={`absolute block -translate-x-1/2 border-4 border-transparent ${
-                isTop
-                  ? 'top-full -mt-2 border-t-[var(--l2-background)]'
-                  : 'bottom-full -mb-2 border-b-[var(--l2-background)]'
-              }`}
-            />
+      {/* Tooltip Popup */}
+      {isVisible && (
+        <div
+          className="animate-in fade-in slide-in-from-bottom-1 absolute bottom-full left-1/2 z-50 mb-2 w-64 -translate-x-1/2 rounded-lg border border-zinc-700 bg-zinc-800 p-4 text-sm text-zinc-100 shadow-xl duration-200"
+          role="tooltip"
+        >
+          {/* Arrow */}
+          <div className="absolute left-1/2 top-full -mt-2 -translate-x-1/2 border-4 border-transparent border-t-zinc-800" />
 
-            <span className="mb-2 block font-medium leading-relaxed">{content}</span>
+          <p className="mb-2 mt-0 font-medium leading-relaxed">{content}</p>
 
-            {link && (
-              <CustomLink
-                href={link}
-                className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-signoz_robin-400 transition-colors hover:text-signoz_robin-300"
-              >
-                {linkText}
-              </CustomLink>
-            )}
-          </span>,
-          document.body
-        )}
+          {link && (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener"
+              className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-blue-300 transition-colors hover:text-blue-200"
+            >
+              {linkText}
+            </a>
+          )}
+        </div>
+      )}
     </span>
   )
 }

--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -22,6 +22,11 @@
       },
       {
         "type": "doc",
+        "label": "Glossary",
+        "route": "/docs/glossary"
+      },
+      {
+        "type": "doc",
         "label": "What's Coming",
         "route": "/docs/roadmap"
       },

--- a/data/docs/alerts-management/anomaly-based-alerts.mdx
+++ b/data/docs/alerts-management/anomaly-based-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-10
+date: 2026-08-25
 description: Learn how anomaly-based alerts work in SigNoz, including metric selection, alert conditions, seasonality options, z-score thresholds, and how anomalies are detected from historical patterns.
 doc_type: explanation
 title: Anomaly based alerts 
@@ -15,7 +15,7 @@ An Anomaly-based alert in SigNoz allows you to define conditions based on metric
 
 ## Step 1: Define the Metric
 In this step, you use the [Metrics Query Builder](https://signoz.io/docs/userguide/query-builder-v5/#metrics-query-builder)
-to choose the metric to monitor. The following fields that are available in Metrics Query Builder includes:
+to choose the metric to monitor. The following fields that are available in Metrics <Tooltip text="Query Builder" content="The visual query interface in SigNoz for building filters, aggregations, and groupings over logs, metrics, and traces without writing query language by hand." link="https://signoz.io/docs/glossary/#query-builder" /> includes:
 
 - **Metric**: A field to select the specific metric you want to monitor (e.g., CPU usage, memory utilization).
 

--- a/data/docs/alerts-management/apdex-alerts.mdx
+++ b/data/docs/alerts-management/apdex-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-17
+date: 2026-08-25
 title: Creating Alerts based on Apdex Score
 description: Create alerts based on Apdex scores in SigNoz to monitor application performance using satisfaction thresholds and PromQL queries.
 doc_type: howto
@@ -45,7 +45,7 @@ This PromQL-based approach only works with histogram metrics that use **cumulati
 
 ### Creating an Alert for Apdex Score
 
-We can create an alert for evaluating Apdex score using a PromQL Query.
+We can create an alert for evaluating Apdex score using a <Tooltip text="PromQL" content="The Prometheus query language, supported in SigNoz for metrics." link="https://signoz.io/docs/glossary/#promql" /> Query.
 
 Let’s assume our threshold to be 2000 ms.
 

--- a/data/docs/alerts-management/troubleshooting/faqs.mdx
+++ b/data/docs/alerts-management/troubleshooting/faqs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-12
+date: 2026-08-25
 description: Frequently asked questions about SigNoz alerts and monitoring features
 title: Alert Management FAQs
 doc_type: reference
@@ -9,7 +9,7 @@ doc_type: reference
 A. Currently synthetic monitoring is not supported in SigNoz. But you can use httpcheck to create HTTP-based health checks for your services. More details [here](https://signoz.io/docs/monitor-http-endpoints/).
 
 ### Q. Can I edit the subject of the alerts?
-A. Yes, you can edit the subject of alerts for Slack, MS Teams, PagerDuty, and Opsgenie notification channels.
+A. Yes, you can edit the subject of alerts for Slack, MS Teams, PagerDuty, and Opsgenie <Tooltip text="notification channels" content="The destination an alert rule sends to when it fires." link="https://signoz.io/docs/glossary/#notification-channel" />.
 To edit the alert subject:
 1. Navigate to **Settings**
 2. Go to **Account Settings**

--- a/data/docs/alerts.mdx
+++ b/data/docs/alerts.mdx
@@ -1,11 +1,11 @@
 ---
-date: 2026-07-30
+date: 2026-08-25
 title: Alerts
 description: Set up and manage alerts across metrics, logs, traces, and anomalies in SigNoz.
 doc_type: explanation
 ---
 
-Alerts in SigNoz give you proactive monitoring across all telemetry signals. Configure alert rules on metrics, logs, traces, anomalies, or exceptions, and route notifications to the right team through your preferred channels.
+Alerts in SigNoz give you proactive monitoring across all telemetry signals. Configure <Tooltip text="alert rules" content="A saved condition evaluated on a query at a fixed interval, which fires notifications to a notification channel when it is met." link="https://signoz.io/docs/glossary/#alert-rule" /> on metrics, logs, traces, anomalies, or exceptions, and route notifications to the right team through your preferred channels.
 
 <Figure
   src="/img/docs/product-features/alerts/alerts-overview-create.gif"

--- a/data/docs/apm-and-distributed-tracing/application-details.mdx
+++ b/data/docs/apm-and-distributed-tracing/application-details.mdx
@@ -1,13 +1,13 @@
 ---
-date: 2026-08-19
+date: 2026-08-25
 title: Application Details
 description: Explore application-level metrics in SigNoz including latency percentiles, error rates, operations per second, key operations, and Apdex scores.
 doc_type: reference
 ---
 
-RED stands for Rate, Errors, and Duration — the three golden signals for monitoring request-driven services. Together, they tell you how much traffic a service handles, how often it fails, and how long requests take.
+RED stands for Rate, Errors, and Duration — the three <Tooltip text="golden signals" content="The four signals Google's SRE practice recommends monitoring for any user-facing system: latency, traffic, errors, and saturation." link="https://signoz.io/docs/glossary/#golden-signals" /> for monitoring request-driven services. Together, they tell you how much traffic a service handles, how often it fails, and how long requests take.
 
-The RED metrics help you spot performance bottlenecks or failures across all your applications. For example, if the error rate of an application increases, you can assume that these errors will impact the experience of your customers. Once you've identified a potential issue, select a row from the Services page to open the application details page.
+The <Tooltip text="RED metrics" content="Rate, Errors, and Duration: the three request-level metrics worth tracking for every service." link="https://signoz.io/docs/glossary/#red-metrics" /> help you spot performance bottlenecks or failures across all your applications. For example, if the error rate of an application increases, you can assume that these errors will impact the experience of your customers. Once you've identified a potential issue, select a row from the Services page to open the application details page.
 
 The application details page has three tabs:
 - **Overview** — latency, rate, error percentage, Apdex, and key operations

--- a/data/docs/apm-and-distributed-tracing/querying-traces.mdx
+++ b/data/docs/apm-and-distributed-tracing/querying-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-08-25
 title: Querying Traces
 description: Query traces in SigNoz using the Query Builder in Trace Explorer and Dashboards, with ClickHouse SQL available in Dashboards.
 doc_type: reference
@@ -9,7 +9,7 @@ SigNoz supports querying traces using the visual **[Query Builder](https://signo
 
 ## Query Builder
 
-The Query Builder is the primary way to query traces. It is available in both Trace Explorer and Dashboards.
+The Query Builder is the primary way to query <Tooltip text="traces" content="The full record of one request's path through a system: a tree of spans connected by parent-child relationships, sharing a trace ID." link="https://signoz.io/docs/glossary/#trace" />. It is available in both Trace Explorer and Dashboards.
 
 ### Filtering
 

--- a/data/docs/cost-meter/cost-meter-dashboard.mdx
+++ b/data/docs/cost-meter/cost-meter-dashboard.mdx
@@ -1,11 +1,11 @@
 ---
-date: 2026-05-18
+date: 2026-08-25
 title: Cost Meter Dashboard - Analyze Observability Ingestion Costs
 description: Use the Cost Meter dashboard in SigNoz to analyze logs, traces, and metrics ingestion, identify expensive signals, and optimize observability costs.
 doc_type: explanation
 ---
 
-The Cost Meter dashboard is the main view for understanding how your observability usage is distributed across logs, traces, and metrics. Use it to compare total ingestion, identify expensive signals, and decide where to drill deeper with Meter Explorer or alerts.
+The <Tooltip text="Cost Meter" content="The SigNoz feature that reports ingestion volume and cost per signal at hourly granularity, so you can attribute spend to services, teams, or attributes." link="https://signoz.io/docs/glossary/#cost-meter" /> dashboard is the main view for understanding how your observability usage is distributed across logs, traces, and metrics. Use it to compare total ingestion, identify expensive signals, and decide where to drill deeper with Meter Explorer or alerts.
 
 <Admonition type="info">
 Meter data is aggregated over hourly intervals. Queries with time ranges under 1 hour will not return any data.

--- a/data/docs/cost-meter/query-api.mdx
+++ b/data/docs/cost-meter/query-api.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-18
+date: 2026-08-25
 title: Query Meter Data via API
 description: Extract daily data volumes and costs for logs, traces, and metrics using the SigNoz Query Range API.
 doc_type: howto
@@ -31,7 +31,7 @@ SigNoz exposes five meter metrics. All use `Sum` / `Delta` temporality: each dat
 
 Filter or group any metric by `service.name`, `deployment.environment`, `host.name`, or `signoz.workspace.key.id` to break costs down by team, environment, or ingestion key.
 
-SigNoz retains meter data for 1 year. 90-day queries are within the retention window.
+SigNoz retains meter data for 1 year. 90-day queries are within the <Tooltip text="retention" content="How long ingested data stays queryable, configured per signal." link="https://signoz.io/docs/glossary/#retention" /> window.
 
 ## API Endpoint
 

--- a/data/docs/dashboards/interactivity.mdx
+++ b/data/docs/dashboards/interactivity.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-01
+date: 2026-08-25
 title: Interactivity in dashboards
 description: Learn how interactive dashboards in SigNoz help you drill down, correlate signals, and troubleshoot faster using context menus, cross filtering, cross-panel sync, and navigation to Logs and Traces.
 
@@ -218,7 +218,7 @@ URL: https://pagerduty.example.com/incidents?service={{_service.name}}&since={{t
 ### Cross Filtering
 
 **Cross Filtering** lets you use clicked data in a panel to update or create **dashboard variables**.  
-When you click on a service, pod, or trace ID, the panel’s **context menu** includes a **Dashboard Variables** option.  
+When you click on a service, pod, or <Tooltip text="trace ID" content="The 16-byte identifier shared by every span in a trace." link="https://signoz.io/docs/glossary/#trace-id" />, the panel’s **context menu** includes a **Dashboard Variables** option.  
 From here, the following actions are available:  
 
 - **Set** – Assign the clicked value to an existing dashboard variable.  

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -103,10 +103,6 @@ For example, a request counter that sees 100 requests in the first minute, 150 i
 
 Following a single request across every service, database call, and queue hop it touches, by stitching [spans](#span) into a [trace](#trace). See [Distributed tracing](https://signoz.io/docs/apm-and-distributed-tracing/querying-traces/).
 
-### Distro
-
-A distribution: a wrapper around an upstream OpenTelemetry repository with defaults or customizations applied, so it works out of the box for a particular platform or vendor.
-
 ### Dropping labels
 
 Removing attributes from a metric at the Collector so they are never stored. Dropping labels alone does not reduce [samples](#sample), since the same data points still arrive, unless the series are also aggregated away. See [Dropping metric labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/).
@@ -127,7 +123,7 @@ In SigNoz, exponential histograms are supported on self-hosted only, not on SigN
 
 ### Exporter
 
-The component that emits telemetry to a consumer: an SDK exporter sending [OTLP](#otlp) to a [Collector](#collector), or a Collector exporter sending data to SigNoz. Exporters can be push- or pull-based.
+The component that emits telemetry to a consumer: an SDK exporter sending [OTLP](#otlp) to a [Collector](#collector), or a Collector exporter sending data to SigNoz. Most exporters push data to their destination as it is ready. A few work the other way round and expose an endpoint that a scraper collects from, which is how the Collector's Prometheus exporter works.
 
 ## F
 
@@ -143,7 +139,9 @@ A visualization of a [trace](#trace) that shows each [span](#span) as a horizont
 
 ### Gauge
 
-A metric that represents a value sampled at a point in time: memory in use, queue depth, temperature. Gauges are not summed across time; the value simply is what it was when read. One gauge data point is one [sample](#sample).
+A metric that reports a value read at a single moment, such as memory in use, queue depth, or CPU temperature. Gauges are never added up across time; each reading replaces the previous one.
+
+For example, a gauge tracking memory in use might export 512 MB, then 480 MB, then 530 MB. The service is using 530 MB at the end, not 1,522 MB, because the numbers describe the same thing at three different moments rather than three separate events to total. Compare a [counter](#counter), where adding the values is exactly the point. One gauge data point is one [sample](#sample).
 
 ### Golden signals
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -15,7 +15,7 @@ If you're here to reason about **metrics volume and cost**, read these five in o
 
 ### Active series
 
-A [time series](#time-series) that is currently receiving [data points](#data-point). Active series count is the main driver of metrics volume: each active series contributes one [sample](#sample) per export interval, so total samples ≈ active series × number of exports in the period. A single series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086 at $0.10 per million). At a 60-second interval, about 43,200. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+A [time series](#time-series) that is currently receiving [data points](#data-point). Active series count is the main driver of metrics volume: each active series contributes one [sample](#sample) per export interval, so total samples ≈ active series × number of exports in the period. A single series exporting every 30 seconds produces about 86,400 samples per month (about \$0.0086 at \$0.10 per million). At a 60-second interval, about 43,200. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Aggregated metric data
 
@@ -269,7 +269,7 @@ An [attribute](#attribute) on a [resource](#resource), such as `service.name`, `
 
 ### Retention
 
-How long ingested data stays queryable, configured per signal. Longer retention raises the per-unit price of ingestion. Metrics are $0.10 per million samples at one month, rising to $0.18 at thirteen months. See [Retention period](https://signoz.io/docs/userguide/retention-period/) and [Pricing](https://signoz.io/pricing/).
+How long ingested data stays queryable, configured per signal. Longer retention raises the per-unit price of ingestion. Metrics are \$0.10 per million samples at one month, rising to \$0.18 at thirteen months. See [Retention period](https://signoz.io/docs/userguide/retention-period/) and [Pricing](https://signoz.io/pricing/).
 
 ## S
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -1,0 +1,389 @@
+---
+date: 2026-08-13
+title: Glossary of Observability and OpenTelemetry Terms
+description: Definitions of OpenTelemetry, observability, and SigNoz terms — from span and resource to sample, cardinality, and identifying attributes.
+doc_type: reference
+---
+
+This glossary defines the terms you'll meet across SigNoz docs, OpenTelemetry specifications, and observability practice. Definitions are short by design; each one links to the doc that goes deeper.
+
+If you're here to reason about **metrics volume and cost**, read these five in order: [sample](#sample), [time series](#time-series), [cardinality](#cardinality), [identifying attribute](#identifying-attribute), and [non-identifying attribute](#non-identifying-attribute). Together they explain why cardinality drives your metrics bill even though SigNoz bills per sample ingested.
+
+[A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [G](#g) · [H](#h) · [I](#i) · [L](#l) · [M](#m) · [N](#n) · [O](#o) · [P](#p) · [Q](#q) · [R](#r) · [S](#s) · [T](#t) · [U](#u) · [V](#v) · [Z](#z)
+
+## A
+
+### Active series
+
+A [time series](#time-series) that is currently receiving [data points](#data-point). Active series count is the main driver of metrics volume: each active series contributes one [sample](#sample) per export interval, so total samples ≈ active series × number of exports in the period. A single series exporting every 30 seconds produces about 86,400 samples per month — about $0.0086 at $0.10 per million; at a 60-second interval, about 43,200. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+
+### Aggregated metric data
+
+Metric data stored at coarser granularity after a [volume control](https://signoz.io/docs/metrics-management/volume-control/) rule aggregates some attributes away. The most recent 24 hours always stay full fidelity, and alerts always evaluate on full-fidelity data. See [Understanding Aggregated Metric Data](https://signoz.io/docs/metrics-management/aggregated-metric-data/).
+
+### Aggregation
+
+Combining many measurements into exact or estimated statistics over a time window — sum, count, average, percentile. Aggregation happens twice: client-side in the SDK (controlled by [instruments](#instrument) and [views](#view)) and query-side in SigNoz. See [Aggregation and grouping](https://signoz.io/docs/querying/aggregation-grouping/).
+
+### Alert rule
+
+A saved condition evaluated on a query at a fixed interval, which fires notifications to a channel when it is met. See [Alerts](https://signoz.io/docs/alerts/).
+
+### APM
+
+Application Performance Monitoring — tracking a service's latency, error rate, throughput, and dependencies. In SigNoz, APM metrics are derived automatically from [spans](#span), so instrumenting traces gives you application metrics for free. See [Application details](https://signoz.io/docs/apm-and-distributed-tracing/application-details/).
+
+### Attribute
+
+A key-value pair that describes the entity producing telemetry. Attributes attach to [spans](#span), [log records](#log-record), metric [data points](#data-point), and [resources](#resource). In metrics, attributes are what produce [cardinality](#cardinality).
+
+## B
+
+### Baggage
+
+A mechanism for propagating key-value metadata across service boundaries alongside trace context, so downstream services can read values set upstream. Baggage is not automatically added to spans as attributes.
+
+### Bucket
+
+One value range of a [histogram](#histogram), holding a count of the observations that fell inside it. Each bucket is stored as its own [time series](#time-series), so bucket count multiplies a histogram's volume: a classic histogram with N buckets stores roughly N + 4 series (the buckets, plus `.count`, `.sum`, `.min`, and `.max`).
+
+## C
+
+### Cardinality
+
+The number of unique [time series](#time-series) a metric produces. Cardinality is the product of the distinct values of the metric's [identifying attributes](#identifying-attribute), including [resource attributes](#resource-attribute).
+
+For example, a metric carrying 10 distinct `http.route` values across 50 pods has 10 × 50 = 500 series. Cardinality is the primary cost driver for metrics — not because SigNoz bills per series (it doesn't), but because every series emits a [sample](#sample) on every export interval. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+
+### Churn
+
+The replacement of [time series](#time-series) by new ones over time — for example, a pod restart producing a new `k8s.pod.name` value and therefore a new series. Churn raises the total number of series stored over a period, but not the number of series active at any one moment, so it does not increase [samples](#sample) per interval. In SigNoz, churn costs nothing extra.
+
+### Collector
+
+The OpenTelemetry Collector — a vendor-agnostic binary that receives, processes, and exports telemetry. Its pipelines are built from [receivers](#receiver), [processors](#processor), and [exporters](#exporter). Running a Collector is the standard place to enrich, filter, batch, or sample data before it reaches SigNoz. See [OpenTelemetry Collector](https://signoz.io/docs/opentelemetry-collection-agents/get-started/).
+
+### Context propagation
+
+The mechanism that carries trace context (and [baggage](#baggage)) across process and service boundaries, so spans emitted by different services join into one [trace](#trace). Usually done by injecting and extracting HTTP headers via a [propagator](#propagator).
+
+### Cost Meter
+
+The SigNoz feature that reports ingestion volume and cost per signal at hourly granularity, so you can attribute spend to services, teams, or attributes. See [Cost Meter](https://signoz.io/docs/cost-meter/overview/).
+
+### Cumulative temporality
+
+A metric [temporality](#temporality) in which each successive data point repeats the same start timestamp and reports a running total — data points cover (T₀, T₁], (T₀, T₂], (T₀, T₃], and so on. This is the OpenTelemetry SDK default. Every active series re-sends its total on every export interval even when nothing changed, so idle series still cost [samples](#sample). Compare [delta temporality](#delta-temporality).
+
+## D
+
+### Dashboard
+
+A saved collection of panels querying logs, metrics, and traces. See [Dashboards](https://signoz.io/docs/dashboards/overview/).
+
+### Data point
+
+The basic unit of metric information: a set of [attributes](#attribute), a value (or values, for a [histogram](#histogram)), and one or two timestamps. One data point belongs to exactly one [time series](#time-series). For billing purposes, a gauge or sum data point is one [sample](#sample); a histogram data point is many.
+
+### Delta temporality
+
+A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export — data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on. Synchronous instruments that recorded nothing during an interval export nothing at all, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
+
+### Distributed tracing
+
+Following a single request across every service, database call, and queue hop it touches, by stitching [spans](#span) into a [trace](#trace). See [Distributed tracing](https://signoz.io/docs/apm-and-distributed-tracing/querying-traces/).
+
+### Distro
+
+A distribution: a wrapper around an upstream OpenTelemetry repository with defaults or customizations applied, so it works out of the box for a particular platform or vendor.
+
+### Dropping labels
+
+Removing attributes from a metric at the Collector so they are never stored. Dropping labels alone does not reduce [samples](#sample) — the same data points still arrive — unless the series are also aggregated away. See [Dropping metric labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/).
+
+## E
+
+### Exemplar
+
+A pointer from an aggregated metric data point back to a specific [trace](#trace) that contributed to it, letting you jump from a latency spike on a chart to a slow request that caused it.
+
+### Exporter
+
+The component that emits telemetry to a consumer — an SDK exporter sending [OTLP](#otlp) to a [Collector](#collector), or a Collector exporter sending data to SigNoz. Exporters can be push- or pull-based.
+
+## F
+
+### Fingerprint
+
+The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. It identifies which [time series](#time-series) a [sample](#sample) belongs to: samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept — nothing in your bill counts fingerprints.
+
+### Flamegraph
+
+A visualization of a [trace](#trace) that shows each [span](#span) as a horizontal bar positioned by start time and sized by duration, making the critical path and the slowest child operations obvious.
+
+## G
+
+### Gauge
+
+A metric that represents a value sampled at a point in time — memory in use, queue depth, temperature. Gauges are not summed across time; the value simply is what it was when read. One gauge data point is one [sample](#sample).
+
+### Golden signals
+
+The four signals Google's SRE practice recommends monitoring for any user-facing system: latency, traffic, errors, and saturation. Compare [RED metrics](#red-metrics).
+
+## H
+
+### Head sampling
+
+Deciding whether to keep a [trace](#trace) at its start, before any spans complete — typically a fixed percentage of traces. Cheap and simple, but blind to what the trace turned out to contain. Compare [tail sampling](#tail-sampling).
+
+### Histogram
+
+A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max — the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). An **exponential histogram** uses exponentially-scaled bucket boundaries instead of explicit ones, covering a wide range with fewer buckets.
+
+## I
+
+### Identifying attribute
+
+An [attribute](#attribute) whose values split otherwise-identical label sets into more [time series](#time-series). Adding one multiplies [cardinality](#cardinality) by its number of distinct values, and therefore multiplies [samples](#sample).
+
+Start with a metric that has a single label set `X`. Add `http.route` with 10 distinct values, and `X` becomes 10 label sets — 10 series, 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying in this sense.
+
+Teams sometimes call this concept a "unique label set" — see [unique label set](#unique-label-set). OpenTelemetry does not yet publish a canonical list of identifying attributes, though the project is moving toward distinguishing them. Compare [non-identifying attribute](#non-identifying-attribute).
+
+### Ingestion key
+
+The credential a Collector or SDK uses to send data to a SigNoz Cloud workspace. See [Ingestion keys](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
+
+### Instrument
+
+The named object an application uses to record measurements — a [counter](#sum), an up-down counter, a [gauge](#gauge), or a [histogram](#histogram). An instrument is defined by its name, kind, and optional unit and description, and is created from a [meter](#meter). **Synchronous** instruments record inline with application code; **asynchronous** (observable) instruments are collected once per export via a callback.
+
+### Instrumentation
+
+The code that produces telemetry. **Manual** instrumentation is written by hand with the OpenTelemetry API; **library** instrumentation ships with or wraps a framework; [zero-code instrumentation](#zero-code-instrumentation) attaches at runtime with no source changes. See [Instrumentation](https://signoz.io/docs/instrumentation/).
+
+## L
+
+### Label
+
+A metric [attribute](#attribute) — the Prometheus term, used interchangeably in metrics contexts. A metric's **label set** is the specific combination of label values that identifies one [time series](#time-series).
+
+### Log record
+
+A timestamped record of an event, with a severity and optional [attributes](#attribute). When emitted inside an active span, a log record carries the trace and span ID, which is what lets SigNoz link logs to traces. See [Logs](https://signoz.io/docs/logs-management/overview/).
+
+### Logs pipeline
+
+A SigNoz-side processing chain that parses, transforms, or enriches log records after ingestion — extracting JSON fields, promoting attributes, redacting values. See [Logs pipelines](https://signoz.io/docs/logs-pipelines/introduction/).
+
+## M
+
+### Meter
+
+The object that creates metric [instruments](#instrument), obtained from a meter provider. Roughly the metrics equivalent of a [tracer](#tracer).
+
+### Metric
+
+A numeric measurement recorded over time — a request count, a latency distribution, a memory reading. Metrics are cheap to store at scale and ideal for dashboards and alerting, at the cost of losing per-request detail. See [Metrics](https://signoz.io/docs/metrics-management/overview/).
+
+## N
+
+### Non-identifying attribute
+
+An [attribute](#attribute) whose value is already determined by attributes present on the series, so adding it creates no new [time series](#time-series) and no additional [samples](#sample). `host.type` is non-identifying when `host.id` is already there: each host has exactly one type, so the label set count is unchanged.
+
+Non-identifying attributes are effectively free in SigNoz — metrics are not billed per label or by label size. EC2 tags added by the AWS resource detector behave this way: they become part of series identity, but because each instance already has its own series, they add no series and no cost. Compare [identifying attribute](#identifying-attribute).
+
+## O
+
+### Observability
+
+The ability to answer questions about a system's internal state from the telemetry it emits — including questions you did not anticipate when you instrumented it. Distinguished from monitoring by that last clause: monitoring answers known questions about known failure modes. Often abbreviated **o11y**.
+
+### OpenTelemetry
+
+The vendor-neutral CNCF project that defines APIs, SDKs, a wire protocol ([OTLP](#otlp)), and [semantic conventions](#semantic-conventions) for traces, metrics, and logs. Instrumenting with OpenTelemetry means your telemetry is not tied to any one backend. Often abbreviated **OTel**. See [What is OpenTelemetry](https://signoz.io/docs/overview/what-is-opentelemetry-and-why-it-matters/).
+
+### OTLP
+
+The OpenTelemetry Protocol — the wire format for sending traces, metrics, and logs, over gRPC or HTTP. It is the protocol SigNoz ingests natively.
+
+## P
+
+### Processor
+
+A [Collector](#collector) pipeline component that sits between receiving and exporting, transforming data in flight — batching, filtering, adding resource attributes, [tail sampling](#tail-sampling).
+
+### PromQL
+
+The Prometheus query language, supported in SigNoz for metrics. PromQL assumes cumulative counters and cannot read [delta temporality](#delta-temporality) series. See [Prometheus metrics](https://signoz.io/docs/userguide/prometheus-metrics/).
+
+### Propagator
+
+The component that serializes and deserializes trace context and [baggage](#baggage) into and out of carriers such as HTTP headers, enabling [context propagation](#context-propagation). The default is W3C Trace Context (`traceparent`).
+
+## Q
+
+### Query Builder
+
+The visual query interface in SigNoz for building filters, aggregations, and groupings over logs, metrics, and traces without writing query language by hand. See [Query Builder](https://signoz.io/docs/userguide/query-builder-v5/).
+
+## R
+
+### RED metrics
+
+Rate, Errors, and Duration — the three request-level metrics worth tracking for every service. SigNoz derives them from [spans](#span) automatically. Compare [golden signals](#golden-signals).
+
+### Receiver
+
+A [Collector](#collector) pipeline component that defines how telemetry enters the Collector — an OTLP endpoint, a Prometheus scrape, a log file tail. Receivers can be push- or pull-based.
+
+### Resource
+
+The entity that produced the telemetry — a service instance, host, container, or pod — described by a set of [resource attributes](#resource-attribute). Every span, metric, and log record carries exactly one resource.
+
+### Resource attribute
+
+An [attribute](#attribute) on a [resource](#resource), such as `service.name`, `host.name`, or `k8s.pod.name`. Resource attributes are not treated specially for metric identity: they are part of the [fingerprint](#fingerprint) exactly like data point attributes, and they can be [identifying](#identifying-attribute) or [non-identifying](#non-identifying-attribute) in the same way.
+
+### Retention
+
+How long ingested data stays queryable, configured per signal. Longer retention raises the per-unit price of ingestion — metrics are $0.10 per million samples at one month, rising to $0.18 at thirteen months. See [Retention period](https://signoz.io/docs/userguide/retention-period/) and [Pricing](https://signoz.io/pricing/).
+
+## S
+
+### Sample
+
+One float value at one timestamp in one [time series](#time-series) — and the unit SigNoz bills metrics on, at **$0.10 per million samples ingested**. There is no charge per series, per unique metric, or per label.
+
+- A [gauge](#gauge) or [sum](#sum) data point is 1 sample.
+- A [histogram](#histogram) data point is (number of [buckets](#bucket) × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
+
+Total samples = [active series](#active-series) × export frequency, which is why [cardinality](#cardinality) and export interval are the two levers that actually move your metrics bill. Lengthening the export interval from 30s to 60s halves the volume. For scale: 100,000 active series at a 30-second interval is about 8.6 billion samples per month, or roughly $864. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/) and [Pricing](https://signoz.io/pricing/).
+
+### Sampling
+
+Keeping only a portion of telemetry to control volume and cost. See [head sampling](#head-sampling) and [tail sampling](#tail-sampling).
+
+### Scope
+
+The instrumentation scope — the name and version of the library or module that emitted the telemetry, which is how you tell "spans from our HTTP client instrumentation" from "spans we wrote by hand". Scope attributes are part of a metric's [fingerprint](#fingerprint).
+
+### Semantic conventions
+
+OpenTelemetry's standard names and values for attributes and metrics — `http.request.method`, `db.system.name`, `service.name`. Following them is what makes telemetry from different languages and libraries comparable, and what lets SigNoz build views that work without configuration.
+
+### Service
+
+A named unit of an application that produces telemetry, identified by the `service.name` resource attribute. It is the primary grouping in APM views, so getting `service.name` right matters more than almost any other attribute.
+
+### Signal
+
+One of the telemetry types OpenTelemetry defines: traces, metrics, or logs. (Profiles are in progress.)
+
+### SLI
+
+Service Level Indicator — the measured quantity in a reliability target, such as the fraction of requests served under 300 ms.
+
+### SLO
+
+Service Level Objective — a target value for an [SLI](#sli) over a time window, such as "99.9% of requests under 300 ms over 30 days". The gap between the objective and 100% is your error budget.
+
+### Span
+
+A single operation within a [trace](#trace) — an HTTP handler, a database query, a queue publish. A span has a name, start and end timestamps, [attributes](#attribute), a [status](#span-status), and a parent, which is what gives a trace its tree structure. See [Span details](https://signoz.io/docs/userguide/span-details/).
+
+### Span event
+
+A timestamped annotation on a [span](#span), used for things that happen at a moment rather than over a duration — a retry, a cache miss, a recorded exception.
+
+### Span link
+
+A pointer from one [span](#span) to another causally related span in a different trace. The standard use is batch processing, where one job span links to each of the many traces that produced its inputs.
+
+### Span status
+
+The outcome of the operation a [span](#span) represents: `Unset`, `Ok`, or `Error`. Span status is what error rate is computed from, so setting it correctly on caught exceptions matters.
+
+### Sum
+
+A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. A **counter** is a monotonic sum — it only goes up, like an odometer. An **up-down counter** is a non-monotonic sum, like queue length.
+
+## T
+
+### Tail sampling
+
+Deciding whether to keep a [trace](#trace) after all its spans have arrived, so the decision can depend on what happened — keep every trace with an error or over 2 seconds, sample the rest at 5%. Requires a Collector that sees the whole trace. See [Tail sampling](https://signoz.io/docs/traces-management/guides/tail-sampling/).
+
+### Temporality
+
+Whether a metric's data points report a running total or only the change since the last export. See [cumulative temporality](#cumulative-temporality) and [delta temporality](#delta-temporality). Temporality is part of a metric's [fingerprint](#fingerprint), so the same metric sent with both temporalities produces separate series.
+
+### Time series
+
+A single stream of [samples](#sample) over time, identified by a metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes — in other words, by one specific label set.
+
+In SigNoz, series are real for storage and querying: each is identified by a [fingerprint](#fingerprint), the label set is stored once per series, and Metrics Explorer reports per-metric series counts. Series are **not** a billing unit — SigNoz bills [samples](#sample) ingested, unlike vendors that charge per time series or per custom metric. See [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/).
+
+### Trace
+
+The full record of one request's path through a system: a tree of [spans](#span) connected by parent-child relationships, sharing a [trace ID](#trace-id).
+
+### Trace funnel
+
+A SigNoz feature for measuring how many traces complete a defined sequence of steps and where they drop off. See [Trace funnels](https://signoz.io/docs/trace-funnels/overview/).
+
+### Trace ID
+
+The 16-byte identifier shared by every [span](#span) in a [trace](#trace). Each span additionally has an 8-byte span ID; together with trace flags they form the span context that [propagators](#propagator) carry between services.
+
+### Tracer
+
+The object that creates [spans](#span), obtained from a tracer provider and named after the [scope](#scope) doing the instrumenting.
+
+## U
+
+### Unique label set
+
+An informal name for what uniquely identifies a [time series](#time-series) — the specific combination of label values that distinguishes it from every other series of the same metric. Adding an [identifying attribute](#identifying-attribute) multiplies the number of unique label sets; adding a [non-identifying attribute](#non-identifying-attribute) does not.
+
+### Unit
+
+The unit of measurement declared on an [instrument](#instrument), written in UCUM notation — `ms`, `By`, `1`. Units are part of a metric's metadata and drive axis formatting.
+
+## V
+
+### View
+
+An SDK-side rule that customizes what the SDK exports — renaming a metric stream, changing its aggregation or histogram buckets, dropping attributes, or ignoring an instrument entirely. Views are the earliest and cheapest place to cut [cardinality](#cardinality), because dropped attributes are never emitted at all.
+
+## Z
+
+### Zero-code instrumentation
+
+Instrumentation attached at runtime without modifying source code — a Java agent, a Python `opentelemetry-instrument` wrapper, an OTel operator injecting a sidecar. Also called auto-instrumentation. See [Instrumentation](https://signoz.io/docs/instrumentation/).
+
+## Related
+
+<DocCardContainer>
+
+<DocCard
+    title="Understanding Metrics Billing and Reducing Costs"
+    description="How samples, cardinality, and export frequency determine your metrics bill"
+    href="https://signoz.io/docs/metrics-management/reducing-costs/"
+/>
+
+<DocCard
+    title="What is OpenTelemetry?"
+    description="Why OpenTelemetry exists and what it standardizes"
+    href="https://signoz.io/docs/overview/what-is-opentelemetry-and-why-it-matters/"
+/>
+
+<DocCard
+    title="Cost Meter"
+    description="Monitor ingestion volume and spend per signal"
+    href="https://signoz.io/docs/cost-meter/overview/"
+/>
+
+</DocCardContainer>

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -45,7 +45,7 @@ One value range of a [histogram](#histogram), holding a count of the observation
 
 For example, a request-duration histogram with boundaries at 5, 10, 25, and 100 milliseconds has five buckets, and a 12 ms request lands in the one spanning 10 ms to 25 ms. In Prometheus form, and so in [PromQL](#promql), each bucket becomes its own series labelled `le` ("less than or equal to"), and those counts are cumulative: `le="25"` counts every request of 25 ms or faster, and `le="+Inf"` counts them all. This is the label you group by when computing percentiles: see the [PromQL guide](https://signoz.io/docs/userguide/write-a-prom-query-with-new-format/).
 
-Each bucket is stored as its own [time series](#time-series), so bucket count drives a histogram's volume: a classic histogram with N buckets stores roughly N + 4 series, the extra four being `.count`, `.sum`, `.min`, and `.max`.
+Each bucket is stored as its own [time series](#time-series), so bucket count drives a histogram's volume: a classic histogram stores one series per bucket, plus `.count` (always present), plus `.sum`, `.min`, and `.max` when the SDK emits them.
 
 ## C
 
@@ -129,7 +129,7 @@ The component that emits telemetry to a consumer: an SDK exporter sending [OTLP]
 
 ### Fingerprint
 
-The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. Each [time series](#time-series) of a metric has exactly one fingerprint and each fingerprint identifies exactly one series, so counting distinct fingerprints over a time range gives that metric's series count for the range. Samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept. Nothing in your bill counts fingerprints.
+The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), the [instrumentation scope](#scope) identity (name, version, schema URL, and attributes), and data point attributes. Each [time series](#time-series) of a metric has exactly one fingerprint and each fingerprint identifies exactly one series, so counting distinct fingerprints over a time range gives that metric's series count for the range. Samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept. Nothing in your bill counts fingerprints.
 
 ### Flamegraph
 
@@ -155,7 +155,7 @@ Deciding whether to keep a [trace](#trace) at its start, before any spans comple
 
 ### Histogram
 
-A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max. This is the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). The buckets here are configured explicitly; compare [exponential histogram](#exponential-histogram), where they are computed instead.
+A metric that aggregates many observations client-side into [buckets](#bucket), plus a count and optional sum, min, and max. This is the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). The buckets here are configured explicitly; compare [exponential histogram](#exponential-histogram), where they are computed instead.
 
 ## I
 
@@ -173,7 +173,7 @@ The credential a Collector or SDK uses to send data to a SigNoz Cloud workspace.
 
 ### Instrument
 
-The named object an application uses to record measurements: a [counter](#sum), an up-down counter, a [gauge](#gauge), or a [histogram](#histogram). An instrument is defined by its name, kind, and optional unit and description, and is created from a [meter](#meter). **Synchronous** instruments record inline with application code; **asynchronous** (observable) instruments are collected once per export via a callback.
+The named object an application uses to record measurements: a [counter](#counter), an up-down counter, a [gauge](#gauge), or a [histogram](#histogram). An instrument is defined by its name, kind, and optional unit and description, and is created from a [meter](#meter). **Synchronous** instruments record inline with application code; **asynchronous** (observable) instruments are collected once per export via a callback.
 
 ### Instrumentation
 
@@ -223,11 +223,11 @@ The ability to answer questions about a system's internal state from the telemet
 
 ### OpenTelemetry
 
-The vendor-neutral CNCF project that defines APIs, SDKs, a wire protocol ([OTLP](#otlp)), and [semantic conventions](#semantic-conventions) for traces, metrics, and logs. Instrumenting with OpenTelemetry means your telemetry is not tied to any one backend. Often abbreviated **OTel**. See [What is OpenTelemetry](https://signoz.io/docs/overview/what-is-opentelemetry-and-why-it-matters/).
+The vendor-neutral CNCF project that defines APIs, SDKs, a wire protocol ([OTLP](#otlp)), and [semantic conventions](#semantic-conventions) for traces, metrics, logs, and (in Alpha) profiles. Instrumenting with OpenTelemetry means your telemetry is not tied to any one backend. Often abbreviated **OTel**. See [What is OpenTelemetry](https://signoz.io/docs/overview/what-is-opentelemetry-and-why-it-matters/).
 
 ### OTLP
 
-The OpenTelemetry Protocol, the wire format for sending traces, metrics, and logs, over gRPC or HTTP. It is the protocol SigNoz ingests natively.
+The OpenTelemetry Protocol, the wire format for sending traces, metrics, logs, and (in Alpha) profiles, over gRPC or HTTP. It is the protocol SigNoz ingests natively.
 
 ## P
 
@@ -278,7 +278,8 @@ How long ingested data stays queryable, configured per signal. Longer retention 
 One float value at one timestamp in one [time series](#time-series), and the unit SigNoz bills metrics on, at **$0.10 per million samples ingested**. There is no charge per series, per unique metric, or per label.
 
 - A [gauge](#gauge) or [sum](#sum) data point is 1 sample.
-- A [histogram](#histogram) data point is (number of [buckets](#bucket) × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
+- A [histogram](#histogram) data point is one sample per [bucket](#bucket) (including `+Inf`), plus `.count` (always present), plus `.sum`, `.min`, and `.max` when the SDK emits them.
+- A summary data point is one sample per quantile, plus `.count` and `.sum`.
 
 Total samples = [active series](#active-series) × export frequency, which is why [cardinality](#cardinality) and export interval are the two levers that actually move your metrics bill. This uses the number of series genuinely active, not the product of your attributes' distinct values, which is only an upper bound. Lengthening the export interval from 30s to 60s halves the volume. For scale: 100,000 active series at a 30-second interval is about 8.6 billion samples per month, or roughly $864. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/) and [Pricing](https://signoz.io/pricing/).
 
@@ -300,7 +301,7 @@ A named unit of an application that produces telemetry, identified by the `servi
 
 ### Signal
 
-One of the telemetry types OpenTelemetry defines: traces, metrics, or logs.
+One of the telemetry types OpenTelemetry defines. SigNoz works with traces, metrics, and logs. OpenTelemetry also defines profiles as a fourth signal, currently in Alpha (see the <a href="https://opentelemetry.io/docs/specs/otel/profiles/" target="_blank" rel="noopener noreferrer nofollow">Profiles specification</a>).
 
 ### SLI
 
@@ -316,7 +317,7 @@ A timestamped annotation on a [span](#span), used for things that happen at a mo
 
 ### Span link
 
-A pointer from one [span](#span) to another causally related span in a different trace. The standard use is batch processing, where one job span links to each of the many traces that produced its inputs.
+A pointer from one [span](#span) to another causally related span in a different trace. The standard use is batch processing, where one job span links to each of the many traces that produced its inputs. See [Span links](https://signoz.io/docs/traces-management/guides/span-links/).
 
 ### Span status
 
@@ -324,7 +325,7 @@ The outcome of the operation a [span](#span) represents: `Unset`, `Ok`, or `Erro
 
 ### Sum
 
-A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. That flag splits sums into two kinds: see [counter](#counter) and [up-down counter](#up-down-counter).
+A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. That flag splits sums into two kinds: see [counter](#counter) and [up-down counter](#up-down-counter). See [Metric types and aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/).
 
 ## T
 
@@ -334,11 +335,11 @@ Deciding whether to keep a [trace](#trace) after all its spans have arrived, so 
 
 ### Temporality
 
-Whether a metric's data points report a running total or only the change since the last export. See [cumulative temporality](#cumulative-temporality) and [delta temporality](#delta-temporality). Temporality applies only to [sums](#sum) and [histograms](#histogram). It is meaningless for a [gauge](#gauge), which reports the value read at a moment, so gauge data points carry no temporality at all. Temporality is part of a metric's [fingerprint](#fingerprint), so the same metric sent with both temporalities produces separate series.
+Whether a metric's data points report a running total or only the change since the last export. See [cumulative temporality](#cumulative-temporality) and [delta temporality](#delta-temporality). Temporality applies only to [sums](#sum) and [histograms](#histogram). It is meaningless for a [gauge](#gauge), which reports the value read at a moment, so gauge data points carry no temporality at all. Temporality is part of a metric's [fingerprint](#fingerprint), so the same metric sent with both temporalities produces separate series. See [Temporality of metrics](https://signoz.io/docs/metrics-management/types-and-aggregation/#temporality-of-metrics).
 
 ### Time series
 
-A single stream of [samples](#sample) over time, identified by a metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. In other words, by one specific label set.
+A single stream of [samples](#sample) over time, identified by a metric name, [temporality](#temporality), [resource attributes](#resource-attribute), the [instrumentation scope](#scope) identity (name, version, schema URL, and attributes), and data point attributes. In other words, by one specific label set.
 
 In SigNoz, series are real for storage and querying: each is identified by a [fingerprint](#fingerprint), the label set is stored once per series, and Metrics Explorer reports per-metric series counts. Series are **not** a billing unit. SigNoz bills [samples](#sample) ingested, unlike vendors that charge per time series or per custom metric. See [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/).
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-25
+date: 2026-08-27
 title: Glossary of Observability and OpenTelemetry Terms
 description: Definitions of OpenTelemetry, observability, and SigNoz terms, from span and resource to sample, cardinality, and identifying attributes.
 doc_type: reference
@@ -97,7 +97,7 @@ The basic unit of metric information: a set of [attributes](#attribute), a value
 
 A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export. Data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on.
 
-For example, the same counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `150`, then nothing at all. Synchronous instruments that recorded nothing during an interval export no data point, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
+For example, a request counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `150`, then nothing at all. Synchronous instruments that recorded nothing during an interval export no data point, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Distributed tracing
 
@@ -116,6 +116,12 @@ Removing attributes from a metric at the Collector so they are never stored. Dro
 ### Exemplar
 
 A pointer from an aggregated metric data point back to a specific [trace](#trace) that contributed to it, letting you jump from a latency spike on a chart to a slow request that caused it.
+
+### Exponential histogram
+
+A [histogram](#histogram) whose [bucket](#bucket) boundaries are computed from a `scale` parameter rather than listed explicitly. Boundaries sit at integer powers of `base = 2^(2^-scale)`, so a higher scale gives finer resolution, and a separate zero bucket counts values whose absolute value falls at or below a zero threshold.
+
+Because the buckets adapt to the data, an exponential histogram covers a wide range of values with small relative error and far fewer buckets than an explicit-bucket histogram, and nobody has to guess boundaries up front. In SigNoz, exponential histogram samples are stored separately from scalar samples, and [volume control](https://signoz.io/docs/metrics-management/volume-control/) rules are not supported on them. See [Metric types and aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/).
 
 ### Exporter
 
@@ -149,7 +155,7 @@ Deciding whether to keep a [trace](#trace) at its start, before any spans comple
 
 ### Histogram
 
-A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max. This is the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). An **exponential histogram** uses exponentially-scaled bucket boundaries instead of explicit ones, covering a wide range with fewer buckets.
+A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max. This is the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). The buckets here are configured explicitly; compare [exponential histogram](#exponential-histogram), where they are computed instead.
 
 ## I
 
@@ -207,7 +213,7 @@ Non-identifying attributes are effectively free in SigNoz, since metrics are not
 
 ### Notification channel
 
-The destination an [alert rule](#alert-rule) sends to when it fires. SigNoz supports Slack, email, PagerDuty, Opsgenie, Microsoft Teams, Google Chat, Jira, incident.io, Rootly, Zenduty, and generic webhooks. A channel is set up once and can then be picked by any alert rule. See [Setup notifications](https://signoz.io/docs/setup-alerts-notification/).
+The destination an [alert rule](#alert-rule) sends to when it fires. A channel is set up once and can then be picked by any alert rule. See [Setup notifications](https://signoz.io/docs/setup-alerts-notification/) for the channels SigNoz supports.
 
 ## O
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -97,7 +97,7 @@ The basic unit of metric information: a set of [attributes](#attribute), a value
 
 A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export. Data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on.
 
-For example, a request counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `150`, then nothing at all. Synchronous instruments that recorded nothing during an interval export no data point, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
+For example, a request counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `150`, then nothing at all. Synchronous instruments that recorded nothing during an interval export no data point, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality).
 
 ### Distributed tracing
 
@@ -121,7 +121,9 @@ A pointer from an aggregated metric data point back to a specific [trace](#trace
 
 A [histogram](#histogram) whose [bucket](#bucket) boundaries are computed from a `scale` parameter rather than listed explicitly. Boundaries sit at integer powers of `base = 2^(2^-scale)`, so a higher scale gives finer resolution, and a separate zero bucket counts values whose absolute value falls at or below a zero threshold.
 
-Because the buckets adapt to the data, an exponential histogram covers a wide range of values with small relative error and far fewer buckets than an explicit-bucket histogram, and nobody has to guess boundaries up front. In SigNoz, exponential histogram samples are stored separately from scalar samples, and [volume control](https://signoz.io/docs/metrics-management/volume-control/) rules are not supported on them. See [Metric types and aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/).
+Because the buckets adapt to the data, an exponential histogram covers a wide range of values with small relative error and far fewer buckets than an explicit-bucket histogram, and nobody has to guess boundaries up front.
+
+In SigNoz, exponential histograms are supported on self-hosted only, not on SigNoz Cloud, and they must be sent with [delta temporality](#delta-temporality): cumulative exponential histograms are not read. See [Metric types and aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/).
 
 ### Exporter
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-13
 title: Glossary of Observability and OpenTelemetry Terms
-description: Definitions of OpenTelemetry, observability, and SigNoz terms — from span and resource to sample, cardinality, and identifying attributes.
+description: Definitions of OpenTelemetry, observability, and SigNoz terms, from span and resource to sample, cardinality, and identifying attributes.
 doc_type: reference
 ---
 
@@ -15,7 +15,7 @@ If you're here to reason about **metrics volume and cost**, read these five in o
 
 ### Active series
 
-A [time series](#time-series) that is currently receiving [data points](#data-point). Active series count is the main driver of metrics volume: each active series contributes one [sample](#sample) per export interval, so total samples ≈ active series × number of exports in the period. A single series exporting every 30 seconds produces about 86,400 samples per month — about $0.0086 at $0.10 per million; at a 60-second interval, about 43,200. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+A [time series](#time-series) that is currently receiving [data points](#data-point). Active series count is the main driver of metrics volume: each active series contributes one [sample](#sample) per export interval, so total samples ≈ active series × number of exports in the period. A single series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086 at $0.10 per million). At a 60-second interval, about 43,200. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Aggregated metric data
 
@@ -23,7 +23,7 @@ Metric data stored at coarser granularity after a [volume control](https://signo
 
 ### Aggregation
 
-Combining many measurements into exact or estimated statistics over a time window — sum, count, average, percentile. Aggregation happens twice: client-side in the SDK (controlled by [instruments](#instrument) and [views](#view)) and query-side in SigNoz. See [Aggregation and grouping](https://signoz.io/docs/querying/aggregation-grouping/).
+Combining many measurements into exact or estimated statistics over a time window: sum, count, average, percentile. Aggregation happens twice: client-side in the SDK (controlled by [instruments](#instrument) and [views](#view)) and query-side in SigNoz. See [Aggregation and grouping](https://signoz.io/docs/querying/aggregation-grouping/).
 
 ### Alert rule
 
@@ -31,7 +31,7 @@ A saved condition evaluated on a query at a fixed interval, which fires notifica
 
 ### APM
 
-Application Performance Monitoring — tracking a service's latency, error rate, throughput, and dependencies. In SigNoz, APM metrics are derived automatically from [spans](#span), so instrumenting traces gives you application metrics for free. See [Application details](https://signoz.io/docs/apm-and-distributed-tracing/application-details/).
+Application Performance Monitoring. Tracks a service's latency, error rate, throughput, and dependencies. In SigNoz, APM metrics are derived automatically from [spans](#span), so instrumenting traces gives you application metrics for free. See [Application details](https://signoz.io/docs/apm-and-distributed-tracing/application-details/).
 
 ### Attribute
 
@@ -53,15 +53,15 @@ One value range of a [histogram](#histogram), holding a count of the observation
 
 The number of unique [time series](#time-series) a metric produces. Cardinality is the product of the distinct values of the metric's [identifying attributes](#identifying-attribute), including [resource attributes](#resource-attribute).
 
-For example, a metric carrying 10 distinct `http.route` values across 50 pods has 10 × 50 = 500 series. Cardinality is the primary cost driver for metrics — not because SigNoz bills per series (it doesn't), but because every series emits a [sample](#sample) on every export interval. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+For example, a metric carrying 10 distinct `http.route` values across 50 pods has 10 × 50 = 500 series. Cardinality is the primary cost driver for metrics. SigNoz does not bill per series; cardinality matters because every series emits a [sample](#sample) on every export interval. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Churn
 
-The replacement of [time series](#time-series) by new ones over time — for example, a pod restart producing a new `k8s.pod.name` value and therefore a new series. Churn raises the total number of series stored over a period, but not the number of series active at any one moment, so it does not increase [samples](#sample) per interval. In SigNoz, churn costs nothing extra.
+The replacement of [time series](#time-series) by new ones over time. For example, a pod restart produces a new `k8s.pod.name` value and therefore a new series. Churn raises the total number of series stored over a period, but not the number of series active at any one moment, so it does not increase [samples](#sample) per interval. In SigNoz, churn costs nothing extra.
 
 ### Collector
 
-The OpenTelemetry Collector — a vendor-agnostic binary that receives, processes, and exports telemetry. Its pipelines are built from [receivers](#receiver), [processors](#processor), and [exporters](#exporter). Running a Collector is the standard place to enrich, filter, batch, or sample data before it reaches SigNoz. See [OpenTelemetry Collector](https://signoz.io/docs/opentelemetry-collection-agents/get-started/).
+The OpenTelemetry Collector, a vendor-agnostic binary that receives, processes, and exports telemetry. Its pipelines are built from [receivers](#receiver), [processors](#processor), and [exporters](#exporter). Running a Collector is the standard place to enrich, filter, batch, or sample data before it reaches SigNoz. See [OpenTelemetry Collector](https://signoz.io/docs/opentelemetry-collection-agents/get-started/).
 
 ### Context propagation
 
@@ -73,7 +73,7 @@ The SigNoz feature that reports ingestion volume and cost per signal at hourly g
 
 ### Cumulative temporality
 
-A metric [temporality](#temporality) in which each successive data point repeats the same start timestamp and reports a running total — data points cover (T₀, T₁], (T₀, T₂], (T₀, T₃], and so on. This is the OpenTelemetry SDK default. Every active series re-sends its total on every export interval even when nothing changed, so idle series still cost [samples](#sample). Compare [delta temporality](#delta-temporality).
+A metric [temporality](#temporality) in which each successive data point repeats the same start timestamp and reports a running total. Data points cover (T₀, T₁], (T₀, T₂], (T₀, T₃], and so on. This is the OpenTelemetry SDK default. Every active series re-sends its total on every export interval even when nothing changed, so idle series still cost [samples](#sample). Compare [delta temporality](#delta-temporality).
 
 ## D
 
@@ -87,7 +87,7 @@ The basic unit of metric information: a set of [attributes](#attribute), a value
 
 ### Delta temporality
 
-A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export — data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on. Synchronous instruments that recorded nothing during an interval export nothing at all, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
+A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export. Data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on. Synchronous instruments that recorded nothing during an interval export nothing at all, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Distributed tracing
 
@@ -99,7 +99,7 @@ A distribution: a wrapper around an upstream OpenTelemetry repository with defau
 
 ### Dropping labels
 
-Removing attributes from a metric at the Collector so they are never stored. Dropping labels alone does not reduce [samples](#sample) — the same data points still arrive — unless the series are also aggregated away. See [Dropping metric labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/).
+Removing attributes from a metric at the Collector so they are never stored. Dropping labels alone does not reduce [samples](#sample), since the same data points still arrive, unless the series are also aggregated away. See [Dropping metric labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/).
 
 ## E
 
@@ -109,13 +109,13 @@ A pointer from an aggregated metric data point back to a specific [trace](#trace
 
 ### Exporter
 
-The component that emits telemetry to a consumer — an SDK exporter sending [OTLP](#otlp) to a [Collector](#collector), or a Collector exporter sending data to SigNoz. Exporters can be push- or pull-based.
+The component that emits telemetry to a consumer: an SDK exporter sending [OTLP](#otlp) to a [Collector](#collector), or a Collector exporter sending data to SigNoz. Exporters can be push- or pull-based.
 
 ## F
 
 ### Fingerprint
 
-The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. It identifies which [time series](#time-series) a [sample](#sample) belongs to: samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept — nothing in your bill counts fingerprints.
+The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. It identifies which [time series](#time-series) a [sample](#sample) belongs to: samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept. Nothing in your bill counts fingerprints.
 
 ### Flamegraph
 
@@ -125,7 +125,7 @@ A visualization of a [trace](#trace) that shows each [span](#span) as a horizont
 
 ### Gauge
 
-A metric that represents a value sampled at a point in time — memory in use, queue depth, temperature. Gauges are not summed across time; the value simply is what it was when read. One gauge data point is one [sample](#sample).
+A metric that represents a value sampled at a point in time: memory in use, queue depth, temperature. Gauges are not summed across time; the value simply is what it was when read. One gauge data point is one [sample](#sample).
 
 ### Golden signals
 
@@ -135,11 +135,11 @@ The four signals Google's SRE practice recommends monitoring for any user-facing
 
 ### Head sampling
 
-Deciding whether to keep a [trace](#trace) at its start, before any spans complete — typically a fixed percentage of traces. Cheap and simple, but blind to what the trace turned out to contain. Compare [tail sampling](#tail-sampling).
+Deciding whether to keep a [trace](#trace) at its start, before any spans complete, typically a fixed percentage of traces. Cheap and simple, but blind to what the trace turned out to contain. Compare [tail sampling](#tail-sampling).
 
 ### Histogram
 
-A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max — the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). An **exponential histogram** uses exponentially-scaled bucket boundaries instead of explicit ones, covering a wide range with fewer buckets.
+A metric that aggregates many observations client-side into [buckets](#bucket), plus a count, sum, and optional min and max. This is the standard way to measure latency distributions. Histograms are the most volume-intensive metric type, because every bucket is its own [time series](#time-series). An **exponential histogram** uses exponentially-scaled bucket boundaries instead of explicit ones, covering a wide range with fewer buckets.
 
 ## I
 
@@ -147,9 +147,9 @@ A metric that aggregates many observations client-side into [buckets](#bucket), 
 
 An [attribute](#attribute) whose values split otherwise-identical label sets into more [time series](#time-series). Adding one multiplies [cardinality](#cardinality) by its number of distinct values, and therefore multiplies [samples](#sample).
 
-Start with a metric that has a single label set `X`. Add `http.route` with 10 distinct values, and `X` becomes 10 label sets — 10 series, 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying in this sense.
+Start with a metric that has a single label set `X`. Add `http.route` with 10 distinct values, and `X` becomes 10 label sets: 10 series, and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying in this sense.
 
-Teams sometimes call this concept a "unique label set" — see [unique label set](#unique-label-set). OpenTelemetry does not yet publish a canonical list of identifying attributes, though the project is moving toward distinguishing them. Compare [non-identifying attribute](#non-identifying-attribute).
+Teams sometimes call this concept a "unique label set" (see [unique label set](#unique-label-set)). OpenTelemetry does not yet publish a canonical list of identifying attributes, though the project is moving toward distinguishing them. Compare [non-identifying attribute](#non-identifying-attribute).
 
 ### Ingestion key
 
@@ -157,7 +157,7 @@ The credential a Collector or SDK uses to send data to a SigNoz Cloud workspace.
 
 ### Instrument
 
-The named object an application uses to record measurements — a [counter](#sum), an up-down counter, a [gauge](#gauge), or a [histogram](#histogram). An instrument is defined by its name, kind, and optional unit and description, and is created from a [meter](#meter). **Synchronous** instruments record inline with application code; **asynchronous** (observable) instruments are collected once per export via a callback.
+The named object an application uses to record measurements: a [counter](#sum), an up-down counter, a [gauge](#gauge), or a [histogram](#histogram). An instrument is defined by its name, kind, and optional unit and description, and is created from a [meter](#meter). **Synchronous** instruments record inline with application code; **asynchronous** (observable) instruments are collected once per export via a callback.
 
 ### Instrumentation
 
@@ -167,7 +167,7 @@ The code that produces telemetry. **Manual** instrumentation is written by hand 
 
 ### Label
 
-A metric [attribute](#attribute) — the Prometheus term, used interchangeably in metrics contexts. A metric's **label set** is the specific combination of label values that identifies one [time series](#time-series).
+A metric [attribute](#attribute). Label is the Prometheus term, used interchangeably in metrics contexts. A metric's **label set** is the specific combination of label values that identifies one [time series](#time-series).
 
 ### Log record
 
@@ -175,7 +175,7 @@ A timestamped record of an event, with a severity and optional [attributes](#att
 
 ### Logs pipeline
 
-A SigNoz-side processing chain that parses, transforms, or enriches log records after ingestion — extracting JSON fields, promoting attributes, redacting values. See [Logs pipelines](https://signoz.io/docs/logs-pipelines/introduction/).
+A SigNoz-side processing chain that parses, transforms, or enriches log records after ingestion: extracting JSON fields, promoting attributes, redacting values. See [Logs pipelines](https://signoz.io/docs/logs-pipelines/introduction/).
 
 ## M
 
@@ -185,7 +185,7 @@ The object that creates metric [instruments](#instrument), obtained from a meter
 
 ### Metric
 
-A numeric measurement recorded over time — a request count, a latency distribution, a memory reading. Metrics are cheap to store at scale and ideal for dashboards and alerting, at the cost of losing per-request detail. See [Metrics](https://signoz.io/docs/metrics-management/overview/).
+A numeric measurement recorded over time: a request count, a latency distribution, a memory reading. Metrics are cheap to store at scale and ideal for dashboards and alerting, at the cost of losing per-request detail. See [Metrics](https://signoz.io/docs/metrics-management/overview/).
 
 ## N
 
@@ -193,13 +193,13 @@ A numeric measurement recorded over time — a request count, a latency distribu
 
 An [attribute](#attribute) whose value is already determined by attributes present on the series, so adding it creates no new [time series](#time-series) and no additional [samples](#sample). `host.type` is non-identifying when `host.id` is already there: each host has exactly one type, so the label set count is unchanged.
 
-Non-identifying attributes are effectively free in SigNoz — metrics are not billed per label or by label size. EC2 tags added by the AWS resource detector behave this way: they become part of series identity, but because each instance already has its own series, they add no series and no cost. Compare [identifying attribute](#identifying-attribute).
+Non-identifying attributes are effectively free in SigNoz, since metrics are not billed per label or by label size. EC2 tags added by the AWS resource detector behave this way: they become part of series identity, but because each instance already has its own series, they add no series and no cost. Compare [identifying attribute](#identifying-attribute).
 
 ## O
 
 ### Observability
 
-The ability to answer questions about a system's internal state from the telemetry it emits — including questions you did not anticipate when you instrumented it. Distinguished from monitoring by that last clause: monitoring answers known questions about known failure modes. Often abbreviated **o11y**.
+The ability to answer questions about a system's internal state from the telemetry it emits, including questions you did not anticipate when you instrumented it. That last clause is what distinguishes it from monitoring, which answers known questions about known failure modes. Often abbreviated **o11y**.
 
 ### OpenTelemetry
 
@@ -207,13 +207,13 @@ The vendor-neutral CNCF project that defines APIs, SDKs, a wire protocol ([OTLP]
 
 ### OTLP
 
-The OpenTelemetry Protocol — the wire format for sending traces, metrics, and logs, over gRPC or HTTP. It is the protocol SigNoz ingests natively.
+The OpenTelemetry Protocol, the wire format for sending traces, metrics, and logs, over gRPC or HTTP. It is the protocol SigNoz ingests natively.
 
 ## P
 
 ### Processor
 
-A [Collector](#collector) pipeline component that sits between receiving and exporting, transforming data in flight — batching, filtering, adding resource attributes, [tail sampling](#tail-sampling).
+A [Collector](#collector) pipeline component that sits between receiving and exporting, transforming data in flight: batching, filtering, adding resource attributes, [tail sampling](#tail-sampling).
 
 ### PromQL
 
@@ -233,15 +233,15 @@ The visual query interface in SigNoz for building filters, aggregations, and gro
 
 ### RED metrics
 
-Rate, Errors, and Duration — the three request-level metrics worth tracking for every service. SigNoz derives them from [spans](#span) automatically. Compare [golden signals](#golden-signals).
+Rate, Errors, and Duration: the three request-level metrics worth tracking for every service. SigNoz derives them from [spans](#span) automatically. Compare [golden signals](#golden-signals).
 
 ### Receiver
 
-A [Collector](#collector) pipeline component that defines how telemetry enters the Collector — an OTLP endpoint, a Prometheus scrape, a log file tail. Receivers can be push- or pull-based.
+A [Collector](#collector) pipeline component that defines how telemetry enters the Collector: an OTLP endpoint, a Prometheus scrape, a log file tail. Receivers can be push- or pull-based.
 
 ### Resource
 
-The entity that produced the telemetry — a service instance, host, container, or pod — described by a set of [resource attributes](#resource-attribute). Every span, metric, and log record carries exactly one resource.
+The entity that produced the telemetry (a service instance, host, container, or pod), described by a set of [resource attributes](#resource-attribute). Every span, metric, and log record carries exactly one resource.
 
 ### Resource attribute
 
@@ -249,13 +249,13 @@ An [attribute](#attribute) on a [resource](#resource), such as `service.name`, `
 
 ### Retention
 
-How long ingested data stays queryable, configured per signal. Longer retention raises the per-unit price of ingestion — metrics are $0.10 per million samples at one month, rising to $0.18 at thirteen months. See [Retention period](https://signoz.io/docs/userguide/retention-period/) and [Pricing](https://signoz.io/pricing/).
+How long ingested data stays queryable, configured per signal. Longer retention raises the per-unit price of ingestion. Metrics are $0.10 per million samples at one month, rising to $0.18 at thirteen months. See [Retention period](https://signoz.io/docs/userguide/retention-period/) and [Pricing](https://signoz.io/pricing/).
 
 ## S
 
 ### Sample
 
-One float value at one timestamp in one [time series](#time-series) — and the unit SigNoz bills metrics on, at **$0.10 per million samples ingested**. There is no charge per series, per unique metric, or per label.
+One float value at one timestamp in one [time series](#time-series), and the unit SigNoz bills metrics on, at **$0.10 per million samples ingested**. There is no charge per series, per unique metric, or per label.
 
 - A [gauge](#gauge) or [sum](#sum) data point is 1 sample.
 - A [histogram](#histogram) data point is (number of [buckets](#bucket) × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
@@ -268,11 +268,11 @@ Keeping only a portion of telemetry to control volume and cost. See [head sampli
 
 ### Scope
 
-The instrumentation scope — the name and version of the library or module that emitted the telemetry, which is how you tell "spans from our HTTP client instrumentation" from "spans we wrote by hand". Scope attributes are part of a metric's [fingerprint](#fingerprint).
+The instrumentation scope: the name and version of the library or module that emitted the telemetry. Scope is how you tell "spans from our HTTP client instrumentation" from "spans we wrote by hand". Scope attributes are part of a metric's [fingerprint](#fingerprint).
 
 ### Semantic conventions
 
-OpenTelemetry's standard names and values for attributes and metrics — `http.request.method`, `db.system.name`, `service.name`. Following them is what makes telemetry from different languages and libraries comparable, and what lets SigNoz build views that work without configuration.
+OpenTelemetry's standard names and values for attributes and metrics: `http.request.method`, `db.system.name`, `service.name`. Following them is what makes telemetry from different languages and libraries comparable, and what lets SigNoz build views that work without configuration.
 
 ### Service
 
@@ -284,15 +284,15 @@ One of the telemetry types OpenTelemetry defines: traces, metrics, or logs.
 
 ### SLI
 
-Service Level Indicator — the measured quantity in a reliability target, such as the fraction of requests served under 300 ms.
+Service Level Indicator: the measured quantity in a reliability target, such as the fraction of requests served under 300 ms.
 
 ### Span
 
-A single operation within a [trace](#trace) — an HTTP handler, a database query, a queue publish. A span has a name, start and end timestamps, [attributes](#attribute), a [status](#span-status), and a parent, which is what gives a trace its tree structure. See [Span details](https://signoz.io/docs/userguide/span-details/).
+A single operation within a [trace](#trace): an HTTP handler, a database query, or a queue publish. A span has a name, start and end timestamps, [attributes](#attribute), a [status](#span-status), and a parent, which is what gives a trace its tree structure. See [Span details](https://signoz.io/docs/userguide/span-details/).
 
 ### Span event
 
-A timestamped annotation on a [span](#span), used for things that happen at a moment rather than over a duration — a retry, a cache miss, a recorded exception.
+A timestamped annotation on a [span](#span), used for things that happen at a moment rather than over a duration: a retry, a cache miss, a recorded exception.
 
 ### Span link
 
@@ -304,13 +304,13 @@ The outcome of the operation a [span](#span) represents: `Unset`, `Ok`, or `Erro
 
 ### Sum
 
-A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. A **counter** is a monotonic sum — it only goes up, like an odometer. An **up-down counter** is a non-monotonic sum, like queue length.
+A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. A **counter** is a monotonic sum that only goes up, like an odometer. An **up-down counter** is a non-monotonic sum, like queue length.
 
 ## T
 
 ### Tail sampling
 
-Deciding whether to keep a [trace](#trace) after all its spans have arrived, so the decision can depend on what happened — keep every trace with an error or over 2 seconds, sample the rest at 5%. Requires a Collector that sees the whole trace. See [Tail sampling](https://signoz.io/docs/traces-management/guides/tail-sampling/).
+Deciding whether to keep a [trace](#trace) after all its spans have arrived, so the decision can depend on what happened. For example, keep every trace with an error or over 2 seconds, and sample the rest at 5%. Requires a Collector that sees the whole trace. See [Tail sampling](https://signoz.io/docs/traces-management/guides/tail-sampling/).
 
 ### Temporality
 
@@ -318,9 +318,9 @@ Whether a metric's data points report a running total or only the change since t
 
 ### Time series
 
-A single stream of [samples](#sample) over time, identified by a metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes — in other words, by one specific label set.
+A single stream of [samples](#sample) over time, identified by a metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. In other words, by one specific label set.
 
-In SigNoz, series are real for storage and querying: each is identified by a [fingerprint](#fingerprint), the label set is stored once per series, and Metrics Explorer reports per-metric series counts. Series are **not** a billing unit — SigNoz bills [samples](#sample) ingested, unlike vendors that charge per time series or per custom metric. See [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/).
+In SigNoz, series are real for storage and querying: each is identified by a [fingerprint](#fingerprint), the label set is stored once per series, and Metrics Explorer reports per-metric series counts. Series are **not** a billing unit. SigNoz bills [samples](#sample) ingested, unlike vendors that charge per time series or per custom metric. See [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/).
 
 ### Trace
 
@@ -342,23 +342,23 @@ The object that creates [spans](#span), obtained from a tracer provider and name
 
 ### Unique label set
 
-An informal name for what uniquely identifies a [time series](#time-series) — the specific combination of label values that distinguishes it from every other series of the same metric. Adding an [identifying attribute](#identifying-attribute) multiplies the number of unique label sets; adding a [non-identifying attribute](#non-identifying-attribute) does not.
+An informal name for what uniquely identifies a [time series](#time-series): the specific combination of label values that distinguishes it from every other series of the same metric. Adding an [identifying attribute](#identifying-attribute) multiplies the number of unique label sets; adding a [non-identifying attribute](#non-identifying-attribute) does not.
 
 ### Unit
 
-The unit of measurement declared on an [instrument](#instrument), written in UCUM notation — `ms`, `By`, `1`. Units are part of a metric's metadata and drive axis formatting.
+The unit of measurement declared on an [instrument](#instrument), written in UCUM notation: `ms`, `By`, `1`. Units are part of a metric's metadata and drive axis formatting.
 
 ## V
 
 ### View
 
-An SDK-side rule that customizes what the SDK exports — renaming a metric stream, changing its aggregation or histogram buckets, dropping attributes, or ignoring an instrument entirely. Views are the earliest and cheapest place to cut [cardinality](#cardinality), because dropped attributes are never emitted at all.
+An SDK-side rule that customizes what the SDK exports: renaming a metric stream, changing its aggregation or histogram buckets, dropping attributes, or ignoring an instrument entirely. Views are the earliest and cheapest place to cut [cardinality](#cardinality), because dropped attributes are never emitted at all.
 
 ## Z
 
 ### Zero-code instrumentation
 
-Instrumentation attached at runtime without modifying source code — a Java agent, a Python `opentelemetry-instrument` wrapper, an OTel operator injecting a sidecar. Also called auto-instrumentation. See [Instrumentation](https://signoz.io/docs/instrumentation/).
+Instrumentation attached at runtime without modifying source code: a Java agent, a Python `opentelemetry-instrument` wrapper, an OTel operator injecting a sidecar. Also called auto-instrumentation. See [Instrumentation](https://signoz.io/docs/instrumentation/).
 
 ## Related
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -23,11 +23,11 @@ Metric data stored at coarser granularity after a [volume control](https://signo
 
 ### Aggregation
 
-Combining many measurements into exact or estimated statistics over a time window: sum, count, average, percentile. Aggregation happens twice: client-side in the SDK (controlled by [instruments](#instrument) and [views](#view)) and query-side in SigNoz. See [Aggregation and grouping](https://signoz.io/docs/querying/aggregation-grouping/).
+Combining many measurements into exact or estimated statistics over a time window: sum, count, average, percentile. In the SDK, the [instrument](#instrument) you record to decides which aggregation applies, and a [view](#view) can override it before anything leaves the process. See [Aggregation and grouping](https://signoz.io/docs/querying/aggregation-grouping/).
 
 ### Alert rule
 
-A saved condition evaluated on a query at a fixed interval, which fires notifications to a channel when it is met. See [Alerts](https://signoz.io/docs/alerts/).
+A saved condition evaluated on a query at a fixed interval, which fires notifications to a [notification channel](#notification-channel) when it is met. See [Alerts](https://signoz.io/docs/alerts/).
 
 ### APM
 
@@ -39,25 +39,27 @@ A key-value pair that describes the entity producing telemetry. Attributes attac
 
 ## B
 
-### Baggage
-
-A mechanism for propagating key-value metadata across service boundaries alongside trace context, so downstream services can read values set upstream. Baggage is not automatically added to spans as attributes.
-
 ### Bucket
 
-One value range of a [histogram](#histogram), holding a count of the observations that fell inside it. Each bucket is stored as its own [time series](#time-series), so bucket count multiplies a histogram's volume: a classic histogram with N buckets stores roughly N + 4 series (the buckets, plus `.count`, `.sum`, `.min`, and `.max`).
+One value range of a [histogram](#histogram), holding a count of the observations that fell inside it. In OTLP, a histogram carries explicit bucket boundaries plus one count per bucket, and an implicit `+Inf` bucket catches everything above the last boundary.
+
+For example, a request-duration histogram with boundaries at 5, 10, 25, and 100 milliseconds has five buckets, and a 12 ms request lands in the one spanning 10 ms to 25 ms. In Prometheus form, and so in [PromQL](#promql), each bucket becomes its own series labelled `le` ("less than or equal to"), and those counts are cumulative: `le="25"` counts every request of 25 ms or faster, and `le="+Inf"` counts them all. This is the label you group by when computing percentiles: see the [PromQL guide](https://signoz.io/docs/userguide/write-a-prom-query-with-new-format/).
+
+Each bucket is stored as its own [time series](#time-series), so bucket count drives a histogram's volume: a classic histogram with N buckets stores roughly N + 4 series, the extra four being `.count`, `.sum`, `.min`, and `.max`.
 
 ## C
 
 ### Cardinality
 
-The number of unique [time series](#time-series) a metric produces. Cardinality is the product of the distinct values of the metric's [identifying attributes](#identifying-attribute), including [resource attributes](#resource-attribute).
+The number of unique [time series](#time-series) a metric actually produces: one series for each distinct combination of its [identifying attributes](#identifying-attribute), including [resource attributes](#resource-attribute).
 
-For example, a metric carrying 10 distinct `http.route` values across 50 pods has 10 × 50 = 500 series. Cardinality is the primary cost driver for metrics. SigNoz does not bill per series; cardinality matters because every series emits a [sample](#sample) on every export interval. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
+Multiplying out the distinct values of each attribute gives an **upper bound**, not the real figure, because only combinations that actually occur become series. A metric with 10 `http.route` values across 50 pods tops out at 10 × 50 = 500 series. But if 40 of those pods serve just 1 route each and the remaining 10 serve all 10, the real cardinality is (40 × 1) + (10 × 10) = 140. Read the true per-metric count from [Metrics Explorer](https://signoz.io/docs/metrics-management/metrics-explorer/) instead of multiplying attribute values.
+
+Cardinality is the primary cost driver for metrics. SigNoz does not bill per series; cardinality matters because every series emits a [sample](#sample) on every export interval. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Churn
 
-The replacement of [time series](#time-series) by new ones over time. For example, a pod restart produces a new `k8s.pod.name` value and therefore a new series. Churn raises the total number of series stored over a period, but not the number of series active at any one moment, so it does not increase [samples](#sample) per interval. In SigNoz, churn costs nothing extra.
+The replacement of [time series](#time-series) by new ones over time. For example, a rollout replaces pods, and each replacement Pod carries a new `k8s.pod.uid`, so its series are new ones. The UID is the dependable signal here: a Deployment's replacement pod also gets a newly generated name, but a StatefulSet's reuses the same ordinal name (`web-0`) while still taking a new UID. A container restarting inside an existing pod changes neither, so it adds no series. Churn raises the total number of series stored over a period, but not the number active at any one moment, so it does not increase [samples](#sample) per interval. In SigNoz, churn costs nothing extra.
 
 ### Collector
 
@@ -65,15 +67,21 @@ The OpenTelemetry Collector, a vendor-agnostic binary that receives, processes, 
 
 ### Context propagation
 
-The mechanism that carries trace context (and [baggage](#baggage)) across process and service boundaries, so spans emitted by different services join into one [trace](#trace). Usually done by injecting and extracting HTTP headers via a [propagator](#propagator).
+The mechanism that carries trace context across process and service boundaries, so spans emitted by different services join into one [trace](#trace). Usually done by injecting and extracting HTTP headers via a [propagator](#propagator).
 
 ### Cost Meter
 
 The SigNoz feature that reports ingestion volume and cost per signal at hourly granularity, so you can attribute spend to services, teams, or attributes. See [Cost Meter](https://signoz.io/docs/cost-meter/overview/).
 
+### Counter
+
+A monotonic [sum](#sum): it only ever increases, like an odometer. Use one for running totals such as requests served or bytes sent. Because the value only climbs, a process restart drops it back to zero, so queries have to treat that fall as a reset rather than as negative traffic. Compare [up-down counter](#up-down-counter).
+
 ### Cumulative temporality
 
-A metric [temporality](#temporality) in which each successive data point repeats the same start timestamp and reports a running total. Data points cover (T₀, T₁], (T₀, T₂], (T₀, T₃], and so on. This is the OpenTelemetry SDK default. Every active series re-sends its total on every export interval even when nothing changed, so idle series still cost [samples](#sample). Compare [delta temporality](#delta-temporality).
+A metric [temporality](#temporality) in which each successive data point repeats the same start timestamp and reports a running total. Data points cover (T₀, T₁], (T₀, T₂], (T₀, T₃], and so on. This is the OpenTelemetry SDK default.
+
+For example, a request counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `250`, then `250` again. That third point repeats the total even though nothing happened, which is why idle series still cost [samples](#sample). Compare [delta temporality](#delta-temporality).
 
 ## D
 
@@ -87,7 +95,9 @@ The basic unit of metric information: a set of [attributes](#attribute), a value
 
 ### Delta temporality
 
-A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export. Data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on. Synchronous instruments that recorded nothing during an interval export nothing at all, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
+A metric [temporality](#temporality) in which each successive data point advances the start timestamp and reports only the change since the previous export. Data points cover (T₀, T₁], (T₁, T₂], (T₂, T₃], and so on.
+
+For example, the same counter that sees 100 requests in the first minute, 150 in the second, and none in the third exports `100`, then `150`, then nothing at all. Synchronous instruments that recorded nothing during an interval export no data point, so idle series produce no [samples](#sample). Set it with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. Note that [PromQL](#promql) cannot read delta series. See [Use delta temporality](https://signoz.io/docs/metrics-management/reducing-costs/).
 
 ### Distributed tracing
 
@@ -115,7 +125,7 @@ The component that emits telemetry to a consumer: an SDK exporter sending [OTLP]
 
 ### Fingerprint
 
-The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. It identifies which [time series](#time-series) a [sample](#sample) belongs to: samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept. Nothing in your bill counts fingerprints.
+The hash SigNoz computes at ingest over the metric name, [temporality](#temporality), [resource attributes](#resource-attribute), [scope](#scope) attributes, and data point attributes. Each [time series](#time-series) of a metric has exactly one fingerprint and each fingerprint identifies exactly one series, so counting distinct fingerprints over a time range gives that metric's series count for the range. Samples are stored as `(fingerprint, timestamp, value)`, while the full label set is stored once per series. Queries join the two and aggregate over any label set. Fingerprints are a storage and aggregation concept. Nothing in your bill counts fingerprints.
 
 ### Flamegraph
 
@@ -145,7 +155,7 @@ A metric that aggregates many observations client-side into [buckets](#bucket), 
 
 ### Identifying attribute
 
-An [attribute](#attribute) whose values split otherwise-identical label sets into more [time series](#time-series). Adding one multiplies [cardinality](#cardinality) by its number of distinct values, and therefore multiplies [samples](#sample).
+An [attribute](#attribute) whose values split otherwise-identical label sets into more [time series](#time-series). Adding one multiplies [cardinality](#cardinality) by up to its number of distinct values, and therefore multiplies [samples](#sample).
 
 Start with a metric that has a single label set `X`. Add `http.route` with 10 distinct values, and `X` becomes 10 label sets: 10 series, and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying in this sense.
 
@@ -195,6 +205,10 @@ An [attribute](#attribute) whose value is already determined by attributes prese
 
 Non-identifying attributes are effectively free in SigNoz, since metrics are not billed per label or by label size. EC2 tags added by the AWS resource detector behave this way: they become part of series identity, but because each instance already has its own series, they add no series and no cost. Compare [identifying attribute](#identifying-attribute).
 
+### Notification channel
+
+The destination an [alert rule](#alert-rule) sends to when it fires. SigNoz supports Slack, email, PagerDuty, Opsgenie, Microsoft Teams, Google Chat, Jira, incident.io, Rootly, Zenduty, and generic webhooks. A channel is set up once and can then be picked by any alert rule. See [Setup notifications](https://signoz.io/docs/setup-alerts-notification/).
+
 ## O
 
 ### Observability
@@ -221,7 +235,7 @@ The Prometheus query language, supported in SigNoz for metrics. PromQL assumes c
 
 ### Propagator
 
-The component that serializes and deserializes trace context and [baggage](#baggage) into and out of carriers such as HTTP headers, enabling [context propagation](#context-propagation). The default is W3C Trace Context (`traceparent`).
+The component that serializes and deserializes trace context into and out of carriers such as HTTP headers, enabling [context propagation](#context-propagation). The default is W3C Trace Context (`traceparent`).
 
 ## Q
 
@@ -260,7 +274,7 @@ One float value at one timestamp in one [time series](#time-series), and the uni
 - A [gauge](#gauge) or [sum](#sum) data point is 1 sample.
 - A [histogram](#histogram) data point is (number of [buckets](#bucket) × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
 
-Total samples = [active series](#active-series) × export frequency, which is why [cardinality](#cardinality) and export interval are the two levers that actually move your metrics bill. Lengthening the export interval from 30s to 60s halves the volume. For scale: 100,000 active series at a 30-second interval is about 8.6 billion samples per month, or roughly $864. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/) and [Pricing](https://signoz.io/pricing/).
+Total samples = [active series](#active-series) × export frequency, which is why [cardinality](#cardinality) and export interval are the two levers that actually move your metrics bill. This uses the number of series genuinely active, not the product of your attributes' distinct values, which is only an upper bound. Lengthening the export interval from 30s to 60s halves the volume. For scale: 100,000 active series at a 30-second interval is about 8.6 billion samples per month, or roughly $864. See [Understanding Metrics Billing and Reducing Costs](https://signoz.io/docs/metrics-management/reducing-costs/) and [Pricing](https://signoz.io/pricing/).
 
 ### Sampling
 
@@ -304,7 +318,7 @@ The outcome of the operation a [span](#span) represents: `Unset`, `Ok`, or `Erro
 
 ### Sum
 
-A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. A **counter** is a monotonic sum that only goes up, like an odometer. An **up-down counter** is a non-monotonic sum, like queue length.
+A metric that reports an additive value, with a [temporality](#temporality) and a monotonic flag. That flag splits sums into two kinds: see [counter](#counter) and [up-down counter](#up-down-counter).
 
 ## T
 
@@ -314,7 +328,7 @@ Deciding whether to keep a [trace](#trace) after all its spans have arrived, so 
 
 ### Temporality
 
-Whether a metric's data points report a running total or only the change since the last export. See [cumulative temporality](#cumulative-temporality) and [delta temporality](#delta-temporality). Temporality is part of a metric's [fingerprint](#fingerprint), so the same metric sent with both temporalities produces separate series.
+Whether a metric's data points report a running total or only the change since the last export. See [cumulative temporality](#cumulative-temporality) and [delta temporality](#delta-temporality). Temporality applies only to [sums](#sum) and [histograms](#histogram). It is meaningless for a [gauge](#gauge), which reports the value read at a moment, so gauge data points carry no temporality at all. Temporality is part of a metric's [fingerprint](#fingerprint), so the same metric sent with both temporalities produces separate series.
 
 ### Time series
 
@@ -342,11 +356,15 @@ The object that creates [spans](#span), obtained from a tracer provider and name
 
 ### Unique label set
 
-An informal name for what uniquely identifies a [time series](#time-series): the specific combination of label values that distinguishes it from every other series of the same metric. Adding an [identifying attribute](#identifying-attribute) multiplies the number of unique label sets; adding a [non-identifying attribute](#non-identifying-attribute) does not.
+An informal name for what uniquely identifies a [time series](#time-series): the specific combination of label values that distinguishes it from every other series of the same metric. Adding an [identifying attribute](#identifying-attribute) increases the number of unique label sets; adding a [non-identifying attribute](#non-identifying-attribute) does not.
 
 ### Unit
 
 The unit of measurement declared on an [instrument](#instrument), written in UCUM notation: `ms`, `By`, `1`. Units are part of a metric's metadata and drive axis formatting.
+
+### Up-down counter
+
+A non-monotonic [sum](#sum): it can rise or fall, like queue length or the count of open connections. Unlike a [counter](#counter), a decrease is a real measurement rather than a reset, so no reset handling applies. Compare [gauge](#gauge), which reports a value read at one moment instead of accumulating changes.
 
 ## V
 

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-13
+date: 2026-08-25
 title: Glossary of Observability and OpenTelemetry Terms
 description: Definitions of OpenTelemetry, observability, and SigNoz terms, from span and resource to sample, cardinality, and identifying attributes.
 doc_type: reference

--- a/data/docs/glossary.mdx
+++ b/data/docs/glossary.mdx
@@ -280,15 +280,11 @@ A named unit of an application that produces telemetry, identified by the `servi
 
 ### Signal
 
-One of the telemetry types OpenTelemetry defines: traces, metrics, or logs. (Profiles are in progress.)
+One of the telemetry types OpenTelemetry defines: traces, metrics, or logs.
 
 ### SLI
 
 Service Level Indicator — the measured quantity in a reliability target, such as the fraction of requests served under 300 ms.
-
-### SLO
-
-Service Level Objective — a target value for an [SLI](#sli) over a time window, such as "99.9% of requests under 300 ms over 30 days". The gap between the objective and 100% is your error budget.
 
 ### Span
 

--- a/data/docs/ingestion/cloud-vs-self-hosted.mdx
+++ b/data/docs/ingestion/cloud-vs-self-hosted.mdx
@@ -17,7 +17,7 @@ Review the [OpenTelemetry environment variables reference](https://signoz.io/doc
   - Self-Host: `http(s)://<signoz-host>:4317` (gRPC) or `http(s)://<signoz-host>:4318` (HTTP)
 - Authentication
   - Cloud: Add header `signoz-ingestion-key: <key>` (or basic auth)
-  - Self-Host: No ingestion key; add auth/TLS at your proxy/ingress if you need it
+  - Self-Host: No <Tooltip text="ingestion key" content="The credential a Collector or SDK uses to send data to a SigNoz Cloud workspace." link="https://signoz.io/docs/glossary/#ingestion-key" />; add auth/TLS at your proxy/ingress if you need it
 - TLS
   - Cloud: Always TLS on `443`
   - Self-Host: Plain HTTP by default; enable TLS via ingress/reverse proxy for production

--- a/data/docs/instrumentation/opentelemetry-deno.mdx
+++ b/data/docs/instrumentation/opentelemetry-deno.mdx
@@ -70,7 +70,7 @@ deno run --allow-env --allow-net app.ts
 ```
 
 <Admonition type="note">
-The `OTEL_DENO=true` flag enables the built-in instrumentation for `http`, `fetch`, runtime metrics, and console logs.
+The `OTEL_DENO=true` flag enables the built-in <Tooltip text="instrumentation" content="The code that produces telemetry." link="https://signoz.io/docs/glossary/#instrumentation" /> for `http`, `fetch`, runtime metrics, and console logs.
 
 By default, auto-instrumentation captures logs as well, to disable logs set the following environmental variable:
 

--- a/data/docs/instrumentation/opentelemetry-python.mdx
+++ b/data/docs/instrumentation/opentelemetry-python.mdx
@@ -5,7 +5,7 @@ description: Learn how to instrument your Python app with OpenTelemetry and send
 doc_type: howto
 ---
 
-This guide shows you how to instrument your Python application with OpenTelemetry and send traces to SigNoz. The auto-instrumentation approach works with Django, Flask, FastAPI, Falcon, Celery, and most Python libraries out of the box.
+This guide shows you how to instrument your Python application with OpenTelemetry and send traces to SigNoz. The <Tooltip text="auto-instrumentation" content="Instrumentation attached at runtime without modifying source code: a Java agent, a Python opentelemetry-instrument wrapper, an OTel operator injecting a sidecar." link="https://signoz.io/docs/glossary/#zero-code-instrumentation" /> approach works with Django, Flask, FastAPI, Falcon, Celery, and most Python libraries out of the box.
 
 <KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
   Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).

--- a/data/docs/instrumentation/python/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/python/manual-instrumentation.mdx
@@ -10,7 +10,7 @@ Manual instrumentation gives you fine-grained control when automatic instrumenta
 
 ## Prerequisites
 
-- Finish the core Python setup in the [OpenTelemetry Python instrumentation guide](https://signoz.io/docs/instrumentation/opentelemetry-python/) so exporters, tracer provider, and propagators are configured.
+- Finish the core Python setup in the [OpenTelemetry Python instrumentation guide](https://signoz.io/docs/instrumentation/opentelemetry-python/) so exporters, tracer provider, and <Tooltip text="propagators" content="The component that serializes and deserializes trace context into and out of carriers such as HTTP headers, enabling context propagation." link="https://signoz.io/docs/glossary/#propagator" /> are configured.
 - Install the API and SDK packages:
   ```bash
   pip install opentelemetry-api opentelemetry-sdk

--- a/data/docs/instrumentation/rust/manual-instrumentation.mdx
+++ b/data/docs/instrumentation/rust/manual-instrumentation.mdx
@@ -196,7 +196,7 @@ pub fn record_exception(cx: &opentelemetry::Context, error: &dyn std::error::Err
 
 ## Step 7. Span links (optional)
 
-Use span links to connect causally related traces, such as batch processing where one span triggers multiple independent operations:
+Use <Tooltip text="span links" content="A pointer from one span to another causally related span in a different trace." link="https://signoz.io/docs/glossary/#span-link" /> to connect causally related traces, such as batch processing where one span triggers multiple independent operations:
 
 ```rust:src/batch_processor.rs
 use opentelemetry::trace::{Tracer, TraceContextExt, Link, SpanContext};

--- a/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
+++ b/data/docs/logs-management/send-logs/nodejs-winston-logs.mdx
@@ -22,7 +22,7 @@ description: Learn how to send logs from Node.js Winston logger to SigNoz using 
 <Tabs entityName="instrumentation">
 <TabItem value="automatic" label="No Code Auto-Instrumentation (recommended)" default>
 
-Auto-instrumentation automatically captures:
+<Tooltip text="Auto-instrumentation" content="Instrumentation attached at runtime without modifying source code: a Java agent, a Python opentelemetry-instrument wrapper, an OTel operator injecting a sidecar." link="https://signoz.io/docs/glossary/#zero-code-instrumentation" /> automatically captures:
 
 - **Winston logs** with trace correlation
 - **HTTP requests** (incoming and outgoing)

--- a/data/docs/logs-pipelines/introduction.mdx
+++ b/data/docs/logs-pipelines/introduction.mdx
@@ -1,12 +1,12 @@
 ---
-date: 2026-06-11
+date: 2026-08-25
 description: "Learn how SigNoz log pipelines process, parse, enrich, filter, and transform logs before storage and analysis."
 title: Log Pipelines and Processing in SigNoz
 meta_title: Log Pipelines and Processing
 doc_type: explanation
 ---
 
-Logs Pipelines transform your raw logs into structured, queryable data before storage. Extract fields, parse JSON, normalize attributes, and enrich your logs from the SigNoz UI without redeploying your applications.
+<Tooltip text="Logs Pipelines" content="A SigNoz-side processing chain that parses, transforms, or enriches log records after ingestion: extracting JSON fields, promoting attributes, redacting values." link="https://signoz.io/docs/glossary/#logs-pipeline" /> transform your raw logs into structured, queryable data before storage. Extract fields, parse JSON, normalize attributes, and enrich your logs from the SigNoz UI without redeploying your applications.
 
 <YouTube id="OneENGNmLd0" mute="false" />
 

--- a/data/docs/metrics-management/aggregated-metric-data.mdx
+++ b/data/docs/metrics-management/aggregated-metric-data.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-14
+date: 2026-08-25
 title: Understanding Aggregated Metric Data - What Changes and Why
 description: What happens when a metric is stored as aggregated data, what volume control rules preserve, what they trade away, and why values can differ from what an alert saw.
 tags: [SigNoz Cloud]
@@ -8,7 +8,7 @@ doc_type: explanation
 
 ## Overview
 
-When a metric has a [volume control](https://signoz.io/docs/metrics-management/volume-control/) rule, some of its attributes are aggregated away to reduce stored cardinality and cost, and queries over older time ranges render from that aggregated data. The data you're looking at is mathematically correct, but it's stored at a coarser granularity than the original. For some questions, that changes the answer.
+When a metric has a [volume control](https://signoz.io/docs/metrics-management/volume-control/) rule, some of its attributes are aggregated away to reduce stored <Tooltip text="cardinality" content="The number of unique time series a metric actually produces: one series for each distinct combination of its identifying attributes." link="https://signoz.io/docs/glossary/#cardinality" /> and cost, and queries over older time ranges render from that aggregated data. The data you're looking at is mathematically correct, but it's stored at a coarser granularity than the original. For some questions, that changes the answer.
 
 This page explains exactly what is preserved, what is lost, and why a query can return different values than it did when the data was fresh.
 
@@ -73,7 +73,7 @@ Once an attribute is aggregated away for a time range, for that range you can no
 - **Count series above a threshold.** Only the count of contributing series per window survives, not their individual values.
 - **See sub-minute detail.** A 15-second spike keeps its magnitude (it's the window max) but loses its exact timing and shape. Rates finer than 60 seconds are no longer meaningful.
 
-Everything expressible over the surviving attributes at 60-second resolution (including exact counter rates and increases) remains correct.
+Everything expressible over the surviving attributes at 60-second resolution (including exact <Tooltip text="counter" content="A monotonic sum: it only ever increases, like an odometer." link="https://signoz.io/docs/glossary/#counter" /> rates and increases) remains correct.
 
 ## Why an Alert's Numbers May Not Reproduce Later
 

--- a/data/docs/metrics-management/dropping-metric-labels.mdx
+++ b/data/docs/metrics-management/dropping-metric-labels.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-14
+date: 2026-08-25
 title: Dropping Metric Labels (Attributes)
 description: Explains why dropping metric labels (attributes) does not reduce cardinality or sample count and provides correct alternatives.
 doc_type: explanation
@@ -8,7 +8,7 @@ doc_type: explanation
 
 ## Overview
 
-A common misconception when working with metrics in OpenTelemetry is that removing labels (attributes) using processors like `attributes` will reduce metric cardinality and, consequently, the number of samples ingested. This document explains why this approach doesn't work as expected and can actually lead to incorrect query results.
+A common misconception when working with metrics in OpenTelemetry is that removing labels (attributes) using processors like `attributes` will reduce metric <Tooltip text="cardinality" content="The number of unique time series a metric actually produces: one series for each distinct combination of its identifying attributes." link="https://signoz.io/docs/glossary/#cardinality" /> and, consequently, the number of samples ingested. This document explains why this approach doesn't work as expected and can actually lead to incorrect query results.
 
 If you are looking to drop entire metrics (not just labels), see [How to Drop and Filter OpenTelemetry Metrics](https://signoz.io/docs/userguide/drop-metrics/).
 ## Understanding Samples vs. Cardinality

--- a/data/docs/metrics-management/metrics-explorer.mdx
+++ b/data/docs/metrics-management/metrics-explorer.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-08-25
 title: Metrics Explorer
 description: Discover, explore, and visualize all metrics flowing into your SigNoz deployment using the Metrics Explorer.
 doc_type: reference
@@ -9,7 +9,7 @@ doc_type: reference
 
 Metrics Explorer provides instant visibility into all metrics flowing into your SigNoz deployment. This feature automatically discovers, categorises, and visualises every metric being ingested, giving you a complete view of your metrics ecosystem without needing to build dashboards first.
 
-Unlike traditional monitoring workflows that require you to guess metric names from dropdowns, Metrics Explorer shows you exactly what's being ingested with real-time metadata, including types, sample counts, time series cardinality, and data sources.
+Unlike traditional monitoring workflows that require you to guess metric names from dropdowns, Metrics Explorer shows you exactly what's being ingested with real-time metadata, including types, sample counts, time series <Tooltip text="cardinality" content="The number of unique time series a metric actually produces: one series for each distinct combination of its identifying attributes." link="https://signoz.io/docs/glossary/#cardinality" />, and data sources.
 
 <Figure
   src="/img/docs/metrics/metrics-explorer/overview-interface-new.webp"
@@ -155,7 +155,7 @@ The Metadata section provides configurable information about the metric:
 />
 
 <Admonition type="info">
-If you feel the Metric Type, description, or temporality is incorrect, you can edit them using the **Edit** button in the Metadata section.
+If you feel the Metric Type, description, or <Tooltip text="temporality" content="Whether a metric's data points report a running total or only the change since the last export." link="https://signoz.io/docs/glossary/#temporality" /> is incorrect, you can edit them using the **Edit** button in the Metadata section.
 </Admonition>
 
 #### 3. All Attributes Section

--- a/data/docs/metrics-management/overview.mdx
+++ b/data/docs/metrics-management/overview.mdx
@@ -45,3 +45,4 @@ Use this section to find guides for sending data, exploring metrics, and setting
 - [Metrics Query API](https://signoz.io/docs/metrics-management/query-range-api/) — API reference for querying SigNoz metrics.
 - [OpenTelemetry Environment Variables](https://signoz.io/docs/ingestion/opentelemetry-environment-variables/) — Configure service identity, OTLP endpoints, headers, protocols, batching, and sampling.
 - [Debug Missing Telemetry](https://signoz.io/docs/ingestion/signoz-cloud/troubleshooting/data-not-appearing/) — Find where your metrics are getting lost between your app and SigNoz.
+- [Glossary](https://signoz.io/docs/glossary/) — Definitions for samples, time series, cardinality, identifying attributes, and temporality.

--- a/data/docs/metrics-management/overview.mdx
+++ b/data/docs/metrics-management/overview.mdx
@@ -45,4 +45,4 @@ Use this section to find guides for sending data, exploring metrics, and setting
 - [Metrics Query API](https://signoz.io/docs/metrics-management/query-range-api/) — API reference for querying SigNoz metrics.
 - [OpenTelemetry Environment Variables](https://signoz.io/docs/ingestion/opentelemetry-environment-variables/) — Configure service identity, OTLP endpoints, headers, protocols, batching, and sampling.
 - [Debug Missing Telemetry](https://signoz.io/docs/ingestion/signoz-cloud/troubleshooting/data-not-appearing/) — Find where your metrics are getting lost between your app and SigNoz.
-- [Glossary](https://signoz.io/docs/glossary/) — Definitions for samples, time series, cardinality, identifying attributes, and temporality.
+- [Glossary](https://signoz.io/docs/glossary/): Definitions for samples, time series, cardinality, identifying attributes, and temporality.

--- a/data/docs/metrics-management/overview.mdx
+++ b/data/docs/metrics-management/overview.mdx
@@ -5,7 +5,7 @@ description: Collect and visualize numerical time-series data from applications 
 doc_type: explanation
 ---
 
-Metrics provide numerical data over time to help you monitor application and infrastructure behavior. SigNoz enables you to collect, query, and visualize metrics from diverse sources, including OpenTelemetry SDKs, the OTel Collector, and Prometheus.
+<Tooltip text="Metrics" content="A numeric measurement recorded over time: a request count, a latency distribution, a memory reading." link="https://signoz.io/docs/glossary/#metric" /> provide numerical data over time to help you monitor application and infrastructure behavior. SigNoz enables you to collect, query, and visualize metrics from diverse sources, including OpenTelemetry SDKs, the OTel Collector, and Prometheus.
 
 <Figure
   src="/img/docs/metrics/metrics-explorer/metrics-explorer-walkthrough.gif"

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -24,7 +24,7 @@ Two consequences worth knowing up front:
 - **Churn is free.** A series replaced by a new one (a rollout giving each replacement pod a new `k8s.pod.uid`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
 - **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse. See [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
 
-Histograms are the exception to "one data point, one sample": a classic histogram data point costs (number of buckets × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
+Histograms and summaries are the exceptions to "one data point, one sample". A classic histogram data point costs one sample per bucket (including the `+Inf` bucket), plus `.count`, which is always present, plus `.sum`, `.min`, and `.max` only when the SDK emits them. A summary data point costs one sample per quantile, plus `.count` and `.sum`.
 
 ## How Attributes Affect Billing
 

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -21,7 +21,7 @@ That gives you exactly two levers: **reduce the number of active series**, or **
 
 Two consequences worth knowing up front:
 
-- **Churn is free.** A series replaced by a new one (a pod restart producing a new `k8s.pod.name`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
+- **Churn is free.** A series replaced by a new one (a rollout giving each replacement pod a new `k8s.pod.uid`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
 - **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse. See [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
 
 Histograms are the exception to "one data point, one sample": a classic histogram data point costs (number of buckets × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
@@ -30,7 +30,7 @@ Histograms are the exception to "one data point, one sample": a classic histogra
 
 Attributes affect the series count in one of two ways:
 
-1. **Identifying attributes**: their values split otherwise-identical label sets into more series, so they multiply samples. If a metric has one label set and you add `http.route` with 10 distinct values, you now have 10 series and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying.
+1. **Identifying attributes**: their values split otherwise-identical label sets into more series, so they multiply samples. If a metric has one label set and you add `http.route`, you get one series per route that actually appears, up to 10 series for 10 distinct routes, and that many data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying.
 2. **Non-identifying attributes**: their value is already determined by attributes present on the series, so they create zero new series and zero new samples. `host.type` is non-identifying when `host.id` is already there, because each host has exactly one type.
 
 Resource attributes are not treated specially: they are part of series identity exactly like data point attributes, and they can be identifying or non-identifying in the same way. EC2 tags added by the AWS resource detector are a common example. They become part of series identity, but since each instance already has its own series, they add no series and no cost.

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -1,22 +1,45 @@
 ---
 date: 2026-08-25
 title: Understanding Metrics Billing and Reducing Costs
-description: Learn how metrics billing works based on cardinality and discover strategies to reduce costs effectively.
+description: How metrics billing works in SigNoz — billed per sample ingested, why cardinality drives cost, and the strategies that actually reduce it.
 doc_type: explanation
 ---
 
 ## Overview
 
-Metrics billing is based on **cardinality** - the number of unique time series created by your metrics. Understanding how attributes affect cardinality is key to managing costs effectively.
+Metrics are billed **per sample ingested, at $0.10 per million samples** (at one-month retention; longer retention raises the rate — see [Pricing](https://signoz.io/pricing/)). A sample is one float value at one timestamp in one time series. There is no charge per time series, per unique metric, or per label. The [glossary](https://signoz.io/docs/glossary/) defines every term used on this page.
+
+Cardinality is still the primary cost driver, and the reason is arithmetic rather than pricing:
+
+```
+total samples = active time series × export frequency
+```
+
+Every active series emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month — about $0.0086. At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
+
+That gives you exactly two levers: **reduce the number of active series**, or **export less often**. When this page says "reduce cardinality", it means reduce the series count so that fewer samples arrive on each interval.
+
+Two consequences worth knowing up front:
+
+- **Churn is free.** A series replaced by a new one (a pod restart producing a new `k8s.pod.name`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
+- **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse — see [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
+
+Histograms are the exception to "one data point, one sample": a classic histogram data point costs (number of buckets × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
 
 ## How Attributes Affect Billing
 
-There are two types of attributes that affect your metrics differently:
+Attributes affect the series count in one of two ways:
 
-1. **Identifying attributes** - These create new time series and contribute to cost. For example, adding a new `host.name` creates a new series.
-2. **Non-identifying/descriptive attributes** - These enrich existing metrics without creating new series. Examples include host family or EC2 tags.
+1. **Identifying attributes** — their values split otherwise-identical label sets into more series, so they multiply samples. If a metric has one label set and you add `http.route` with 10 distinct values, you now have 10 series and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying.
+2. **Non-identifying attributes** — their value is already determined by attributes present on the series, so they create zero new series and zero new samples. `host.type` is non-identifying when `host.id` is already there, because each host has exactly one type.
 
-You can add as many non-identifying attributes as needed without additional cost, but each new identifying attribute with unique values increases your bill, often exponentially.
+Resource attributes are not treated specially: they are part of series identity exactly like data point attributes, and they can be identifying or non-identifying in the same way. EC2 tags added by the AWS resource detector are a common example — they become part of series identity, but since each instance already has its own series, they add no series and no cost.
+
+You can add as many non-identifying attributes as you like at no additional cost; metrics are not billed by label count or label size. Each new identifying attribute, however, multiplies your series count by its number of distinct values.
+
+<Admonition type="info">
+OpenTelemetry does not yet publish a canonical list of identifying attributes, though the project is moving toward distinguishing them. Until then, the practical test is the one above: would this attribute's values split an existing label set into more series?
+</Admonition>
 
 ## Common Cost Drivers
 

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -15,7 +15,7 @@ Cardinality is still the primary cost driver, and the reason is arithmetic rathe
 total samples = active time series × export frequency
 ```
 
-Every <Tooltip text="active series" content="A time series that is currently receiving data points." link="https://signoz.io/docs/glossary/#active-series" /> emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086). At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
+Every <Tooltip text="active series" content="A time series that is currently receiving data points." link="https://signoz.io/docs/glossary/#active-series" /> emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month (about \$0.0086). At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about \$864.
 
 That gives you exactly two levers: **reduce the number of active series**, or **export less often**. When this page says "reduce cardinality", it means reduce the series count so that fewer samples arrive on each interval.
 

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -1,13 +1,13 @@
 ---
 date: 2026-08-25
 title: Understanding Metrics Billing and Reducing Costs
-description: How metrics billing works in SigNoz — billed per sample ingested, why cardinality drives cost, and the strategies that actually reduce it.
+description: How metrics billing works in SigNoz: billed per sample ingested, why cardinality drives cost, and the strategies that actually reduce it.
 doc_type: explanation
 ---
 
 ## Overview
 
-Metrics are billed **per sample ingested, at $0.10 per million samples** (at one-month retention; longer retention raises the rate — see [Pricing](https://signoz.io/pricing/)). A sample is one float value at one timestamp in one time series. There is no charge per time series, per unique metric, or per label. The [glossary](https://signoz.io/docs/glossary/) defines every term used on this page.
+Metrics are billed **per sample ingested, at $0.10 per million samples** (at one-month retention; longer retention raises the rate, see [Pricing](https://signoz.io/pricing/)). A sample is one float value at one timestamp in one time series. There is no charge per time series, per unique metric, or per label. The [glossary](https://signoz.io/docs/glossary/) defines every term used on this page.
 
 Cardinality is still the primary cost driver, and the reason is arithmetic rather than pricing:
 
@@ -15,14 +15,14 @@ Cardinality is still the primary cost driver, and the reason is arithmetic rathe
 total samples = active time series × export frequency
 ```
 
-Every active series emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month — about $0.0086. At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
+Every active series emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086). At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
 
 That gives you exactly two levers: **reduce the number of active series**, or **export less often**. When this page says "reduce cardinality", it means reduce the series count so that fewer samples arrive on each interval.
 
 Two consequences worth knowing up front:
 
 - **Churn is free.** A series replaced by a new one (a pod restart producing a new `k8s.pod.name`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
-- **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse — see [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
+- **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse. See [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
 
 Histograms are the exception to "one data point, one sample": a classic histogram data point costs (number of buckets × 1) + 4 samples, the extra four being `.sum`, `.count`, `.min`, and `.max`.
 
@@ -30,10 +30,10 @@ Histograms are the exception to "one data point, one sample": a classic histogra
 
 Attributes affect the series count in one of two ways:
 
-1. **Identifying attributes** — their values split otherwise-identical label sets into more series, so they multiply samples. If a metric has one label set and you add `http.route` with 10 distinct values, you now have 10 series and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying.
-2. **Non-identifying attributes** — their value is already determined by attributes present on the series, so they create zero new series and zero new samples. `host.type` is non-identifying when `host.id` is already there, because each host has exactly one type.
+1. **Identifying attributes**: their values split otherwise-identical label sets into more series, so they multiply samples. If a metric has one label set and you add `http.route` with 10 distinct values, you now have 10 series and 10 data points per export interval instead of one. `http.route`, `http.response.status_code`, and `host.name` are all identifying.
+2. **Non-identifying attributes**: their value is already determined by attributes present on the series, so they create zero new series and zero new samples. `host.type` is non-identifying when `host.id` is already there, because each host has exactly one type.
 
-Resource attributes are not treated specially: they are part of series identity exactly like data point attributes, and they can be identifying or non-identifying in the same way. EC2 tags added by the AWS resource detector are a common example — they become part of series identity, but since each instance already has its own series, they add no series and no cost.
+Resource attributes are not treated specially: they are part of series identity exactly like data point attributes, and they can be identifying or non-identifying in the same way. EC2 tags added by the AWS resource detector are a common example. They become part of series identity, but since each instance already has its own series, they add no series and no cost.
 
 You can add as many non-identifying attributes as you like at no additional cost; metrics are not billed by label count or label size. Each new identifying attribute, however, multiplies your series count by its number of distinct values.
 

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2026-08-25
 title: Understanding Metrics Billing and Reducing Costs
-description: How metrics billing works in SigNoz: billed per sample ingested, why cardinality drives cost, and the strategies that actually reduce it.
+description: How SigNoz bills metrics per sample ingested, why cardinality is the primary cost driver, and the strategies that actually reduce your metrics bill.
 doc_type: explanation
 ---
 

--- a/data/docs/metrics-management/reducing-costs.mdx
+++ b/data/docs/metrics-management/reducing-costs.mdx
@@ -15,7 +15,7 @@ Cardinality is still the primary cost driver, and the reason is arithmetic rathe
 total samples = active time series × export frequency
 ```
 
-Every active series emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086). At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
+Every <Tooltip text="active series" content="A time series that is currently receiving data points." link="https://signoz.io/docs/glossary/#active-series" /> emits one sample per export interval, whether or not its value changed. So one series exporting every 30 seconds produces about 86,400 samples per month (about $0.0086). At the more common 60-second interval, about 43,200, or half that. Scale it up and 100,000 active series at a 30-second interval is roughly 8.6 billion samples per month, about $864.
 
 That gives you exactly two levers: **reduce the number of active series**, or **export less often**. When this page says "reduce cardinality", it means reduce the series count so that fewer samples arrive on each interval.
 
@@ -24,7 +24,7 @@ Two consequences worth knowing up front:
 - **Churn is free.** A series replaced by a new one (a rollout giving each replacement pod a new `k8s.pod.uid`) sends the same number of samples. SigNoz does not bill per series, so churn adds no cost.
 - **Dropping labels alone saves nothing.** The same samples still arrive. Attributes have to be *aggregated away* so that the series collapse. See [Volume control](https://signoz.io/docs/metrics-management/volume-control/).
 
-Histograms and summaries are the exceptions to "one data point, one sample". A classic histogram data point costs one sample per bucket (including the `+Inf` bucket), plus `.count`, which is always present, plus `.sum`, `.min`, and `.max` only when the SDK emits them. A summary data point costs one sample per quantile, plus `.count` and `.sum`.
+<Tooltip text="Histograms" content="A metric that aggregates many observations client-side into buckets, plus a count and optional sum, min, and max." link="https://signoz.io/docs/glossary/#histogram" /> and summaries are the exceptions to "one data point, one sample". A classic histogram data point costs one sample per bucket (including the `+Inf` bucket), plus `.count`, which is always present, plus `.sum`, `.min`, and `.max` only when the SDK emits them. A summary data point costs one sample per quantile, plus `.count` and `.sum`.
 
 ## How Attributes Affect Billing
 

--- a/data/docs/metrics-management/reference.mdx
+++ b/data/docs/metrics-management/reference.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-13
+date: 2026-08-25
 title: Metrics Reference
 description: Reference documentation for SigNoz metrics — querying, API reference, billing details, and aggregated metric data.
 ---

--- a/data/docs/metrics-management/reference.mdx
+++ b/data/docs/metrics-management/reference.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-14
+date: 2026-08-13
 title: Metrics Reference
 description: Reference documentation for SigNoz metrics — querying, API reference, billing details, and aggregated metric data.
 ---
@@ -14,7 +14,7 @@ description: Reference documentation for SigNoz metrics — querying, API refere
 
 <DocCard
     title="Understanding Metrics Billing & Reducing Costs"
-    description="Learn how cardinality affects billing and how to optimize metrics costs"
+    description="How per-sample billing works, why cardinality drives cost, and how to reduce it"
     href="https://signoz.io/docs/metrics-management/reducing-costs/"
 />
 

--- a/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
+++ b/data/docs/metrics-management/send-metrics/applications/opentelemetry-nodejs.mdx
@@ -204,7 +204,7 @@ module.exports = { handleRequest };
 ```
 
 <Admonition type="info">
-This example shows a Counter, which only increases. OpenTelemetry supports other metric types like UpDownCounter, Histogram, and Observable Gauge. See [Custom Metrics Examples](#custom-metrics-examples) for complete examples of each type.
+This example shows a Counter, which only increases. OpenTelemetry supports other metric types like <Tooltip text="UpDownCounter" content="A non-monotonic sum: it can rise or fall, like queue length or the count of open connections." link="https://signoz.io/docs/glossary/#up-down-counter" />, Histogram, and Observable Gauge. See [Custom Metrics Examples](#custom-metrics-examples) for complete examples of each type.
 </Admonition>
 
 ### Step 4. Run your application

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-10
+date: 2026-08-25
 title: Metric Types and Aggregation
 description: Learn about the different metric types (Counter, Gauge, Histogram, Exponential Histogram) supported by SigNoz and how temporal and spatial aggregation works for each type.
 doc_type: explanation
@@ -22,7 +22,7 @@ SigNoz supports the following types of metrics:
 <Admonition type="info">
 Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them in your OTel Collector configuration:
 1. Set `enable_exp_hist: true` in both the `clickhousemetricswrite` and `signozclickhousemetrics` exporters in your collector config.
-2. Ensure your metrics use delta temporality. Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.
+2. Ensure your metrics use <Tooltip text="delta temporality" content="A metric temporality in which each successive data point advances the start timestamp and reports only the change since the previous export." link="https://signoz.io/docs/glossary/#delta-temporality" />. Although OpenTelemetry supports both delta and <Tooltip text="cumulative temporality" content="A metric temporality in which each successive data point repeats the same start timestamp and reports a running total." link="https://signoz.io/docs/glossary/#cumulative-temporality" /> for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.
 For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
 </Admonition>
 
@@ -45,10 +45,10 @@ A table representing the different types of metrics and their temporality suppor
 
 The Gauge metric type does not have a temporality, as it represents a single value at a point in time.
 
-SigNoz records the temporality of every data point. A Counter metric can send all cumulative points, all delta points, or both together. Both appear together after you switch the temporality, and also when different time series of the same metric use different temporality. The Query Builder queries all three cases, so your older cumulative data stays queryable after a switch.
+SigNoz records the temporality of every <Tooltip text="data point" content="The basic unit of metric information: a set of attributes, a value (or values, for a histogram), and one or two timestamps." link="https://signoz.io/docs/glossary/#data-point" />. A Counter metric can send all cumulative points, all delta points, or both together. Both appear together after you switch the temporality, and also when different time series of the same metric use different temporality. The Query Builder queries all three cases, so your older cumulative data stays queryable after a switch.
 
 <Admonition type="warning">
-PromQL does not read delta series. A PromQL panel or alert on a metric that you switch to delta keeps running and receives no new samples. Move those queries to the Query Builder before you change the temporality.
+PromQL does not read delta series. A PromQL panel or alert on a metric that you switch to delta keeps running and receives no new <Tooltip text="samples" content="One float value at one timestamp in one time series, and the unit SigNoz bills metrics on, at $0.10 per million samples ingested." link="https://signoz.io/docs/glossary/#sample" />. Move those queries to the Query Builder before you change the temporality.
 </Admonition>
 
 <Admonition type="tip">
@@ -326,7 +326,7 @@ This step is the same as the Cumulative Counter.
 
 ## Histogram & Exponential Histogram
 
-The aggregation of Histogram metrics is similar to that of Counter metrics. The difference is that Histogram metrics store the distribution of a set of values. There is no configuration required for temporal aggregation as the values get aggregated into buckets based on the histogram configuration. The result of the temporal aggregation is a single aggregated histogram for each interval within the time series.
+The aggregation of Histogram metrics is similar to that of Counter metrics. The difference is that Histogram metrics store the distribution of a set of values. There is no configuration required for temporal aggregation as the values get aggregated into <Tooltip text="buckets" content="One value range of a histogram, holding a count of the observations that fell inside it." link="https://signoz.io/docs/glossary/#bucket" /> based on the histogram configuration. The result of the temporal aggregation is a single aggregated histogram for each interval within the time series.
 
 The spatial aggregation step aggregates the values across multiple time series. The result of this step is a single numerical value indicating the percentile value for each interval for a group of time series. The grouping is done based on the group tags specified in the query. If no group tags are specified, all time series are considered as a single group.
 

--- a/data/docs/metrics-management/volume-control.mdx
+++ b/data/docs/metrics-management/volume-control.mdx
@@ -8,7 +8,7 @@ doc_type: howto
 
 ## Overview
 
-Volume control lets you reduce the stored volume and cardinality of a metric by aggregating away attributes you don't need. You pick a metric and the attributes to keep (or drop). SigNoz then mathematically aggregates all series that differ only in the dropped attributes into a single series, at storage. The remaining attributes stay fully queryable, and the aggregated values stay correct: counter rates account for restarts and resets, and gauges keep their min, max, and averages.
+Volume control lets you reduce the stored volume and <Tooltip text="cardinality" content="The number of unique time series a metric actually produces: one series for each distinct combination of its identifying attributes." link="https://signoz.io/docs/glossary/#cardinality" /> of a metric by aggregating away attributes you don't need. You pick a metric and the attributes to keep (or drop); SigNoz then mathematically aggregates all series that differ only in the dropped attributes into a single series, at storage. The remaining attributes stay fully queryable, and the aggregated values stay correct: counter rates account for restarts and resets, and gauges keep their min, max, and averages.
 
 This is different from dropping labels with a collector processor, which does not reduce cost and silently corrupts your data. See [Dropping Metric Labels](https://signoz.io/docs/metrics-management/dropping-metric-labels/) for why, and [why the collector can't do this](#why-you-cant-do-this-in-your-collector) below.
 
@@ -23,7 +23,7 @@ Use volume control when a metric's cardinality comes from an attribute you never
 Common attributes worth aggregating away:
 
 - `service.instance.id`, `host.name`, `container.id`: per-instance identity on services behind a load balancer
-- `k8s.pod.name`, `k8s.pod.uid`: pod identity that churns on every rollout, creating new series each time
+- `k8s.pod.name`, `k8s.pod.uid`: pod identity that <Tooltip text="churns" content="The replacement of time series by new ones over time." link="https://signoz.io/docs/glossary/#churn" /> on every rollout, creating new series each time
 
 ## Managing Rules
 

--- a/data/docs/migration/migrate-from-grafana/metrics.mdx
+++ b/data/docs/migration/migrate-from-grafana/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-25
 title: Migrate Metrics from Prometheus & Grafana to SigNoz
 description: Learn how to migrate metrics from Prometheus, Mimir, and Grafana Agent to SigNoz using the OpenTelemetry Collector, with receiver mappings and validation steps.
 doc_type: howto
@@ -148,7 +148,7 @@ For a complete list of all supported metric collection methods, see [Send Metric
 
 ### Switching to Native OTel Metrics
 
-For new applications, we recommend using OpenTelemetry SDKs directly instead of Prometheus client libraries. This avoids the need for scraping and provides better context (exemplars).
+For new applications, we recommend using OpenTelemetry SDKs directly instead of Prometheus client libraries. This avoids the need for scraping and provides better context (<Tooltip text="exemplars" content="A pointer from an aggregated metric data point back to a specific trace that contributed to it, letting you jump from a latency spike on a chart to a slow request that caused it." link="https://signoz.io/docs/glossary/#exemplar" />).
 
 See [Instrumentation Guides](https://signoz.io/docs/instrumentation/) for your language.
 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/configuration.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-29
+date: 2026-08-25
 title: OpenTelemetry Collector Configuration
 meta_title: OpenTelemetry Collector Configuration
 description: "Configure the OpenTelemetry Collector: receivers, processors, exporters, extensions, and service pipelines for collecting and exporting telemetry."
@@ -72,7 +72,7 @@ service:
 
 ### 1. Receivers
 
-Receivers define how telemetry data enters the OTel Collector. Receivers can collect telemetry data from one or more sources and they can be pull or push based. Each receiver listens on a network endpoint, or scrapes metrics from targets.
+<Tooltip text="Receivers" content="A Collector pipeline component that defines how telemetry enters the Collector: an OTLP endpoint, a Prometheus scrape, a log file tail." link="https://signoz.io/docs/glossary/#receiver" /> define how telemetry data enters the OTel Collector. Receivers can collect telemetry data from one or more sources and they can be pull or push based. Each receiver listens on a network endpoint, or scrapes metrics from targets.
 
 #### OTLP Receiver
 
@@ -159,7 +159,7 @@ The forward slash separator is required. Writing `httpcheckcritical` (without th
 
 ### 2. Processors
 
-Processors are used to transform, filter, or enrich telemetry data between receivers and exporters.
+<Tooltip text="Processors" content="A Collector pipeline component that sits between receiving and exporting, transforming data in flight: batching, filtering, adding resource attributes, tail sampling." link="https://signoz.io/docs/glossary/#processor" /> are used to transform, filter, or enrich telemetry data between receivers and exporters.
 
 #### Batch Processor
 
@@ -175,7 +175,7 @@ processors:
 
 #### Memory Limiter
 
-This processor prevents out-of-memory (OOM) errors by continuously checking and limiting the memory usage of the collector.
+This processor prevents out-of-memory (OOM) errors by continuously checking and limiting the memory usage of the <Tooltip text="collector" content="The OpenTelemetry Collector, a vendor-agnostic binary that receives, processes, and exports telemetry." link="https://signoz.io/docs/glossary/#collector" />.
 
 ```yaml
 processors:
@@ -338,7 +338,7 @@ The `timeout` defines how long the processor waits for detection to complete. Se
 
 ### 3. Exporters
 
-Exporters send processed telemetry data to observability backends. You can configure multiple exporters to send data to various backends.
+<Tooltip text="Exporters" content="The component that emits telemetry to a consumer: an SDK exporter sending OTLP to a Collector, or a Collector exporter sending data to SigNoz." link="https://signoz.io/docs/glossary/#exporter" /> send processed telemetry data to observability backends. You can configure multiple exporters to send data to various backends.
 
 #### OTLP gRPC Exporter
 

--- a/data/docs/opentelemetry-collection-agents/opentelemetry-collector/geoip-processor.mdx
+++ b/data/docs/opentelemetry-collection-agents/opentelemetry-collector/geoip-processor.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-23
+date: 2026-08-25
 title: OpenTelemetry Collector GeoIP Processor
 description: Enrich traces, logs, and metrics with geographic location data by looking up IP addresses against a MaxMind database using the GeoIP processor in otelcol-contrib.
 doc_type: howto
@@ -72,7 +72,7 @@ For a public IP address like `8.8.8.8`, the processor writes `geo.city_name`, `g
 </details>
 
 <Admonition type="warning">
-  **Most applications need `context: record`.** The default `context: resource` reads from the OpenTelemetry resource, which holds SDK-level fields like `service.name`. Most apps set the caller IP as a span attribute or log record attribute. For that case, set `context: record`. With the default `resource` context, the processor finds no IP and adds no geo attributes.
+  **Most applications need `context: record`.** The default `context: resource` reads from the OpenTelemetry resource, which holds SDK-level fields like `service.name`. Most apps set the caller IP as a span attribute or <Tooltip text="log record" content="A timestamped record of an event, with a severity and optional attributes." link="https://signoz.io/docs/glossary/#log-record" /> attribute. For that case, set `context: record`. With the default `resource` context, the processor finds no IP and adds no geo attributes.
 </Admonition>
 
 ### Step 2: Enable in pipelines

--- a/data/docs/overview/what-is-opentelemetry-and-why-it-matters.mdx
+++ b/data/docs/overview/what-is-opentelemetry-and-why-it-matters.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-04-17
+date: 2026-08-25
 title: What Is OpenTelemetry and Why It Matters
 description: A beginner-friendly introduction to OpenTelemetry — what it is, why to use it instead of a vendor's proprietary agent, and how to start with SigNoz.
 doc_type: explanation
@@ -9,7 +9,7 @@ doc_type: explanation
 
 Your app is slow. A user reports an error. A request takes 8 seconds instead of 200 milliseconds. You open the code, but the code looks fine. What happened in production?
 
-Without data from inside your running application, you are guessing. You need **telemetry** — the signals that tell you what your app is doing, where it spends time, and when it fails. OpenTelemetry is how teams produce those signals today.
+Without data from inside your running application, you are guessing. You need **telemetry** — the <Tooltip text="signals" content="One of the telemetry types OpenTelemetry defines: traces, metrics, or logs." link="https://signoz.io/docs/glossary/#signal" /> that tell you what your app is doing, where it spends time, and when it fails. OpenTelemetry is how teams produce those signals today.
 
 ## Where OpenTelemetry fits in
 

--- a/data/docs/traces-management/guides/correlate-traces-and-logs.mdx
+++ b/data/docs/traces-management/guides/correlate-traces-and-logs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-25
 title: Correlate Logs and Traces in SigNoz
 meta_title: Correlate Logs and Traces
 description: Learn how to correlate logs and traces in SigNoz to debug requests faster and connect application events to traces.
@@ -134,7 +134,7 @@ Each log entry gets `trace_id`, `span_id`, and `trace_flags` injected when a spa
 </TabItem>
 <TabItem value="go" label="Go">
 
-Go has no automatic context propagation for logs. Set up a logger bridge and pass `context.Context` on every log call. The bridge extracts `trace_id` and `span_id` from the active span in that context.
+Go has no automatic <Tooltip text="context propagation" content="The mechanism that carries trace context across process and service boundaries, so spans emitted by different services join into one trace." link="https://signoz.io/docs/glossary/#context-propagation" /> for logs. Set up a logger bridge and pass `context.Context` on every log call. The bridge extracts `trace_id` and `span_id` from the active span in that context.
 
 Initialize your `LoggerProvider` and register it globally before calling `NewLogger`. Skip this and nothing exports. `go.opentelemetry.io/otel/log/global` is experimental; its import path may change when the Go log API stabilizes.
 

--- a/data/docs/traces-management/guides/drop-spans.mdx
+++ b/data/docs/traces-management/guides/drop-spans.mdx
@@ -19,7 +19,7 @@ You can control span volume at two stages:
 
 ## At the application
 
-Dropping spans at the application is HEAD sampling. The sampling decision happens at the start of the trace.
+Dropping spans at the application is <Tooltip text="HEAD sampling" content="Deciding whether to keep a trace at its start, before any spans complete, typically a fixed percentage of traces." link="https://signoz.io/docs/glossary/#head-sampling" />. The sampling decision happens at the start of the trace.
 
 ### TraceIdRatioBased sampler
 

--- a/data/docs/traces-management/guides/span-links.mdx
+++ b/data/docs/traces-management/guides/span-links.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-08
+date: 2026-08-25
 title: Span Links - Connect Async and Batch OpenTelemetry Spans
 description: Learn what OpenTelemetry span links are, when to use them instead of parent-child spans, and how to link a batch job to source requests in SigNoz.
 doc_type: explanation
@@ -20,7 +20,7 @@ A span link is a typed pointer from one span to another. OpenTelemetry uses link
 
 Parent-child works when a caller starts an operation and waits for it inside the same trace. That breaks once work crosses a queue or runs later in a batch: the downstream operation begins a fresh trace with its own trace ID and no parent, so the path back to what triggered it is gone. A span link restores that path.
 
-Add links when you start the span. A head sampler sees only what exists at span creation, so a link attached afterward may not influence its sampling decision.
+Add links when you start the span. A head sampler sees only what exists at span creation, so a link attached afterward may not influence its <Tooltip text="sampling" content="Keeping only a portion of telemetry to control volume and cost." link="https://signoz.io/docs/glossary/#sampling" /> decision.
 
 ## Span links vs parent-child relationships
 

--- a/data/docs/traces-management/guides/tail-sampling.mdx
+++ b/data/docs/traces-management/guides/tail-sampling.mdx
@@ -12,7 +12,7 @@ Tail sampling evaluates a complete trace before deciding whether to keep or drop
 Use tail sampling when your sampling decision depends on trace-level data (error status, total duration, a specific span name) that isn't available until the trace completes.
 
 <Admonition type="warning" title="Impact on APM metrics">
-  SigNoz computes APM metrics (`signoz_calls_total`, `signoz_latency_sum`, and related RED metrics) from ingested trace data. When you enable tail-based sampling, those metrics cover only the sampled traces, so absolute values like total request counts undercount real traffic. Latency trends and error spikes stay reliable. SigNoz is aware of this gap and plans to address it in a future release.
+  SigNoz computes <Tooltip text="APM" content="Application Performance Monitoring." link="https://signoz.io/docs/glossary/#apm" /> metrics (`signoz_calls_total`, `signoz_latency_sum`, and related RED metrics) from ingested trace data. When you enable tail-based sampling, those metrics cover only the sampled traces, so absolute values like total request counts undercount real traffic. Latency trends and error spikes stay reliable. SigNoz is aware of this gap and plans to address it in a future release.
 </Admonition>
 
 ## Prerequisites

--- a/data/docs/userguide/drop-metrics.mdx
+++ b/data/docs/userguide/drop-metrics.mdx
@@ -130,7 +130,7 @@ This environment variable will prevent the SDK from generating any metrics, redu
 
 ### Disable Specific Instrumentations
 
-To disable instruments from specific packages, you can use environment variables depending on your programming language:
+To disable <Tooltip text="instruments" content="The named object an application uses to record measurements: a counter, an up-down counter, a gauge, or a histogram." link="https://signoz.io/docs/glossary/#instrument" /> from specific packages, you can use environment variables depending on your programming language:
 
 <Tabs entityName="language">
 <TabItem value="python" label="Python">

--- a/data/docs/userguide/envoy-metrics.mdx
+++ b/data/docs/userguide/envoy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-03-14
+date: 2026-08-25
 title: Send Envoy Metrics to SigNoz using OpenTelemetry
 description: Send metrics from Envoy to SigNoz using the OpenTelemetry Collector.
 doc_type: howto
@@ -76,7 +76,7 @@ docker run --name=envoy -p 9901:9901 -p 10000:10000 -v $(pwd)/envoy.yaml:/etc/en
 
 ### Step 3: Configure OpenTelemetry Collector
 
-Ensure your OpenTelemetry Collector is configured to receive OTLP metrics on port `4317` (gRPC). The SigNoz OTel Collector already listens on port `4317` to receive OTLP metrics by default.
+Ensure your OpenTelemetry Collector is configured to receive <Tooltip text="OTLP" content="The OpenTelemetry Protocol, the wire format for sending traces, metrics, and logs, over gRPC or HTTP." link="https://signoz.io/docs/glossary/#otlp" /> metrics on port `4317` (gRPC). The SigNoz OTel Collector already listens on port `4317` to receive OTLP metrics by default.
 
 For more details on configuring the collector, refer to the [OpenTelemetry Collector Configuration](https://signoz.io/docs/opentelemetry-collection-agents/get-started/) guide.
 

--- a/data/docs/userguide/exceptions.mdx
+++ b/data/docs/userguide/exceptions.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-05
+date: 2026-08-25
 title: Errors and Exceptions - Record, View, and Group Them
 description: Learn how SigNoz collects and groups exceptions from your traces, links each one to its request, and how to record exceptions in your code.
 doc_type: howto
@@ -9,7 +9,7 @@ doc_type: howto
 
 SigNoz reads exceptions from the traces that your services already send. Your instrumentation records each exception as an `exception` span event. SigNoz collects these events into the **Exceptions** view. The view groups them by service, exception type, and exception message.
 
-Every exception carries the span ID and the trace ID of its request. You can therefore move from a row in the list to the flame graph of that request. Nothing appears until your services send traces. If your services are not instrumented, [instrument them first](https://signoz.io/docs/instrumentation/overview/).
+Every exception carries the span ID and the trace ID of its request. You can therefore move from a row in the list to the <Tooltip text="flame graph" content="A visualization of a trace that shows each span as a horizontal bar positioned by start time and sized by duration, making the critical path and the slowest child operations obvious." link="https://signoz.io/docs/glossary/#flamegraph" /> of that request. Nothing appears until your services send traces. If your services are not instrumented, [instrument them first](https://signoz.io/docs/instrumentation/overview/).
 
 With the Exceptions view you can:
 
@@ -86,7 +86,7 @@ Instrumentation libraries record an exception event when the exception escapes t
 
 Record an exception yourself when it marks a failed operation that no library captured. An example is an error that you catch at a request boundary and turn into a 500 response. OpenTelemetry <a href="https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/" target="_blank" rel="noopener noreferrer nofollow">no longer recommends</a> a record of an exception that you catch and recover from inside the span. These exceptions add noise to the Exceptions view and to your alerts.
 
-To record an exception, get the current span from the tracer. Then call `recordException()` or the equivalent for your language. This call adds the span event, but it does not change the span status. Set the status to error separately when the exception means that the operation failed.
+To record an exception, get the current span from the tracer. Then call `recordException()` or the equivalent for your language. This call adds the span event, but it does not change the <Tooltip text="span status" content="The outcome of the operation a span represents: Unset, Ok, or Error." link="https://signoz.io/docs/glossary/#span-status" />. Set the status to error separately when the exception means that the operation failed.
 
 The Java, Go, Python, JavaScript, and Ruby examples read the span that is current in a request handler. These examples must run inside an active span. Outside an active span, these APIs return a no-op span (`undefined` in JavaScript). The exception then goes nowhere. The .NET and PHP examples create their own span, so these two run alone when you configure a tracer provider.
 

--- a/data/docs/userguide/metrics.mdx
+++ b/data/docs/userguide/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-06
+date: 2026-08-25
 title: View Services
 description: Understand the Services section in SigNoz — RED metrics, filtering, sorting, global time, refresh interval, and sharing.
 doc_type: explanation
@@ -89,7 +89,7 @@ helm upgrade <release-name> signoz/signoz -n <namespace> -f values.yaml
 - `<release-name>`: The name of your [SigNoz Helm release](https://signoz.io/docs/install/kubernetes/). Run `helm list -A` to find it.
 - `<namespace>`: The Kubernetes namespace that runs SigNoz. The same `helm list -A` output shows it.
 
-The new dimension appears in the filter bar for new data. Keep the list short, because each dimension increases the number of span metric time series.
+The new dimension appears in the filter bar for new data. Keep the list short, because each dimension increases the number of span metric <Tooltip text="time series" content="A single stream of samples over time, identified by a metric name, temporality, resource attributes, scope attributes, and data point attributes." link="https://signoz.io/docs/glossary/#time-series" />.
 </Admonition>
 
 ## Global Time
@@ -124,7 +124,7 @@ Click **Share** in the top-right corner to copy a shareable link to the current 
 
 ## How Services and RED Metrics Are Determined 
 
-We rely on the semantic conventions provided by OpenTelemetry. Every unique `service.name` configured and received is part of the service list.
+We rely on the <Tooltip text="semantic conventions" content="OpenTelemetry's standard names and values for attributes and metrics: http.request.method, db.system.name, service.name." link="https://signoz.io/docs/glossary/#semantic-conventions" /> provided by OpenTelemetry. Every unique `service.name` configured and received is part of the service list.
 
 <Figure
   src="/img/docs/trace-request-shop.webp"

--- a/data/docs/userguide/opentelemetry-statsd.mdx
+++ b/data/docs/userguide/opentelemetry-statsd.mdx
@@ -2,10 +2,10 @@
 title: Send StatsD Metrics to SigNoz using OpenTelemetry Collector
 description: Learn how to configure the OpenTelemetry Collector to receive and forward StatsD metrics to SigNoz.
 doc_type: howto
-date: 2026-03-09
+date: 2026-08-25
 ---
 
-<a href="https://github.com/statsd/statsd" target="_blank" rel="noopener noreferrer nofollow">StatsD</a> is a popular network daemon that listens for statistics (like counters, timers, and gauges) sent over UDP or TCP and aggregates them before forwarding to a backend. You can send custom metrics from your applications using StatsD clients to SigNoz by configuring the OpenTelemetry Collector's `statsd` receiver.
+<a href="https://github.com/statsd/statsd" target="_blank" rel="noopener noreferrer nofollow">StatsD</a> is a popular network daemon that listens for statistics (like counters, timers, and <Tooltip text="gauges" content="A metric that represents a value sampled at a point in time: memory in use, queue depth, temperature." link="https://signoz.io/docs/glossary/#gauge" />) sent over UDP or TCP and aggregates them before forwarding to a backend. You can send custom metrics from your applications using StatsD clients to SigNoz by configuring the OpenTelemetry Collector's `statsd` receiver.
 
 This guide explains how to set up the OpenTelemetry Collector to listen for StatsD metrics and send them to SigNoz.
 

--- a/data/docs/userguide/span-details.mdx
+++ b/data/docs/userguide/span-details.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-30
+date: 2026-08-25
 title: Trace Details
 description: Visualize and analyze individual traces using the flamegraph, waterfall chart, and span inspection tools in SigNoz.
 doc_type: howto
@@ -43,7 +43,7 @@ Both views are collapsible — click the section header to expand or collapse th
 
 ## Inspecting a Span
 
-Click on a specific span in either the flame graph or waterfall view to open the **Span Details** panel. The panel is a floating, resizable window that can be docked to the right side or bottom of the screen, allowing you to arrange your workspace.
+Click on a specific <Tooltip text="span" content="A single operation within a trace: an HTTP handler, a database query, or a queue publish." link="https://signoz.io/docs/glossary/#span" /> in either the flame graph or waterfall view to open the **Span Details** panel. The panel is a floating, resizable window that can be docked to the right side or bottom of the screen, allowing you to arrange your workspace.
 
 The panel header shows:
 - **Span name** and **service name**

--- a/data/docs/userguide/traces.mdx
+++ b/data/docs/userguide/traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-27
+date: 2026-08-25
 title: Trace Explorer
 description: Understand the Trace Explorer in SigNoz — views, filtering, trace matching, and how to save and act on your results.
 doc_type: explanation
@@ -126,7 +126,7 @@ Both Time Series and Table views use the Query Builder for filtering, aggregatio
 
 A span shows as missing when a collected span references a Parent Span ID that no other span in the trace matches. That parent span still exists in your system but never reached SigNoz, so the waterfall view shows a gap where it should sit. SigNoz marks these traces with a "This trace has missing spans" banner in the trace details view.
 
-Tail sampling, spans dropped in transit, and services that never export are the usual causes. For the full explanation and how to identify each cause, see [Why are some spans missing from a trace?](https://signoz.io/docs/traces-management/troubleshooting/faqs/#q-why-are-some-spans-missing-from-a-trace).
+<Tooltip text="Tail sampling" content="Deciding whether to keep a trace after all its spans have arrived, so the decision can depend on what happened." link="https://signoz.io/docs/glossary/#tail-sampling" />, spans dropped in transit, and services that never export are the usual causes. For the full explanation and how to identify each cause, see [Why are some spans missing from a trace?](https://signoz.io/docs/traces-management/troubleshooting/faqs/#q-why-are-some-spans-missing-from-a-trace).
 
 ## Export Spans and Traces
 
@@ -241,7 +241,7 @@ To clear a filter, click **Clear All** next to the filter category. To reset all
 
 ### Adding Custom Quick Filters
 
-The quick filters panel shows a set of default filters (like Duration, Service Name, HTTP Method, etc.), but you can add any span or resource attribute as a custom quick filter.
+The quick filters panel shows a set of default filters (like Duration, Service Name, HTTP Method, etc.), but you can add any span or <Tooltip text="resource attribute" content="An attribute on a resource, such as service.name, host.name, or k8s.pod.name." link="https://signoz.io/docs/glossary/#resource-attribute" /> as a custom quick filter.
 
 To customize: click the **settings icon** at the top-right of the quick filters panel, then select **Edit quick filters**. This opens an editor showing your currently added filters and all other available attributes. Search for any attribute and add it to the panel.
 

--- a/data/docs/userguide/writing-clickhouse-traces-query.mdx
+++ b/data/docs/userguide/writing-clickhouse-traces-query.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-08-25
 
 title: Traces Schema - Write ClickHouse Queries & Build Dashboard Panels
 description: Explore the OpenTelemetry traces schema in ClickHouse. Discover how to build custom dashboard panels, analyze span kinds, and calculate latency metrics with advanced queries.
@@ -636,7 +636,7 @@ ORDER BY interval ASC;
 
 ### Querying span events
 
-Span events are stored as a JSON array in the `events` column. You can extract data from them using ClickHouse's array and JSON functions.
+<Tooltip text="Span events" content="A timestamped annotation on a span, used for things that happen at a moment rather than over a duration: a retry, a cache miss, a recorded exception." link="https://signoz.io/docs/glossary/#span-event" /> are stored as a JSON array in the `events` column. You can extract data from them using ClickHouse's array and JSON functions.
 
 #### Count of each `customer_id` from a span event
 

--- a/utils/docs/agentMarkdownStubs.ts
+++ b/utils/docs/agentMarkdownStubs.ts
@@ -48,6 +48,7 @@ export const KNOWN_AGENT_MDX_COMPONENT_NAMES = [
   'CodeTab',
   'CodeTabs',
   'ToggleHeading',
+  'Tooltip',
   'TroubleshootingWizard',
 ] as const
 export const REVIEWED_FALLBACK_AGENT_MDX_COMPONENT_NAMES = [
@@ -432,6 +433,20 @@ const createKnownComponentStubs = (
     )
   },
   ToggleHeading: (props) => React.createElement('div', null, props.children),
+  // Hovering means nothing in plain text, so keep the term inline as a link to its
+  // definition. Must stay inline (not a block) or the surrounding sentence splits apart.
+  Tooltip: (props) => {
+    const text = getStringProp(props, 'text')
+    const link = getStringProp(props, 'link')
+
+    if (!text) {
+      return React.createElement(React.Fragment, null)
+    }
+
+    return link
+      ? React.createElement('a', { href: link }, text)
+      : React.createElement('span', null, text)
+  },
   TroubleshootingWizard: createTroubleshootingWizardStub(),
   RegionTable: () => {
     return React.createElement(


### PR DESCRIPTION
## What

Adds **`/docs/glossary`** — 73 alphabetical terms with an A–Z letter index, covering OpenTelemetry, observability practice, and SigNoz specifics. Every term is its own `###` heading, so each has a stable anchor that can be linked directly (e.g. `.../docs/glossary/#identifying-attribute`).

Also corrects the opening of **`metrics-management/reducing-costs`**, which stated the billing model incorrectly.

## Preview

- **Glossary** — https://staging.signoz.io/docs/glossary/
- **Metrics billing (rewritten)** — https://staging.signoz.io/docs/metrics-management/reducing-costs/
- Anchor example for support replies — https://staging.signoz.io/docs/glossary/#identifying-attribute

## Why

Two gaps that keep coming up when someone tries to model and attribute metrics cost:

1. **No canonical vocabulary.** "Identifying attribute" is used in our billing doc but defined nowhere, and there's no documented set. Without a canonical term, people invent their own — "unique label set" being the common one — and then can't map it back to our docs.
2. **The billing doc stated the model wrong.** It opened with "Metrics billing is based on **cardinality** - the number of unique time series created by your metrics." Metrics are billed per sample ingested. Cardinality is the primary cost driver by arithmetic, not by pricing unit — and stating it as the unit reads as contradicting the fact that we don't bill per time series, which is a deliberate differentiator.

## Glossary contents

**Metrics / cost cluster** — cross-linked so a reader landing on one can't miss the others:

| Term | Substance |
|---|---|
| Sample | The billing unit, $0.10/M. Gauge/sum = 1; histogram = (buckets × 1) + 4 for `.sum`/`.count`/`.min`/`.max` |
| Time series | Real for storage and querying (fingerprint, label set stored once, Metrics Explorer counts) — explicitly **not** a billing unit |
| Identifying attribute | With the worked example: one label set + `http.route` at 10 distinct values → 10 series, 10 datapoints per interval |
| Non-identifying attribute | `host.type` given `host.id`; EC2 tags from the AWS resource detector add series identity but no series and no cost |
| Unique label set | Included as its own entry, pointing at the canonical terms — it's the phrase people reach for when none is documented |
| Fingerprint | Hash over metric name, temporality, resource attrs, scope attrs, datapoint attrs; a storage/aggregation concept, never billed |
| Churn | Free — a replaced series sends the same number of samples |
| Cardinality, active series, bucket, cumulative/delta temporality | |

**Rest of the glossary:** OTel core (span, span link/event/status, trace ID, resource, scope, semantic conventions, OTLP, collector, receiver/processor/exporter, propagator, baggage, distro, zero-code instrumentation, view, exemplar), observability practice (golden signals, RED, SLI, head vs tail sampling, o11y), SigNoz specifics (Cost Meter, Query Builder, trace funnel, aggregated metric data, ingestion key).

## reducing-costs rewrite

Now leads with the billing unit and derives cardinality's role instead of asserting it:

- Billed per sample ingested, **$0.10 per million** at one-month retention
- `total samples = active time series × export frequency`
- One series at 30s ≈ 86,400 samples/month ≈ $0.0086; 100k series at 30s ≈ 8.6B samples ≈ $864
- Exactly two levers: fewer active series, or export less often — so "reduce cardinality" means "reduce series count so fewer samples arrive per interval"
- Churn is free; **dropping labels alone saves nothing** without aggregation
- Attributes section rebuilt around the split-the-label-set test, noting resource attributes get no special treatment
- Callout that OTel has no canonical identifying-attribute list yet, with the practical test to use until then

## Discovery

- Sidebar: under **Overview**, after "What Is OpenTelemetry?"
- Links added from the metrics overview ("Concepts and reference") and metrics reference pages

## Verification

- `check:docs-metadata` + `test:docs-metadata` (30 pass)
- `check:doc-redirects` + `test:doc-redirects` (13 pass)
- `check:stale-urls`
- All pre-commit hooks pass
- **Rendered locally** — all four pages return 200; glossary shows 73 `<h3>` terms with all 21 letter anchors and every key term anchor present. (Checks alone don't catch MDX that compiles but 404s.)
- New path, so no redirect needed

## Review notes

- Pricing is hardcoded as $0.10/M rather than link-only. The retention entry notes it rises to $0.18 at thirteen months, matching the pricing estimator.
- **@SrikanthChekuri** — the billing definitions and the samples/interval arithmetic are drawn from your explanation of the model, not from anything previously documented. Worth your eye on `reducing-costs.mdx` in particular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

