### PR TITLE
fix(proxy): honour Accept q-values when negotiating markdown

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -11,6 +11,7 @@ import {
 import { buildDocsOnboardingPath, isDocsPathname } from '@/utils/docs/onboardingPath'
 import { ONBOARDING_SOURCE } from '@/constants/globals'
 import { QUERY_PARAMS } from '@/constants/queryParams'
+import { prefersMarkdownFromAccept } from '@/utils/acceptNegotiation'
 import {
   buildApiReferenceOpenAPISpecRewritePath,
   shouldRewriteApiReferenceToOpenAPISpec,
@@ -57,7 +58,7 @@ export function proxy(req: NextRequest) {
   const acceptHeader = req.headers.get('accept') || ''
   const contentTypeHeader = req.headers.get('content-type') || ''
 
-  const prefersMarkdown = acceptHeader.toLowerCase().includes('text/markdown')
+  const prefersMarkdown = prefersMarkdownFromAccept(acceptHeader)
 
   // Get request details
   const pathname = req.nextUrl.pathname

--- a/tests/accept-negotiation.test.js
+++ b/tests/accept-negotiation.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { loadTsModule } = require('./helpers/loadTsModule')
+
+const { prefersMarkdownFromAccept, parseAcceptHeader } = loadTsModule('utils/acceptNegotiation.ts')
+
+test('explicit markdown opts in', () => {
+  assert.equal(prefersMarkdownFromAccept('text/markdown'), true)
+  assert.equal(prefersMarkdownFromAccept('TEXT/MARKDOWN'), true)
+  assert.equal(prefersMarkdownFromAccept(' text/markdown '), true)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;charset=utf-8'), true)
+})
+
+test('a tie resolves to markdown so existing agent traffic is unchanged', () => {
+  // The dominant production pattern: both default to q=1.
+  assert.equal(prefersMarkdownFromAccept('text/markdown, text/html'), true)
+  assert.equal(prefersMarkdownFromAccept('text/html, text/markdown'), true)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=0.5, text/html;q=0.5'), true)
+})
+
+test('higher-ranked HTML wins — the acceptmarkdown.com q-value warning', () => {
+  assert.equal(prefersMarkdownFromAccept('text/html;q=0.9, text/markdown;q=0.1'), false)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=0.1, text/html;q=0.9'), false)
+  assert.equal(
+    prefersMarkdownFromAccept(
+      'text/html,application/xhtml+xml,application/xml;q=0.9,text/markdown;q=0.1'
+    ),
+    false
+  )
+})
+
+test('q=0 is an explicit refusal, not a request', () => {
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=0'), false)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=0.0'), false)
+  assert.equal(prefersMarkdownFromAccept('text/html, text/markdown;q=0'), false)
+})
+
+test('wildcards never opt in — default curl and crawlers keep getting HTML', () => {
+  assert.equal(prefersMarkdownFromAccept('*/*'), false)
+  assert.equal(prefersMarkdownFromAccept('text/*'), false)
+  assert.equal(prefersMarkdownFromAccept('text/html,application/xhtml+xml,*/*;q=0.8'), false)
+})
+
+test('markdown still wins against a wildcard fallback', () => {
+  assert.equal(prefersMarkdownFromAccept('text/markdown, */*'), true)
+  assert.equal(prefersMarkdownFromAccept('text/markdown, */*;q=0.1'), true)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=0.2, */*;q=0.8'), false)
+})
+
+test('missing or malformed headers fall back safely', () => {
+  assert.equal(prefersMarkdownFromAccept(''), false)
+  assert.equal(prefersMarkdownFromAccept(null), false)
+  assert.equal(prefersMarkdownFromAccept(undefined), false)
+  // Unparseable q keeps the RFC default of 1 rather than dropping the range.
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=abc'), true)
+  assert.equal(prefersMarkdownFromAccept('text/markdown;q=7'), true)
+  assert.equal(prefersMarkdownFromAccept(',,text/markdown,,'), true)
+})
+
+test('parseAcceptHeader reports types and qualities', () => {
+  assert.deepEqual(parseAcceptHeader('text/html;q=0.9, text/markdown;q=0.1'), [
+    { type: 'text/html', quality: 0.9 },
+    { type: 'text/markdown', quality: 0.1 },
+  ])
+  assert.deepEqual(parseAcceptHeader('text/markdown'), [{ type: 'text/markdown', quality: 1 }])
+})

--- a/utils/acceptNegotiation.ts
+++ b/utils/acceptNegotiation.ts
@@ -1,0 +1,79 @@
+/**
+ * Accept-header parsing for markdown content negotiation.
+ *
+ * The proxy previously decided with `accept.includes('text/markdown')`, a
+ * substring test that ignores quality values entirely. That served markdown to
+ * clients that ranked HTML higher, and even to clients that explicitly refused
+ * markdown with `text/markdown;q=0`.
+ *
+ * Kept dependency-free so tests can load it via loadTsModule.
+ */
+
+const MARKDOWN_TYPE = 'text/markdown'
+const HTML_TYPE = 'text/html'
+
+type MediaRange = {
+  type: string
+  quality: number
+}
+
+/**
+ * RFC 9110 §12.4.2: quality is `q=` between 0 and 1. Anything malformed falls
+ * back to the default of 1 rather than dropping the range, so a client with a
+ * sloppy header still gets a sensible representation.
+ */
+const parseQuality = (parameters: string[]): number => {
+  const qParam = parameters.find((parameter) => parameter.trim().toLowerCase().startsWith('q='))
+  if (!qParam) return 1
+
+  const parsed = Number.parseFloat(qParam.trim().slice(2))
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1
+
+  return parsed
+}
+
+export const parseAcceptHeader = (accept: string): MediaRange[] =>
+  accept
+    .split(',')
+    .map((entry) => {
+      const [rawType, ...parameters] = entry.split(';')
+      const type = rawType.trim().toLowerCase()
+      if (!type) return null
+
+      return { type, quality: parseQuality(parameters) }
+    })
+    .filter((range): range is MediaRange => range !== null)
+
+/** Highest quality across the ranges that match `type`, or null if absent. */
+const qualityFor = (ranges: MediaRange[], type: string): number | null => {
+  const matches = ranges.filter((range) => range.type === type)
+  if (matches.length === 0) return null
+
+  return Math.max(...matches.map((range) => range.quality))
+}
+
+/**
+ * True when the client asked for markdown and ranked it at least as high as
+ * HTML.
+ *
+ * Deliberate choices:
+ * - Only an explicit `text/markdown` opts in. Wildcards (`*​/*`, `text/*`) never
+ *   do, so a default `curl` or a crawler sending `*​/*` keeps getting HTML.
+ * - A tie resolves to markdown. Agents commonly send `text/markdown, text/html`
+ *   with both at the default q=1, and that is the bulk of production markdown
+ *   traffic — flipping ties to HTML would regress it.
+ * - `text/markdown;q=0` means "not acceptable" and is honoured as a refusal.
+ */
+export const prefersMarkdownFromAccept = (accept: string | null | undefined): boolean => {
+  if (!accept) return false
+
+  const ranges = parseAcceptHeader(accept)
+  const markdownQuality = qualityFor(ranges, MARKDOWN_TYPE)
+
+  if (markdownQuality === null || markdownQuality === 0) return false
+
+  const htmlQuality =
+    qualityFor(ranges, HTML_TYPE) ?? qualityFor(ranges, 'text/*') ?? qualityFor(ranges, '*/*') ?? 0
+
+  return markdownQuality >= htmlQuality
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Markdown negotiation decides with a substring test — `proxy.ts`:

```ts
const prefersMarkdown = acceptHeader.toLowerCase().includes('text/markdown')
```

That ignores quality values entirely. Verified against **production** today:

| `Accept:` sent | Served | Correct? |
|---|---|---|
| `text/html;q=0.9, text/markdown;q=0.1` | `text/markdown` | ❌ HTML was ranked higher |
| `text/html,application/xhtml+xml,application/xml;q=0.9,text/markdown;q=0.1` | `text/markdown` | ❌ browser-shaped header |
| **`text/markdown;q=0`** | **`text/markdown`** | ❌❌ `q=0` means *not acceptable* |

The last row is the clear defect: RFC 9110 §12.4.2 defines `q=0` as an explicit refusal, and we serve it anyway. The browser-shaped row is the one with real reach — **any client that lists markdown as a low-priority fallback receives it as the primary representation.** This is the header we tell every agent to use in `llms.txt` and at the top of every markdown page, so it is the primary channel, not an edge case.

Flagged by [acceptmarkdown.com](https://acceptmarkdown.com/#readiness), which scores `signoz.io/docs/introduction/` at **75/100** with *"Honors q-values"* as a warning (`Served text/markdown; charset=utf-8 — expected HTML (higher q)`).

**Fix:** a real parser in `utils/acceptNegotiation.ts`, with four deliberate choices:

- **Only an explicit `text/markdown` opts in.** Wildcards (`*/*`, `text/*`) never do, so default `curl` and crawlers keep getting HTML.
- **A tie resolves to markdown.** Agents commonly send `text/markdown, text/html` with both at the default `q=1`, and that is the bulk of production markdown traffic (~11M requests/day). Flipping ties to HTML would regress it. This is the important compatibility decision in the PR.
- **`text/markdown;q=0` is honoured as a refusal.**
- **Malformed `q` falls back to the RFC default of 1** rather than dropping the range, so a sloppy header still gets a sensible representation.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
Faulty assumption: `Accept` was treated as a flat string to search rather than a ranked list of media ranges. `String.includes('text/markdown')` cannot distinguish *"markdown please"* from *"anything but markdown"*.

#### Fix Strategy
Parse `Accept` into `{ type, quality }` ranges, take the highest `q` for `text/markdown` and for `text/html` (falling back to `text/*`, then `*/*`), and serve markdown only when markdown's `q` is at least HTML's and non-zero.

---

### 🧪 Testing Strategy

**Tests added:** `tests/accept-negotiation.test.js` — 8 tests covering explicit opt-in, ties, the three production failures above, `q=0` refusal, wildcard non-opt-in, markdown vs wildcard fallback, malformed/missing headers, and the parser's own output.

**Existing suites:** `proxy` (39), `agent-markdown-routing` (14), `docs-markdown-routing` (13), `agent-discovery` (6) — all pass. `yarn lint` 0 errors. `yarn build` succeeds.

**Manual verification:** the three failing rows in the table above were reproduced against `https://signoz.io/docs/introduction/` before the change, and the new unit tests encode each one.

**Edge cases covered:** case-insensitivity, surrounding whitespace, empty entries (`,,text/markdown,,`), extra parameters (`text/markdown;charset=utf-8`), `q` out of range (`q=7`), non-numeric `q` (`q=abc`), null/undefined/empty header.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one boolean in `proxy.ts`. It gates every markdown rewrite, so it runs site-wide — but it only ever changes the answer for headers that carry an explicit `q`, and no rewrite path, route, or response body changes.
- **Potential regressions:** the real risk is narrowing negotiation and losing existing markdown traffic. Mitigated by resolving ties to markdown and by never requiring `q` to be present — `Accept: text/markdown` and `Accept: text/markdown, text/html` behave exactly as before, with tests pinning both.
- **Rollback plan:** revert; behaviour returns to the substring test.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | `Accept: text/markdown` negotiation now respects quality values, so clients that prefer HTML — or that decline markdown with `q=0` — receive HTML. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none — ties and bare `text/markdown` are unchanged by design)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**Deliberately not fixed:** the same scan warns that unsupported types return 200 instead of 406 (`Accept: application/x-content-negotiation-probe`). The scanner's own note concedes *"RFC 9110 also permits ignoring Accept and returning a default representation."* 406-ing unrecognised `Accept` headers would turn working pages into errors for clients that send junk or overly narrow headers. Serving HTML as the default is the safer, conformant behaviour — this warning should stay unfixed.

**Pre-existing unrelated failure:** `tests/llms-txt.test.js` has one failing assertion on `main` (the llms.txt H1 blockquote). It is not touched here and is fixed in #4094.

No overlap with #4067 or #4094 — different files, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
