### PR TITLE
docs: document custom columns in Logs Explorer

### DIFF
--- a/data/docs/userguide/logs_query_builder.mdx
+++ b/data/docs/userguide/logs_query_builder.mdx
@@ -94,12 +94,14 @@ Add or remove columns for different attributes available in your logs. This work
   caption="List View settings showing Format, Font Size, Max Lines Per Row, and Columns options"
 />
 
-The columns search also accepts field names that do not appear in the suggestions list, including nested JSON paths written in dot notation (for example `body.orderId`). Type the name, and when it does not match an existing suggestion or an already-added column, it surfaces as an addable row at the top of the **Other Fields** section. Select it to add the column, then click **Save Changes**. Names are matched case-insensitively, and the search keeps the casing you type.
+The columns search also accepts field names that do not appear in the suggestions list, including nested JSON paths written in dot notation. Type the field name as it appears inside the log body, without a `body.` prefix, for example `orderId` for a top-level body field or `order.id` for a nested one. When the name does not match an existing suggestion or an already-added column, it surfaces as an addable row at the top of the **Other Fields** section. Select it to add the column, then click **Save Changes**. Names are matched case-insensitively, and the search keeps the casing you type.
 
 This works the same in the Logs Explorer and the [Live View](#live-view), and applies to logs only.
 
 <Admonition type="info">
-Resolving values from nested JSON body fields requires JSON body parsing to be enabled for your deployment. Without it, the column is added but its cells stay empty. Array-indexed paths and paths written with a leading `body.` prefix do not resolve values in the table yet.
+Resolving values from nested JSON body fields requires JSON body parsing to be enabled for your deployment. Without it, the column is added but its cells stay empty.
+
+A path written with a leading `body.` prefix, such as `body.orderId`, is still accepted and added as a column, but its cells stay empty. Drop the prefix and type just `orderId` to see values. Array-indexed paths do not resolve values in the table yet either.
 </Admonition>
 
 #### Show in Context

--- a/data/docs/userguide/logs_query_builder.mdx
+++ b/data/docs/userguide/logs_query_builder.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-06
+date: 2026-08-24
 title: Logs Explorer
 meta_title: "Logs Explorer: Query, Search & Analyze Logs Efficiently"
 description: Explore logs with SigNoz Logs Explorer. Query, search and analyze logs efficiently using powerful log explorer queries and real-time insights.
@@ -93,6 +93,14 @@ Add or remove columns for different attributes available in your logs. This work
   alt="List View Settings in Logs Explorer"
   caption="List View settings showing Format, Font Size, Max Lines Per Row, and Columns options"
 />
+
+The columns search also accepts field names that do not appear in the suggestions list, including nested JSON paths written in dot notation (for example `body.orderId`). Type the name, and when it does not match an existing suggestion or an already-added column, it surfaces as an addable row at the top of the **Other Fields** section. Select it to add the column, then click **Save Changes**. Names are matched case-insensitively, and the search keeps the casing you type.
+
+This works the same in the Logs Explorer and the [Live View](#live-view), and applies to logs only.
+
+<Admonition type="info">
+Resolving values from nested JSON body fields requires JSON body parsing to be enabled for your deployment. Without it, the column is added but its cells stay empty. Array-indexed paths and paths written with a leading `body.` prefix do not resolve values in the table yet.
+</Admonition>
 
 #### Show in Context
 


### PR DESCRIPTION
## Description

- Documents free-typed custom columns in the Logs Explorer **Edit columns** panel: typing a field name that is not in the suggestions (including dot-notation nested paths like `body.orderId`) surfaces it as an addable row at the top of **Other Fields**.
- Notes case-insensitive matching and that the search now preserves typed casing.
- Notes the feature works the same in List View and Live View, logs only.
- Adds an Admonition on the caveat that nested JSON body values only resolve when JSON body parsing is enabled, and that array-indexed / leading-`body.` paths do not resolve in the table yet.
- Updated the `date` frontmatter to today on the edited file.

Prose-only: PR #12602 merged the same day and the demo build lags, so no updated screenshots were captured.

## Issues closed by this PR

Source PRs: #12602

Auto-generated by docs-sync pipeline