### PR TITLE
docs: add Text panel type documentation

### DIFF
--- a/data/docs-side-nav/main.json
+++ b/data/docs-side-nav/main.json
@@ -2510,6 +2510,11 @@
                 "type": "doc",
                 "route": "/docs/dashboards/panel-types/value",
                 "label": "Number"
+              },
+              {
+                "type": "doc",
+                "route": "/docs/dashboards/panel-types/text",
+                "label": "Text"
               }
             ]
           },

--- a/data/docs/dashboards/panel-types.mdx
+++ b/data/docs/dashboards/panel-types.mdx
@@ -1,7 +1,7 @@
 ---
-date: 2026-05-13
+date: 2026-09-12
 title: Panel types in Dashboards
-description: Explore the available dashboard panel types in SigNoz including timeseries, table, value, pie, histogram, list, and bar chart.
+description: Explore the available dashboard panel types in SigNoz including timeseries, table, value, pie, histogram, list, bar chart, and text.
 ---
 
 The panel types currently available when creating a Dashboard in SigNoz. 
@@ -48,6 +48,12 @@ The panel types currently available when creating a Dashboard in SigNoz.
     title="📄️ Number"
     description="Learn how to use Number panel type"
     href="https://signoz.io/docs/dashboards/panel-types/value/"
+/>
+
+<DocCard
+    title="📄️ Text"
+    description="Add Markdown notes with the Text panel type, no query required"
+    href="https://signoz.io/docs/dashboards/panel-types/text/"
 />
 
 </DocCardContainer>

