### PR TITLE
hotfix(analytics): allow option to exclude specific user agents from events

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,11 @@ import type { NextRequest } from 'next/server'
 import { waitUntil, ipAddress } from '@vercel/functions'
 import { v4 as uuidv4 } from 'uuid'
 import { NOT_FOUND_PATHNAME_HEADER } from '@/components/not-found/constants'
-import { detectBotFromUserAgent, logEventServerSide } from './utils/logEvent'
+import {
+  detectBotFromUserAgent,
+  isAnalyticsExcludedUserAgent,
+  logEventServerSide,
+} from './utils/logEvent'
 import { getPageType } from '@/utils/getPageType'
 import {
   buildDocsMarkdownRewritePath,
@@ -56,6 +60,7 @@ export function proxy(req: NextRequest) {
   // Get user agent and detect bot
   const userAgent = req.headers.get('user-agent') || ''
   const { isBot, botType } = detectBotFromUserAgent(userAgent)
+  const isExcludedFromAnalytics = isAnalyticsExcludedUserAgent(userAgent)
 
   const acceptHeader = req.headers.get('accept') || ''
   const contentTypeHeader = req.headers.get('content-type') || ''
@@ -90,7 +95,7 @@ export function proxy(req: NextRequest) {
   requestHeaders.set(GROWTHBOOK_ANONYMOUS_ID_HEADER, growthBookAnonymousId)
 
   // Log bot requests
-  if (isBot) {
+  if (isBot && !isExcludedFromAnalytics) {
     // Use waitUntil to ensure logging completes before function termination
     waitUntil(
       logEventServerSide({
@@ -163,7 +168,7 @@ export function proxy(req: NextRequest) {
     }
 
     // Markdown responses run no client JS, so log the page view server-side.
-    if (!isBot && req.method === 'GET') {
+    if (!isBot && !isExcludedFromAnalytics && req.method === 'GET') {
       const pageTypePath = pathname.replace(/\/+$/, '').replace(/\.md$/, '') || '/'
 
       waitUntil(

--- a/utils/logEvent.test.ts
+++ b/utils/logEvent.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { logEvent } from './logEvent'
+import { isAnalyticsExcludedUserAgent, logEvent } from './logEvent'
 
 describe('logEvent', () => {
   beforeEach(() => {
@@ -76,5 +76,34 @@ describe('logEvent', () => {
 
     expect(fetch).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
+  })
+})
+
+describe('isAnalyticsExcludedUserAgent', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('excludes user agents containing a configured substring, case-insensitively', () => {
+    vi.stubEnv('ANALYTICS_EXCLUDED_USER_AGENTS', 'acme-crawler')
+
+    expect(isAnalyticsExcludedUserAgent('Acme-Crawler/1.2.0')).toBe(true)
+    expect(isAnalyticsExcludedUserAgent('node-fetch acme-crawler')).toBe(true)
+    expect(isAnalyticsExcludedUserAgent('Mozilla/5.0 (Macintosh)')).toBe(false)
+  })
+
+  it('supports a comma-separated list and ignores surrounding whitespace', () => {
+    vi.stubEnv('ANALYTICS_EXCLUDED_USER_AGENTS', 'acme-crawler, sample-probe ,,')
+
+    expect(isAnalyticsExcludedUserAgent('Sample-Probe/0.1')).toBe(true)
+    expect(isAnalyticsExcludedUserAgent('acme-crawler')).toBe(true)
+    expect(isAnalyticsExcludedUserAgent('curl/8.0')).toBe(false)
+  })
+
+  it('excludes nothing when the env var is unset or the user agent is empty', () => {
+    expect(isAnalyticsExcludedUserAgent('acme-crawler')).toBe(false)
+
+    vi.stubEnv('ANALYTICS_EXCLUDED_USER_AGENTS', 'acme-crawler')
+    expect(isAnalyticsExcludedUserAgent('')).toBe(false)
   })
 })

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -17,6 +17,18 @@ export type LogEventOptions = {
   transport?: 'fetch' | 'beacon'
 }
 
+export const isAnalyticsExcludedUserAgent = (userAgent: string): boolean => {
+  const excludedPatterns = process.env.ANALYTICS_EXCLUDED_USER_AGENTS
+  if (!excludedPatterns || !userAgent) return false
+
+  const ua = userAgent.toLowerCase()
+  return excludedPatterns
+    .split(',')
+    .map((pattern) => pattern.trim().toLowerCase())
+    .filter(Boolean)
+    .some((pattern) => ua.includes(pattern))
+}
+
 const buildQueryString = (queryParams?: Record<string, string>) => {
   if (!queryParams) return ''
 


### PR DESCRIPTION


## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

To add functionality to exclude specific UA strings from sending analytics events.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.
NA

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
NA, hotfix

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Updated
- Manual verification: NA
- Edge cases covered: NA

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Analytics events exclusion 
- Potential regressions: NA
- Rollback plan: Revert PR


---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
