### PR TITLE
docs: document log details drawer across infra and dashboard surfaces

### DIFF
--- a/data/docs/dashboards/panel-types/list.mdx
+++ b/data/docs/dashboards/panel-types/list.mdx
@@ -1,7 +1,7 @@
 ---
 
 title: List Chart Panel Type
-date: 2026-07-29
+date: 2026-08-20
 description: Learn how to use the List Chart panel type in SigNoz dashboards to display ranked metrics data.
 doc_type: reference
 ---
@@ -49,6 +49,10 @@ List panels page through results server-side. Use the pager at the bottom of the
 <Admonition type="info">
 The column header search filters the rows on the current page only. To search across the whole result set, narrow the panel's query instead.
 </Admonition>
+
+#### Log details
+
+When a List panel shows logs, click any log row to open the log details drawer. It matches the drawer in the [Logs Explorer](https://signoz.io/docs/userguide/logs_query_builder/#log-details), so you can inspect the body, attributes, and JSON, and the header shows the correct log timestamp. Quick filter actions such as **Filter for value**, **Group By Attribute**, and **Replace filters** are not shown in dashboard panels.
 
 ### Get Help
 

--- a/data/docs/infrastructure-monitoring/host-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/host-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-20
 title: Host Monitoring
 description: Monitor host performance in SigNoz, covering CPU, memory, disk, and network metrics with correlated traces and logs.
 doc_type: explanation
@@ -221,6 +221,7 @@ Access and search through host logs with powerful filtering capabilities.
 - Click **Run Query** to execute your filter
 - Click **Explore in Logs Explorer** to open the full Logs Explorer retaining time ranges and filters
 - Highlighted warning and error messages
+- Click any log line to open the log details drawer, matching the [Logs Explorer](https://signoz.io/docs/userguide/logs_query_builder/#log-details) drawer. Use **Filter for value** or **Filter out value** on any attribute (including the log body and nested fields) to refine the tab's query. **Group By Attribute** and **Replace filters** are available only in the Logs Explorer.
 
 **Filter Categories:**
 

--- a/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
+++ b/data/docs/infrastructure-monitoring/kubernetes-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-03
+date: 2026-08-20
 title: Kubernetes Monitoring - Pods, Nodes & Workloads
 description: Monitor Kubernetes pods, nodes, and workloads in SigNoz with resource utilization and correlated traces, logs, and events for every cluster resource type.
 doc_type: explanation
@@ -72,6 +72,12 @@ Click the columns icon in the toolbar to open the **Columns** panel. It shows th
 ### Detail Page
 
 Click any entity name to open its detail page. Most entities have four tabs: **Metrics**, **Logs**, **Traces**, and **Events**, so you can correlate infrastructure performance with application behavior. Volumes is the exception: its detail page shows only the Metrics tab.
+
+On the **Logs** tab, click any log line to open the log details drawer. It matches the drawer in the [Logs Explorer](https://signoz.io/docs/userguide/logs_query_builder/#log-details), with the Overview, JSON, Context, and Metrics tabs. Hover over any attribute value and use **Filter for value** or **Filter out value** to refine the tab's query. Both actions work on the log body and on nested attribute fields.
+
+<Admonition type="info">
+**Group By Attribute** and **Replace filters** are available only in the Logs Explorer. They are not shown in the log details drawer on Infrastructure Monitoring pages.
+</Admonition>
 
 <Figure
   src="/img/docs/infrastructure-monitoring/kubernetes-nodes-view.webp"

--- a/data/docs/userguide/logs_query_builder.mdx
+++ b/data/docs/userguide/logs_query_builder.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-06
+date: 2026-08-20
 title: Logs Explorer
 meta_title: "Logs Explorer: Query, Search & Analyze Logs Efficiently"
 description: Explore logs with SigNoz Logs Explorer. Query, search and analyze logs efficiently using powerful log explorer queries and real-time insights.
@@ -207,6 +207,12 @@ From the attribute values, you can:
   alt="Quick actions on attribute values in Log Details"
   caption="Quick actions on attribute values: Filter for value, Filter out value, Group By Attribute, Replace filters"
 />
+
+The same log details drawer also opens from [Infrastructure Monitoring](https://signoz.io/docs/infrastructure-monitoring/kubernetes-monitoring/) entity Logs tabs and from dashboard [List panels](https://signoz.io/docs/dashboards/panel-types/list/). The available quick actions depend on where you open it:
+
+- **Logs Explorer**: all four actions (Filter for value, Filter out value, Group By Attribute, and Replace filters).
+- **Infrastructure Monitoring**: Filter for value and Filter out value, including filters on the log body and nested attribute fields. Group By Attribute and Replace filters are not shown.
+- **Dashboard panels**: the drawer opens for inspecting the body, attributes, and JSON. Quick filter actions are not shown.
 
 ### JSON
 


### PR DESCRIPTION
## Description

The V2 log details drawer now opens on Infrastructure Monitoring entity Logs tabs and dashboard List panels, not just the Logs Explorer. Available quick actions vary by surface, and a dashboard-panel timestamp bug was fixed.

- `logs_query_builder.mdx`: note that Group By Attribute and Replace filters are Logs Explorer-only; Filter for value / Filter out value also work on Infrastructure Monitoring (body and nested fields); dashboard panels open the drawer for viewing only.
- `kubernetes-monitoring.mdx`: describe the Logs-tab drawer and its available actions on Kubernetes entity detail pages.
- `host-monitoring.mdx`: same for the host detail Logs tab.
- `dashboards/panel-types/list.mdx`: note that clicking a log row opens the drawer with the correct timestamp.
- Updated frontmatter `date` on all edited files.

Prose-only: the source PRs merged 2026-08-19 and the demo has not caught up, so no screenshots were captured.

## Issues closed by this PR

Source PRs: #12623, #12624

Auto-generated by docs-sync pipeline