### PR TITLE
fix(tabs): spacing below docs tab bars and unclip pill underline

### DIFF
--- a/components/Tabs.module.css
+++ b/components/Tabs.module.css
@@ -26,6 +26,11 @@
   background-size: 100% 1px;
 }
 
+.root > :global(div[data-variant='primary']) {
+  --tab-active-slider-bottom: 0px;
+  padding-bottom: var(--spacing-4, 8px);
+}
+
 .segmented > :global(div[data-variant='secondary']) {
   width: fit-content;
   max-width: 100%;

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -129,6 +129,7 @@ const Tabs = ({
           '--tab-list-wrapper-secondary-padding-left': '0px',
           /* Short left gutter stub (faded in Tabs.module.css) */
           '--tab-border-spacer-min-width': 'var(--spacing-5)',
+          '--tab-gap': 'var(--spacing-6, 12px)',
           ...segmentedVars,
         } as React.CSSProperties
       }
@@ -150,7 +151,7 @@ const Tabs = ({
           )
         })}
       </TabsList>
-      <div className="mt-4">
+      <div data-tab-panels="" className="[&>[data-tab-value]>*:first-child]:mt-0">
         {visibleChildren.map((child) => {
           const isActive = child.props.value === activeTab
           return (

--- a/components/__tests__/Tabs.test.tsx
+++ b/components/__tests__/Tabs.test.tsx
@@ -38,7 +38,9 @@ beforeEach(() => {
 const getTabButtons = () => screen.queryAllByRole('tab')
 const getTabButton = (name: string) => screen.queryByRole('tab', { name })
 const getTabPanels = () =>
-  document.querySelectorAll<HTMLDivElement>('[data-tabs-root] > .mt-4 > [data-tab-value]')
+  document.querySelectorAll<HTMLDivElement>(
+    '[data-tabs-root] > [data-tab-panels] > [data-tab-value]'
+  )
 
 const activateTab = (name: string) => {
   fireEvent.mouseDown(getTabButton(name)!)
@@ -330,7 +332,9 @@ describe('nested tabs do not reset parent plans tab', () => {
     render(<NestedTabs />)
 
     const parentRoot = document.querySelectorAll('[data-tabs-root]')[0]
-    const parentPanels = parentRoot.querySelectorAll(':scope > .mt-4 > [data-tab-value]')
+    const parentPanels = parentRoot.querySelectorAll(
+      ':scope > [data-tab-panels] > [data-tab-value]'
+    )
     const cloudPanel = Array.from(parentPanels).find(
       (p) => p.getAttribute('data-tab-value') === 'cloud'
     )
@@ -342,7 +346,9 @@ describe('nested tabs do not reset parent plans tab', () => {
     expect(selfHostPanel).not.toHaveAttribute('hidden')
 
     const nestedRoot = document.querySelectorAll('[data-tabs-root]')[1]
-    const nestedPanels = nestedRoot.querySelectorAll(':scope > .mt-4 > [data-tab-value]')
+    const nestedPanels = nestedRoot.querySelectorAll(
+      ':scope > [data-tab-panels] > [data-tab-value]'
+    )
     const yarnPanel = Array.from(nestedPanels).find(
       (p) => p.getAttribute('data-tab-value') === 'yarn'
     )


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Docs tab bars had inconsistent, oversized spacing below them, and the `variant="pill"` tabs never showed their active-tab underline - it was clipped by the tab list's horizontal-scroll container.


#### Screenshots / Screen Recordings (if applicable)

**Pill tabs - active underline** (`/docs/instrumentation/opentelemetry-php`)

| Before | After |
|---|---|
| <img width="2560" height="1440" alt="before-pill-underline" src="https://github.com/user-attachments/assets/67c040f4-7905-4ca7-9cff-cb4dfa0eacee" /> | <img width="2560" height="1440" alt="after-pill-underline" src="https://github.com/user-attachments/assets/609abaa2-5bde-4247-9478-1ee7a5dad35b" /> |

**Segmented tabs - spacing** (`/docs/instrumentation/opentelemetry-python`)

| Before | After |
|---|---|
| <img width="2560" height="1440" alt="before-segmented-tabs" src="https://github.com/user-attachments/assets/b6bbdc0e-51ab-4d32-8dd2-274b57202f0b" /> | <img width="2560" height="1440" alt="after-segmented-tabs" src="https://github.com/user-attachments/assets/6bbf3d5a-3aac-4836-8355-2a0a92130d24" /> |

#### Issues closed by this PR

Closes SigNoz/growth-pod#1189

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
1. **Spacing:** the gap below tabs is sum of the design system's root flex `gap` (8px default) and a hard-coded `mt-4` (16px) on the panel wrapper in `components/Tabs.tsx` - plus whatever top margin the panel's first prose element carried so in some places it can appear huge.
2. **Hidden pill underline:** `Tabs.tsx` applies `overflow-x-auto` to the tab list wrapper (needed for horizontally overflowing tab bars on small screens). The design system positions the pill variant's active underline absolutely at `bottom: -8px` - *outside* the wrapper's box - so the overflow container clipped it on every pill tab bar making the active tab difficult to distinguish.

#### Fix Strategy
- `components/Tabs.tsx`: set `--tab-gap: var(--spacing-6, 12px)` on the tabs root and drop the `mt-4`; the panel wrapper now zeroes the first child's prose top-margin (`[&>[data-tab-value]>*:first-child]:mt-0`) so content starts exactly 12px below the bar. The wrapper carries a `data-tab-panels` attribute as a stable structural hook.
- `components/Tabs.module.css`: the pill list wrapper gets `padding-bottom: var(--spacing-4, 8px)` with `--tab-active-slider-bottom: 0px`, keeping the underline in the exact same position relative to the tab labels but *inside* the wrapper box, where the overflow container can't clip it.

---

### 🧪 Testing Strategy

- Tests added/updated: `components/__tests__/Tabs.test.tsx` panel selectors updated from the removed `.mt-4` class to the new `[data-tab-panels]` hook; all 15 tests pass.
- Manual verification: Spot checked on local, screenshots attached
- Edge cases covered: nested tabs (each level gets its own 12px + first-child reset), onboarding tab filtering unchanged, hidden panels unaffected.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: every docs page using `<Tabs>` (~232 MDX files) plus two non-docs consumers (`distributed-tracing` page, `SourcesTabsGrid`) which get the same 12px - correct for them too since their bottom border sits at the list's bottom edge. The TroubleshootingWizard's SegmentedControl shares `segmentedTabVars`/`.segmented`, which are untouched, so it is visually unchanged.
- Potential regressions: DOM contracts used by `DocsTOC`, Copy Markdown (`buildCopyMarkdownFromRendered.ts`), and agent markdown rely only on `data-tabs-root`/`data-tab-value`, both unchanged. 
- Rollback plan: CSS/markup-only change, if any bugs we should attempt fixing but if unfixable - reverting the PR should be fine.

---


### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The remaining two items from the discussion (active-tab dot, -16px secondary-tab offset) are intentionally not in this PR, will reopen the issue and implement changes if needed, only fixed the spacing issue in this PR.

---