--- a/data/docs/dashboards/panel-types/text.mdx
+++ b/data/docs/dashboards/panel-types/text.mdx
@@ -1,0 +1,81 @@
+---
+
+title: Text Panel - Add Markdown Notes to SigNoz Dashboards
+date: 2026-09-12
+description: Learn how to use the Text panel in SigNoz dashboards to add Markdown notes, banners, task lists, and variables without writing a query.
+doc_type: reference
+---
+
+## Text
+
+The Text panel renders authored Markdown content, with no data source or query. Use it to add rich notes, formatted instructions, task lists, and colored banners next to the data panels on a dashboard.
+
+Text panels are available on V2 dashboards on both SigNoz Cloud and self-hosted, with no feature flag.
+
+### Add a Text panel
+
+1. Open a V2 dashboard and select **New Panel**.
+2. In the panel type picker, choose **Text**. Unlike the data panels, Text does not ask for a signal, metric, or query.
+3. The panel editor opens with a Markdown editor pane on the left and a live preview pane on the right. The preview updates as you type, indicated by the **Preview updates as you type** hint.
+4. Write your Markdown, then save the panel.
+
+When the panel body is empty or contains only whitespace, the rendered panel shows an empty state: **Nothing written yet / Add Markdown to this panel to show content.**
+
+### Use variables in the body
+
+Reference dashboard variables inside the Markdown body using any of these four syntaxes:
+
+- `{{var}}`
+- `{{.var}}`
+- `[[var]]`
+- `$var`
+
+The `$var` form also accepts dotted names such as `$service.name`. A variable name that is not defined on the dashboard renders as literal text, so a stray token never breaks the panel.
+
+When you rename a variable that a Text panel references, the [variable impact dialog](https://signoz.io/docs/userguide/manage-variables/#rename-impact-review) lists **Markdown body** as an affected usage and rewrites the panel body to the new name along with the rest of the included changes.
+
+<Admonition type="info">
+Variable interpolation needs the dashboard's variable runtime. On [public dashboards](https://signoz.io/docs/dashboards/public-sharing/), variable tokens render as literal text because public views have no variable runtime.
+</Admonition>
+
+### Panel appearance
+
+The **Panel appearance** section controls how the Markdown body sits inside the panel card.
+
+- **Horizontal alignment** — `Left`, `Center`, or `Right`.
+- **Vertical alignment** — `Top`, `Middle`, or `Bottom`.
+- **Background** — choose one of:
+    - **Transparent** — removes the card border and title bar background entirely, so the panel blends into the dashboard grid.
+    - **Default** — the standard panel surface.
+    - A named color preset: **Robin**, **Purple**, **Sakura**, **Cherry**, **Amber**, **Forest**, **Sienna**, or **Slate**. Each preset adapts to light and dark themes.
+    - **Custom** — pick any hex color.
+
+<Admonition type="warning">
+When a custom background color does not have enough contrast against the text, SigNoz shows a WCAG contrast ratio warning beneath the color picker (the ratio must be at least 4.5:1). Pick a darker or lighter color until the warning clears to keep the text legible.
+</Admonition>
+
+### Panel header
+
+Enable **Hide header** in the **Panel Details** section to remove the title strip from the panel. Hovering a headerless panel reveals a drag handle pill and a floating actions menu, so you can still move and manage it.
+
+### Scroll for more
+
+When the Markdown content is taller than the panel's visible height, a **Scroll for more** pill with chevron icons appears at the bottom edge. Click it to smoothly scroll the panel to the end.
+
+### Interactive task lists
+
+Markdown checkbox items (`- [ ]` and `- [x]`) are interactive in the rendered panel. Toggling a checkbox writes back to the panel spec immediately. Hovering a checkbox shows the tooltip **Toggling this updates the panel spec.**
+
+Toggling is disabled in read-only contexts, such as the View modal and public dashboards.
+
+### View modal
+
+Opening the **View** modal for a Text panel (from the panel's **⋯** menu) shows the Markdown editor pane alongside the live preview, instead of the query and chart toolbar used by data panels. Select **Switch to Edit Mode** in the modal header to open the full panel editor.
+
+### Public dashboards
+
+On [public (shared) dashboards](https://signoz.io/docs/dashboards/public-sharing/), Text panels render the Markdown body in read-only mode. Variable tokens appear as literal text because public dashboards have no variable runtime, and the **Hide header** setting is respected.
+
+### Get Help
+
+<GetHelp />

--- a/data/docs/dashboards/public-sharing.mdx
+++ b/data/docs/dashboards/public-sharing.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-29
+date: 2026-09-12
 title: Public Sharing in Dashboards
 description: Share SigNoz dashboards publicly with a generated link and control the default time range available to viewers.
 doc_type: howto
@@ -46,6 +46,10 @@ When the recipient opens the link, SigNoz applies your variable selections and k
 
 <Admonition type="warning">
   **Include variables** works only with private, authenticated share links. The public dashboard URLs created through the **Publish** flow below do not support variables.
+</Admonition>
+
+<Admonition type="info" title="Text panels on public dashboards">
+  [Text panels](https://signoz.io/docs/dashboards/panel-types/text/) render their Markdown body on public dashboards, but any variable token in the body (for example `{{service}}`) appears as literal text because public dashboards have no variable runtime. The panel's **Hide header** setting is respected.
 </Admonition>
 
 ## Enable Public Sharing

--- a/data/docs/userguide/manage-variables.mdx
+++ b/data/docs/userguide/manage-variables.mdx
@@ -1,5 +1,5 @@
 ---
-date: 2026-07-30
+date: 2026-09-12
 title: Manage Variables in SigNoz
 description: Learn how to create and use dashboard variables in SigNoz to build dynamic, reusable dashboards across services and infrastructure.
 doc_type: howto
@@ -302,7 +302,7 @@ When you rename or delete a variable that is referenced by panel queries or by o
 
 1. Open **Configure** and go to the **Variables** tab, then edit the variable.
 2. Change the **Name** and select **Save**.
-3. The impact dialog lists every usage of the variable across Query Builder, PromQL, and ClickHouse panels, and any other variable definitions that reference it. Each row shows:
+3. The impact dialog lists every usage of the variable across Query Builder, PromQL, and ClickHouse panels, [Text panel](https://signoz.io/docs/dashboards/panel-types/text/) bodies (shown as **Markdown body**), and any other variable definitions that reference it. Each row shows:
     - **Current**: the existing query text (read-only).
     - **Result**: the proposed rewrite with the new variable name. You can edit this field before confirming.
     - A checkbox to include or exclude that usage from the rename.


### PR DESCRIPTION
## Description

Documents the new V2 dashboard **Text** panel type, which renders authored Markdown with no query.

- New page `dashboards/panel-types/text`: adding the panel, Markdown editor and live preview, variable interpolation (`{{var}}`, `{{.var}}`, `[[var]]`, `$var`) and rename propagation, alignment controls, background presets and custom color with the WCAG contrast warning, hide-header, the scroll pill, interactive task lists, the View modal, and public-dashboard behavior.
- Panel types index and sidebar: added the Text entry.
- `manage-variables`: variable renames now also patch Text panel bodies ("Markdown body" in the impact dialog).
- `public-sharing`: variable tokens render as literal text in Text panels on public dashboards.
- Updated frontmatter `date` on every edited file.

All claims verified against product source (#12845). Prose-only: feature merged 2026-09-11 and the demo lags, so screenshots are pending.

## Issues closed by this PR

Source PRs: #12778, #12845

## Additional Information

Open questions for the author:
- Minimum backend version required for Text panel spec (#12711) to persist correctly?
- Are task-list checkboxes disabled specifically for Viewer-role users, or only in public/View-modal read-only contexts?
- Does the custom background hex color survive dashboard JSON export/import, with any validation?

Auto-generated by docs-sync pipeline