### PR TITLE
docs: remove threading mention from google chat notification channel

### DIFF
--- a/data/docs/alerts-management/notification-channel/google-chat.mdx
+++ b/data/docs/alerts-management/notification-channel/google-chat.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-08-19
 doc_type: howto
 title: Configure Google Chat Channel
 description: Set up Google Chat as a notification channel in SigNoz to receive alerts as rich cards in your team's space.
@@ -47,7 +47,7 @@ Once configured, SigNoz posts a card to the space whenever an alert fires (or re
 - The alert title as the card heading, and the rendered Description as the body.
 - Deep-link buttons: **Open in SigNoz**, and **View Related Logs** / **View Related Traces** when the alert carries those links.
 
-Related alerts are threaded together using the alert's group key, so updates to the same alert group stay in one conversation thread.
+Each notification is posted as a new standalone message in the space. Repeat notifications for an ongoing alert also appear as new messages.
 
 <Figure src="/img/docs/alerts-in-google-chat.webp" alt="A firing alert delivered as a card in Google Chat." caption="A firing alert delivered as a card in Google Chat." />
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

- Backend removed Google Chat threaded replies (SigNoz/signoz#12609); this updates the doc to match.
- Replaced the "related alerts are threaded together" line with: each notification is a new standalone message; repeat notifications for an ongoing alert also appear as new messages.
- Bumped frontmatter `date`.

#### Issues closed by this PR

Part of SigNoz/pulse-pod#285

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🧪 Testing Strategy

- Manual verification: `yarn check:docs-metadata` and `yarn check:doc-redirects` pass (also run by pre-commit hooks).

---

## 👀 Notes for Reviewers

- Single-line behavior doc change; no path/nav/redirect changes.
- Merge after SigNoz/signoz#12609 is deployed, so docs don't get ahead of live behavior.