### PR TITLE
docs: document AI Traces alert type in alerts docs

### DIFF
--- a/data/docs/alerts-management/migrate-alert-history-api-v1-to-v2.mdx
+++ b/data/docs/alerts-management/migrate-alert-history-api-v1-to-v2.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-31
+date: 2026-09-11
 title: Migrate the Alert History API from v1 to v2 Endpoints
 description: Migrate from the deprecated v1 alert history API endpoints to the v2 replacements, including request, pagination, and response changes.
 doc_type: reference
@@ -180,6 +180,7 @@ The v2 payloads carry the same information with a few shape changes:
 - Timeline responses include `nextCursor` alongside `items` and `total`; it is omitted on the last page. The v1 top-level `labels` map on the timeline response is gone; use `filter_keys` and `filter_values` instead.
 - `currentAvgResolutionTime` and `pastAvgResolutionTime` in the stats response are now numbers (seconds) instead of formatted strings.
 - `relatedTracesLink` and `relatedLogsLink` are omitted when empty instead of always being present.
+- Timeline items and top contributors also carry `relatedAITracesLink`. AI trace alerts (`alertType: AI_TRACES_BASED_ALERT`) populate this field with a link to the AI Observability Explorer and leave `relatedTracesLink` empty; other alert types leave `relatedAITracesLink` empty.
 
 Full response schemas for every endpoint are in the [SigNoz API Reference](https://signoz.io/api-reference/).
 

--- a/data/docs/alerts-management/trace-based-alerts.mdx
+++ b/data/docs/alerts-management/trace-based-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-27
+date: 2026-09-11
 title: Trace based alerts
 description: Create trace-based alerts in SigNoz using the Traces Query Builder to monitor span attributes, latency, and error rates.
 doc_type: reference
@@ -7,7 +7,11 @@ doc_type: reference
 
 A Trace-based alert in SigNoz allows you to define conditions based on trace data, triggering alerts when these conditions are met. You can define your trace query using **Query Builder** or **ClickHouse queries**.
 
-This page covers the configuration options available for Trace-based alerts — from defining the trace query to setting conditions and notification preferences.
+This page covers the configuration options available for Trace-based alerts, from defining the trace query to setting conditions and notification preferences.
+
+<Admonition type="info">
+To alert on AI observability data such as token counts, cost, or latency, use the AI Traces alert type (`alertType: AI_TRACES_BASED_ALERT`). It is a threshold alert built over `gen_ai` spans using the AI Observability Explorer's query, and is currently created through the alerts API rather than the alert builder UI. Its related links and notifications open the AI Observability Explorer instead of the Traces Explorer; everything else on this page applies unchanged.
+</Admonition>
 
 At the top of the alert creation page, you can set:
 


### PR DESCRIPTION
## Description

Documents the user-facing surfaces of the new AI Traces alert type (PR #12783) that are stable on published docs today:

- **Trace based alerts**: note that the AI Traces alert type (`AI_TRACES_BASED_ALERT`) targets `gen_ai` spans for token/cost/latency alerting, is currently created via the alerts API (no builder UI yet), and routes related links/notifications to the AI Observability Explorer.
- **Alert History v1→v2 migration**: document the new `relatedAITracesLink` v2 response field on timeline items and top contributors.
- Updated `date` frontmatter on both edited files.

Prose-only: demo credentials were unavailable this session, so no screenshots.

**Deferred (out of scope for this batch):**
- Explorer filter bar changes (PR #12716: gen_ai-scoped and context-aware value suggestions) have no published home. The AI Observability Explorer docs page (open PRs #4065/#3753) is not merged to `main` yet; these belong there once it lands.
- The `AI_TRACES_BASED_ALERT` enum auto-appears in the generated API Reference, so no hand-authored alert-types page/DocCard was added (would imply a UI selector and dedicated page that do not exist).

## Additional Information

AI Traces alert creation is API-only in PR #12783 (no Create Alert UI in the AI Observability Explorer). PR #12795/#12796 signal an upcoming Traces Explorer view that will need docs separately.

Source PRs: #12783

Auto-generated by docs-sync pipeline