### PR TITLE
docs(llm): embed demo videos in five LLM monitoring guides

### DIFF
--- a/data/docs/cline-monitoring.mdx
+++ b/data/docs/cline-monitoring.mdx
@@ -12,6 +12,8 @@ doc_type: howto
 
 Cline ships an <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> exporter inside the VS Code extension, so this needs no plugin or wrapper. It emits events and metrics under the service name `cline`. With Cline monitoring in SigNoz you can see token spend and cost broken down by model and by developer, how effective the prompt cache is, which tools the agent reaches for and which fail, request latency and time to first token, and every provider API error with its message.
 
+<YouTube id="bCAFEqIxdfc" mute="false" />
+
 ## Prerequisites
 
 - SigNoz setup (choose one):

--- a/data/docs/cursor-observability.mdx
+++ b/data/docs/cursor-observability.mdx
@@ -14,6 +14,8 @@ This guide closes that gap using <a href="https://opentelemetry.io/" target="_bl
 
 With Cursor IDE observability in SigNoz, you can see how many tokens your team is spending and on which models, how long a turn actually takes end to end, which tools the agent reaches for most, which ones fail and why, and how all of that breaks down per repository and branch.
 
+<YouTube id="jMJtJPBZ7Fw" mute="false" />
+
 ## Prerequisites
 
 - SigNoz setup (choose one):

--- a/data/docs/deepseek-harness-observability.mdx
+++ b/data/docs/deepseek-harness-observability.mdx
@@ -1,5 +1,6 @@
 ---
-date: 2026-08-19
+published_date: 2026-08-19
+updated_date: 2026-09-02
 title: DeepSeek Harness Observability & Monitoring with OpenTelemetry
 meta_title: DeepSeek Harness OpenTelemetry Monitoring
 description: Monitor DeepSeek Harness (dsh) with OpenTelemetry and SigNoz. Trace every agent turn, model call, and tool execution, and track token spend.
@@ -15,6 +16,8 @@ With full DeepSeek Harness observability in SigNoz, you can see how much your te
 <Admonition type="info" title="DeepSeek Harness emits traces, not metrics">
 The plugin exports two metrics, `gen_ai.client.operation.duration` and `gen_ai.client.token.usage`, but neither carries a session, user, or error dimension. Everything worth grouping by lives on the spans, so this guide and the dashboard both work from traces.
 </Admonition>
+
+<YouTube id="hMqjiXy9Qg0" mute="false" />
 
 ## Prerequisites
 

--- a/data/docs/openai-agents-sdk-observability.mdx
+++ b/data/docs/openai-agents-sdk-observability.mdx
@@ -1,5 +1,6 @@
 ---
-date: 2026-08-25
+published_date: 2026-08-25
+updated_date: 2026-09-02
 title: OpenAI Agents SDK Observability & Monitoring with OpenTelemetry
 meta_title: OpenAI Agents SDK OpenTelemetry Monitoring
 description: Monitor OpenAI Agents SDK apps with OpenTelemetry and SigNoz. Trace agent runs, model calls, tool executions and handoffs, and track token usage and errors.
@@ -15,6 +16,8 @@ This guide bridges that built-in tracing to OpenTelemetry so the same spans land
 OpenAI Agents SDK observability is the practice of collecting traces from agent applications so you can see what each run did: which agents ran, which models they called, how many tokens they consumed, which tools they invoked, and where they failed.
 
 With full OpenAI Agents SDK observability in SigNoz, you can trace a complete agent run end to end, attribute token spend to a model, watch tool call volume for loops that do not terminate, and correlate an agent failure with the rest of your application.
+
+<YouTube id="BsR5DnbTBCU" mute="false" />
 
 ## Prerequisites
 

--- a/data/docs/qwen-code-observability.mdx
+++ b/data/docs/qwen-code-observability.mdx
@@ -1,5 +1,6 @@
 ---
 published_date: 2026-08-24
+updated_date: 2026-09-02
 title: Qwen Code Observability and Monitoring with OpenTelemetry
 meta_title: Qwen Code CLI OpenTelemetry Monitoring
 description: Monitor Qwen Code CLI with OpenTelemetry and SigNoz. Trace every agent turn, model call, and tool execution, and track token spend across your team.
