### PR TITLE
feat(llms.txt): surface the OpenAPI spec and access-control docs

### DIFF
--- a/app/(site)/llms.txt/route.ts
+++ b/app/(site)/llms.txt/route.ts
@@ -7,6 +7,7 @@ import {
 import { agentResponse } from '@/utils/agentResponseHeaders'
 
 const AGENT_TOOLING_ROUTE_PREFIX = '/docs/ai/'
+const ACCESS_CONTROL_ROUTE_PREFIX = '/docs/manage/administrator-guide/iam/'
 
 const formatLink = (item: LlmStarterLink): string => {
   const url = `${siteMetadata.siteUrl}${item.route}/`
@@ -29,18 +30,28 @@ const FALLBACK_AGENT_TOOLING_LINES = [
 
 export async function GET() {
   const starters = await getLlmStarterLinks()
-  const starterDocs = starters.filter((item) => !item.route.startsWith(AGENT_TOOLING_ROUTE_PREFIX))
   const agentTooling = starters.filter((item) => item.route.startsWith(AGENT_TOOLING_ROUTE_PREFIX))
+  const accessControl = starters.filter((item) =>
+    item.route.startsWith(ACCESS_CONTROL_ROUTE_PREFIX)
+  )
+  const starterDocs = starters.filter(
+    (item) =>
+      !item.route.startsWith(AGENT_TOOLING_ROUTE_PREFIX) &&
+      !item.route.startsWith(ACCESS_CONTROL_ROUTE_PREFIX)
+  )
 
   const starterLines =
     starterDocs.length > 0 ? starterDocs.map(formatLink).join('\n') : FALLBACK_STARTER_LINES
   const agentToolingLines =
     agentTooling.length > 0 ? agentTooling.map(formatLink).join('\n') : FALLBACK_AGENT_TOOLING_LINES
+  const accessControlLines = accessControl.map(formatLink)
 
   const body = [
     '# SigNoz',
     '',
-    'SigNoz Cloud brings your traces, metrics, and logs into one OpenTelemetry-native platform. Simple usage-based pricing, and the freedom to run on your infrastructure with Self-Hosted SigNoz.',
+    // llmstxt.org: the H1 must be followed by a blockquote summary. This was
+    // emitted as a plain paragraph, which tests/llms-txt.test.js already caught.
+    '> SigNoz Cloud brings your traces, metrics, and logs into one OpenTelemetry-native platform. Simple usage-based pricing, and the freedom to run on your infrastructure with Self-Hosted SigNoz.',
     '',
     `Markdown versions of every page are available: append ".md" to any signoz.io page URL — docs (${siteMetadata.siteUrl}/docs/introduction.md), blog posts (${siteMetadata.siteUrl}/blog/<slug>.md), comparisons, guides, and product pages like ${siteMetadata.siteUrl}/pricing.md — or request any page with "Accept: text/markdown".`,
     '',
@@ -54,6 +65,14 @@ export async function GET() {
     '',
     agentToolingLines,
     `- [skill.md](${siteMetadata.siteUrl}/skill.md): Root Agent Skill file describing SigNoz skills and when the MCP server is required.`,
+    '',
+    '## API and access control',
+    '',
+    'The SigNoz HTTP API authenticates with a SigNoz-Api-Key header; the OpenAPI document below declares the security schemes and every operation.',
+    '',
+    `- [API reference](${siteMetadata.siteUrl}/api-reference/): Interactive reference for the SigNoz HTTP API.`,
+    `- [OpenAPI specification](${siteMetadata.siteUrl}/api/api-reference-openapi/latest/): Machine-readable OpenAPI document for the SigNoz HTTP API, including security schemes.`,
+    ...accessControlLines,
     '',
     '## Optional',
     '',

--- a/tests/agent-discovery.test.js
+++ b/tests/agent-discovery.test.js
@@ -84,5 +84,7 @@ test('getLlmStarterLinks is unique and respects default max size', async () => {
   const uniqueRoutes = new Set(routes)
 
   assert.equal(uniqueRoutes.size, routes.length)
-  assert.equal(starters.length <= 24, true)
+  // Raised from 24 when the access-control matchers were added, so the new
+  // entries cannot evict existing starter docs from the cap.
+  assert.equal(starters.length <= 30, true)
 })

--- a/tests/llms-txt.test.js
+++ b/tests/llms-txt.test.js
@@ -53,7 +53,10 @@ test('llms.txt emits the exact introduction entry from issue #1173', async () =>
 test('every ## section contains at least one parseable markdown link', async () => {
   const sections = sectionsOf(await getBody())
 
-  assert.deepEqual([...sections.keys()], ['Starter docs', 'Agent tooling', 'Optional'])
+  assert.deepEqual(
+    [...sections.keys()],
+    ['Starter docs', 'Agent tooling', 'API and access control', 'Optional']
+  )
   sections.forEach((lines, name) => {
     const links = lines.filter((line) => MARKDOWN_LINK_LINE.test(line))
     assert.equal(links.length > 0, true, `section "${name}" has no parseable markdown link`)
@@ -82,4 +85,31 @@ test('emitted links use trailing slashes except file-extension URLs', async () =
       `link would redirect (trailingSlash): ${url}`
     )
   })
+})
+
+test('API and access control section links the spec and the access-control docs', async () => {
+  const sections = sectionsOf(await getBody())
+  const lines = sections.get('API and access control').join('\n')
+
+  // The OpenAPI document already existed at this path but was referenced from
+  // nowhere agents look, so scanners reported "no OpenAPI specification found".
+  assert.match(lines, /https:\/\/signoz\.io\/api\/api-reference-openapi\/latest\//)
+  assert.match(lines, /https:\/\/signoz\.io\/api-reference\//)
+
+  ;[
+    'iam/roles/',
+    'iam/service-accounts/',
+    'iam/user-guides/self-service-api-keys-for-viewers/',
+    'iam/user-guides/scope-telemetry-access-by-ingestion-key/',
+  ].forEach((route) => {
+    assert.equal(lines.includes(route), true, `missing access-control link: ${route}`)
+  })
+})
+
+test('access-control docs are not duplicated into Starter docs', async () => {
+  const sections = sectionsOf(await getBody())
+  const starters = sections.get('Starter docs').join('\n')
+
+  assert.equal(starters.includes('/iam/roles/'), false)
+  assert.equal(starters.includes('/iam/service-accounts/'), false)
 })

--- a/utils/docs/agentDiscovery.ts
+++ b/utils/docs/agentDiscovery.ts
@@ -63,6 +63,16 @@ const LLM_STARTER_ROUTE_MATCHERS: Array<(route: string) => boolean> = [
   (route) => /^\/docs\/dashboards(?:\/|$)/.test(route),
   (route) => /^\/docs\/manage\/administrator-guide(?:\/|$)/.test(route),
   (route) => /^\/docs\/migration(?:\/|$)/.test(route),
+  // Access control: agents asking "how do I authenticate against the API?"
+  // had no path to these from /llms.txt, so the docs existed but were
+  // undiscoverable. They render as their own llms.txt section.
+  (route) => route === '/docs/manage/administrator-guide/iam/roles',
+  (route) => route === '/docs/manage/administrator-guide/iam/service-accounts',
+  (route) =>
+    route === '/docs/manage/administrator-guide/iam/user-guides/self-service-api-keys-for-viewers',
+  (route) =>
+    route ===
+    '/docs/manage/administrator-guide/iam/user-guides/scope-telemetry-access-by-ingestion-key',
 ]
 
 const normalizeDocsRoute = (route?: string): string | null => {
@@ -210,7 +220,7 @@ async function getDocsDescriptionLookup(): Promise<Map<string, string>> {
   return lookup
 }
 
-export async function getLlmStarterLinks(limit = 24): Promise<LlmStarterLink[]> {
+export async function getLlmStarterLinks(limit = 30): Promise<LlmStarterLink[]> {
   const routes = await getDocsRouteList()
   const descriptions = await getDocsDescriptionLookup()
   const starters: LlmStarterLink[] = []


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The [is-agentic scan](https://is-agentic.com/scan/signoz.io) (63/100, Essential 43.3/80) reports two failures for signoz.io:

- **"OpenAPI spec published — No OpenAPI/Swagger specification found"**
- **"Scoped permissions — No declared OAuth scopes, security schemes, or scoped-permission documentation"**

Both are **discoverability failures, not missing capabilities.** We already have all of it:

| Thing | Where it already lives | Referenced from llms.txt? |
|---|---|---|
| OpenAPI document | `/api/api-reference-openapi/latest/` → **200**, valid YAML, with `securitySchemes` (`SigNoz-Api-Key` apiKey + bearer) | ❌ **0 mentions** |
| Roles | `iam/roles.mdx` | ❌ |
| Service accounts | `iam/service-accounts.mdx` | ❌ |
| Self-service API keys | `iam/user-guides/self-service-api-keys-for-viewers.mdx` | ❌ |
| Ingestion-key-scoped telemetry access | `iam/user-guides/scope-telemetry-access-by-ingestion-key.mdx` | ❌ |

The spec is also referenced 0 times in `llms-full.txt`, `docs/sitemap.md` and `robots.txt`. So an agent asking *"how do I authenticate against the SigNoz API?"* has no path to any of this from our own map — which is the exact failure mode the [Mintlify docs-URL benchmark](https://mintlify.com/blog/docs-url-benchmark) identifies: agents don't fail because content is missing, they fail because nothing points at it.

**Change:** add an `## API and access control` section to `/llms.txt`.

```
## API and access control

The SigNoz HTTP API authenticates with a SigNoz-Api-Key header; the OpenAPI document
below declares the security schemes and every operation.

- [API reference](https://signoz.io/api-reference/): Interactive reference for the SigNoz HTTP API.
- [OpenAPI specification](https://signoz.io/api/api-reference-openapi/latest/): Machine-readable OpenAPI document for the SigNoz HTTP API, including security schemes.
- [Roles](…/iam/roles/): Create and manage roles in SigNoz — managed roles, custom roles, …
- [Service Accounts](…/iam/service-accounts/): Create and manage service accounts for programmatic API access in SigNoz
- [Self Service API Keys](…/iam/user-guides/self-service-api-keys-for-viewers/): Let viewer users generate their own read-only API keys …
- [Scope Telemetry Access](…/iam/user-guides/scope-telemetry-access-by-ingestion-key/): Restrict a role to only the logs, traces, and metrics sent with a specific ingestion key …
```

The four docs entries go through `LLM_STARTER_ROUTE_MATCHERS`, so **labels and descriptions come from the docs index** rather than being hand-maintained here. The starter cap moves `24 → 30` so the new matchers cannot evict existing starter docs.

#### Drive-by fix (pre-existing, same file)

llmstxt.org requires the H1 to be followed by a **blockquote** summary; we emitted a plain paragraph. `tests/llms-txt.test.js` already asserted this and **had been failing on `main`** — production `/llms.txt` has 0 blockquote lines. One-line fix, test now green.

---

### ✅ Change Type

- [x] ✨ Feature
- [x] 🐛 Bug fix (blockquote / failing test)
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- **New tests:** the `API and access control` section links the spec + all four access-control docs; access-control docs are not duplicated into `Starter docs`.
- **Updated:** section-list assertion; starter cap assertion `24 → 30` (with rationale).
- **Suites:** 27 tests across `llms-txt`, `agent-discovery`, `llms-full-markdown`, `sitemap-markdown`, `agent-response-headers` — all pass.
- **Checks:** `check:stale-urls` + `test:stale-urls` pass; `yarn lint` 0 errors; `yarn build` succeeds.
- **Manual:** every added URL confirmed **200** in production before linking.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** `/llms.txt` output only. No routing, rendering, or docs content changes.
- **Potential regressions:** the starter cap change could alter which docs appear in `Starter docs` — covered by the no-duplication test and the uniqueness/cap test.
- **Note:** the OpenAPI link points at the path that works **today**. If #4067 lands, switch it to `/openapi.json` — no conflict, this PR touches neither file #4067 touches.
- **Rollback:** revert.

---

### 📋 Checklist
- [x] Tests added
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

## 👀 Notes for Reviewers

Deliberately **not** included, from the same scan: the `CLI tool available` check is a **false positive** — is-agentic matched the substring `cli` inside *"one-click"* in llms.txt line 14; there is no CLI mention. And `MCP resources exposed` / `MCP resource quality` are structurally unachievable — listing MCP resources requires auth, and our server correctly returns `401` with a spec-compliant `www-authenticate` challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
