### PR TITLE
chore: move changelog from footer to topnav

### DIFF
--- a/components/TopNav/constants.tsx
+++ b/components/TopNav/constants.tsx
@@ -263,6 +263,12 @@ export const resourcesDropdownItems = {
       description: 'Explore dashboard templates for your use cases',
       name: 'Dashboard Templates',
     },
+    {
+      key: 'changelog',
+      url: '/changelog/',
+      description: 'Learn about latest product developments',
+      name: 'Changelog',
+    },
   ] as ResourceItem[],
 }
 

--- a/components/mainFooter.tsx
+++ b/components/mainFooter.tsx
@@ -165,7 +165,6 @@ function Footer({ inDocsShell = false }: FooterProps) {
                   Launch Week
                   <ArrowUpRight size={16} />
                 </FooterPillLink>
-                <FooterPillLink href="/changelog/">Changelog</FooterPillLink>
                 <FooterPillLink href="/docs/dashboards/dashboard-templates/overview/" newTab>
                   Dashboard Templates
                   <ArrowUpRight size={16} />


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Moves changelog from footer to topnav



#### Screenshots / Screen Recordings (if applicable)

Before:

<img width="1917" height="865" alt="Screenshot 2026-08-14 at 11 56 22" src="https://github.com/user-attachments/assets/8cba55f1-f1d2-4b7f-a153-b08fc95b38ad" />

After:
<img width="1920" height="868" alt="Screenshot 2026-08-14 at 11 57 02" src="https://github.com/user-attachments/assets/2752dd8f-edfa-4aa2-bff7-0bbee1866b4c" />
<img width="388" height="677" alt="Screenshot 2026-08-14 at 11 57 44" src="https://github.com/user-attachments/assets/fcce428f-b9f9-4439-ae43-59055d5b52ba" />


#### Issues closed by this PR
> Closes https://github.com/SigNoz/growth-pod/issues/1187 

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: NA
- Manual verification: Done on preview
- Edge cases covered: None, small change

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Topnav and footer
- Potential regressions: None, small change
- Rollback plan: Not needed


---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers


---
