### PR TITLE
docs: clarify exponential histogram delta-only querying

### DIFF
--- a/data/docs/metrics-management/troubleshooting/faqs.mdx
+++ b/data/docs/metrics-management/troubleshooting/faqs.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-26
+date: 2026-08-27
 title: Metrics Management FAQs
 description: Frequently asked questions about metrics management and troubleshooting in SigNoz
 doc_type: reference
@@ -29,3 +29,14 @@ A Counter metric can send all cumulative points, all delta points, or both toget
 Metrics Explorer shows one temporality in the metric details, even when the metric carries both. This affects the display only, not your query results.
 
 For more information about metric temporality, see [Metric Types and Aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/#temporality-of-metrics).
+
+### Q. My percentile query on an exponential histogram fails with `only 'delta' exponential histograms are supported`
+
+This HTTP `501` error means the exponential histogram metric was recorded with **cumulative** temporality. SigNoz supports only **delta** temporality for exponential histograms, so cumulative series cannot be queried. (Earlier versions returned incorrect values for these queries instead of failing.)
+
+To fix it, configure your instrument to export delta temporality:
+
+- For an application SDK, set the delta temporality preference. See [Use Delta Temporality](https://signoz.io/docs/metrics-management/reducing-costs/#1-use-delta-temporality) for the per-language configuration.
+- Regular (non-exponential) histograms support both temporalities, so percentile queries on them are unaffected.
+
+After the instrument starts emitting delta data points, re-run the query. See [Metric Types and Aggregation](https://signoz.io/docs/metrics-management/types-and-aggregation/#temporality-of-metrics) for the full temporality support table.

--- a/data/docs/metrics-management/types-and-aggregation.mdx
+++ b/data/docs/metrics-management/types-and-aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-10
+date: 2026-08-27
 title: Metric Types and Aggregation
 description: Learn about the different metric types (Counter, Gauge, Histogram, Exponential Histogram) supported by SigNoz and how temporal and spatial aggregation works for each type.
 doc_type: explanation
@@ -22,7 +22,7 @@ SigNoz supports the following types of metrics:
 <Admonition type="info">
 Exponential histograms are supported only in self-hosted SigNoz (not SigNoz Cloud). To enable them in your OTel Collector configuration:
 1. Set `enable_exp_hist: true` in both the `clickhousemetricswrite` and `signozclickhousemetrics` exporters in your collector config.
-2. Ensure your metrics use delta temporality. Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz currently only supports delta, so cumulative temporality metrics will not work.
+2. Ensure your metrics use delta temporality. Although OpenTelemetry supports both delta and cumulative temporality for exponential histograms, SigNoz supports only delta. Querying an exponential histogram recorded with cumulative temporality fails with an HTTP `501` error: `only 'delta' exponential histograms are supported`.
 For background, see <a href="https://github.com/SigNoz/signoz-otel-collector/issues/625#issuecomment-2994987941" target="_blank" rel="noopener noreferrer nofollow">the collector issue notes</a>.
 </Admonition>
 


### PR DESCRIPTION
## Description

PR #12640 fixes incorrect percentile results for delta exponential histogram metrics and now rejects cumulative exponential histogram queries with an explicit HTTP 501 error (`only 'delta' exponential histograms are supported`) instead of returning silently wrong data.

- Tightened the exponential histogram limitation callout in `types-and-aggregation.mdx` to state the exact query-time error and 501 response for cumulative temporality.
- Added a troubleshooting FAQ keyed on the exact error string, explaining the cause (cumulative temporality) and the delta-temporality fix.
- Updated `date` frontmatter on both edited files.

No upgrade-guide callout: the docs already documented cumulative exponential histograms as unsupported, so this is a clearer error, not a newly-broken documented behavior. No screenshots: exponential histograms are self-host-only and the change is backend/API-only.

## Issues closed by this PR

Source PRs: #12640

## Additional Information

Auto-generated by docs-sync pipeline