### PR TITLE
docs: document AI Observability Explorer tab

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -225,6 +225,24 @@
       {
         "type": "category",
         "isExpanded": false,
+        "label": "AI Observability (in SigNoz)",
+        "route": "/docs/ai-observability",
+        "items": [
+          {
+            "type": "doc",
+            "route": "/docs/ai-observability",
+            "label": "Overview"
+          },
+          {
+            "type": "doc",
+            "route": "/docs/ai-observability-explorer",
+            "label": "Explorer"
+          }
+        ]
+      },
+      {
+        "type": "category",
+        "isExpanded": false,
         "label": "SigNoz UI",
         "route": "/docs/manage/signoz-ui",
         "items": [

--- a/data/docs/ai-observability-explorer.mdx
+++ b/data/docs/ai-observability-explorer.mdx
@@ -1,0 +1,98 @@
+---
+date: 2026-08-27
+title: AI Observability Explorer - Query LLM & AI Trace Data
+description: Explore LLM and AI trace data in SigNoz with the AI Observability Explorer. Query spans, traces, time series, and tables, then export results to a dashboard.
+doc_type: howto
+---
+
+The **Explorer** is the query tab of the [AI Observability](https://signoz.io/docs/ai-observability/) section. While the Overview tab shows a fixed, read-only dashboard, the Explorer lets you query the underlying LLM and AI trace data directly and switch between four views: list, trace, time series, and aggregated table.
+
+Use this page to open the Explorer, run and refine queries, customize the results table, and export a query to a dashboard.
+
+<Admonition type="info">
+The Explorer lives inside the AI Observability section, which is gated behind the `enable_ai_observability` feature flag and is disabled by default. If the flag is not enabled for your organization, the **AI Observability** entry does not appear in the side navigation. See the [AI Observability overview](https://signoz.io/docs/ai-observability/#prerequisites) for how to enable it.
+</Admonition>
+
+## Open the Explorer
+
+1. Open the AI Observability section from the side navigation **More** menu.
+2. In the tab bar at the top, select **Explorer**. It sits between **Overview** and **Model pricing**.
+3. SigNoz opens the Explorer at `/ai-observability/explorer`.
+
+The Explorer is available to all user roles (Admin, Editor, and Viewer).
+
+## Query toolbar
+
+The toolbar at the top of the Explorer controls query execution and the layout:
+
+- **Run Query**: execute the current query and load results into the active view.
+- **Cancel Query**: abort a query that is still running. Results reset until you run again.
+- **Auto-refresh**: toggle periodic re-runs so the active view stays current without manual re-runs.
+- **Filter panel toggle**: collapse or expand the quick filters sidebar to reclaim horizontal space.
+
+## Quick filters sidebar
+
+A collapsible sidebar on the left surfaces common trace-signal attributes so you can filter results without editing the query builder directly. Selecting values narrows the query, and the active view refreshes to match. Use the toolbar filter toggle to hide the sidebar for a full-width layout.
+
+## Explorer views
+
+Switch views from the toolbar. Each view renders the same query differently.
+
+### List view
+
+The default view. It displays individual spans in a paginated table ordered by timestamp. The default columns are:
+
+- Service name
+- Operation name
+- Duration
+- HTTP method
+- Response status code
+- Timestamp
+
+These are standard trace columns, so they apply to any instrumented service, not only LLM spans.
+
+The List view table is fully customizable:
+
+- **Add or remove columns** with the column selector.
+- **Reorder columns** by dragging a column into a new position.
+- **Resize columns** by dragging a column edge.
+
+### Trace view
+
+The Trace view groups spans into traces and shows **root spans only**. Its columns are fixed and cannot be changed:
+
+- Service name
+- Operation name
+- Duration
+- Span count
+- Trace ID
+
+<Admonition type="info">
+The Trace view shows only root spans. To inspect the full span tree for a trace, open the trace from its trace ID.
+</Admonition>
+
+### Timeseries view
+
+The Timeseries view renders a time-series chart of trace metrics. The Y-axis unit is selected automatically based on the aggregated attribute (milliseconds for duration attributes, `short` for everything else) and you can override it manually from the chart's unit control.
+
+### Table view
+
+The Table view displays aggregated query results in a grid. Use its export menu to download the aggregated results as CSV.
+
+## Export a query to a dashboard
+
+You can turn any Explorer query into a dashboard panel:
+
+1. Build and run the query you want to keep.
+2. Open the Explorer options menu and select the export to dashboard action.
+3. Choose an existing dashboard or create a new one. SigNoz adds the query as a new panel and opens it in the dashboard editor.
+
+## AI Assistant page actions
+
+When the AI Assistant feature is licensed and enabled for your account, the Explorer exposes additional page-level actions that the assistant can trigger: **run query**, **add filter**, and **change view**. On accounts without the AI Assistant license these actions are inactive.
+
+## Related
+
+- [AI Observability overview](https://signoz.io/docs/ai-observability/): the read-only dashboard and the attributes it needs.
+- [LLM Observability integrations](https://signoz.io/docs/llm-observability/): instrument OpenAI, Anthropic, LiteLLM, CrewAI, and other frameworks.
+- [Dashboards](https://signoz.io/docs/dashboards/): build custom panels from exported queries.

--- a/data/docs/ai-observability.mdx
+++ b/data/docs/ai-observability.mdx
@@ -1,0 +1,104 @@
+---
+date: 2026-08-27
+title: AI Observability - Monitor LLM Cost, Tokens, Latency
+description: Monitor LLM apps in SigNoz with the AI Observability dashboard. Track cost, token usage, latency, errors, TTFT, and tool calls by model and service.
+doc_type: howto
+---
+
+AI Observability is a built-in section in SigNoz that gives you a single, read-only overview of your LLM and GenAI workloads. It reads OpenTelemetry GenAI attributes off your traces and renders cost, token usage, latency, error rate, time to first token (TTFT), and tool call metrics, all filterable by model, environment, and service.
+
+Use this page to enable the feature, understand what each panel shows, and confirm your application emits the attributes the dashboard needs.
+
+## Overview
+
+The AI Observability **Overview** tab is a locked, read-only dashboard named "AI Observability Overview". You can filter and inspect it, but you cannot edit, rearrange, or clone its panels from this view. It is designed as a fixed starting point for LLM monitoring: instrument your app with the GenAI semantic conventions, and the panels populate automatically.
+
+<Admonition type="info">
+AI Observability is gated behind the `enable_ai_observability` feature flag and is disabled by default. If the flag is not enabled for your organization, the **AI Observability** entry does not appear in the side navigation, and visiting an `/ai-observability/*` URL returns you to the home screen. Contact SigNoz support to have the flag enabled for your workspace.
+</Admonition>
+
+## Prerequisites
+
+- The `enable_ai_observability` feature flag enabled for your organization.
+- An LLM or agent application instrumented with OpenTelemetry so its spans carry the GenAI attributes listed in [Required attributes](#required-opentelemetry-attributes). See the [LLM Observability integrations](https://signoz.io/docs/llm-observability/) for framework-specific setup (OpenAI, Anthropic, LiteLLM, CrewAI, and more).
+
+## Open AI Observability
+
+1. Open the side navigation and expand the **More** menu.
+2. Select **AI Observability** (Brain icon, marked with a **New** badge).
+3. SigNoz opens the **Overview** tab at `/ai-observability/overview`. The **AI Observability** item stays highlighted in the side nav while you are on any AI Observability page.
+
+The navigation bar at the top of the section holds four tabs, in order: **Overview**, **Explorer**, **Model pricing**, and **Attribute Mapping**. Use **Overview** for the read-only dashboard and the [**Explorer**](https://signoz.io/docs/ai-observability-explorer/) to query the underlying LLM and AI trace data directly.
+
+## Summary stat cards
+
+Five cards summarize the current state across the selected filters:
+
+- **Total cost**: total LLM cost across all calls (from `gen_ai.usage.cost`).
+- **Total tokens**: sum of input and output tokens.
+- **Avg latency (p95)**: p95 latency of LLM spans.
+- **Error rate**: percentage of LLM calls that errored.
+- **TTFT (p95)**: p95 time to first token.
+
+## Time series and table panels
+
+| Panel | What it shows |
+| --- | --- |
+| **Cost over time** | Cost broken down by model. |
+| **Token usage over time** | Input tokens versus output tokens. |
+| **LLM call latency over time** | p95 latency trend by model. |
+| **LLM call latency percentiles** | Table of p50, p90, p95, and p99 latency per model. |
+| **Error count** | Errors grouped by error type. |
+| **Time to first token** | p95 TTFT by model. |
+| **Top 10 span names** | The span names generating the most GenAI calls, by count. |
+
+## Tool call panels
+
+Three panels track the reliability of tool (function) calls, scoped to spans named `execute_tool`:
+
+- **Tool call rate**: tool calls per second.
+- **Tool error rate**: percentage of tool calls that errored.
+- **Tool duration (p50)**: median tool call duration.
+
+## Filter the dashboard
+
+A variable bar at the top of the Overview tab provides three multi-select dropdowns, each with an **All** option. Selecting values re-scopes every panel on the page.
+
+| Filter | Source attribute |
+| --- | --- |
+| **model** | `gen_ai.request.model` |
+| **environment** | `deployment.environment` (resource attribute) |
+| **service_name** | `service.name` (resource attribute) |
+
+## Required OpenTelemetry attributes
+
+The dashboard reads these attributes off your GenAI spans. Panels that depend on an attribute stay empty until your instrumentation emits it. Most follow the <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry GenAI semantic conventions</a>; `gen_ai.usage.cost` is a SigNoz-derived cost attribute.
+
+| Attribute | Powers |
+| --- | --- |
+| `gen_ai.request.model` | Model filter and all per-model breakdowns. |
+| `gen_ai.usage.cost` | Total cost, Cost over time. |
+| `gen_ai.usage.input_tokens` | Total tokens, Token usage over time (input). |
+| `gen_ai.usage.output_tokens` | Total tokens, Token usage over time (output). |
+| `gen_ai.server.ttft` | TTFT (p95) card, Time to first token. |
+| `gen_ai.error.type` | Error count. |
+| `gen_ai.system` | GenAI system identification. |
+| `deployment.environment` | Environment filter. |
+| `service.name` | Service name filter. |
+
+Tool call panels rely on spans named `execute_tool` carrying span status, so tool executions must be recorded as their own spans.
+
+## Other tabs
+
+Alongside **Overview**, the AI Observability section includes three more tabs:
+
+- **Explorer** at `/ai-observability/explorer`: a trace-backed query explorer for individual spans, traces, time series, and aggregated tables. See [AI Observability Explorer](https://signoz.io/docs/ai-observability-explorer/).
+- **Model pricing** at `/ai-observability/configuration`.
+- **Attribute Mapping** at `/ai-observability/attribute-mapping`.
+
+Documentation for the Model pricing and Attribute Mapping tabs will follow as they stabilize.
+
+## Limitations
+
+- The AI Observability section replaces the earlier in-product `/llm-observability/*` routes. Those paths no longer resolve; update any saved links or bookmarks to `/ai-observability/*`.
+- The Overview dashboard is read-only. To build your own LLM dashboards, use the standard [Dashboards](https://signoz.io/docs/dashboards/) workflow.


### PR DESCRIPTION
## Description

Documents the new **Explorer** tab in the AI Observability section (source PRs #12484 and #12682).

- New page `data/docs/ai-observability-explorer.mdx` (`/docs/ai-observability-explorer`) covering the query toolbar (Run/Cancel Query, auto-refresh, filter-panel toggle), the quick filters sidebar, the four views (List, Trace, Timeseries, Table), List-view column customization, the root-spans-only behavior of Trace view, export to dashboard, and the license-gated AI Assistant page actions.
- Updated the AI Observability overview page to add **Explorer** to the tab navigation (between Overview and Model pricing).
- Added both pages to the docs sidebar under Manage.
- Updated `date` frontmatter to today on every edited file.

All feature claims were verified against the product source (routes, view/column configs, toolbar, tab order, `enable_ai_observability` flag). Prose-only: the section is flag-gated and off on the demo, so no screenshots were captured. The "save view" AI Assistant action is a stub in source and is intentionally omitted.

**Stacking note:** the parent `/docs/ai-observability` overview page originates from open PR #3753, which has not merged. That single file is carried in here so this PR is self-contained; if #3753 merges first, reconcile the one-file overlap.

## Issues closed by this PR

Source PRs: #12484, #12682

Auto-generated by docs-sync pipeline