### PR TITLE
feat(analytics): log markdown-negotiated requests, not just detected bots

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -28,6 +28,25 @@ const INCLUDE_MARKDOWN_REWRITE_DEBUG_HEADER = process.env.NODE_ENV !== 'producti
 
 const GROWTHBOOK_ANONYMOUS_ID_HEADER = 'x-gb-anonymous-id'
 
+/**
+ * Markdown-negotiated requests are ~91% of production traffic (~11M/day), and
+ * the largest client does not identify itself as a known bot — so gating agent
+ * telemetry on `isBot` alone misses almost all of it. Log those requests too,
+ * but sample them: unsampled they would be ~340M analytics events/month.
+ *
+ * `isBot` requests stay unsampled so existing reports are unaffected. Every
+ * event carries `custom_log_sample_rate` so sampled rows can be weighted.
+ */
+const parsedMarkdownLogSampleRate = Number.parseFloat(
+  process.env.AGENT_MARKDOWN_LOG_SAMPLE_RATE ?? ''
+)
+const MARKDOWN_LOG_SAMPLE_RATE =
+  Number.isFinite(parsedMarkdownLogSampleRate) &&
+  parsedMarkdownLogSampleRate >= 0 &&
+  parsedMarkdownLogSampleRate <= 1
+    ? parsedMarkdownLogSampleRate
+    : 0.01
+
 // Extract OS from user agent (server-side version)
 const getOSFromUserAgent = (userAgent: string): string => {
   if (!userAgent) return 'unknown'
@@ -82,8 +101,12 @@ export function proxy(req: NextRequest) {
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set(GROWTHBOOK_ANONYMOUS_ID_HEADER, growthBookAnonymousId)
 
-  // Log bot requests
-  if (isBot) {
+  // Log bot requests, plus a sample of markdown-negotiated requests from
+  // clients that bot detection does not recognize.
+  const isSampledMarkdownRequest =
+    !isBot && prefersMarkdown && Math.random() < MARKDOWN_LOG_SAMPLE_RATE
+
+  if (isBot || isSampledMarkdownRequest) {
     // Use waitUntil to ensure logging completes before function termination
     waitUntil(
       logEventServerSide({
@@ -97,13 +120,14 @@ export function proxy(req: NextRequest) {
           custom_referrer: referer,
           custom_ip: ip,
           custom_source: 'server',
-          custom_is_bot: true,
+          custom_is_bot: isBot,
           custom_request_method: req.method,
           custom_has_javascript: false,
           custom_vercel_ip: vercelIp,
           custom_accept_header: acceptHeader,
           custom_content_type_header: contentTypeHeader,
           custom_prefers_markdown: prefersMarkdown,
+          custom_log_sample_rate: isSampledMarkdownRequest ? MARKDOWN_LOG_SAMPLE_RATE : 1,
         },
         anonymousId: growthBookAnonymousId,
       })


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Agent telemetry in `proxy.ts` is gated on `isBot`, so an event is only recorded when `detectBotFromUserAgent` recognizes the user-agent. The largest markdown client on the site does **not** identify itself as a known bot, so the gate silently drops almost all agent traffic:

| Source | Markdown requests, 7 days |
|---|---|
| Vercel runtime logs (`/api/docs-markdown`) | **~77,000,000** |
| Mixpanel `Bot Page Request`, `custom_prefers_markdown=true` | **7,493** |

That's ~0.01% coverage, and what survives is biased toward crawlers polite enough to name themselves (`gpt`, `claude`, `openai`, `perplexitybot`). Any navigation, flow, or 404-rate analysis built on it today is drawn from a rounding error.

**Change:** log markdown-negotiated requests regardless of bot detection.

**Why sampled:** unsampled this is ~340M analytics events/month, which is a real cost. Non-bot markdown requests are sampled at `AGENT_MARKDOWN_LOG_SAMPLE_RATE` (default **0.01**). `isBot` requests stay **unsampled**, so every existing report is byte-for-byte unaffected. Each event now carries `custom_log_sample_rate` so sampled rows can be weighted back up in analysis.

Also fixes `custom_is_bot`, which was hardcoded `true`. It's now `isBot` — meaningful, since the event no longer implies a detected bot.

#### Known limitation — deliberately not fixed here

Agents don't persist cookies, so `growthBookAnonymousId` falls through to a fresh `uuidv4()` on **every** request. That means agent requests cannot be grouped into a session, and per-session metrics ("404s per task", the metric the Mintlify docs-URL benchmark reports) are not derivable even after this change. That needs a session key derived from IP + user-agent, which is a separate change with its own privacy review.

---

### ✅ Change Type

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- `tests/proxy.test.js` — 39 tests pass
- `yarn lint` — 0 errors
- `yarn build` — succeeds

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** analytics volume only. No routing, rendering, or response behavior changes.
- **Cost:** at the 0.01 default this adds roughly 100–120k events/day. Raise `AGENT_MARKDOWN_LOG_SAMPLE_RATE` deliberately, and watch the Mixpanel event count before going above ~0.05.
- **Existing reports:** unchanged — `isBot` events are still logged at 100%, and `custom_is_bot` lets any report that assumed "all events are bots" filter explicitly.
- **Rollback:** set `AGENT_MARKDOWN_LOG_SAMPLE_RATE=0`, or revert.

---

### 📋 Checklist
- [x] Tests pass
- [x] Manually verified
- [x] Breaking changes documented (none; `custom_is_bot` semantics widen — noted above)
- [x] Backward compatibility considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
