### PR TITLE
docs(openai): standardize the Python install and fix silent instrumentation failures

### DIFF
--- a/data/docs/openai-monitoring.mdx
+++ b/data/docs/openai-monitoring.mdx
@@ -41,14 +41,14 @@ source .venv/bin/activate
 ### Step 2. Install the OpenTelemetry dependencies
 
 ```bash
-pip install opentelemetry-distro~=0.51b0
-pip install opentelemetry-exporter-otlp~=1.30.0
-pip install opentelemetry-instrumentation-openai-v2
+pip install opentelemetry-distro opentelemetry-exporter-otlp
 pip install httpx
 ```
 
+You do not need to install `opentelemetry-instrumentation-openai-v2` yourself. `opentelemetry-bootstrap` in the next step detects `openai` in your environment and installs the matching instrumentation for you, the same way it does for `requests`, `fastapi`, or `psycopg`.
+
 <Admonition type="warning">
-  `httpx` is required even though you may not use it directly. The OpenAI Python SDK v3 ships its own HTTP client under the module name `httpx2`, while `opentelemetry-instrumentation-openai-v2` still does `from httpx import URL`. Without `httpx` installed, that import raises `ModuleNotFoundError`, `opentelemetry-instrument` skips the OpenAI instrumentor **silently**, and your OpenAI calls show up as generic `POST` spans with no `gen_ai.*` attributes and no error explaining why.
+  `httpx` is the one dependency bootstrap does not resolve for you, and it is required even though you may not use it directly. The OpenAI Python SDK v3 ships its own HTTP client under the module name `httpx2`, while `opentelemetry-instrumentation-openai-v2` still does `from httpx import URL`. Without `httpx` installed, that import raises `ModuleNotFoundError`, `opentelemetry-instrument` skips the OpenAI instrumentor **silently**, and your OpenAI calls show up as generic `POST` spans with no `gen_ai.*` attributes and no error explaining why.
 </Admonition>
 
 ### Step 3. Add automatic instrumentation
@@ -56,6 +56,10 @@ pip install httpx
 ```bash
 opentelemetry-bootstrap --action=install
 ```
+
+<Admonition type="info">
+  Bootstrap instruments only what is already installed in the environment, so run it after your application's own dependencies (including `openai`). If you add a library later, re-run this command.
+</Admonition>
 
 ### Step 4. Run your application
 
