### PR TITLE
fix(ci): gate chromatic pr runs behind run-visual-testing and fix the main baseline

### DIFF
--- a/.github/workflows/chromatic-main.yml
+++ b/.github/workflows/chromatic-main.yml
@@ -1,13 +1,14 @@
 name: 'Chromatic (main)'
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
     types: [closed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:
@@ -18,14 +19,15 @@ jobs:
     name: Run Chromatic
     runs-on: ubuntu-latest
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'update-visual-testing')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'update-visual-testing'))
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -39,7 +41,7 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@latest
         env:
-          CHROMATIC_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           CHROMATIC_BRANCH: main
           CHROMATIC_SLUG: ${{ github.repository }}
         with:

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -4,36 +4,30 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'components/**'
-      - 'shared/**'
-      - 'stories/**'
-      - '.storybook/**'
-      - 'css/**'
-      - 'utils/mdx/**'
-      - 'tailwind.config.js'
-      - 'postcss.config.js'
-      - 'package.json'
-      - 'yarn.lock'
-      - 'chromatic.config.json'
-      - '.github/workflows/chromatic-pr.yml'
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'labeled' }}
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-visual-testing') &&
+      (github.event.action != 'labeled' || github.event.label.name != 'update-visual-testing') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -49,4 +43,9 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
-          exitOnceUploaded: true
+
+      - name: Mark PR as visually tested
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label update-visual-testing --remove-label run-visual-testing

--- a/VISUAL_TESTING.md
+++ b/VISUAL_TESTING.md
@@ -27,24 +27,35 @@ browse a story; it is not part of the snapshot diff.
 
 ## How it runs
 
+Visual testing is opt-in per PR, driven by two labels:
+
+| Label                   | Who adds it | Meaning                                                              |
+| ----------------------- | ----------- | -------------------------------------------------------------------- |
+| `run-visual-testing`    | You         | Run Chromatic on this PR.                                            |
+| `update-visual-testing` | CI          | This PR's snapshots become the new `main` baseline when it merges.   |
+
 Two workflows:
 
-| Workflow                               | Trigger                                                        | What it does                                                                                                                              |
-| -------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `.github/workflows/chromatic-pr.yml`   | Every PR to `main`                                             | Builds and publishes the Storybook, diffs against the `main` baseline, posts the **Storybook Publish** and **UI Tests** checks on the PR. |
-| `.github/workflows/chromatic-main.yml` | PR merged to `main` **with the `update-visual-testing` label** | Republishes from the merge commit and auto-accepts the result as the new baseline.                                                        |
+| Workflow                               | Trigger                                                                          | What it does                                                                                                                              |
+| -------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/chromatic-pr.yml`   | PR to `main` carrying the `run-visual-testing` label                             | Builds and publishes the Storybook, diffs against the `main` baseline, posts the **Storybook Publish** and **UI Tests** checks on the PR. |
+| `.github/workflows/chromatic-main.yml` | PR merged to `main` with the `update-visual-testing` label, or manual dispatch   | Republishes from the merge commit and auto-accepts the result as the new baseline.                                                        |
 
 Day to day:
 
-1. Open a PR that touches components, stories, or CSS.
+1. Open a PR that touches components, stories, or CSS, and add the
+   `run-visual-testing` label. Nothing runs without it - the workflow does not
+   even start, so an unlabelled PR costs no CI at all.
 2. Open the **UI Tests** check and review each diff - accept intended changes, deny regressions.
 3. Use the **Storybook Publish** check link to browse that commit's Storybook.
-4. When merging a PR whose visual changes should become the new baseline, add the
-   `update-visual-testing` label before merge.
+4. On a clean run the workflow swaps your label for `update-visual-testing` and
+   removes `run-visual-testing`. Merge as normal; the baseline moves on merge.
+   A PR with unreviewed diffs goes red and is *not* labelled - review the diffs
+   and push again, or re-add `run-visual-testing` to re-run.
 
-`onlyChanged: true` (TurboSnap) is enabled, so a PR that touches no story or its
-dependencies publishes the Storybook but snapshots nothing. Docs-only PRs cost no
-snapshots.
+`onlyChanged: true` (TurboSnap) is enabled, so even a labelled PR that touches no
+story or its dependencies publishes the Storybook but snapshots nothing.
+
 
 ## The snapshot budget
 
@@ -126,10 +137,20 @@ loaded when the snapshot was taken.
 
 ## Baseline management
 
-The baseline is whatever was last accepted on `main`. It moves only through
+The baseline is whatever was last accepted on `main`. It moves through
 `chromatic-main.yml`, which requires the `update-visual-testing` label on the merged
 PR. If a baseline drifts wrong - for example a regression was accepted by mistake -
 fix the component and merge with the label to reset it.
+
+`chromatic-main.yml` also has a `workflow_dispatch` trigger, which rebuilds and
+re-accepts the baseline from the current tip of `main`:
+
+```bash
+gh workflow run chromatic-main.yml --ref main
+```
+
+Use it to seed the very first baseline, after merging a PR, or to recover
+when the baseline no longer reflects `main`.
 
 Avoid accepting diffs you do not understand. An accepted regression becomes the
 reference every later PR is compared against.
@@ -143,8 +164,8 @@ reference every later PR is compared against.
 | `.storybook/preview-head.html`         | Fonts and panel styling                                          |
 | `.storybook/manager.ts`                | Storybook UI theme                                               |
 | `chromatic.config.json`                | Project id, TurboSnap, build dir                                 |
-| `.github/workflows/chromatic-pr.yml`   | Per-PR build and diff                                            |
-| `.github/workflows/chromatic-main.yml` | Baseline update on labelled merge                                |
+| `.github/workflows/chromatic-pr.yml`   | Per-PR build and diff, gated on `run-visual-testing`              |
+| `.github/workflows/chromatic-main.yml` | Baseline update on labelled merge, or manual dispatch            |
 
 Local commands:
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Chromatic didn't produce a build on `main`, so there is no accepted baseline and no `main` permalink to link to. This PR fixes this, and moves PR runs behind an opt-in label similar to [`SigNoz/components`](https://github.com/SigNoz/components/blob/main/.github/workflows/chromatic-pr.yml).


#### Screenshots / Screen Recordings (if applicable)

N/A 


#### Issues closed by this PR

N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- **Tests added/updated:** none
- **Manual verification:** NA
- **Edge cases covered:** NA

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Chromatic workflow only
- **Potential regressions:** PR merge without label will cause baseline to drift
- **Rollback plan:**  Revert the PR

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers


---
