### PR TITLE
docs(ai): recommend plugin in MCP server docs and sync AI docs with source repos

### DIFF
--- a/data/docs/ai/agent-skills.mdx
+++ b/data/docs/ai/agent-skills.mdx
@@ -1,14 +1,14 @@
 ---
-date: 2026-08-17
+date: 2026-08-21
 title: Agent Skills & Plugin
-meta_title: SigNoz Agent Skills & Plugin - AI Coding Assistant Setup
-description: Install the SigNoz plugin and Agent Skills so AI assistants like Claude Code, Codex, Cursor, and Gemini can query data, build dashboards, manage alerts, and explore SigNoz docs.
+meta_title: SigNoz Agent Skills & Plugin - AI Coding Agent Setup
+description: Install the SigNoz plugin and Agent Skills so AI agents like Claude Code, Codex, Cursor, and Gemini can query data, build dashboards, manage alerts, and explore SigNoz docs.
 doc_type: howto
 ---
 
-<a href="https://agentskills.io" target="_blank" rel="noopener noreferrer nofollow">Agent Skills</a> are an open format for extending AI coding assistants with specialized knowledge and capabilities. Once installed, your agent uses them whenever it detects a relevant task - no prompting required.
+<a href="https://agentskills.io" target="_blank" rel="noopener noreferrer nofollow">Agent Skills</a> are an open format for extending AI coding agents with specialized knowledge and capabilities. Once installed, your agent uses them whenever it detects a relevant task - no prompting required.
 
-When you ask your AI assistant something like "why did this alert fire," "create a dashboard for my Postgres database," or "write a ClickHouse query for these logs," the agent picks the matching skill and follows its instructions.
+When you ask your AI agent something like "why did this alert fire," "create a dashboard for my Postgres database," or "write a ClickHouse query for these logs," the agent picks the matching skill and follows its instructions.
 
 SigNoz ships these skills two ways:
 
@@ -77,9 +77,11 @@ Then, in a Codex session started from your project:
 The plugin is not yet on the public Cursor Marketplace, so install it through a Team Marketplace:
 
 1. Add `https://github.com/SigNoz/agent-skills` as a team marketplace under **Settings → Plugins**.
-2. Install the `signoz` plugin from the marketplace panel.
-3. In an agent chat, run `/signoz-mcp-setup` with your SigNoz Cloud region or self-hosted HTTP MCP URL.
+2. Install the `signoz` plugin from the marketplace panel. When prompted for your **SigNoz Region**, select your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`) or choose **self-hosted**. Cloud regions fill in `https://mcp.<region>.signoz.cloud/mcp` automatically.
+3. Self-hosted only: run `/signoz-mcp-setup` in an agent chat with your HTTP MCP URL (for example `/signoz-mcp-setup http://localhost:8000/mcp`). Until then, the MCP endpoint stays unconfigured. SigNoz Cloud users can skip this step.
 4. Reload Cursor, then open MCP settings and complete authentication for the `signoz` server if prompted.
+
+To change the region or endpoint later, run `/signoz-mcp-setup` again with the correct region or URL and reload Cursor.
 
 </TabItem>
 <TabItem value="gemini-cli" label="Gemini CLI">
