### PR TITLE
fix(agent-md): resolve directory-index .md URL shapes, add /agents.md

### DIFF
--- a/app/(site)/agents.md/route.ts
+++ b/app/(site)/agents.md/route.ts
@@ -1,0 +1,39 @@
+import siteMetadata from '@/data/siteMetadata'
+import { agentResponse } from '@/utils/agentResponseHeaders'
+
+/**
+ * `/agents.md` is a widely-adopted agent entry point, and agents request it
+ * unprompted (it was the single most-requested missing `.md` path in
+ * production logs). Its job is to hand over the map: benchmarks of agent docs
+ * navigation show that linking an index like /llms.txt — not markdown alone —
+ * is what stops agents guessing URLs that were never real.
+ */
+const AGENTS_MD = `# SigNoz for agents
+
+SigNoz is an open-source, OpenTelemetry-native observability platform for traces, metrics, and logs.
+
+## Start here
+
+- [llms.txt](${siteMetadata.siteUrl}/llms.txt): index of every section, with titles and descriptions. Read this before guessing a URL.
+- [llms-full.txt](${siteMetadata.siteUrl}/llms-full.txt): the same map expanded with per-section markdown sitemaps.
+- [Docs sitemap](${siteMetadata.siteUrl}/docs/sitemap.md): every documentation page as markdown.
+
+## Fetching markdown
+
+Every page on signoz.io serves a markdown representation two ways:
+
+- Append \`.md\` to the page URL — ${siteMetadata.siteUrl}/docs/introduction.md, ${siteMetadata.siteUrl}/blog/<slug>.md, ${siteMetadata.siteUrl}/pricing.md
+- Send \`Accept: text/markdown\` to the canonical URL
+
+Both return identical bytes. Use the flat page URL: \`/docs/install/docker.md\`, not \`/docs/install/docker/index.html.md\`.
+
+## Tooling
+
+- [Agent Skills](${siteMetadata.siteUrl}/skill.md): install SigNoz skills for coding agents.
+- [MCP server](${siteMetadata.siteUrl}/docs/ai/signoz-mcp-server/): query traces, logs, and metrics, and manage dashboards and alerts.
+- [API reference](${siteMetadata.siteUrl}/api-reference/): programmatic access to your telemetry data.
+`
+
+export async function GET() {
+  return agentResponse(AGENTS_MD)
+}

