### PR TITLE
docs: embed walkthrough videos in GitHub Copilot and Grok Build docs

### DIFF
--- a/data/docs/github-copilot-monitoring.mdx
+++ b/data/docs/github-copilot-monitoring.mdx
@@ -12,6 +12,8 @@ GitHub Copilot observability gives you real-time visibility into how the Copilot
 
 With full GitHub Copilot monitoring in SigNoz, you can see which models the agent routes work to, track token spend and prompt-cache savings, measure time to first chunk as the developer actually experiences it, break down which tools the agent reaches for, and catch failing tool calls and rate limits before they slow the team down.
 
+<YouTube id="ccPSBysRELQ" mute="false" />
+
 ## Prerequisites
 
 - A [SigNoz Cloud account](https://signoz.io/teams/) with an active ingestion key or [Self Hosted SigNoz instance](https://signoz.io/docs/install/self-host/)

--- a/data/docs/grok-build-observability.mdx
+++ b/data/docs/grok-build-observability.mdx
@@ -16,6 +16,8 @@ With full Grok Build observability in SigNoz, you can see how much your team is 
 Unlike most integrations in this section, Grok Build has no traces exporter. Everything arrives as metrics under the `ai.xai.grok_code` meter scope and as OTLP log records. There is no trace waterfall to explore, so the dashboard is the primary view.
 </Admonition>
 
+<YouTube id="G30t8Q4d8S0" mute="false" />
+
 ## Prerequisites
 
 - SigNoz setup (choose one):


### PR DESCRIPTION
Embeds the walkthrough videos in the two LLM observability docs that were missing them.

- `data/docs/github-copilot-monitoring.mdx` → https://youtu.be/ccPSBysRELQ
- `data/docs/grok-build-observability.mdx` → https://youtu.be/G30t8Q4d8S0

Both use the existing `<YouTube id="..." mute="false" />` component and sit at the end of the intro section, just before `## Prerequisites`, matching the placement in the other LLM docs (Claude Code, Codex, DeepSeek, Grok).