### PR TITLE
docs: document boolean quick filters and time-scoped value suggestions

### DIFF
--- a/data/docs/dashboards/dashboard-templates/langflow-dashboard.mdx
+++ b/data/docs/dashboards/dashboard-templates/langflow-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-31
+date: 2026-09-09
 title: Langflow Dashboard
 description: Monitor Langflow flows and agents with a focus on LLM usage such as token consumption, per-model breakdown, call latency, tool calls, and errors.
 doc_type: explanation
@@ -50,7 +50,7 @@ This dashboard tracks critical performance and cost metrics for your Langflow se
 | **Avg Tokens / Call** | Value | Average of `gen_ai.usage.total_tokens` per LLM call |
 | **Agent / Flow Runs** | Value | Count of `invoke_agent LangGraph` spans, representing agent and flow executions |
 | **Tool Calls** | Value | Count of spans whose name matches `execute_tool%`, representing tool invocations |
-| **Errors** | Value | Count of spans with `hasError = true`; highlights failures in the selected window |
+| **Errors** | Value | Count of spans with `has_error = true`; highlights failures in the selected window |
 
 ### Token & Model Usage
 

--- a/data/docs/logs-management/features/logs-quick-filters.mdx
+++ b/data/docs/logs-management/features/logs-quick-filters.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-04
+date: 2026-09-09
 title: Logs Quick Filters
 description: Learn how to use quick filters in the SigNoz Logs Explorer to narrow log results by key attributes and speed up troubleshooting.
 doc_type: howto
@@ -52,5 +52,11 @@ To customize: click the **settings icon** at the top-right of the quick filters 
 <Admonition type="info">
 Only users with the **Admin** role can edit quick filters. Users with the Viewer or Editor role do not have access to this feature.
 </Admonition>
+
+## Boolean and Time-Scoped Filters
+
+When you expand a quick filter backed by a boolean attribute, SigNoz shows **true** and **false** as selectable checkboxes instead of a blank panel.
+
+Quick filter value suggestions are scoped to the selected time range: the values listed for a filter such as **Service Name** reflect activity within the current time window. Searching for a field in the **Edit quick filters** picker is case-insensitive for built-in columns, so typing `SEVERITY` matches `severity_text`.
 
 For the list of default filter attributes and their OpenTelemetry mappings, see the [Default Quick Filters Reference](https://signoz.io/docs/logs-management/features/logs-quick-filters-reference/).

--- a/data/docs/userguide/traces.mdx
+++ b/data/docs/userguide/traces.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-25
+date: 2026-09-09
 title: Trace Explorer
 description: Understand the Trace Explorer in SigNoz — views, filtering, trace matching, and how to save and act on your results.
 doc_type: explanation
@@ -238,6 +238,16 @@ The Traces Explorer provides quick filtering of spans using various parameters o
 To clear a filter, click **Clear All** next to the filter category. To reset all filters at once, use the Reset button at the top.
 
 </details>
+
+### Boolean Filters
+
+Boolean quick filters render **true** and **false** as selectable checkboxes when you expand them, instead of a blank panel. This applies to the **Has Error** span field (`has_error`) and to any custom quick filter backed by a boolean attribute.
+
+The **Is Root** and **Is Entry Point** filters offer only **true**, because spans cannot be explicitly filtered to `false` for these search scopes.
+
+<Admonition type="info">
+Quick filter value suggestions are scoped to the selected time range. When you expand a filter such as **Service Name** or **HTTP Host**, the listed values reflect activity within the current time window. Field key search in the **Edit quick filters** picker is case-insensitive for built-in columns, so `HTTP_` matches `http_host`.
+</Admonition>
 
 ### Adding Custom Quick Filters
 


### PR DESCRIPTION
## Pull Request

### 📄 Summary

Documents the Quick Filters improvements from SigNoz PR #12794.

- **Trace Explorer** (`userguide/traces.mdx`): new *Boolean Filters* subsection noting that boolean quick filters (`has_error` and custom boolean attributes) now show **true**/**false** checkboxes, that **Is Root** / **Is Entry Point** offer only `true`, and that value suggestions are scoped to the selected time range with case-insensitive field key search.
- **Logs Quick Filters** (`logs-management/features/logs-quick-filters.mdx`): new *Boolean and Time-Scoped Filters* section covering the same behavior for logs.
- **Langflow Dashboard template**: corrected the stray `hasError = true` reference to `has_error = true` (the only literal `hasError` left in docs; every other page already uses `has_error`).
- Updated the `date` frontmatter on all edited files.

#### Screenshots / Screen Recordings (if applicable)

None. The feature merged 2026-09-08 and the demo build lags, so no new screenshots were captured. Add them once the demo catches up.

---

## 👀 Notes for Reviewers

- Prose-only, scoped to PR #12794.
- Migration 126 rewrites stored quick filter configs to canonical field names automatically on first startup, with no user action or data loss. It is non-breaking, so no upgrade-guide entry was added (the relevant `upgrade-0-141` file does not yet exist on `main`).

Source PRs: #12794

Auto-generated by docs-sync pipeline