--- a/tests/markdown-directory-index-normalization.test.js
+++ b/tests/markdown-directory-index-normalization.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const {
+  normalizeDocsSlugFromPathname,
+  buildDocsMarkdownRewritePath,
+  stripDirectoryIndexSuffix,
+  hasDocsMarkdownExtension,
+} = loadTsModule('utils/docs/markdownRouting.ts')
+
+const {
+  parseContentMarkdownPath,
+  buildPageMarkdownRewritePath,
+  shouldRewritePageToMarkdown,
+  shouldRewriteContentToMarkdown,
+} = loadTsModule('utils/agentMarkdownRouting.ts')
+
+// Agents derive markdown URLs from the rendered page's index.html form. These
+// shapes 404'd in production while the flat `.md` path returned 200.
+
+test('docs slug collapses index.html.md, index.md and bare .md onto the flat slug', () => {
+  assert.equal(
+    normalizeDocsSlugFromPathname('/docs/install/docker/index.html.md'),
+    'install/docker'
+  )
+  assert.equal(normalizeDocsSlugFromPathname('/docs/install/docker/index.md'), 'install/docker')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/operate/upgrade/.md'), 'operate/upgrade')
+  assert.equal(
+    normalizeDocsSlugFromPathname('/docs/llm-observability/index.md'),
+    'llm-observability'
+  )
+})
+
+test('docs slug is unchanged for already-flat and trailing-slash paths', () => {
+  assert.equal(normalizeDocsSlugFromPathname('/docs/install/docker.md'), 'install/docker')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/install/docker/'), 'install/docker')
+  assert.equal(normalizeDocsSlugFromPathname('/docs/introduction.md'), 'introduction')
+  assert.equal(normalizeDocsSlugFromPathname('/docs'), '')
+})
+
+test('stripDirectoryIndexSuffix only matches a trailing index segment', () => {
+  // Guards the one docs slug containing the substring "index".
+  assert.equal(stripDirectoryIndexSuffix('llamaindex-observability'), 'llamaindex-observability')
+  assert.equal(stripDirectoryIndexSuffix('a/indexed/page'), 'a/indexed/page')
+  assert.equal(stripDirectoryIndexSuffix('a/index'), 'a')
+  assert.equal(stripDirectoryIndexSuffix('a/index.html'), 'a')
+  assert.equal(stripDirectoryIndexSuffix('a/index.htm'), 'a')
+})
+
+test('index shapes still register as explicit markdown requests', () => {
+  assert.equal(hasDocsMarkdownExtension('/docs/install/docker/index.html.md'), true)
+  assert.equal(hasDocsMarkdownExtension('/docs/operate/upgrade/.md'), true)
+})
+
+test('docs rewrite path resolves index shapes to the real markdown endpoint', () => {
+  assert.equal(
+    buildDocsMarkdownRewritePath('/docs/install/docker/index.html.md'),
+    '/api/docs-markdown/install/docker'
+  )
+  assert.equal(
+    buildDocsMarkdownRewritePath('/docs/metrics-management/query-range-api/index.html.md'),
+    '/api/docs-markdown/metrics-management/query-range-api'
+  )
+})
+
+test('content sections collapse index shapes onto the post slug', () => {
+  assert.deepEqual(parseContentMarkdownPath('/blog/some-post/index.html.md'), {
+    section: 'blog',
+    slug: 'some-post',
+  })
+  assert.deepEqual(parseContentMarkdownPath('/guides/aws-monitoring/index.md'), {
+    section: 'guides',
+    slug: 'aws-monitoring',
+  })
+  assert.equal(shouldRewriteContentToMarkdown('/blog/some-post/index.html.md', false), true)
+})
+
+test('page pipeline collapses index shapes instead of treating them as files', () => {
+  assert.equal(shouldRewritePageToMarkdown('/pricing/index.html.md', false), true)
+  assert.equal(buildPageMarkdownRewritePath('/pricing/index.html.md'), '/api/page-markdown/pricing')
+  assert.equal(buildPageMarkdownRewritePath('/index.md'), '/api/page-markdown')
+})
+
+test('real file resources are still left alone', () => {
+  assert.equal(shouldRewritePageToMarkdown('/llms.txt', true), false)
+  assert.equal(shouldRewritePageToMarkdown('/sitemap.xml', true), false)
+  assert.equal(shouldRewritePageToMarkdown('/skill.md', false), false)
+  assert.equal(shouldRewritePageToMarkdown('/agents.md', false), false)
+  assert.equal(shouldRewritePageToMarkdown('/blogs/sitemap.md', false), false)
+})