@@ -90,7 +92,7 @@ Install the extension:
 gemini extensions install https://github.com/SigNoz/agent-skills
 ```
 
-When prompted, enter your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`). Then authenticate:
+When prompted for the **SigNoz MCP endpoint**, enter `https://mcp.<region>.signoz.cloud/mcp` with your SigNoz Cloud region (`us`, `us2`, `eu`, `eu2`, `in`, or `in2`), or your self-hosted URL (for example `http://localhost:8000/mcp`). Then authenticate:
 
 ```bash
 /mcp auth signoz

--- a/data/docs/ai/overview.mdx
+++ b/data/docs/ai/overview.mdx
@@ -1,8 +1,8 @@
 ---
-date: 2026-06-16
+date: 2026-08-21
 title: Noz & AI Tools
-meta_title: Noz & AI Tools - SigNoz AI Teammate, MCP Server & Agent Skills
-description: Bring agent-native observability to SigNoz with Noz, the in-product AI teammate, the MCP Server for coding agents, and Agent Skills.
+meta_title: Noz & AI Tools - SigNoz AI Teammate, MCP Server, Plugin & Agent Skills
+description: Bring agent-native observability to SigNoz with Noz, the in-product AI teammate, the MCP Server for coding agents, and the SigNoz plugin with Agent Skills.
 doc_type: explanation
 ---
 
@@ -33,15 +33,15 @@ The <a href="https://github.com/SigNoz/signoz-mcp-server" target="_blank" rel="n
 
 [Get started with the MCP Server →](https://signoz.io/docs/ai/signoz-mcp-server/)
 
-### Agent Skills
+### Agent Skills & Plugin
 
-<a href="https://github.com/SigNoz/agent-skills" target="_blank" rel="noopener noreferrer nofollow">SigNoz Agent Skills</a> are an open-format library of `SKILL.md` files that teach coding agents how to work with SigNoz. Your agent picks the right skill whenever a task calls for it - no prompting required.
+<a href="https://github.com/SigNoz/agent-skills" target="_blank" rel="noopener noreferrer nofollow">SigNoz Agent Skills</a> are an open-format library of `SKILL.md` files that teach coding agents how to work with SigNoz. Your agent picks the right skill whenever a task calls for it - no prompting required. The plugin is the recommended install: it bundles every skill plus the MCP server registration, so one setup covers both.
 
 - Look up docs, generate queries, build and explain dashboards, create and triage alerts, and manage saved views
-- Install everything as the SigNoz plugin, or add individual skills via skills.sh
+- Install the plugin for the complete setup, or add individual skills via skills.sh
 - Works with Claude Code, Codex, Cursor, Gemini, and other `SKILL.md` compatible agents
 
-[Get started with Agent Skills →](https://signoz.io/docs/ai/agent-skills/)
+[Get started with Agent Skills & Plugin →](https://signoz.io/docs/ai/agent-skills/)
 
 ## AI Use Cases
 

--- a/data/docs/ai/signoz-mcp-server.mdx
+++ b/data/docs/ai/signoz-mcp-server.mdx
@@ -1,12 +1,14 @@
 ---
 date: 2026-08-17
 title: SigNoz MCP Server
-meta_title: SigNoz MCP Server - AI Assistant Integration Guide
-description: Connect Claude, Cursor, Copilot, and other AI assistants to SigNoz via MCP for natural language access to metrics, logs, traces, and alerts.
+meta_title: SigNoz MCP Server - AI Agent Integration Guide
+description: Connect Claude, Cursor, Copilot, and other AI agents to SigNoz via MCP for natural language access to metrics, logs, traces, and alerts.
 doc_type: howto
 ---
 
-The SigNoz MCP Server implements the <a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer nofollow">Model Context Protocol (MCP)</a> — an open standard that lets AI assistants interact with your SigNoz observability data. Query metrics, traces, logs, alerts, and dashboards through natural language.
+The SigNoz MCP Server implements the <a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer nofollow">Model Context Protocol (MCP)</a>, an open standard that lets AI agents interact with your SigNoz observability data. Query metrics, traces, logs, alerts, and dashboards through natural language.
+
+The MCP server works best with the [SigNoz plugin](https://signoz.io/docs/ai/agent-skills/#install-the-plugin): one install adds the server registration and every Agent Skill, so your agent can query, build, and troubleshoot in SigNoz from the first prompt.
 
 <KeyPointCallout title="Already configured?" defaultCollapsed="true">
 If you've already set up the MCP server, skip ahead to the [use cases](https://signoz.io/docs/ai/use-cases/) to see what you can do with it.
@@ -17,7 +19,7 @@ If you've already set up the MCP server, skip ahead to the [use cases](https://s
 <Tabs entityName="plans">
 <TabItem value="cloud" label="SigNoz Cloud" default>
 
-Connect your AI tool to SigNoz Cloud's hosted MCP server. No installation required — just add the URL and authenticate.
+Connect your AI tool to SigNoz Cloud's hosted MCP server. No installation required: just add the URL and authenticate.
 
 ```
 https://mcp.<region>.signoz.cloud/mcp
@@ -272,7 +274,7 @@ grok mcp doctor
 
 When you add the hosted MCP URL to your client, the MCP client will initiate an authentication flow. You will be prompted to enter:
 1. Your **SigNoz instance URL** (e.g., `https://your-instance.signoz.cloud`)
-2. Your **API key** — go to **Settings → Service Accounts** in SigNoz, create a service account, and generate an API key (requires **Admin** role). See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
+2. Your **API key**: go to **Settings → Service Accounts** in SigNoz, create a service account, and generate an API key (requires **Admin** role). See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
 
 <Admonition type="info" title="How authentication works?" defaultCollapsed="true">
 SigNoz Cloud's hosted MCP server uses OAuth 2.1 for client-to-MCP authentication. MCP clients discover the auth endpoints from the server metadata, dynamically register as an OAuth client using Dynamic Client Registration (DCR, RFC 7591) when supported, then use Authorization Code + PKCE. During the browser step, SigNoz asks for your SigNoz instance URL and service account API key; the MCP server validates those credentials and issues bearer/refresh tokens for future MCP requests.