@@ -65,7 +69,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="https://ingest.<region>.signoz.cloud:443" \
 OTEL_EXPORTER_OTLP_HEADERS="signoz-ingestion-key=<your-ingestion-key>" \
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true \
-OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true \
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT \
 OPENAI_API_KEY=<your-openai-key> \
 opentelemetry-instrument <your_run_command>
 ```
@@ -499,7 +503,7 @@ This instrumentation captures comprehensive telemetry data for your OpenAI appli
 ### Logs
 
 - **Structured logs** for each API call when `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true` is set
-- **Message content logs** (prompts and completions) when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` is enabled
+- **Message content logs** (prompts and completions) when `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is set to `SPAN_AND_EVENT` or `EVENT_ONLY`
 - **Error logs** for failed API calls with detailed error information and stack traces
 - **Performance logs** showing request duration and timing information
 
@@ -554,15 +558,15 @@ More details about the metrics can be found [here](https://opentelemetry.io/docs
 By default, message content such as prompts and completions are not captured. To capture message content as log events, set the environment variable:
 
 ```bash
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
 ```
 
+The accepted values are `NO_CONTENT`, `SPAN_ONLY`, `EVENT_ONLY`, and `SPAN_AND_EVENT`. `SPAN_AND_EVENT` records content both as span attributes and as log events.
+
 <Admonition type="warning">
-  **This value depends on the version you installed.** Content capture moved out of the instrumentation's own boolean flag and into the shared `opentelemetry-util-genai` library, which takes an enum instead: `NO_CONTENT`, `SPAN_ONLY`, `EVENT_ONLY`, or `SPAN_AND_EVENT`.
+  Older guides and blog posts set this to `true`. That is no longer accepted: content capture moved out of the instrumentation's own boolean flag and into the shared `opentelemetry-util-genai` library, which takes the enum above. On current versions `true` is rejected with a warning and falls back to `NO_CONTENT`, so prompts and completions never reach the span.
 
-  `true` is correct for the pinned versions this guide installs. If you install `opentelemetry-distro` and `opentelemetry-instrumentation-openai-v2` unpinned, use `SPAN_AND_EVENT` instead. On those newer versions `true` is rejected with a warning and falls back to `NO_CONTENT`, so prompts and completions never reach the span.
-
-  To confirm which one you are on, check whether your spans carry `gen_ai.input.messages` and `gen_ai.output.messages`.
+  To confirm content capture is working, check that your spans carry `gen_ai.input.messages` and `gen_ai.output.messages`.
 </Admonition>
 
 **Note:** Be cautious when enabling this in production as it may capture sensitive user data. This feature is already included in the run command above.
@@ -625,7 +629,7 @@ If you don't see your telemetry data:
 3. **Check ingestion key** - Verify your SigNoz ingestion key is correct
 4. **Wait for data** - OpenTelemetry batches data before sending, so wait 10-30 seconds after making API calls
 5. **Spans named `POST` with no `gen_ai.*` attributes** - The OpenAI instrumentor was skipped because `httpx` is not installed. Run `pip install httpx` and restart your app.
-6. **Spans arrive but carry no prompts or completions** - The value of `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` does not match your installed version. See [Capturing Message Content](#capturing-message-content-optional).
+6. **Spans arrive but carry no prompts or completions** - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is set to `true` rather than one of the accepted values. See [Capturing Message Content](#capturing-message-content-optional).
 
 </details>
 

--- a/data/docs/openai-monitoring.mdx
+++ b/data/docs/openai-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
-date: 2026-08-03
+published_date: 2026-08-03
+updated_date: 2026-08-21
 title: OpenAI Monitoring with OpenTelemetry
 description: Set up OpenAI monitoring and observability with SigNoz. Track token usage, model latency, request traces, and error rates across your LLM apps in real time.
 doc_type: howto
@@ -43,7 +44,12 @@ source .venv/bin/activate
 pip install opentelemetry-distro~=0.51b0
 pip install opentelemetry-exporter-otlp~=1.30.0
 pip install opentelemetry-instrumentation-openai-v2
+pip install httpx
 ```
+
+<Admonition type="warning">
+  `httpx` is required even though you may not use it directly. The OpenAI Python SDK v3 ships its own HTTP client under the module name `httpx2`, while `opentelemetry-instrumentation-openai-v2` still does `from httpx import URL`. Without `httpx` installed, that import raises `ModuleNotFoundError`, `opentelemetry-instrument` skips the OpenAI instrumentor **silently**, and your OpenAI calls show up as generic `POST` spans with no `gen_ai.*` attributes and no error explaining why.
+</Admonition>
 
 ### Step 3. Add automatic instrumentation
 
@@ -551,6 +557,14 @@ By default, message content such as prompts and completions are not captured. To
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 ```
 
+<Admonition type="warning">
+  **This value depends on the version you installed.** Content capture moved out of the instrumentation's own boolean flag and into the shared `opentelemetry-util-genai` library, which takes an enum instead: `NO_CONTENT`, `SPAN_ONLY`, `EVENT_ONLY`, or `SPAN_AND_EVENT`.
+
+  `true` is correct for the pinned versions this guide installs. If you install `opentelemetry-distro` and `opentelemetry-instrumentation-openai-v2` unpinned, use `SPAN_AND_EVENT` instead. On those newer versions `true` is rejected with a warning and falls back to `NO_CONTENT`, so prompts and completions never reach the span.
+
+  To confirm which one you are on, check whether your spans carry `gen_ai.input.messages` and `gen_ai.output.messages`.
+</Admonition>
+
 **Note:** Be cautious when enabling this in production as it may capture sensitive user data. This feature is already included in the run command above.
 
 
@@ -610,6 +624,8 @@ If you don't see your telemetry data:
 2. **Verify network connectivity** - Ensure your application can reach SigNoz Cloud endpoints
 3. **Check ingestion key** - Verify your SigNoz ingestion key is correct
 4. **Wait for data** - OpenTelemetry batches data before sending, so wait 10-30 seconds after making API calls
+5. **Spans named `POST` with no `gen_ai.*` attributes** - The OpenAI instrumentor was skipped because `httpx` is not installed. Run `pip install httpx` and restart your app.
+6. **Spans arrive but carry no prompts or completions** - The value of `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` does not match your installed version. See [Capturing Message Content](#capturing-message-content-optional).
 
 </details>
 


### PR DESCRIPTION
## What

Brings the Python path of the OpenAI monitoring guide in line with the [upstream OpenTelemetry zero-code guide](https://opentelemetry.io/docs/zero-code/python/) and fixes two ways the current instructions silently produce OpenAI spans with **no `gen_ai.*` attributes**.

### 1. Use the standard install and drop the version pins

```diff
-pip install opentelemetry-distro~=0.51b0
-pip install opentelemetry-exporter-otlp~=1.30.0
-pip install opentelemetry-instrumentation-openai-v2
+pip install opentelemetry-distro opentelemetry-exporter-otlp
```

The pins made this guide diverge from upstream and quietly broke `opentelemetry-bootstrap`. With `opentelemetry-distro~=0.51b0`, the bundled `bootstrap_gen` list maps `openai` to a version that does not exist on PyPI:

```
{'library': 'openai >= 1.26.0', 'instrumentation': 'opentelemetry-instrumentation-openai-v2==2.2b0.dev'}
```

```
ERROR: Could not find a version that satisfies the requirement
  opentelemetry-instrumentation-openai-v2==2.2b0.dev
  (from versions: 2.0b0, 2.1b0, 2.2b0, 2.3b0, 2.4b0)