--- a/utils/agentMarkdownRouting.ts
+++ b/utils/agentMarkdownRouting.ts
@@ -36,9 +36,22 @@ const stripTrailingSlashes = (pathname: string): string => pathname.replace(/\/+
 export const hasMarkdownExtension = (pathname: string): boolean =>
   stripTrailingSlashes(pathname).endsWith('.md')
 
+/**
+ * Agents derive markdown URLs from the rendered page's `index.html` form,
+ * producing `/blog/some-post/index.html.md`, `.../index.md` or a bare
+ * `.../.md`. Collapse those directory-index shapes onto the flat path the
+ * content actually lives at. Mirrors `stripDirectoryIndexSuffix` in
+ * `utils/docs/markdownRouting.ts` for the docs pipeline.
+ */
+const stripDirectoryIndexSuffix = (pathname: string): string =>
+  pathname.replace(/\/index(?:\.html?)?$/, '') || '/'
+
 const stripMarkdownExtension = (pathname: string): string => {
   const normalized = stripTrailingSlashes(pathname)
-  return normalized.endsWith('.md') ? normalized.slice(0, -'.md'.length) : normalized
+  const withoutExtension = normalized.endsWith('.md')
+    ? normalized.slice(0, -'.md'.length)
+    : normalized
+  return stripTrailingSlashes(stripDirectoryIndexSuffix(withoutExtension))
 }
 
 const isPathWithinPrefix = (pathname: string, prefix: string): boolean =>
@@ -101,7 +114,7 @@ const PAGE_MARKDOWN_EXCLUDED_PREFIXES = [
 
 // Real .md resources served by their own routes; the suffix is part of the
 // path, not a markdown-alternate marker.
-const MARKDOWN_ROUTE_PATHS = new Set(['/skill.md'])
+const MARKDOWN_ROUTE_PATHS = new Set(['/skill.md', '/agents.md'])
 
 /**
  * File-like paths (e.g. /llms.txt, /sitemap.xml, /favicon.ico) are real

--- a/utils/docs/markdownRouting.ts
+++ b/utils/docs/markdownRouting.ts
@@ -1,6 +1,19 @@
+/**
+ * Agents routinely derive markdown URLs from the rendered page's `index.html`
+ * form, producing `/docs/install/docker/index.html.md`, `.../index.md` or a
+ * bare `.../.md`. The content lives at the flat slug, so collapse those
+ * directory-index shapes instead of 404-ing on a page that exists.
+ *
+ * No docs slug is named `index` or ends in `/index`, so the suffix-anchored
+ * match cannot swallow a real page (e.g. `llamaindex-observability` is safe).
+ */
+export const stripDirectoryIndexSuffix = (slug: string): string =>
+  slug.replace(/\/index(?:\.html?)?$/, '').replace(/\/+$/, '')
+
 export const normalizeDocsSlugFromPathname = (pathname: string): string => {
   const withoutPrefix = pathname.replace(/^\/docs\/?/, '')
-  return withoutPrefix.replace(/\/+$/, '').replace(/\.md$/, '')
+  const withoutMarkdownExtension = withoutPrefix.replace(/\/+$/, '').replace(/\.md$/, '')
+  return stripDirectoryIndexSuffix(withoutMarkdownExtension)
 }
 
 // Agents commonly fetch docs by appending `.md` to the page URL


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Follow-up to #3948. That PR took the site from **1** working `.md` URL to **63** — but production logs show a residual 404 tail on `.md` paths whose content exists and whose flat URL returns 200:

```
/docs/install/docker/index.html.md  → 404
/docs/install/docker/index.md       → 404
/docs/operate/upgrade/.md           → 404
/docs/install/docker.md             → 200   ← same page, works
```

Agents derive markdown URLs from the rendered page's `index.html` form, so they land on a shape we don't resolve. This is ~20 of the ~69 daily `.md` 404s, and it is the "agents guessing wrong pages" failure class rather than missing content.

**Cause:** `normalizeDocsSlugFromPathname` strips the `.md` suffix but not the directory-index segment, so `/docs/install/docker/index.html.md` resolves to the slug `install/docker/index.html`, which doesn't exist.

**Fix:** collapse `/index.html`, `/index`, `/index.htm` and a bare `/.md` onto the flat path, in both pipelines.

In the non-docs pipeline the normalization has to run *inside* `stripMarkdownExtension` so it lands before `isFileLikePath` — otherwise `index.html` reads as a real file and the rewrite is skipped entirely.

**Also adds `/agents.md`** — the most-requested missing `.md` path in production (~5/day, steady, every day for the last month). Following the [Mintlify docs-URL benchmark](https://mintlify.com/blog/docs-url-benchmark) finding that *the map, not markdown, is what stops agents 404ing*, it leads with `llms.txt`, `llms-full.txt` and the docs sitemap, and states the flat-URL convention explicitly so agents stop deriving `index.html` forms in the first place.

#### Safety of the regex

Suffix-anchored, and no docs slug is named `index` or ends in `/index`. The one slug containing the substring — `llamaindex-observability` — has an explicit regression test.

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- **Tests added:** `tests/markdown-directory-index-normalization.test.js` — 8 tests covering docs slug collapsing, the `llamaindex-observability` guard, `hasDocsMarkdownExtension` on index shapes, rewrite-path resolution, content-section slugs, the page pipeline vs `isFileLikePath`, and that real file resources (`/llms.txt`, `/sitemap.xml`, `/skill.md`, `/agents.md`, `/blogs/sitemap.md`) are still left alone.
- **Existing suites:** 49 tests across `docs-markdown-routing`, `agent-markdown-routing`, `agent-discovery`, `agent-response-headers`, `page-html-to-markdown` — all pass.
- **Checks:** `yarn check:stale-urls` + `yarn test:stale-urls` pass; `yarn lint` 0 errors; `yarn build` succeeds with `/agents.md` in the route manifest.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** two pure string helpers on the markdown routing path. Only reached when a request already carries explicit markdown intent (`.md` suffix or `Accept: text/markdown`); HTML rendering is untouched.
- **Potential regressions:** (1) a real page whose slug ends in `/index` would be mis-collapsed — none exist, and the suffix anchor is tested; (2) `isFileLikePath` ordering — covered by the page-pipeline test.
- **Rollback:** revert; behavior returns to 404 on these shapes.

---

### 📋 Checklist
- [x] Tests added
- [x] Manually tested
- [x] Breaking changes documented (none — additive; previously-404ing URLs now resolve)
- [x] Backward compatibility considered (flat `.md`, trailing-slash and `Accept` paths unchanged)

---

## 👀 Notes for Reviewers

Two related paths deliberately **not** fixed here, since they look mid-flight in the Agent Score stack: `/api-reference.md` and `/auth.md` still 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