@@ -289,7 +291,7 @@ Only **Admin** users can create API keys. If you don't see the option, contact y
 Some MCP clients (like Cursor Automations) run entirely in the cloud and cannot perform interactive OAuth authentication. For these clients, use header-based authentication by passing your API key and instance URL directly in the request headers.
 
 <Admonition type="info" title="When to use header-based authentication?">
-If your MCP client doesn't support OAuth flows or stdio transport — for example, Cursor Automations: use this header-based configuration instead.
+If your MCP client doesn't support OAuth flows or stdio transport (for example, Cursor Automations), use this header-based configuration instead.
 </Admonition>
 
 ```json title="mcp.json"
@@ -311,7 +313,7 @@ If your MCP client doesn't support OAuth flows or stdio transport — for exampl
 - `<your-signoz-instance-url>`: Your SigNoz Cloud instance URL
 
 <Admonition type="warning">
-Keep your API key secure — never commit `mcp.json` to version control when it contains secrets.
+Keep your API key secure: never commit `mcp.json` to version control when it contains secrets.
 </Admonition>
 
 </TabItem>
@@ -326,7 +328,7 @@ For self-hosted SigNoz, you run the MCP server locally. The server supports two 
 3. Create a service account, open its **Keys** tab, click **Add Key**, and copy the generated key. See [Service Accounts](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/) for details.
 
 <Admonition type="warning">
-Only **Admin** users can create API keys. Keep your key secure — never commit it to version control.
+Only **Admin** users can create API keys. Keep your key secure: never commit it to version control.
 </Admonition>
 
 ### Install the MCP server
@@ -879,10 +881,12 @@ Environment variables for the self-hosted MCP server. SigNoz Cloud users do not 
 | `TRANSPORT_MODE` | Transport protocol: `stdio` or `http` | `stdio` |
 | `MCP_SERVER_HOST` | Host/interface for the HTTP server. Empty listens on all interfaces; set `127.0.0.1` for loopback-only access | _(all interfaces)_ |
 | `MCP_SERVER_PORT` | Port for HTTP server (when `TRANSPORT_MODE=http`) | `8000` |
+| `MCP_MAX_REQUEST_BYTES` | Max inbound MCP HTTP request body size in bytes (HTTP mode) | `4194304` (4 MiB) |
 | `LOG_LEVEL` | Logging verbosity: `debug`, `info`, `warn`, `error` | `info` |
 | `CLIENT_CACHE_SIZE` | Maximum cached tenant clients in multi-tenant HTTP mode | `256` |
 | `CLIENT_CACHE_TTL_MINUTES` | Tenant-client cache lifetime in minutes | `30` |
 | `SIGNOZ_CUSTOM_HEADERS` | Extra HTTP headers added to every SigNoz API request, such as reverse-proxy auth headers. Format: `Key1:Value1,Key2:Value2` | _(optional)_ |
+| `SIGNOZ_INSTANCE_URL_ALLOWLIST` | Multi-tenant HTTP mode only: comma-separated allowlist of SigNoz backend hosts the server will proxy to. Empty allows any host | _(any host)_ |
 | `SIGNOZ_DOCS_REFRESH_INTERVAL` | Refresh interval for the embedded docs sitemap used by `signoz_search_docs` / `signoz_fetch_doc` (Go duration) | `6h` |
 | `SIGNOZ_DOCS_FULL_REFRESH_INTERVAL` | Full refresh interval for the embedded docs corpus (Go duration) | `24h` |
 | `OAUTH_ENABLED` | Enable OAuth 2.1 authentication (`true`/`false`) | `false` |
@@ -900,23 +904,24 @@ Environment variables for the self-hosted MCP server. SigNoz Cloud users do not 
 
 After connecting, verify the server is working:
 
-1. Open your AI assistant.
+1. Open your AI agent.
 2. Ask: _"List all alerts"_ or _"Show me all available services"_.
-3. The assistant should return structured results from your SigNoz instance.
+3. The agent should return structured results from your SigNoz instance.
 
 <details>
 <ToggleHeading>
 ## Available Tools
 </ToggleHeading>
 
-The MCP server exposes the following tools to your AI assistant:
+The MCP server exposes the following tools to your AI agent:
 
 <Admonition type="note">
-Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check_metric_usage`, v0.120.0 or later for alert-rule list/get/create/update/delete tools, and v0.118.0 or later for `signoz_get_alert_history`. Notification-channel tools also use newer channels APIs. Older SigNoz deployments may return HTTP 404 from affected tools.
+Some tools use newer SigNoz APIs. Dashboard tools (create/get/update/patch/list/delete/import) require SigNoz v0.135.0 or later because they use the v2 dashboards API. `signoz_check_metric_usage` needs v0.135.0 for dashboard usage; its alert usage works from v0.131.0. Alert-rule list/get/create/update/delete tools require v0.120.0 or later, and `signoz_get_alert_history` requires v0.118.0 or later. Notification-channel tools also use newer channels APIs. Older SigNoz deployments may return HTTP 404 from affected tools.
 </Admonition>
 
 | Tool | Description |
 |------|-------------|
