### PR TITLE
docs(mcp): add Grok Build client tabs

### DIFF
--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-22
+date: 2026-08-17
 title: SigNoz MCP Server
 meta_title: SigNoz MCP Server - AI Assistant Integration Guide
 description: Connect Claude, Cursor, Copilot, and other AI assistants to SigNoz via MCP for natural language access to metrics, logs, traces, and alerts.
@@ -222,6 +222,48 @@ Or manually add to `mcp_config.json`:
 After saving the config, it will prompt you to complete the OAuth flow. To edit the config from within Antigravity, click the `...` menu at the top of the Agent pane → **MCP Servers** → **Manage MCP Servers** → **View raw config**.
 
 If you run into authentication issues, open the command palette and run **Authentication: Remove Dynamic Authentication Providers** to clear cached OAuth credentials and re-authenticate.
+
+</TabItem>
+<TabItem value="cloud-grok" label="Grok Build">
+
+### Configure
+
+Add the MCP server via CLI:
+
+```bash
+grok mcp add -t http signoz https://mcp.<region>.signoz.cloud/mcp
+```
+
+Or add this configuration to `~/.grok/config.toml`:
+
+```toml title="config.toml"
+[mcp_servers.signoz]
+url = "https://mcp.<region>.signoz.cloud/mcp"
+enabled = true
+```
+
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint) 
+
+Adding the server does not authenticate it. Start Grok Build, run `/mcps`, select the `signoz` server, and complete the OAuth flow in your browser:
+
+```bash
+grok
+```
+
+```
+/mcps
+```
+
+No API key is stored in the config file; credentials are saved separately once the OAuth flow completes.
+
+Add `-s project` to the `add` command to write to `./.grok/config.toml` instead, sharing the server with everyone working in that directory.
+
+Verify the connection:
+
+```bash
+grok mcp list
+grok mcp doctor
+```
 
 </TabItem>
 </Tabs>
@@ -775,6 +817,50 @@ Add to `mcp_config.json` (open via `...` menu → **MCP Servers** → **Manage M
   }
 }
 ```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="sh-grok" label="Grok Build">
+
+<Tabs entityName="grok-transport">
+<TabItem value="sh-grok-stdio" label="Stdio (Recommended)" default>
+
+Add the MCP server via CLI:
+
+```bash
+grok mcp add signoz <path-to-binary>/signoz-mcp-server \
+  -e SIGNOZ_URL=<your-signoz-url> \
+  -e SIGNOZ_API_KEY=<your-api-key> \
+  -e LOG_LEVEL=info
+```
+
+- `<path-to-binary>`: Absolute path to the `signoz-mcp-server` binary
+- `<your-signoz-url>`: Your SigNoz instance URL
+- `<your-api-key>`: The API key from [Fetch your API key](#fetch-your-api-key)
+
+Stdio is the default transport, so no `-t` flag is needed. The server is written to `~/.grok/config.toml`; add `-s project` to write to `./.grok/config.toml` instead.
+
+</TabItem>
+<TabItem value="sh-grok-http" label="HTTP">
+
+1. Start the MCP server in HTTP mode.
+2. Add the MCP server via CLI:
+
+```bash
+grok mcp add -t http signoz http://localhost:8000/mcp
+```
+
+Or add to `~/.grok/config.toml`:
+
+```toml title="config.toml"
+[mcp_servers.signoz]
+url = "http://localhost:8000/mcp"
+enabled = true
+```
+
+Use `-H "<name>: <value>"` on the `add` command to pass an authentication header if your deployment requires one.
 
 </TabItem>
 </Tabs>

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -830,7 +830,7 @@ Add to `mcp_config.json` (open via `...` menu → **MCP Servers** → **Manage M
 Add the MCP server via CLI:
 
 ```bash
-grok mcp add signoz <path-to-binary>/signoz-mcp-server \
+grok mcp add signoz "<path-to-binary>/signoz-mcp-server" \
   -e SIGNOZ_URL=<your-signoz-url> \
   -e SIGNOZ_API_KEY=<your-api-key> \
   -e LOG_LEVEL=info


### PR DESCRIPTION
Adds **Grok Build** (xAI) to the MCP server page, so it sits alongside Cursor, VS Code / GitHub Copilot, Claude Desktop, Claude Code, OpenAI Codex, Gemini CLI, Windsurf and Antigravity.

Grok Build ships an MCP client but was not documented, so users had to work the config out from `grok mcp add --help`.

Companion PR on the server repo: SigNoz/signoz-mcp-server#291

## What is added

Two tabs, matching how every other client appears in both tab groups.

**SigNoz Cloud → Grok Build**
- `grok mcp add -t http signoz https://mcp.<region>.signoz.cloud/mcp`
- The equivalent `~/.grok/config.toml` block
- The `/mcps` OAuth step
- `-s project` scope note and `grok mcp list` / `grok mcp doctor` verification

**Self-Hosted → Grok Build** (Stdio and HTTP sub-tabs)
- Stdio via `grok mcp add` with `-e` env flags for `SIGNOZ_URL`, `SIGNOZ_API_KEY`, `LOG_LEVEL`
- HTTP via `-t http` against `http://localhost:8000/mcp`, plus the `-H` header flag

## Validation

Verified against a real Grok Build install rather than written from documentation:

- `grok --version` → `grok 1.0.4 (d846eb93d94d) [stable]`
- `grok mcp add --help` confirms `-t/--transport {stdio,http,sse}`, `-s/--scope {user,project}`, `-e/--env KEY=value`, `-H/--header "NAME: VALUE"`, and that stdio is the default transport
- The Cloud TOML block is copied from a live `~/.grok/config.toml` written by the CLI itself, not hand-authored
- `grok mcp list` → `signoz: https://mcp.us.signoz.cloud/mcp`
- The hosted OAuth flow was exercised end to end against SigNoz Cloud US

The `/mcps` step is called out explicitly because adding the server does **not** authenticate it. This matches the existing Claude Code tab ("Select the signoz server and complete the authentication flow") and the Gemini CLI tab (`/mcp auth signoz`).

## Checks

- `yarn check:docs-metadata` → pass
- `yarn check:doc-redirects` → pass (no path or URL changes)
- Tab structure balanced: 43 `<TabItem>` open / 43 close, 13 `<Tabs>` open / 13 close

Two notes for the reviewer:

1. **`date` bumped** from `2026-07-22` to `2026-08-17`. `check:docs-metadata` fails a modified doc whose `date` is more than 7 days old when body content changes, so this bump is required for the check to pass.
2. **`yarn test:docs-metadata` fails, but not because of this change.** The failing case is `should allow date exactly 7 days in the past`, a boundary test over synthetic fixtures. I confirmed it fails identically on unmodified `main` (stashed this change, re-ran, same single failure), so it is pre-existing and out of scope here.