@@ -11,6 +12,8 @@ doc_type: howto
 <a href="https://github.com/QwenLM/qwen-code" target="_blank" rel="noopener noreferrer nofollow">Qwen Code</a> is Alibaba's open-source terminal coding agent. It ships its own <a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry</a> exporter, so instrumenting it is a matter of configuration: there is no library to install and no collector to run. Once enabled it emits all three signals, with traces covering every agent turn, model call, and tool execution, metrics covering token usage and runtime health, and structured log events for each session.
 
 With full Qwen Code observability in SigNoz, you can see how many tokens your team is spending and on which models, how much of each prompt is served from cache, how many round trips a single request actually takes, which tools the agent reaches for, and how much you are paying for background work nobody asked for.
+
+<YouTube id="46chzMkMhF8" mute="false" />
 
 ## Prerequisites
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Five LLM monitoring guides had a recorded walkthrough on YouTube but no embed on the page, so the video was only reachable from YouTube itself. This PR embeds each video in its matching doc.

| Doc | Video |
|---|---|
| `cline-monitoring` | [Cline Monitoring with OpenTelemetry](https://youtu.be/bCAFEqIxdfc) |
| `cursor-observability` | [Cursor IDE Monitoring with OpenTelemetry](https://youtu.be/jMJtJPBZ7Fw) |
| `openai-agents-sdk-observability` | [OpenAI Agents SDK Monitoring with OpenTelemetry](https://youtu.be/BsR5DnbTBCU) |
| `qwen-code-observability` | [Qwen Code Monitoring with OpenTelemetry](https://youtu.be/46chzMkMhF8) |
| `deepseek-harness-observability` | [DeepSeek Harness Monitoring with OpenTelemetry](https://youtu.be/hMqjiXy9Qg0) |

Each embed uses the existing `<YouTube id="..." mute="false" />` component and sits after the intro section and directly before `## Prerequisites`, which is where every other LLM doc with a video puts it (`agno-monitoring`, `langflow-observability`, `dify-observability`, and others). No prose was changed.

Two docs also move from the legacy `date` frontmatter field to `published_date` + `updated_date`:

- `deepseek-harness-observability` (`date: 2026-08-19`)
- `openai-agents-sdk-observability` (`date: 2026-08-25`)

`check-docs-metadata` rejects a modified doc whose date is more than 7 days old. Bumping `date` in place would have overwritten the real publish date, so the new-style pair is used instead, keeping the original publish date and recording the edit separately. `qwen-code-observability` already used `published_date`, so it only gains `updated_date`. `cline-monitoring` and `cursor-observability` are recent enough to need no date change.

#### Screenshots / Screen Recordings (if applicable)
N/A — the embed renders as the standard responsive YouTube iframe already used across the LLM docs.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
N/A — not a bug fix.

---

### 🧪 Testing Strategy

- Tests added/updated: none required; this is content only, and the `YouTube` component is unchanged.
- Manual verification:
  - `yarn check:docs-metadata` — passes on all five files.
  - `yarn check:doc-redirects` + `yarn test:doc-redirects` — pass.
  - `yarn test:docs-metadata` — one pre-existing failure, `should allow date exactly 7 days in the past`, which also fails on a clean `main` checkout and is unrelated to this change.
  - Every video ID confirmed against the YouTube oEmbed API so each doc carries the right video.
- Edge cases covered: no docs paths or URLs changed, so no redirect or sidebar update is needed.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: five docs pages under `data/docs/`. Nothing else on the site is touched.
- Potential regressions: minimal. Worst case is a wrong video on a page or an iframe blocked in a restricted network, neither of which affects the written instructions.
- Rollback plan: revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | The Cline, Cursor IDE, OpenAI Agents SDK, Qwen Code, and DeepSeek Harness monitoring docs now include an embedded video walkthrough. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

None of these five pages is a control page in either running `meta_title` SEO experiment, so the frontmatter change on `deepseek-harness-observability` and `openai-agents-sdk-observability` does not disturb the measurement.

Worth a second look at the frontmatter migration on those two files if the team would rather keep the legacy `date` field and use the `skip-date-check` label instead.
