### PR TITLE
docs: update onboarding picker destination docs

### DIFF
--- a/data/docs/aws-monitoring/lambda/lambda-traces.mdx
+++ b/data/docs/aws-monitoring/lambda/lambda-traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-08-20
 title: Send your AWS Lambda Traces to SigNoz
 meta_title: AWS Lambda Traces - OpenTelemetry Auto-Instrumentation
 description: Learn to send Lambda traces using OpenTelemetry auto-instrumentation layers for Python, Node.js, Java, and Ruby to track serverless performance.
@@ -11,6 +11,10 @@ doc_type: howto
 This documentation provides a detailed walkthrough on how to set up an AWS Lambda function to collect AWS Lambda traces 
 using OpenTelemetry auto-instrumentation. This will enable you to automatically sends your Lambda traces to SigNoz, 
 enabling you to trace the activities of your Lambda function.
+
+<Admonition type="info" title="Running a Go Lambda function?">
+This guide uses the OpenTelemetry auto-instrumentation Lambda layers, which cover Python, Node.js, Java, and Ruby. Go has no such layer, so instrument it with the OpenTelemetry Go SDK instead. See [Monitor Go AWS Lambda Traces with OpenTelemetry SDK](https://signoz.io/docs/aws-monitoring/lambda/lambda-traces-golang/).
+</Admonition>
 
 <KeyPointCallout title="Using self-hosted SigNoz?" defaultCollapsed="true">
 Most steps are identical. To adapt this guide, update the endpoint and remove the ingestion key header as shown in [Cloud → Self-Hosted](https://signoz.io/docs/ingestion/cloud-vs-self-hosted/#cloud-to-self-hosted).

--- a/data/docs/integrations/supabase.mdx
+++ b/data/docs/integrations/supabase.mdx
@@ -1,10 +1,15 @@
 ---
-date: 2026-06-11
+date: 2026-08-20
 title: Supabase Metrics Integration
 description: Monitor your Supabase project health and performance in SigNoz by collecting platform metrics.
+doc_type: howto
 ---
 
 Monitor your Supabase project’s health and performance in SigNoz by collecting platform metrics via the OpenTelemetry (OTEL) Collector and Prometheus receiver.
+
+<Admonition type="tip" title="Looking for Supabase logs?">
+See [Send Supabase Logs to SigNoz](https://signoz.io/docs/logs-management/send-logs/supabase-logs/) to forward platform logs with Supabase Log Drains over OTLP.
+</Admonition>
 
 ## How Supabase Metrics Integration Works
 


### PR DESCRIPTION
## Description

PR #12595 (product) added 22 data sources to the onboarding picker, split Traefik/MySQL into separate metric and log cards, and added a runtime selector on AWS Lambda → Traces. This docs-sync PR reconciles the docs the picker links to.

Findings from verifying the 22 card destinations:

- All destination docs pages already exist (created in prior batches) and are already wired into the discovery listicles (Grok Build, GitHub Copilot, Dify, Firecrawl, Neon, Kong, KEDA, etc.).
- Traefik and MySQL logs pages are already standalone guides with cross-link admonitions back to their metrics/traces counterparts, so the card split is already reflected.
- The six Azure and two GCP redirect cards point to the in-product integrations dashboard; their services (Cosmos DB, MongoDB vCore, PostgreSQL Flexible Server, Redis, SQL Managed Instance, Cassandra / Cloud SQL for PostgreSQL, Memorystore for Redis) all have existing docs pages under `integrations/azure/` and `integrations/gcp/`.

Changes in this PR:

- **AWS Lambda traces**: added a callout on the auto-instrumentation guide pointing Go users to the OpenTelemetry Go SDK guide, matching the picker's new runtime split (auto-instrumentation layers cover Python/Node.js/Java/Ruby; Go uses the SDK path).
- **Supabase**: added a cross-link from the Supabase metrics integration page to the new Supabase Logs guide (the logs page already linked back to metrics). Also added the missing `doc_type` frontmatter key.
- Updated `date` frontmatter to today on both edited files.

Verified against the merged onboarding config in #12595 rather than the demo, since the product change merged today and the demo lags fresh merges. Both edits are prose cross-links, so no screenshots were required.

## Additional Information

Source PRs: #12595

Auto-generated by docs-sync pipeline