### PR TITLE
docs(llm): add query-matched meta_title to Ollama and Hermes

### DIFF
--- a/data/docs/hermes-monitoring.mdx
+++ b/data/docs/hermes-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Hermes Monitoring and Observability with OpenTelemetry
+meta_title: "Hermes Agent Observability and Telemetry"
 description: Set up Hermes Agent monitoring with OpenTelemetry and SigNoz. Trace long-running agent sessions, skill execution, subagent runs, and model calls.
 doc_type: howto
 ---

--- a/data/docs/ollama-monitoring.mdx
+++ b/data/docs/ollama-monitoring.mdx
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-03
 title: Ollama Monitoring & Observability with OpenTelemetry
+meta_title: "Ollama Monitoring: Telemetry and Metrics"
 description: Set up Ollama monitoring and observability with OpenTelemetry and SigNoz. Track traces, logs, and metrics for full LLM visibility in real-time.
 doc_type: howto
 ---


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds `meta_title` to two LLM docs whose current titles do not contain the words people actually search for.

This is deliberately **two pages, not fifty-two**. The controlled `meta_title` experiment on 11 guides (#3904, merged 2026-08-06) has now had three reads and shows **no measurable CTR effect**: difference-in-differences of -0.013 pp with a 95% CI of [-0.41, +0.38]. Populating the field is not the lever. Matching the query is, and only a handful of pages have a measured gap worth closing.

Both changes come from GSC `page,query` data over the last 90 days, restricted to reachable queries (machine fan-out, `site:` operators and below-position-20 queries excluded).

**`ollama-monitoring`**

Current title is `Ollama Monitoring & Observability with OpenTelemetry`. It contains neither "telemetry" as a standalone word nor "metrics", which together are 532 of 1,383 reachable attributable impressions.

| Query | Impressions | Position |
|---|---|---|
| `ollama telemetry` | 240 | 3.8 |
| `ollama monitoring` | 216 | 5.9 |
| `ollama metrics` | 169 | 7.7 |
| `ollama monitor` | 139 | 7.2 |

New: `Ollama Monitoring: Telemetry and Metrics`

**`hermes-monitoring`**

Current title is `Hermes Monitoring and Observability with OpenTelemetry`. The word "agent" appears in 414 of 760 reachable attributable impressions (54%) and is absent from the title entirely.

| Query | Impressions | Position |
|---|---|---|
| `hermes agent observability` | 98 | 4.2 |
| `hermes agent telemetry` | 97 | 4.4 |
| `hermes observability` | 90 | 1.9 |
| `hermes telemetry` | 64 | 5.0 |
| `hermes agent monitoring` | 56 | 6.3 |

New: `Hermes Agent Observability and Telemetry`

Both render at 54 characters including the `| SigNoz Docs` template suffix from `app/(site)/docs/layout.tsx`, so neither truncates in the SERP. The current titles render at 66 and 68 and do truncate.

#### Screenshots / Screen Recordings (if applicable)

N/A. Frontmatter-only change; no visual surface is affected. The `meta_title` field is consumed by `generateMetadata` in `app/(site)/docs/(main-docs)/[...slug]/page.tsx` and appears only in the `<title>` tag, not on the rendered page. The on-page H1 still comes from `title` and is unchanged.

#### Issues closed by this PR

None.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

Documentation metadata. None of the above categories fit cleanly.

---

### 🐛 Bug Context

N/A. Not a bug fix.

---