```

Bootstrap installs the other 12 instrumentations and **still exits 0**, so the OpenAI one is skipped without failing the command. That is why the guide needed the explicit `pip install opentelemetry-instrumentation-openai-v2`.

Unpinned, bootstrap resolves `openai-v2` 2.4b0 by itself, so the explicit install is redundant and is removed. Added a note that bootstrap only sees dependencies already installed, so it has to run after them.

### 2. `httpx` is missing from the install list

The OpenAI Python SDK v3 vendors its HTTP client as `httpx2`, but `opentelemetry-instrumentation-openai-v2` still does `from httpx import URL`. Without plain `httpx`, that import raises `ModuleNotFoundError`, `opentelemetry-instrument` skips the OpenAI instrumentor silently, and calls land as generic `POST` spans:

```
  File ".../opentelemetry/instrumentation/openai_v2/utils.py", line 23, in <module>
    from httpx import URL
ModuleNotFoundError: No module named 'httpx'
```

Bootstrap does not resolve this one either. Worth noting it installs `opentelemetry-instrumentation-httpx` anyway, matching the vendored `httpx2` distribution against its `httpx` entry, which makes `pip list` look like httpx is present when it is not.

### 3. Message content flag now takes an enum

Content capture moved from the instrumentation's own boolean onto the shared `opentelemetry-util-genai` enum (`NO_CONTENT` / `SPAN_ONLY` / `EVENT_ONLY` / `SPAN_AND_EVENT`). On the versions this guide now installs, `true` is rejected with a warning and falls back to `NO_CONTENT`, so prompts and completions never reach the span. Switched the run command and the content section to `SPAN_AND_EVENT` and documented the accepted values.

## Verification

Followed the rewritten steps literally in a clean venv. Bootstrap exits 0 and installs `opentelemetry-instrumentation-openai-v2 2.4b0` + `opentelemetry-util-genai 1.1b0`, and a single chat completion produces:

```
"name": "chat gpt-4.1-mini"
"gen_ai.request.model": "gpt-4.1-mini"
"gen_ai.usage.input_tokens": 16
"gen_ai.usage.output_tokens": 1
"gen_ai.input.messages": "[{\"role\":\"user\"...
"gen_ai.output.messages": "[{\"role\":\"assistant\"...
```

| Check | Result |
|---|---|
| `yarn check:docs-metadata` | pass |
| `yarn check:doc-redirects` | pass |
| `yarn test:doc-redirects` | pass (13/13) |
| `yarn test:docs-metadata` | 1 failure, **pre-existing** |

The `test:docs-metadata` failure is `should allow date exactly 7 days in the past`, a unit test of the validation script itself. It fails identically on a clean `origin/main` with no changes applied.

## Also

- Two new entries under Common Issues, keyed to the symptom rather than the cause.
- Frontmatter migrated from `date` to `published_date` + `updated_date` so `check:docs-metadata` passes on a modified file.

Scope note: only the Python tab was touched. The Java sections are unchanged and untested here.