### PR TITLE
docs: update billing and subscription permission documentation

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -258,6 +258,11 @@
           },
           {
             "type": "doc",
+            "route": "/docs/operate/migration/upgrade-0-141",
+            "label": "Upgrade to v0.141"
+          },
+          {
+            "type": "doc",
             "route": "/docs/operate/migration/upgrade-0-137",
             "label": "Upgrade to v0.137"
           },

--- a/data/docs/faqs/general.mdx
+++ b/data/docs/faqs/general.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-20
+date: 2026-09-08
 title: General FAQs
 description: Answers to common SigNoz questions covering setup, billing, and account management.
 ---
@@ -48,6 +48,10 @@ You can ingest data from across your environments and tag your telemetry with th
 
 A. SigNoz Cloud subscriptions are cancelled by emailing the support team. Open **Settings → Billing**, click **Cancel subscription**, type `cancel` in the confirmation field, and click **Cancel subscription** to confirm. 
 You can also reach out via the chatbox at the bottom right corner of your SigNoz Cloud interface instead.
+
+<Admonition type="info">
+The Billing page is open to all roles, but the **Cancel subscription** action requires the subscription `delete` permission. By default only the built-in admin role has it. To let a non-admin cancel, an admin grants the relation through a [custom role](https://signoz.io/docs/manage/administrator-guide/iam/reference/transactions/#subscription).
+</Admonition>
 
 ### Q. What happens when my SigNoz Cloud trial expires?
 

--- a/data/docs/faqs/product.mdx
+++ b/data/docs/faqs/product.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-11
+date: 2026-09-08
 
 title: Product - FAQs
 description: Frequently Asked Questions About SigNoz
@@ -42,6 +42,10 @@ add or update your info by clicking on `Update information`.
     <img src="/img/docs/faq/product-faq/Product-faq-billing-1.webp" width="80%" alt="Update Billing Information"/>
     <figcaption><i>Update Billing Information</i></figcaption>
 </figure>
+
+<Admonition type="info">
+All roles can open the **Billing** tab. Individual actions are gated by the subscription permission: **Upgrade Plan** needs `create`, **Manage Billing** needs `update`, and the usage data needs `read`. By default only the built-in admin role holds these, so non-admins see the actions disabled with a tooltip until an admin grants the relations through a [custom role](https://signoz.io/docs/manage/administrator-guide/iam/reference/transactions/#subscription).
+</Admonition>
 
 </details>
 

--- a/data/docs/manage/administrator-guide/iam/reference/transactions.mdx
+++ b/data/docs/manage/administrator-guide/iam/reference/transactions.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-09-08
 title: Transactions Reference
 description: Complete reference of transactions for each resource in SigNoz covering relations, selector formats, and managed role access.
 tags: [SigNoz Cloud, Self-Hosted Enterprise]
@@ -19,7 +19,7 @@ A transaction is a single relation on a resource, optionally scoped to specific 
 For an explanation of relations and how access control works, see the [Authorization Overview](https://signoz.io/docs/manage/administrator-guide/iam/overview/).
 
 <Admonition type="info">
-This page currently covers roles, service accounts, API keys, and telemetry resources (logs, traces, metrics, meter metrics). Transactions for other observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
+This page currently covers roles, service accounts, API keys, the subscription (billing) resource, and telemetry resources (logs, traces, metrics, meter metrics). Transactions for other observability resources such as dashboards, alerts, and pipelines will be documented as they become available for fine-grained access control.
 </Admonition>
 
 ## Resources
@@ -65,6 +65,24 @@ This page currently covers roles, service accounts, API keys, and telemetry reso
 | `read` | View API key metadata (name, expiration, last used). | signoz-admin |
 | `update` | Modify API key metadata (for example, change the expiration date). | signoz-admin |
 | `delete` | Permanently revoke an API key. | signoz-admin |
+
+### Subscription
+
+**Resource:** `metaresource` · **Kind:** `subscription` · **Selector:** organization-wide (wildcard only)
+
+The subscription resource governs the **Settings > Billing** page and its actions. Each relation controls one part of that page. All users can open the Billing page, but the usage data and each action are gated by the relations below.
+
+| Relation | Description | Managed Role Access |
+|----------|-------------|---------------------|
+| `read` | View the usage graph, usage breakdown table, and CSV download on the Billing page. Without it, these are replaced by a "not authorized" callout. | signoz-admin |
+| `create` | Start a checkout session to upgrade the plan (the **Upgrade Plan** button, and the credit-card and chat actions on the Support page). | signoz-admin |
+| `update` | Open the Stripe billing portal (the **Manage Billing** button). Enforced together with `list`. | signoz-admin |
+| `list` | Read the subscription state the billing portal needs. Enforced together with `update` for **Manage Billing**. | signoz-admin |
+| `delete` | Cancel the subscription (the **Cancel subscription** action on the Billing page). | signoz-admin |
+
+<Admonition type="info">
+Only the built-in **signoz-admin** role receives subscription transactions by default; a database migration backfills them on upgrade. Users in the **signoz-editor** and **signoz-viewer** roles can open the Billing page but see the usage data and every action disabled (with an authorization tooltip) until an admin grants the relevant relations through a custom role. Delete has no dedicated API route; it gates the **Cancel subscription** action in the UI, and cancellation is completed through the Stripe billing portal.
+</Admonition>
 
 ### Logs
 
@@ -137,3 +155,4 @@ Some operations require transactions on multiple resources. Both transactions mu
 | Unassign a role from a service account | `serviceaccount:detach` AND `role:detach` |
 | Create an API key for a service account | `factor-api-key:create` AND `serviceaccount:attach` |
 | Revoke an API key from a service account | `factor-api-key:delete` AND `serviceaccount:detach` |
+| Open the billing portal (Manage Billing) | `subscription:list` AND `subscription:update` |

--- a/data/docs/operate/migration/upgrade-0-141.mdx
+++ b/data/docs/operate/migration/upgrade-0-141.mdx
@@ -1,0 +1,79 @@
+---
+date: 2026-09-08
+title: Upgrade SigNoz to v0.141.0 and Migrate Billing to Subscriptions
+tags: [Self-Hosted Community, Self-Hosted Enterprise]
+description: Upgrade self-hosted SigNoz to v0.141.0. The legacy billing endpoints are removed for the new subscription API, and SIGNOZ_LICENSE_API_KEY is no longer read.
+doc_type: howto
+---
+
+SigNoz v0.141.0 replaces the legacy billing endpoints with a unified `/api/v1/subscriptions` resource and removes the `SIGNOZ_LICENSE_API_KEY` environment variable. No action is needed if you only use billing through the SigNoz UI. If you call the billing endpoints from scripts or set `SIGNOZ_LICENSE_API_KEY` in your deployment, read the breaking changes below before you upgrade.
+
+<Admonition type="warning" title="The legacy billing endpoints are removed">
+`POST /api/v1/checkout`, `GET /api/v1/billing`, and `POST /api/v1/portal` are removed in v0.141.0. Any script or integration that calls them fails with `404 Not Found` after the upgrade. Move to the [subscription endpoints](#migrate-to-the-subscription-endpoints) first.
+</Admonition>
+
+## Upgrade self-hosted SigNoz
+
+### Step 1: Remove `SIGNOZ_LICENSE_API_KEY`
+
+SigNoz no longer reads the `SIGNOZ_LICENSE_API_KEY` environment variable. If you set it in your deployment configuration (Helm values, Docker Compose, `.env`, or a systemd unit), remove it. Leaving it set has no effect, but cleaning it up keeps your configuration accurate.
+
+### Step 2: Upgrade SigNoz
+
+<Tabs entityName="installer">
+<TabItem value="foundry" label="Foundry" default>
+
+Upgrade <a href="https://github.com/SigNoz/foundry/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer nofollow">foundryctl</a> to pick up the v0.141.0 defaults, then re-apply your existing `casting.yaml`:
+
+```bash
+curl -fsSL https://signoz.io/foundry.sh | bash
+foundryctl cast -f casting.yaml
+```
+
+If your <a href="https://github.com/SigNoz/foundry/blob/main/docs/reference/casting-file.md" target="_blank" rel="noopener noreferrer nofollow">casting.yaml</a> pins image versions, the new defaults will not override them (your config wins), so bump the SigNoz image pin to v0.141.0 yourself.
+
+</TabItem>
+<TabItem value="helm" label="Kubernetes (Helm chart)">
+
+Update the <a href="https://github.com/SigNoz/charts" target="_blank" rel="noopener noreferrer nofollow">chart</a> and upgrade. Replace `<namespace>` and `<release-name>` with your own values:
+
+```bash
+helm repo update
+helm -n <namespace> upgrade <release-name> signoz/signoz
+```
+
+`helm upgrade` takes the newest chart; add `--version 0.141.0` to pin the v0.141.0 chart.
+
+</TabItem>
+</Tabs>
+
+For Docker or binary deployments, follow the [standard upgrade guide](https://signoz.io/docs/operate/migration/upgrade-standard/) and set the target version to v0.141.0. If you are more than one release behind, check the [Upgrade Path Tool](https://signoz.io/upgrade-path/) for required stops before you move to v0.141.0.
+
+### Step 3: Verify the upgrade
+
+1. Pods and containers are healthy (`kubectl get pods -n <namespace>`, `docker compose ps`, or `systemctl status 'signoz-*'`).
+2. SigNoz reports v0.141.0 under **Settings**.
+3. If you use SigNoz Cloud or Enterprise billing, open **Settings > Billing** and confirm the page loads.
+
+## Migrate to the subscription endpoints
+
+The three legacy billing routes are replaced one-for-one by the `/api/v1/subscriptions` resource. Update any scripts to the new endpoints:
+
+| Removed endpoint | Replacement | Notes |
+|------------------|-------------|-------|
+| `POST /api/v1/checkout` | `POST /api/v1/subscriptions` | Starts a Stripe checkout session and returns a `redirectURL`. Returns `409 Conflict` if checkout is already complete. |
+| `POST /api/v1/portal` | `PUT /api/v1/subscriptions` | Opens the Stripe billing portal and returns a `redirectURL`. The HTTP method changes from `POST` to `PUT`, and the success status changes from `201` to `200`. |
+| `GET /api/v1/billing` | `GET /api/v1/subscriptions` | Returns the current subscription status, billing period, discount, and a day-wise usage breakdown (per signal type, unit, and tier pricing). |
+
+<Admonition type="info" title="Enterprise-only and admin-only">
+The subscription endpoints require the admin scope and are available only in Enterprise deployments. Community deployments return an explicit `subscription_unsupported` error (not a `404`) for all three. Access is governed by the new subscription resource in fine-grained access control. See the [Transactions Reference](https://signoz.io/docs/manage/administrator-guide/iam/reference/transactions/#subscription) for the relations that gate each action.
+</Admonition>
+
+For the full request and response schema, see the subscription endpoints in the [SigNoz API reference](https://signoz.io/api-reference/).
+
+## Getting help
+
+- [SigNoz Documentation](https://signoz.io/docs/introduction/)
+- <a href="https://github.com/SigNoz/signoz/issues" target="_blank" rel="noopener noreferrer nofollow">GitHub Issues</a>
+- [Community Slack](https://signoz.io/slack/)
+


### PR DESCRIPTION
## Description

The Zeus billing migration (PRs #12766, #12767, #12769, #12771) replaces the legacy billing endpoints with a unified `/api/v1/subscriptions` resource and gates billing actions behind a new subscription permission. This documents the user-facing and operator-facing changes.

- Added the **Subscription** resource to the FGA Transactions Reference: the five relations (read/create/update/list/delete), the UI action each gates, and the `subscription:list` + `subscription:update` compound requirement for Manage Billing. Verified against the product's managed-role registry and route definitions.
- Documented the access model on the billing FAQs: all roles can open the Billing page, but usage data and each action are gated by the subscription permission, which only the built-in admin role holds by default.
- Added the **v0.141.0 upgrade guide** covering the removal of `POST /api/v1/checkout`, `GET /api/v1/billing`, and `POST /api/v1/portal`, their `/api/v1/subscriptions` replacements (including the portal POST→PUT / 201→200 change), and the removal of the `SIGNOZ_LICENSE_API_KEY` environment variable.
- Updated the migration sidebar entry and the `date` frontmatter on every edited file.

The API reference is auto-generated from the product `openapi.yml`, so the new endpoints are not hand-authored here. Changes are prose-only: the features are not yet in a release (ship in v0.141.0) and are unavailable on the demo, so no screenshots were captured.

## Additional Information

Notes for the reviewer (from source verification):
- Migration `125_add_subscription_tuples` backfills subscription tuples for **signoz-admin only**. The deliverable stated Editor and Viewer also receive defaults; the code does not grant them any, so the docs say non-admins need a custom role. Please confirm this is intended.
- Target version **v0.141.0** derived from tag+1 (latest tag is v0.140.0; these commits are not yet released). Rename the upgrade guide if the release lands under a different version.

Source PRs: #12766, #12767, #12769, #12771

Auto-generated by docs-sync pipeline