### PR TITLE
docs: document license access control and v4 license API

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -258,6 +258,11 @@
           },
           {
             "type": "doc",
+            "route": "/docs/operate/migration/upgrade-0-140",
+            "label": "Upgrade to v0.140"
+          },
+          {
+            "type": "doc",
             "route": "/docs/operate/migration/upgrade-0-137",
             "label": "Upgrade to v0.137"
           },

--- a/data/docs/manage/administrator-guide/iam/reference/transactions.mdx
+++ b/data/docs/manage/administrator-guide/iam/reference/transactions.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-09-03
 title: Transactions Reference
 description: Complete reference of transactions for each resource in SigNoz covering relations, selector formats, and managed role access.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -19,7 +19,7 @@ A transaction is a single relation on a resource, optionally scoped to specific 
 For an explanation of relations and how access control works, see the [Authorization Overview](https://signoz.io/docs/manage/administrator-guide/iam/overview/).
 
 <Admonition type="info">
-This page currently covers roles, service accounts, API keys, and telemetry resources (logs, traces, metrics, meter metrics). Transactions for other observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
+This page currently covers roles, service accounts, API keys, licenses, and telemetry resources (logs, traces, metrics, meter metrics). Transactions for other observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
 </Admonition>
 
 ## Resources
@@ -65,6 +65,22 @@ This page currently covers roles, service accounts, API keys, and telemetry reso
 | `read` | View API key metadata (name, expiration, last used). | signoz-admin |
 | `update` | Modify API key metadata (for example, change the expiration date). | signoz-admin |
 | `delete` | Permanently revoke an API key. | signoz-admin |
+
+### License
+
+**Resource:** `metaresource` · **Kind:** `license` · **Selector:** license ID
+
+| Relation | Description | Managed Role Access |
+|----------|-------------|---------------------|
+| `create` | Activate a license by key. | signoz-admin |
+| `list` | List all licenses in the organization. | signoz-admin |
+| `read` | View a license's details, including the license key shown in Settings. | signoz-admin |
+| `update` | Refresh the active license from the SigNoz licensing server. | signoz-admin |
+| `delete` | Delete a self-hosted license. | signoz-admin |
+
+<Admonition type="info">
+`license:read` controls where the license key is exposed in the UI. Users with `license:read` see the masked license key and its copy button on the **Settings > General** and **Settings > My Settings** pages, and can load usage data on the **Billing** page. Users without it see a "not authorized" message in place of the key, and the Billing usage section does not load. On upgrade to v0.140.0, existing admin roles receive all five license relations automatically (see the [v0.140.0 upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-140/)); the signoz-editor and signoz-viewer managed roles do not receive license relations by default.
+</Admonition>
 
 ### Logs
 

--- a/data/docs/manage/administrator-guide/iam/roles.mdx
+++ b/data/docs/manage/administrator-guide/iam/roles.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-31
+date: 2026-09-03
 title: Roles
 description: Create and manage roles in SigNoz — managed roles, custom roles, and configuring transactions with the interactive or JSON editor.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -65,7 +65,7 @@ A role's access is defined by its **Transaction Groups** — the set of relation
 
 ### Interactive mode
 
-Interactive mode presents one card per resource (**Roles**, **Service Accounts**, **API Keys**). Use **Expand all** / **Collapse all** to open every card at once. Within a card, set the scope for each action (relation):
+Interactive mode presents one card per resource (**Roles**, **Service Accounts**, **API Keys**, **Licenses**). Use **Expand all** / **Collapse all** to open every card at once. Within a card, set the scope for each action (relation):
 
 - **All** — Grants the transaction on every instance of that resource type.
 - **Only selected** — Grants the transaction only on specific instances. Enter the selector for each instance (for example, a role name or a service account ID) and press **Add**. See the [Transactions Reference](https://signoz.io/docs/manage/administrator-guide/iam/reference/transactions/) for the selector format used by each resource.

--- a/data/docs/operate/migration/upgrade-0-140.mdx
+++ b/data/docs/operate/migration/upgrade-0-140.mdx
@@ -1,0 +1,96 @@
+---
+date: 2026-09-03
+title: Upgrade SigNoz to v0.140.0 and Migrate to the v4 License API
+tags: [Self-Hosted Enterprise]
+description: Upgrade self-hosted SigNoz to v0.140.0. Migration 120 grants admin roles the new license permissions, and the license API moves from v3 to v4.
+doc_type: howto
+---
+
+SigNoz v0.140.0 puts license management behind fine-grained access control and adds a `/api/v4/licenses` API. Viewing the license key now requires the `license:read` permission, a database migration grants that permission to admin roles automatically, and the `/api/v3/licenses` endpoints are deprecated. If you use SigNoz only through the UI as an admin, nothing changes. If you read the license key from the API or from a non-admin account, review the changes below.
+
+<Admonition type="info" title="Viewing the license key now requires license:read">
+The license key on **Settings > General** and **Settings > My Settings**, and the usage data on the **Billing** page, are now gated by the `license:read` permission. Migration 120 grants it to admin roles on startup, so admins keep access. Users on the signoz-editor and signoz-viewer roles (or custom roles without the grant) see a "not authorized" message in place of the key, and the Billing usage section does not load. To restore access for a custom role, add the `license:read` relation to it. See the [Transactions Reference](https://signoz.io/docs/manage/administrator-guide/iam/reference/transactions/).
+</Admonition>
+
+<Admonition type="info" title="The v3 license endpoints are deprecated">
+`POST /api/v3/licenses` and `PUT /api/v3/licenses` keep working in v0.140.0, but they are deprecated. Move new integrations to the [v4 endpoints](#the-new-v4-license-api). The v4 responses drop the license key from `GET /api/v4/licenses/active`, so scripts that read the key must switch to `GET /api/v4/licenses/{id}` with the `license:read` permission.
+</Admonition>
+
+## Upgrade self-hosted SigNoz
+
+### Step 1: Back up your data
+
+Role assignments and license records live in the SigNoz Metastore alongside dashboards and alerts. Back up the Metastore (SQLite or Postgres) before you start. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops before you move to v0.140.0.
+
+### Step 2: Upgrade SigNoz
+
+Migration 120 runs once, automatically, when the server starts on the new version. It grants the built-in Admin role the five license relations (`create`, `list`, `read`, `update`, `delete`) for every organization. No manual step is required.
+
+<Tabs entityName="installer">
+<TabItem value="foundry" label="Foundry" default>
+
+Upgrade <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">foundryctl</a> to pick up the v0.140.0 defaults, then re-apply your existing `casting.yaml`:
+
+```bash
+curl -fsSL https://signoz.io/foundry.sh | bash
+foundryctl cast -f casting.yaml
+```
+
+If your <a href="https://github.com/SigNoz/foundry/blob/main/docs/reference/casting-file.md" target="_blank" rel="noopener noreferrer nofollow">casting.yaml</a> pins image versions, the new defaults will not override them (your config wins), so bump the SigNoz image pin to v0.140.0 yourself.
+
+</TabItem>
+<TabItem value="helm" label="Kubernetes (Helm chart)">
+
+Update the <a href="https://github.com/SigNoz/charts" target="_blank" rel="noopener noreferrer nofollow">chart</a> and upgrade. Replace `<namespace>` and `<release-name>` with your own values:
+
+```bash
+helm repo update
+helm -n <namespace> upgrade <release-name> signoz/signoz
+```
+
+`helm upgrade` takes the newest chart; add `--version 0.140.0` to pin the v0.140.0 chart.
+
+</TabItem>
+</Tabs>
+
+For Docker or binary deployments, follow the [standard upgrade guide](https://signoz.io/docs/operate/migration/upgrade-standard/) and set the target version to v0.140.0.
+
+### Step 3: Verify the upgrade
+
+1. Pods and containers are healthy (`kubectl get pods -n <namespace>`, `docker compose ps`, or `systemctl status 'signoz-*'`).
+2. SigNoz reports v0.140.0 under **Settings**.
+3. Open **Settings > General** as an admin and confirm the masked license key and its copy button are visible.
+4. Open **Settings > Organization > Roles**, edit any admin role, and confirm the **Licenses** resource card shows the `create`, `list`, `read`, `update`, and `delete` relations.
+
+## What changes for API callers
+
+### The v4 license API
+
+v0.140.0 adds six endpoints under `/api/v4/licenses`. Each write and read of a specific license is scoped by a `license` permission:
+
+| Endpoint | Purpose | Required permission |
+|----------|---------|---------------------|
+| `POST /api/v4/licenses` | Activate a license by key. Returns `201 Created` with the new license ID. | `license:create` |
+| `GET /api/v4/licenses` | List all licenses for the organization. | `license:list` |
+| `GET /api/v4/licenses/active` | Get the active license metadata. The license key is **not** included. | Open access (no permission required) |
+| `GET /api/v4/licenses/{id}` | Get a specific license, including its license key. | `license:read` |
+| `PUT /api/v4/licenses/{id}` | Refresh the active license from the SigNoz licensing server. | `license:update` |
+| `DELETE /api/v4/licenses/{id}` | Delete a self-hosted license. Licenses managed by SigNoz Cloud are rejected. | `license:delete` |
+
+For the full request and response schema, see the Licenses endpoints in the [SigNoz API reference](https://signoz.io/api-reference/).
+
+### Response format changes
+
+The v4 responses differ from v3 in three ways:
+
+- **Fields are camelCase.** For example, `valid_from` becomes `validFrom`, `free_until` becomes `freeUntil`, `event_queue` becomes `eventQueue`, and `created_at` / `updated_at` become `createdAt` / `updatedAt`.
+- **Enum values are lowercase.** License state, status, and platform values are lowercase (for example, `ACTIVATED` becomes `activated`, `CLOUD` becomes `cloud`, and `EVALUATION_EXPIRED` becomes `evaluation_expired`).
+- **The license key is absent from the active-license response.** `GET /api/v4/licenses/active` no longer returns the key. To read the key, call `GET /api/v4/licenses/{id}` with the `license:read` permission.
+
+## Getting help
+
+- [SigNoz Documentation](https://signoz.io/docs/introduction/)
+- <a href="https://github.com/SigNoz/signoz/issues" target="_blank" rel="noopener noreferrer nofollow">GitHub Issues</a>
+- [Community Slack](https://signoz.io/slack/)
+</content>
+</invoke>


### PR DESCRIPTION
## Description

Documents the license access-control and v4 license API changes from #12731 and #12736 (ships in v0.140.0).

- **Transactions Reference** — added the new `License` resource (`metaresource` / kind `license`) with its five relations (create / list / read / update / delete), all granted to signoz-admin. Added a note that `license:read` gates the license key on Settings > General / My Settings and usage data on Billing, and that signoz-editor/signoz-viewer do not receive it.
- **Roles** — added the **Licenses** card to the interactive-mode resource list.
- **Upgrade guide (new, v0.140.0)** — documents migration 120 (auto-grants license relations to admin roles on startup), the license-key visibility change for non-admins, the v3 deprecation, the six `/api/v4/licenses` endpoints with their required permission scopes, and the response-format changes (camelCase fields, lowercase enums, key removed from the active-license response).
- **Sidebar** — added the v0.140 upgrade guide entry.
- Updated the `date` frontmatter on every edited file.

### Notes for reviewers

- The API Reference renders from the product `openapi.yml` by release tag, so the v4 endpoints and v3-deprecation flags will surface there automatically once v0.140.0 is tagged. No hand-authored API MDX was added.
- Deliverable feature 16 ("POST /api/v3/licenses now returns 409 instead of 202") appears inaccurate: both v3 and v4 already return 409 on an already-active license, so no behavioral change is documented.
- Screenshots pending: demo credentials were unavailable and the feature merged the day before this batch, so the PR is prose-only. The Settings license-key row, the restricted "not authorized" state, and the Roles > Licenses panel still need capture.

Source PRs: #12731, #12736

Auto-generated by docs-sync pipeline