### PR TITLE
chore: remove docs badge in topnav

### DIFF
--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -9,7 +9,6 @@ import GitHubStars from '../GithubStars/GithubStars'
 import Tabs from '@/components/ResourceCenter/Tabs'
 import TrackingLink from '@/components/TrackingLink'
 import TrackingButton from '@/components/TrackingButton'
-import { Badge } from '@signozhq/ui/badge'
 import { Button } from '@/components/ui/Button'
 import { cn } from 'app/lib/utils'
 import { TABS, TAB_PATHNAMES } from './constants'
@@ -110,12 +109,6 @@ export default function TopNav() {
               />
               <span className="text-[17.111px] font-medium">SigNoz</span>
             </TrackingLink>
-            {isDocsBasePath && (
-              <Badge color="cherry" className="ml-1 self-center uppercase">
-                docs
-              </Badge>
-            )}
-
             {!isLoginRoute && (
               <NavDropdownProvider>
                 <div


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Removes the red "docs" badge that appeared next to the SigNoz logo in the top navbar on all `/docs/*` pages. The badge added visual noise beside the logo without providing meaningful context, so it is being removed per the design decision in the linked issue.

#### Screenshots / Screen Recordings (if applicable)

Removed:
<img width="1920" height="865" alt="Screenshot 2026-08-13 at 17 18 05" src="https://github.com/user-attachments/assets/1cd09773-7237-4a35-ab50-998306574f8a" />


#### Issues closed by this PR
Closes SigNoz/growth-pod#1264

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Not required — pure UI element removal, no logic change.
- Manual verification: `yarn lint` (0 errors), `yarn check:stale-urls` + `yarn test:stale-urls` (all pass). Local `yarn build` skipped (fails at `/blog` prerender without CMS access — expected; covered by CI).
- Edge cases covered: Verified `isDocsBasePath` remains used for logo gap, nav margin, and mobile docs sidebar toggle.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Top navbar on `/docs/*` pages only.
- Potential regressions: None expected — removal of a purely decorative element.
- Rollback plan: Revert this commit.

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Single-file change in `components/TopNav/TopNav.tsx`: removed the badge JSX block and its import. No other `Badge` usage existed in this file.

---
