### PR TITLE
docs(cursor): rename the Cursor pages from Cursor IDE to Cursor AI

### DIFF
--- a/constants/listicles/dashboard-templates.json
+++ b/constants/listicles/dashboard-templates.json
@@ -158,9 +158,9 @@
       "icon": "/svgs/icons/LLMMonitoring/crewai-logo.svg"
     },
     {
-      "name": "Cursor IDE",
+      "name": "Cursor AI",
       "href": "/docs/dashboards/dashboard-templates/cursor-dashboard",
-      "clickName": "Cursor IDE Dashboard Template",
+      "clickName": "Cursor AI Dashboard Template",
       "icon": "/svgs/icons/LLMMonitoring/cursor-logo.svg"
     },
     {

--- a/constants/listicles/llm-monitoring.json
+++ b/constants/listicles/llm-monitoring.json
@@ -73,9 +73,9 @@
       "icon": "/svgs/icons/LLMMonitoring/crewai-logo.svg"
     },
     {
-      "name": "Cursor IDE",
+      "name": "Cursor AI",
       "href": "/docs/cursor-observability/",
-      "clickName": "Cursor IDE Monitoring",
+      "clickName": "Cursor AI Monitoring",
       "icon": "/svgs/icons/LLMMonitoring/cursor-logo.svg"
     },
     {

--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -2779,7 +2779,7 @@
           {
             "type": "doc",
             "route": "/docs/dashboards/dashboard-templates/cursor-dashboard",
-            "label": "Cursor IDE"
+            "label": "Cursor AI"
           },
           {
             "type": "doc",
@@ -3582,7 +3582,7 @@
       },
       {
         "route": "/docs/cursor-observability",
-        "label": "Cursor IDE",
+        "label": "Cursor AI",
         "type": "doc"
       },
       {

--- a/data/docs/cursor-observability.mdx
+++ b/data/docs/cursor-observability.mdx
@@ -1,8 +1,8 @@
 ---
 published_date: 2026-08-27
-title: Cursor IDE Observability & Monitoring with OpenTelemetry
-meta_title: Cursor IDE OpenTelemetry Monitoring
-description: Monitor Cursor IDE with OpenTelemetry and SigNoz. Trace every agent turn, model call, and tool execution, and track token spend across your team.
+title: Cursor AI Observability & Monitoring with OpenTelemetry
+meta_title: Cursor AI OpenTelemetry Monitoring
+description: Monitor Cursor AI with OpenTelemetry and SigNoz. Trace every agent turn, model call, and tool execution, and track token spend across your team.
 doc_type: howto
 ---
 

--- a/data/docs/dashboards/dashboard-templates/cursor-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/cursor-dashboard.mdx
@@ -1,8 +1,8 @@
 ---
 published_date: 2026-08-27
-title: Cursor IDE Dashboard
-meta_title: Cursor IDE Usage Dashboard
-description: "Monitor Cursor IDE usage in SigNoz: token spend by model, turn and tool latency, tool mix, and tool failures across your development team."
+title: Cursor AI Dashboard
+meta_title: Cursor AI Usage Dashboard
+description: "Monitor Cursor AI usage in SigNoz: token spend by model, turn and tool latency, tool mix, and tool failures across your development team."
 doc_type: explanation
 ---
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Renames the two Cursor docs pages from **Cursor IDE** to **Cursor AI** in their titles, meta titles, descriptions, and nav labels. Follow-up to #4073, which is merged.

The pages were named "Cursor IDE" to fence the scope, since the Cursor CLI cannot feed this setup. That is accurate but it is not what people search. Checked against Google autocomplete, which orders completions by popularity:

| Suggested by Google | Not suggested |
|---|---|
| `cursor ai monitoring` | `cursor ide monitoring` |
| `cursor agent monitoring` | `cursor ide observability` |
| `cursor agent observability` | |
| `cursor ai telemetry` (ranks above `cursor ide telemetry`) | |

`cursor ai` is also the top completion of bare `cursor`. Every `cursor ide` completion is consumer intent instead: download, pricing, themes, vs vscode.

**"Cursor Agent" was considered and rejected.** It scores best on intent, but it is Cursor's own product name for the CLI ([their launch post](https://cursor.com/blog/cli) is titled "Cursor Agent CLI", binary `cursor-agent`). These pages cannot serve CLI users, so that title would attract traffic that can never convert.

**The qualifier does not cost us the bare term.** `codex-monitoring` carries "OpenAI" in its title and still ranks far better without it: 16,251 impressions on queries without "openai" against 573 with it, over the last 12 months. So "Cursor AI" still catches `cursor monitoring` and `cursor observability`.

Body headings deliberately keep "Cursor IDE". That stays accurate about scope, and it covers the IDE variant alongside the AI variant in the title.

#### Screenshots / Screen Recordings (if applicable)

n/a, frontmatter and nav labels only.

#### Issues closed by this PR

None.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: none, no behavior change
- Manual verification: `yarn check:docs-metadata`, `yarn check:doc-redirects`, and `yarn check:stale-urls` all pass. All three JSON files re-parse cleanly after the edit.
- Edge cases covered: no slug or URL changes, so no redirect is needed. The `cursor-observability` slug is unchanged and stays valid, including the hardcoded guide link in SigNoz/dashboards#408.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: two docs pages, four days old, plus their labels in two listicles and the docs side nav. No routes, no components.
- Potential regressions: the Mixpanel `clickName` values change with the labels, so click events for these two cards split across the old and new names. Four days of data on pages that are barely indexed, so the loss is negligible.
- Rollback plan: revert the commit. Nothing else depends on these strings.
