### PR TITLE
docs: note session revocation on password reset

### DIFF
--- a/data/docs/userguide/authentication.mdx
+++ b/data/docs/userguide/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-16
+date: 2026-08-14
 title: Authentication and Login
 description: Understand authentication in SigNoz — supported roles, inviting members, and managing user permissions.
 doc_type: explanation
@@ -41,6 +41,11 @@ You can edit permission levels of members by going to `Settings-> Org Settings` 
 You can also generate password reset link if they have forgotten their password and it needs to be reset.
 
 ![edit-member](/img/docs/edit-member.webp)
+
+<Admonition type="info">
+Completing a password reset, whether through the forgot-password link or by changing the password from account settings, immediately revokes all of that account's active sessions. Every device or browser that was signed in is logged out and must sign in again with the new password.
+</Admonition>
+
 
 
 ## Permission Matrix for Admin, Editor and Viewer:


### PR DESCRIPTION
## Description

- Added a note to the Authentication and Login page clarifying that completing a password reset (via the forgot-password link or a self-initiated password change) immediately revokes all of the account's active sessions, logging out every signed-in device.
- Updated the `date` frontmatter to today.

This reflects the behavior change in SigNoz/signoz#12531, where token-based (forgot-password) resets now revoke existing sessions, aligning them with voluntary password changes. Background security behavior with no UI change, so no screenshots.

## Issues closed by this PR

Source PRs: SigNoz/signoz#12531

Auto-generated by docs-sync pipeline