### PR TITLE
chore(analytics): rename server side website page view to bot page request

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -167,13 +167,13 @@ export function proxy(req: NextRequest) {
       res.headers.set('x-markdown-rewrite', 'true')
     }
 
-    // Markdown responses run no client JS, so log the page view server-side.
+    // Markdown responses run no client JS, so log the page view server-side as a Bot Page Request.
     if (!isBot && !isExcludedFromAnalytics && req.method === 'GET') {
       const pageTypePath = pathname.replace(/\/+$/, '').replace(/\.md$/, '') || '/'
 
       waitUntil(
         logEventServerSide({
-          eventName: 'Website Page View',
+          eventName: 'Bot Page Request',
           eventType: 'track',
           attributes: {
             pageLocation: pathname,

--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -291,7 +291,7 @@ test('flags markdown-preferring bots with x-prefers-markdown', () => {
   assert.equal(res.headers.get('x-prefers-markdown'), 'true')
 })
 
-test('logs Website Page View via tunnel for human markdown rewrites', async () => {
+test('logs Bot Page Request via tunnel for human markdown rewrites', async () => {
   const originalFetch = global.fetch
   const originalTunnel = process.env.NEXT_PUBLIC_TUNNEL_ENDPOINT
   process.env.NEXT_PUBLIC_TUNNEL_ENDPOINT = 'https://tunnel.example.com'
@@ -318,7 +318,7 @@ test('logs Website Page View via tunnel for human markdown rewrites', async () =
     ])
 
     assert.ok(pageViewRequest)
-    assert.equal(pageViewRequest.body.eventName, 'Website Page View')
+    assert.equal(pageViewRequest.body.eventName, 'Bot Page Request')
     assert.equal(pageViewRequest.body.attributes.pageLocation, '/pricing.md')
     assert.equal(pageViewRequest.body.attributes.custom_prefers_markdown, true)
     assert.equal(pageViewRequest.body.attributes.custom_content_type, 'text/markdown')
@@ -410,7 +410,7 @@ test('does not log server page views for browser HTML requests', async () => {
   assert.deepEqual(events, [])
 })
 
-test('logs a server page view for browser docs .md requests alongside the rewrite', async () => {
+test('logs a server Bot Page Request for browser docs .md requests alongside the rewrite', async () => {
   let res
   const events = await captureTunnelEvents(() => {
     res = run('/docs/introduction.md', { headers: { 'user-agent': HUMAN_UA } })
@@ -418,13 +418,13 @@ test('logs a server page view for browser docs .md requests alongside the rewrit
 
   assert.equal(rewriteTarget(res), '/api/docs-markdown/introduction')
   assert.equal(events.length, 1)
-  assert.equal(events[0].eventName, 'Website Page View')
+  assert.equal(events[0].eventName, 'Bot Page Request')
   assert.equal(events[0].attributes.pageLocation, '/docs/introduction.md')
   assert.equal(events[0].attributes.pageType, 'Docs Page')
   assert.equal(events[0].attributes.custom_prefers_markdown, true)
 })
 
-test('logs a server page view for browser Accept: text/markdown requests', async () => {
+test('logs a server Bot Page Request for browser Accept: text/markdown requests', async () => {
   const events = await captureTunnelEvents(() => {
     run('/blog/some-post', {
       headers: { 'user-agent': HUMAN_UA, accept: 'text/markdown' },
@@ -432,7 +432,7 @@ test('logs a server page view for browser Accept: text/markdown requests', async
   })
 
   assert.equal(events.length, 1)
-  assert.equal(events[0].eventName, 'Website Page View')
+  assert.equal(events[0].eventName, 'Bot Page Request')
   assert.equal(events[0].attributes.pageLocation, '/blog/some-post')
   assert.equal(events[0].attributes.pageType, 'Blog Page')
   assert.equal(events[0].attributes.custom_source, 'server')


### PR DESCRIPTION

## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Website Page View on server side is a misnomer, we should reserve it for user browsers so renaming the server side event to Bot Page Request


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

NA

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

NA, follow up for https://github.com/SigNoz/signoz.io/pull/4149 to rename event

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Updated
- Manual verification: NA
- Edge cases covered: NA, small rename

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Analytics event name Website Page view triggered on server side. 
- Potential regressions: NA
- Rollback plan: Revert to original name

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