+| `signoz_get_org_overview` | Get the current status and overall posture of your SigNoz deployment |
 | `signoz_list_metrics` | Discover active metric names and catalog metadata such as type, temporality, and unit |
 | `signoz_query_metrics` | Query a known metric for values, trends, breakdowns, or formulas with metric-aware defaults |
 | `signoz_get_top_metrics` | Return top 100 metrics ranked by ingested sample volume with percentages for cost and volume analysis |
@@ -935,6 +940,7 @@ Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check
 | `signoz_get_dashboard` | Get full dashboard configuration |
 | `signoz_create_dashboard` | Create a new dashboard |
 | `signoz_update_dashboard` | Update an existing dashboard |
+| `signoz_patch_dashboard` | Apply a partial JSON Patch to a dashboard without resending the whole definition |
 | `signoz_delete_dashboard` | Delete a dashboard by UUID |
 | `signoz_list_dashboard_templates` | List the bundled SigNoz dashboard template catalog so the model can pick one |
 | `signoz_import_dashboard` | Create a dashboard from a curated SigNoz dashboard template by path |
@@ -959,7 +965,7 @@ Some tools use newer SigNoz APIs. Use SigNoz v0.131.0 or later for `signoz_check
 | `signoz_update_notification_channel` | Update a notification channel and send a test notification |
 | `signoz_delete_notification_channel` | Delete a notification channel by ID |
 
-The server also exposes read-only MCP resources (`signoz://...` URIs) with schemas, query-builder guides, and payload examples that AI assistants read before composing alert, dashboard, and view payloads.
+The server also exposes read-only MCP resources (`signoz://...` URIs) with schemas, query-builder guides, and payload examples that AI agents read before composing alert, dashboard, and view payloads.
 
 For detailed parameter reference and the full resource list, see the <a href="https://github.com/SigNoz/signoz-mcp-server?tab=readme-ov-file#available-tools" target="_blank" rel="noopener noreferrer nofollow">GitHub repository README</a>.
 


### PR DESCRIPTION
## Description

- Recommend the SigNoz plugin in the MCP Server intro and the AI overview, positioning it as the install that bundles Agent Skills plus MCP registration in one setup
- Sync the MCP Server reference with the current server: add `signoz_get_org_overview` and `signoz_patch_dashboard` tools, add `MCP_MAX_REQUEST_BYTES` and `SIGNOZ_INSTANCE_URL_ALLOWLIST` env vars, and correct SigNoz version floors (dashboard tools and dashboard usage of `signoz_check_metric_usage` need v0.135.0+; alert usage works from v0.131.0)
- Fix the Cursor install flow (region/self-hosted prompt appears at install; `/signoz-mcp-setup` is only needed for self-hosted or later changes) and the Gemini CLI prompt (expects the full MCP endpoint URL, accepts self-hosted)
- Rename the AI overview section to "Agent Skills & Plugin" so plugins are mentioned alongside Agent Skills
- Replace remaining em dashes in `signoz-mcp-server.mdx` with guide-compliant punctuation

## Checklist

### Docs Changes

- [x] Frontmatter is complete and correct
- [x] The primary job is clear and the happy path is easy to follow
- [x] Links, redirects, and discovery updates are handled (no URL changes, so no redirects needed)
- [x] No new docs images
- [x] Relevant docs checks were run

## Checks run

- `git diff --check`
- `yarn check:docs-metadata`
- `yarn check:doc-redirects` + `yarn test:doc-redirects`
- `yarn test:docs-metadata` (29/30 pass; the 1 failure "should allow date exactly 7 days in the past" is pre-existing on `main`, verified by stashing changes and re-running)

## Verification against source repos

- Tools, env vars, and version floors verified against `signoz-mcp-server` README and `CHANGELOG.md`
- Cursor and Gemini CLI install flows verified against `agent-skills` README and `gemini-extension.json`
