### PR TITLE
docs(ai): add Grok Build to the Agent Skills plugin page

### DIFF
--- a/data/docs/ai/agent-skills.mdx
+++ b/data/docs/ai/agent-skills.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-22
+date: 2026-08-17
 title: Agent Skills & Plugin
 meta_title: SigNoz Agent Skills & Plugin - AI Coding Assistant Setup
 description: Install the SigNoz plugin and Agent Skills so AI assistants like Claude Code, Codex, Cursor, and Gemini can query data, build dashboards, manage alerts, and explore SigNoz docs.
@@ -12,7 +12,7 @@ When you ask your AI assistant something like "why did this alert fire," "create
 
 SigNoz ships these skills two ways:
 
-- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, and Antigravity CLI.
+- **The SigNoz plugin** - the recommended path. One install bundles every skill plus the MCP server registration, so your agent can both reason about SigNoz *and* act on your data. Available for Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, Grok Build, and Antigravity CLI.
 - **Individual skills via skills.sh** - install one or more skill files on their own, for any skills.sh-compatible agent.
 
 ## Install the plugin
@@ -142,6 +142,39 @@ Follow the prompts to enter your SigNoz instance URL and API key.
    This rewrites `serverUrl` in the installed `mcp_config.json`. SigNoz Cloud `us` users can skip this step.
 
 3. Authenticate. In the `agy` prompt, type `/mcp`, select the `signoz` server, and choose **Authenticate** to start the OAuth flow, then complete it in the browser. Self-hosted endpoints need no OAuth unless the server runs with `OAUTH_ENABLED=true`.
+
+</TabItem>
+<TabItem value="grok-build" label="Grok Build">
+
+1. Add the marketplace and install the plugin. `--trust` is required for the bundled MCP server and hooks to activate - without it the skills load but the `signoz` server stays inactive:
+
+   ```bash
+   grok plugin marketplace add SigNoz/agent-skills
+   grok plugin install signoz --trust
+   ```
+
+   To skip the marketplace source, install the plugin subdirectory directly with `grok plugin install SigNoz/agent-skills#plugins/signoz --trust`.
+
+2. The plugin defaults to the SigNoz Cloud `us` endpoint (`https://mcp.us.signoz.cloud/mcp`), so `us` users can skip this step. To point it at a different region or a self-hosted instance, add the endpoint to Grok's own config with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, `in2`) or a self-hosted HTTP MCP URL (ex: `http://localhost:8000/mcp`):
+
+   ```bash
+   grok mcp add signoz -t http https://mcp.<region>.signoz.cloud/mcp -s user
+   ```
+
+   A `[mcp_servers.signoz]` entry replaces the plugin's own registration rather than adding a second server, and unlike the bundled file it survives plugin updates. Use `-s project` to write `./.grok/config.toml` and share the endpoint with everyone working in that directory. You can also run `/signoz-mcp-setup <region-or-mcp-url>` in a Grok session and let the setup skill do it.
+
+3. Authenticate. Run `/mcps` to open the MCP Servers modal, press `r` to refresh the list, select the `signoz` server, and press `i` to start the OAuth flow, then complete it in the browser. Self-hosted endpoints need no OAuth unless the server runs with `OAUTH_ENABLED=true`. Verify with `grok mcp doctor signoz`.
+
+To update after new releases:
+
+```bash
+grok plugin marketplace update
+grok plugin update signoz
+```
+
+<Admonition type="note">
+Grok reads `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` as compatibility sources. If you already have SigNoz configured in Claude Code or Cursor, Grok loads that server alongside the plugin's, leaving two servers named `signoz` pointing at different endpoints. The `[mcp_servers.signoz]` entry in step 2 outranks both and collapses them to one.
+</Admonition>
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Adds a **Grok Build** tab to [`/docs/ai/agent-skills`](https://signoz.io/docs/ai/agent-skills/), alongside Claude Code, Codex, Cursor, Gemini CLI, Devin CLI, and Antigravity CLI, and lists it in the intro paragraph.

## Motivation

[Grok Build](https://docs.x.ai/build/overview) is xAI's coding-agent CLI. It installs the SigNoz plugin natively — all 13 skills, the hooks, and the bundled MCP registration — but the page had no setup path for it.

This is the plugin/skills counterpart to #4005, which covers the raw MCP server setup on the MCP page.

## What the tab covers

- **Install** via `grok plugin marketplace add` + `grok plugin install signoz --trust`, with the direct `#plugins/signoz` subdirectory form as an alternative. `--trust` is called out because without it the skills load but the MCP server and hooks stay inactive, which is a confusing failure mode.
- **Region / self-hosted selection.** Grok has no install-time endpoint prompt the way Claude Code and Cursor do, so the tab documents `grok mcp add signoz -t http <url> -s user|project` and the `/signoz-mcp-setup` skill. Two points worth keeping: a `[mcp_servers.signoz]` entry *replaces* the plugin's own registration rather than adding a second server, and it survives plugin updates (unlike the bundled registrations on other clients, which reset). `us` users need no configuration at all, since the bundled registration already defaults to the Cloud `us` endpoint.
- **Authentication** via the `/mcps` modal (`r` to refresh, `i` to authenticate), plus `grok mcp doctor signoz` to verify.
- **A compatibility-source note.** Grok reads `~/.claude.json`, `~/.cursor/mcp.json`, and `.mcp.json` alongside its own config, and a compat-sourced server loads *beside* the plugin's rather than replacing it. Users already running SigNoz in Claude Code or Cursor get two live servers named `signoz` at different endpoints until they add the config entry. This is easy to hit and hard to diagnose, so it's an `Admonition` rather than buried prose.

## Verification

Per the docs verification matrix:

- `yarn check:docs-metadata` — pass
- `yarn check:doc-redirects` — pass
- `yarn test:docs-metadata` — pass
- `yarn test:doc-redirects` — pass

Tab open/close tags balanced (1 `Tabs`, 7 `TabItem`), no duplicate tab values.

The doc `date` is bumped to `2026-08-17`; the metadata check rejects edits to a file whose date is more than 7 days old.

## Dependency — please do not merge before this lands

The plugin-side support is in **SigNoz/agent-skills#83**. Until that merges and is released, `grok plugin install signoz` resolves our Claude-format manifest, whose `${user_config.SIGNOZ_MCP_URL}` placeholder Grok cannot expand — it registers a dead server and fails the handshake with `RelativeUrlWithoutBase`. The `us`-works-out-of-the-box behavior described in step 2 comes from the `.grok-plugin` manifest added in that PR.

## Checklist

- [x] Frontmatter is complete and correct.
- [x] The primary job is clear and the happy path is easy to follow.
- [x] Links handled; no redirects, images, or sidebar changes needed (existing page, no URL change).
- [x] Relevant docs checks were run.
