### PR TITLE
docs: document Lambda dashboard FunctionName filter

### DIFF
--- a/data/docs/integrations/aws/lambda.mdx
+++ b/data/docs/integrations/aws/lambda.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-27
+date: 2026-08-19
 tags: [SigNoz Cloud]
 title: AWS Lambda Integration
 description: Monitor Lambda functions with SigNoz using One-Click AWS Integration. Collect key Lambda metrics and view them with an out of the box dashboard.
@@ -119,6 +119,18 @@ The integration provides a comprehensive overview dashboard with key Lambda metr
 - **Duration**: Analyze function execution time.
 - **Throttles**: Monitor throttled invocations.
 - **Concurrency**: Track concurrent execution levels.
+
+#### Filter the dashboard
+
+Use the filter bar at the top of the dashboard to scope every panel:
+
+- **Account**: Limit panels to a specific AWS account.
+- **Region**: Limit panels to a specific AWS region.
+- **FunctionName**: Scope panels to one or more Lambda functions. This dropdown is multi-select, so you can compare several functions at once or select **All** to view every function.
+
+<Admonition type="info">
+Existing Lambda dashboards are updated in place to include the **FunctionName** filter when SigNoz starts after an upgrade. No manual reconfiguration is required.
+</Admonition>
 
 ---
 


### PR DESCRIPTION
## Description

- Documented the AWS Lambda Overview dashboard filter bar: **Account**, **Region**, and the new multi-select **FunctionName** variable (from product PR #12599).
- Added a note that existing Lambda dashboards are migrated in place on upgrade, with no manual action required.
- Updated the `date` frontmatter on the edited page.

Screenshots are prose-only this batch: the AWS integration is not connected on the demo (no enabled services), so the Lambda Overview dashboard is disabled and the FunctionName filter cannot be captured live.

## Issues closed by this PR

Source PRs: #12599

Auto-generated by docs-sync pipeline